### PR TITLE
ObjectStore: add an object store class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ jobs:
       script: make rpm-nodeps
     - name: pipeline-noop
       before_install: sudo apt-get install -y systemd-container
-      script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/noop.json
+      script:
+        - sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/noop.json
+        - sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/noop.json
     - name: pipeline-yum
       before_install: sudo apt-get install -y systemd-container yum
       script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/build-from-yum.json

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The above pipeline has no base and produces a qcow2 image.
 ## Running
 
 ```
-usage: python3 -m osbuild [-h] [--objects DIRECTORY] [-l DIRECTORY] -o DIRECTORY
+usage: python3 -m osbuild [-h] [--store DIRECTORY] [-l DIRECTORY] -o DIRECTORY
                    PIPELINE
 
 Build operating system images
@@ -77,7 +77,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  --objects DIRECTORY   the directory where intermediary os trees are stored
+  --store DIRECTORY   the directory where intermediary os trees are stored
   -l DIRECTORY, --libdir DIRECTORY
                         the directory containing stages, assemblers, and the
                         osbuild library

--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -14,8 +14,8 @@ def main():
     parser = argparse.ArgumentParser(description="Build operating system images")
     parser.add_argument("pipeline_path", metavar="PIPELINE",
                         help="json file containing the pipeline that should be built")
-    parser.add_argument("--objects", metavar="DIRECTORY", type=os.path.abspath,
-                        default=".osbuild/objects",
+    parser.add_argument("--store", metavar="DIRECTORY", type=os.path.abspath,
+                        default=".osbuild/store",
                         help="the directory where intermediary os trees are stored")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath,
                         help="the directory containing stages, assemblers, and the osbuild library")
@@ -28,7 +28,7 @@ def main():
         pipeline = osbuild.load(json.load(f))
 
     try:
-        pipeline.run(args.output_dir, args.objects, interactive=True, libdir=args.libdir)
+        pipeline.run(args.output_dir, args.store, interactive=True, libdir=args.libdir)
     except KeyboardInterrupt:
         print()
         print(f"{RESET}{BOLD}{RED}Aborted{RESET}")

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -20,7 +20,7 @@ logging.basicConfig(level=logging.getLevelName(os.environ.get("TESTS_LOGLEVEL", 
 
 
 def run_osbuild(pipeline: str, check=True):
-    cmd = OSBUILD + ["--objects", OBJECTS, "-o", OUTPUT_DIR, pipeline]
+    cmd = OSBUILD + ["--store", OBJECTS, "-o", OUTPUT_DIR, pipeline]
     logging.info(f"Running osbuild: {cmd}")
     osbuild = subprocess.run(cmd, capture_output=True)
     if osbuild.returncode != 0:


### PR DESCRIPTION
This also changes the structure of the object store, though the
basic idea is the same.

The object store contains a directory of objects, which are content
addressable filesystem trees. Currently we only ever use their
content-hash internally, but the idea for this is basically Lars
Karlitski's and Kay Sievers `treesum()`. We may exopse this in the
future.

Moreover, it contains a directory of refs, which are symlinks named
by the stage id they correspond to (as before), pointing to an object
generated from that stage-id.

The ObjectStore exposes two methods, meant to be used with
`whith` blocks, both yielding a path to a tree.

`new_tree()`: When a base_id is provided, the directory will be
initalized with the given base_id, and when a tree_id is given,
the directory will be saved to the content store and a ref by that
tree_id is made to it (possibly atomically replacing any existing
refs by the same id).
`get_tree(): When the given tree_id exists, a read-only instance
of the tree is yielded, otherwise None is.