### PR TITLE
travis: test osbuild itself in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ jobs:
     - name: pylint
       install: pip install pylint
       script: pylint osbuild osbuild-run assemblers/* stages/*
+    - name: rpm
+      before_install:
+        - sudo apt-get install -y rpm python3-setuptools
+        - sudo wget --directory-prefix=/usr/lib/rpm/macros.d https://src.fedoraproject.org/rpms/python-rpm-macros/raw/master/f/macros.python-srpm
+        - sudo wget --directory-prefix=/usr/lib/rpm/macros.d https://src.fedoraproject.org/rpms/python-rpm-macros/raw/master/f/macros.python
+        - sudo wget --directory-prefix=/usr/lib/rpm/macros.d https://src.fedoraproject.org/rpms/python-rpm-macros/raw/master/f/macros.python3
+      script: make rpm-nodeps
     - name: pipeline-noop
       before_install: sudo apt-get install -y systemd-container
       script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/noop.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,14 @@ dist: bionic
 language: python
 python:
   - "3.7"
-before_install:
-  - sudo apt-get install -y systemd-container yum
-install:
-  - pip install pylint
 jobs:
   include:
     - name: pylint
+      install: pip install pylint
       script: pylint osbuild osbuild-run assemblers/* stages/*
     - name: pipeline-noop
+      before_install: sudo apt-get install -y systemd-container
       script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/noop.json
     - name: pipeline-yum
+      before_install: sudo apt-get install -y systemd-container yum
       script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/build-from-yum.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
 jobs:
   include:
     - name: pylint
-      script: pylint osbuild assemblers/* stages/*
+      script: pylint osbuild osbuild-run assemblers/* stages/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - "3.7"
 before_install:
-  - sudo apt-get install -y systemd-container
+  - sudo apt-get install -y systemd-container yum
 install:
   - pip install pylint
 jobs:
@@ -12,3 +12,5 @@ jobs:
       script: pylint osbuild osbuild-run assemblers/* stages/*
     - name: pipeline-noop
       script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/noop.json
+    - name: pipeline-yum
+      script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/build-from-yum.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ dist: bionic
 language: python
 python:
   - "3.7"
+before_install:
+  - sudo apt-get install -y systemd-container
 install:
   - pip install pylint
 jobs:
   include:
     - name: pylint
       script: pylint osbuild osbuild-run assemblers/* stages/*
+    - name: pipeline-noop
+      script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/noop.json

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,22 @@ rpm: $(PACKAGE_NAME).spec tarball
 	rm -r "`pwd`/rpmbuild"
 	rm -r "`pwd`/build"
 
+rpm-nodeps: $(PACKAGE_NAME).spec tarball
+	- rm -r "`pwd`/output"
+	mkdir -p "`pwd`/output"
+	mkdir -p "`pwd`/rpmbuild"
+	/usr/bin/rpmbuild -bb \
+	  --nodeps \
+	  --define "_sourcedir `pwd`" \
+	  --define "_specdir `pwd`" \
+	  --define "_builddir `pwd`/rpmbuild" \
+	  --define "_srcrpmdir `pwd`" \
+	  --define "_rpmdir `pwd`/output" \
+	  --define "_buildrootdir `pwd`/build" \
+	  $(PACKAGE_NAME).spec
+	rm -r "`pwd`/rpmbuild"
+	rm -r "`pwd`/build"
+
 copy-rpms-to-test: rpm
 	- rm test/testing-rpms/*.rpm
 	find `pwd`/output -name '*.rpm' -printf '%f\n' -exec cp {} test/testing-rpms/ \;

--- a/assemblers/org.osbuild.noop
+++ b/assemblers/org.osbuild.noop
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+
+import json
+import sys
+
+def main(_tree, _output_dir, options):
+    print("Not doing anything with these options:", json.dumps(options))
+
+if __name__ == '__main__':
+    args = json.load(sys.stdin)
+    r = main(args["tree"], args["output_dir"], args.get("options", {}))
+    sys.exit(r)

--- a/osbuild-run
+++ b/osbuild-run
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import shutil
 import os
 import subprocess
 import sys
@@ -20,6 +21,9 @@ def sysusers():
 
 
 def update_ca_trust():
+    if not shutil.which("update-ca-trust"):
+        return
+
     # generate /etc/pki/tls/certs/ca-bundle.crt
     os.makedirs("/etc/pki/ca-trust/extracted/pem")
     os.makedirs("/etc/pki/tls/certs")

--- a/osbuild-run
+++ b/osbuild-run
@@ -31,15 +31,40 @@ def update_ca_trust():
     subprocess.run(["update-ca-trust"])
 
 
+def append_certs(cert_conf, dir_fd, parents=b""):
+    for entry in os.scandir(f"/proc/self/fd/{dir_fd}".encode()):
+        if entry.is_file():
+            line = os.path.join(parents, entry.name)
+            cert_conf.write(line)
+            cert_conf.write(b"\n")
+        elif entry.is_dir():
+            append_certs(cert_conf,
+                         os.open(entry.name, os.O_DIRECTORY, dir_fd=dir_fd),
+                         os.path.join(parents, entry.name))
+
+
+def update_ca_certificates():
+    if not shutil.which("update-ca-certificates"):
+        return
+
+    # generate /etc/ssl/certs/ca-certificates.crt
+    os.makedirs("/etc/ssl/certs")
+    with open("/etc/ca-certificates.conf", "wb") as f:
+        append_certs(f, os.open("/usr/share/ca-certificates", os.O_DIRECTORY))
+    subprocess.run(["update-ca-certificates"])
+
+
 def tmpfiles():
     # Allow systemd-tmpfiles to return non-0. Some packages want to create
     # directories owned by users that are not set up with systemd-sysusers.
     subprocess.run(["systemd-tmpfiles", "--create"])
 
+
 if __name__ == "__main__":
     ldconfig()
     sysusers()
     update_ca_trust()
+    update_ca_certificates()
     tmpfiles()
 
     r = subprocess.run(sys.argv[1:])

--- a/osbuild-run
+++ b/osbuild-run
@@ -5,25 +5,38 @@ import subprocess
 import sys
 
 
-# ld.so.conf must exist, or `ldconfig` throws a warning
-subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
-subprocess.run(["ldconfig"], check=True)
+def ldconfig():
+    # ld.so.conf must exist, or `ldconfig` throws a warning
+    subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
+    subprocess.run(["ldconfig"], check=True)
 
-try:
-    subprocess.run(["systemd-sysusers"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
-except subprocess.CalledProcessError as error:
-    sys.stderr.write(error.stdout)
-    sys.exit(1)
 
-# generate /etc/pki/tls/certs/ca-bundle.crt
-os.makedirs("/etc/pki/ca-trust/extracted/pem")
-os.makedirs("/etc/pki/tls/certs")
-os.symlink("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", "/etc/pki/tls/certs/ca-bundle.crt")
-subprocess.run(["update-ca-trust"])
+def sysusers():
+    try:
+        subprocess.run(["systemd-sysusers"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as error:
+        sys.stderr.write(error.stdout)
+        sys.exit(1)
 
-# Allow systemd-tmpfiles to return non-0. Some packages want to create
-# directories owned by users that are not set up with systemd-sysusers.
-subprocess.run(["systemd-tmpfiles", "--create"])
 
-r = subprocess.run(sys.argv[1:])
-sys.exit(r.returncode)
+def update_ca_trust():
+    # generate /etc/pki/tls/certs/ca-bundle.crt
+    os.makedirs("/etc/pki/ca-trust/extracted/pem")
+    os.makedirs("/etc/pki/tls/certs")
+    os.symlink("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", "/etc/pki/tls/certs/ca-bundle.crt")
+    subprocess.run(["update-ca-trust"])
+
+
+def tmpfiles():
+    # Allow systemd-tmpfiles to return non-0. Some packages want to create
+    # directories owned by users that are not set up with systemd-sysusers.
+    subprocess.run(["systemd-tmpfiles", "--create"])
+
+if __name__ == "__main__":
+    ldconfig()
+    sysusers()
+    update_ca_trust()
+    tmpfiles()
+
+    r = subprocess.run(sys.argv[1:])
+    sys.exit(r.returncode)

--- a/samples/build-from-yum.json
+++ b/samples/build-from-yum.json
@@ -1,0 +1,22 @@
+{
+  "name": "build-from-yum",
+  "stages": [
+    {
+      "name": "org.osbuild.yum",
+      "options": {
+        "releasever": "27",
+        "repos": {
+          "fedora": {
+            "name": "Fedora",
+            "baseurl": "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/$releasever/Everything/$basearch/os/",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch"
+          }
+        },
+        "packages": [
+          "dnf",
+          "systemd"
+        ]
+      }
+    }
+  ]
+}

--- a/samples/noop.json
+++ b/samples/noop.json
@@ -1,0 +1,11 @@
+{
+  "name": "noop",
+  "stages": [
+    {
+      "name": "org.osbuild.noop"
+    }
+  ],
+  "assembler": {
+    "name": "org.osbuild.noop"
+  }
+}

--- a/stages/org.osbuild.yum
+++ b/stages/org.osbuild.yum
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+import json
+import subprocess
+import sys
+
+
+def main(tree, options):
+    repos = options["repos"]
+    packages = options["packages"]
+    releasever = options["releasever"]
+    operation = options.get("operation", "install")
+    verbosity = options.get("verbosity", "info")
+
+    with open("/tmp/yum.conf", "w") as conf:
+        for repoid, repo in repos.items():
+            conf.write(f"[{repoid}]\n")
+            for key, value in repo.items():
+                if isinstance(value, str):
+                    s = value
+                elif isinstance(value, list):
+                    s = " ".join(value)
+                elif isinstance(value, bool):
+                    s = "1" if value else "0"
+                elif isinstance(value, int):
+                    s = str(value)
+                else:
+                    print(f"unkown type for `{key}`: {value} ({type(value)})")
+                    return 1
+                conf.write(f"{key}={s}\n")
+
+    script = f"""
+        set -e
+        mkdir -p {tree}/dev {tree}/sys {tree}/proc
+        mount -t devtmpfs none {tree}/dev
+        mount -t sysfs none {tree}/sys
+        mount -t proc none {tree}/proc
+    """
+    returncode = subprocess.run(["/bin/sh", "-c", script]).returncode
+
+    if returncode != 0:
+        print(f"setting up API VFS in target tree failed: {returncode}")
+        return returncode
+
+    cmd = [
+        "yum", "-y", "-v",
+        f"--installroot={tree}",
+        "--setopt=\"reposdir=\"",
+        f"--releasever={releasever}",
+        f"--rpmverbosity={verbosity}",
+        "--config=/tmp/yum.conf",
+        operation
+    ] + packages
+
+    print(" ".join(cmd), flush=True)
+    return subprocess.run(cmd).returncode
+
+
+if __name__ == '__main__':
+    args = json.load(sys.stdin)
+    r = main(args["tree"], args["options"])
+    sys.exit(r)


### PR DESCRIPTION
This adds two tests: noop and yum.

Noop just runs osbuild with one noop stage and a noop assembler.

Yum creates a Fedora 27 build image containing dnf and systemd. F27 was chosen as it is the most recent version of Fedora that can installed using yum. The reason to use yum at all is that travis runs on Ubuntu and ubuntu shipps yum (but not dnf).