### PR TITLE
qcow2: remove partition_table_id

### DIFF
--- a/assemblers/org.osbuild.qcow2
+++ b/assemblers/org.osbuild.qcow2
@@ -61,7 +61,7 @@ def main(tree, output_dir, options, loop_client):
         subprocess.run(["truncate", "--size", str(size), image], check=True)
 
         # Set up the partition table of the image
-        partition_table = "label: mbr\nlabel-id: {partition_table_id}\nbootable, type=83"
+        partition_table = "label: mbr\nbootable, type=83"
         subprocess.run(["sfdisk", "-q", image], input=partition_table, encoding='utf-8', check=True)
         r = subprocess.run(["sfdisk", "--json", image], stdout=subprocess.PIPE, encoding='utf-8', check=True)
         partition_table = json.loads(r.stdout)

--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -6,8 +6,7 @@
       "name": "org.osbuild.qcow2",
       "options": {
 	"filename": "base.qcow2",
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-	"partition_table_id": "0xdeadbeef"
+        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
       }
     }
 }

--- a/test/2-configure-web-server.json
+++ b/test/2-configure-web-server.json
@@ -29,8 +29,7 @@
     {
       "name": "org.osbuild.grub2",
       "options": {
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-        "partition_table_id": "0xdeadbeef"
+        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
       }
     }
   ]

--- a/test/3-compose-qcow2.json
+++ b/test/3-compose-qcow2.json
@@ -5,8 +5,7 @@
     "name": "org.osbuild.qcow2",
     "options": {
       "filename": "base.qcow2",
-      "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-      "partition_table_id": "0xdeadbeef"
+      "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
     }
   }
 }

--- a/test/4-all.json
+++ b/test/4-all.json
@@ -46,8 +46,7 @@
     {
       "name": "org.osbuild.grub2",
       "options": {
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-        "partition_table_id": "0xdeadbeef"
+        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
       }
     }
   ],
@@ -55,8 +54,7 @@
     "name": "org.osbuild.qcow2",
     "options": {
       "filename": "base.qcow2",
-      "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-      "partition_table_id": "0xdeadbeef"
+      "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
     }
   }
 }


### PR DESCRIPTION
It's not necessary to specify it.

I don't think I need to set update any `base_ids`, because I only changed the assembler sample.