### PR TITLE
introduce custamization stage

### DIFF
--- a/stages/org.osbuild.customizations
+++ b/stages/org.osbuild.customizations
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+import json
+import subprocess
+import sys
+import os
+
+
+def run_systemd_firstboot(tree, option, value, delete_file=None):
+    # We need to remove the "delete_file" first, because it is created while we install RPM packages. systemd-firstboot
+    # expects that if "delete_file" exists it is a user-defined value and does not change it, but the assumption is
+    # wrong, because it contains a default value from RPM package.
+    # This is (hopefully) a temporary workaround.
+    if delete_file is not None:
+        try:
+            os.remove(f"{tree}/{delete_file}")
+            # ^ This will fail once systemd RPM package stops shipping the file
+            print(f"{delete_file} already exists. Replacing.")
+        except FileNotFoundError:
+            pass
+
+    subprocess.run(["systemd-firstboot", f"--root={tree}", f"--{option}={value}"], check=True)
+
+    return 0
+
+
+def main(tree, options):
+    hostname = options["hostname"]
+    return run_systemd_firstboot(tree, "hostname", hostname, "/etc/hostname")
+
+
+if __name__ == '__main__':
+    args = json.load(sys.stdin)
+    r = main(args["tree"], args["options"])
+    sys.exit(r)


### PR DESCRIPTION
We can't map all the customizations from https://weldr.io/lorax/lorax-composer.html#customizations to this stage. But I guess we could use it for all of them that does not belong to any other stage (like `grub2` for kernel parameters, or `systemd` for services)

WDYT?