### PR TITLE
Allow nested piplines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ jobs:
     - name: pipeline-yum
       before_install: sudo apt-get install -y systemd-container yum
       script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/build-from-yum.json
+    - name: pipeline-base-from-yum
+      before_install: sudo apt-get install -y systemd-container yum
+      script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/base-from-yum.json

--- a/osbuild-run
+++ b/osbuild-run
@@ -60,12 +60,23 @@ def tmpfiles():
     subprocess.run(["systemd-tmpfiles", "--create"])
 
 
+def nsswitch():
+    # the default behavior is fine, but using nss-resolve does not
+    # necessarily work in a non-booted container, so make sure that
+    # is not configured.
+    try:
+        os.remove("/etc/nsswitch.conf")
+    except FileNotFoundError:
+        pass
+
+
 if __name__ == "__main__":
     ldconfig()
     sysusers()
     update_ca_trust()
     update_ca_certificates()
     tmpfiles()
+    nsswitch()
 
     r = subprocess.run(sys.argv[1:])
     sys.exit(r.returncode)

--- a/samples/base-from-yum.json
+++ b/samples/base-from-yum.json
@@ -1,0 +1,45 @@
+{
+  "name": "base",
+  "build": {
+    "name": "build",
+    "stages": [
+      {
+        "name": "org.osbuild.yum",
+        "options": {
+          "releasever": "27",
+          "repos": {
+            "fedora": {
+              "name": "Fedora",
+              "baseurl": "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/$releasever/Everything/$basearch/os/",
+              "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch"
+            }
+          },
+          "packages": [
+            "dnf",
+            "systemd"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "repos": {
+          "fedora": {
+            "name": "Fedora",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch"
+          }
+        },
+        "packages": [
+          "@Core",
+          "selinux-policy-targeted",
+          "grub2-pc"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This allows the build tree to be generated from a pipeline, an operation which can be nested arbitrarily.
This in particular allows us to bootstrap on Travis, so we can run some more comprehensive tests.