### PR TITLE
Add description() methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 *.rpm
 *.tar.gz
 *.egg-info
-output
+__pycache__
+
+/.osbuild
+/output
+
+/test/.vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ jobs:
     - name: pylint
       install: pip install pylint
       script: pylint osbuild osbuild-run assemblers/* stages/*
+    - name: unit-tests
+      script: python3 -m unittest test.test_osbuild
     - name: rpm
       before_install:
         - sudo apt-get install -y rpm python3-setuptools

--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -287,6 +287,13 @@ class Stage:
         self.name = name
         self.options = options
 
+    def description(self):
+        description = {}
+        description["name"] = self.name
+        if self.options:
+            description["options"] = self.options
+        return description
+
     def run(self, tree, build_tree, interactive=False, check=True, libdir=None):
         with BuildRoot(build_tree) as buildroot:
             if interactive:
@@ -321,6 +328,13 @@ class Assembler:
     def __init__(self, name, options):
         self.name = name
         self.options = options
+
+    def description(self):
+        description = {}
+        description["name"] = self.name
+        if self.options:
+            description["options"] = self.options
+        return description
 
     def run(self, tree, build_tree, output_dir=None, interactive=False, check=True, libdir=None):
         with BuildRoot(build_tree) as buildroot:
@@ -381,6 +395,18 @@ class Pipeline:
 
     def set_assembler(self, name, options=None):
         self.assembler = Assembler(name, options or {})
+
+    def description(self):
+        description = {}
+        if self.base:
+            description["base"] = self.base
+        if self.build:
+            description["build"] = self.build.description()
+        if self.stages:
+            description["stages"] = [s.description() for s in self.stages]
+        if self.assembler:
+            description["assembler"] = self.assembler.description()
+        return description
 
     @contextlib.contextmanager
     def get_buildtree(self, object_store):

--- a/test/test_osbuild.py
+++ b/test/test_osbuild.py
@@ -1,0 +1,77 @@
+
+import osbuild
+import unittest
+
+
+class TestDescriptions(unittest.TestCase):
+    def test_canonical(self):
+        """Degenerate case. Make sure we always return the same canonical
+        description when passing empty or null values."""
+
+        cases = [
+            {},
+            { "assembler": None },
+            { "stages": [] },
+            { "build": {} },
+            { "build": None }
+        ]
+        for pipeline in cases:
+            with self.subTest(pipeline):
+                self.assertEqual(osbuild.load(pipeline).description(), {})
+
+    def test_stage(self):
+        name = "org.osbuild.test"
+        options = { "one": 1 }
+        cases = [
+            (osbuild.Stage(name, None, None, {}), {"name": name}),
+            (osbuild.Stage(name, None, None, None), {"name": name}),
+            (osbuild.Stage(name, None, None, options), {"name": name, "options": options}),
+        ]
+        for stage, description in cases:
+            with self.subTest(description):
+                self.assertEqual(stage.description(), description)
+
+    def test_assembler(self):
+        name = "org.osbuild.test"
+        options = { "one": 1 }
+        cases = [
+            (osbuild.Assembler(name, {}), {"name": name}),
+            (osbuild.Assembler(name, None), {"name": name}),
+            (osbuild.Assembler(name, options), {"name": name, "options": options}),
+        ]
+        for assembler, description in cases:
+            with self.subTest(description):
+                self.assertEqual(assembler.description(), description)
+
+    def test_pipeline(self):
+        build = osbuild.Pipeline()
+        build.add_stage("org.osbuild.test", { "one": 1 })
+
+        pipeline = osbuild.Pipeline()
+        pipeline.set_build(build)
+        pipeline.add_stage("org.osbuild.test", { "one": 2 })
+        pipeline.set_assembler("org.osbuild.test")
+
+        self.assertEqual(pipeline.description(), {
+              "build": {
+                "stages": [
+                  {
+                    "name": "org.osbuild.test",
+                    "options": { "one": 1 }
+                  }
+                ]
+              },
+              "stages": [
+                {
+                  "name": "org.osbuild.test",
+                  "options": { "one": 2 }
+                }
+              ],
+              "assembler": {
+                "name": "org.osbuild.test"
+              }
+            })
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We already allow loading from a description. This adds the opposite direction to export Pipelines, Stages, and Assemblers.
