### PR TITLE
Add flag to preserve build tree for interactive inspection

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-disable=missing-docstring,too-few-public-methods,invalid-name,duplicate-code,superfluous-parens,too-many-locals,attribute-defined-outside-init,too-many-arguments
+disable=missing-docstring,too-few-public-methods,invalid-name,duplicate-code,superfluous-parens,too-many-locals,attribute-defined-outside-init,too-many-arguments,too-many-branches
 max-line-length=120
 
 [TYPECHECK]

--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -19,6 +19,8 @@ def main():
                         help="the directory where intermediary os trees are stored")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath,
                         help="the directory containing stages, assemblers, and the osbuild library")
+    parser.add_argument("-k", "--keepalive", action="store_true",
+                        help="keep the build tree alive and run bash on failure")
     requiredNamed = parser.add_argument_group('required named arguments')
     requiredNamed.add_argument("-o", "--output", dest="output_dir", metavar="DIRECTORY", type=os.path.abspath,
                                help="provide the empty DIRECTORY as output argument to the last stage", required=True)
@@ -28,7 +30,7 @@ def main():
         pipeline = osbuild.load(json.load(f))
 
     try:
-        pipeline.run(args.output_dir, args.store, interactive=True, libdir=args.libdir)
+        pipeline.run(args.output_dir, args.store, interactive=True, libdir=args.libdir, keepalive=args.keepalive)
     except KeyboardInterrupt:
         print()
         print(f"{RESET}{BOLD}{RED}Aborted{RESET}")


### PR DESCRIPTION
In case the stage or assembler fails, the build tree is cleaned up
automatically, this option allow us to examine the tree in interactive
bash before it gets removed.