### PR TITLE
Improve packaging and deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+build/
+dist/
+*.egg-info
+.eggs/
 *.rpm
 *.tar.gz
 *.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,12 @@ jobs:
     - name: pipeline-base-from-yum
       before_install: sudo apt-get install -y systemd-container yum
       script: sudo env "PATH=$PATH" python3 -m osbuild --libdir . --output . samples/base-from-yum.json
+
+deploy:
+  - provider: pypi
+    user: osbuild
+    password: your-secure-password
+    on:
+      tags: true
+    distributions: sdist bdist_wheel
+    skip_existing: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,27 @@
+[metadata]
+name = osbuild
+description = A build system for OS images
+long_description = file: README.rst
+long_description_content_type = text/markdown
+keywords = pipeline, build, os, images
+license = Apache-2.0
+classifiers =
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Operating System :: POSIX :: Linux
+    Topic :: System :: Operating System
+
+[options]
+zip_safe = False
+include_package_data = True
+packages = osbuild
+setup_requires =
+  setuptools_scm
+
+[options.entry_points]
+console_scripts =
+  osbuild = osbuild.__main__:main
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,5 @@
-import glob
 import setuptools
 
 setuptools.setup(
-    name="osbuild",
-    version="1",
-    description="A build system for OS images",
-    packages=["osbuild"],
-    license='Apache-2.0',
-    entry_points={
-        "console_scripts": ["osbuild = osbuild.__main__:main"]
-    },
+    use_scm_version=True,
 )


### PR DESCRIPTION
- automatically retrieve version from scm version (git tag in our case)
- deploy on pypi triggered by git tag push on github
- prefer using setup.cfg instead of setup.py to reduce python code
- improve packages classifiers