### PR TITLE
osbuild: check for right errno from os.rename()

### DIFF
--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -188,7 +188,7 @@ class ObjectStore:
             try:
                 os.rename(tree, output_tree)
             except OSError as e:
-                if e.errno == errno.EEXIST:
+                if e.errno == errno.ENOTEMPTY:
                     pass # tree with the same content hash already exist, use that
                 else:
                     raise


### PR DESCRIPTION
Renaming a directory over an existing one is only an error if the
existing one is not empty, in which case ENOEMPTY is thrown.

Tested with:

    >>> os.mkdir("foo")
    >>> os.mkdir("bar")
    >>> os.rename("foo", "bar")
    # no error

    >>> open("foo/a", "w").write("a")
    1
    >>> try: os.rename("bar", "foo")
    ... except OSError as e: e.errno == errno.ENOTEMPTY
    ...
    True