### PR TITLE
stages/dnf: supress error from completion module

### DIFF
--- a/stages/org.osbuild.dnf
+++ b/stages/org.osbuild.dnf
@@ -49,6 +49,7 @@ def main(tree, options):
         "--setopt", "install_weak_deps=False",
         "--releasever", releasever,
         "--rpmverbosity", verbosity,
+        "--disableplugin=generate_completion_cache", # supress error that completion db can't be opened
         "--config", "/tmp/dnf.conf",
         operation
     ] + packages


### PR DESCRIPTION
Disable the module. There's no need to update the completion databse in
the container.