### PR TITLE
stages/fix-bls: add workaround for grub2-mkrelpath

### DIFF
--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -36,6 +36,9 @@
       "options": {
         "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
       }
+    },
+    {
+      "name": "org.osbuild.fix-bls"
     }
   ],
   "assembler":

--- a/stages/org.osbuild.fix-bls
+++ b/stages/org.osbuild.fix-bls
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+import glob
+import json
+import re
+import sys
+
+
+def main(tree, _options):
+    """Fix broken paths in /boot/loader/entries.
+
+    grub2-mkrelpath uses /proc/self/mountinfo to find the source of the file
+    system it is installed to. This breaks in a container, because we
+    bind-mount the tree from the host.
+    """
+
+    path_re = re.compile(r"(/.*)+/boot")
+
+    for name in glob.glob(f"{tree}/boot/loader/entries/*.conf"):
+        with open(name) as f:
+            entry = f.read().splitlines(keepends=True)
+
+        with open(name, "w") as f:
+            for line in entry:
+                f.write(path_re.sub("/boot", line))
+
+    return 0
+
+
+if __name__ == '__main__':
+    args = json.load(sys.stdin)
+    r = main(args["tree"], args["options"])
+    sys.exit(r)


### PR DESCRIPTION
grub2-mkrelpath uses /proc/self/mountinfo to find the source of the file
system it is installed to. This breaks in a container.

Add org.osbuild.fix-bls which goes through /boot/loader/entries and
fixes paths by removing anything before /boot.