### PR TITLE
dnf/fstab/qcow2: create images more similar to the stock fedora ones

### DIFF
--- a/assemblers/org.osbuild.qcow2
+++ b/assemblers/org.osbuild.qcow2
@@ -71,13 +71,15 @@ def main(tree, output_dir, options, loop_client):
 
         # Populate the first partition of the image with an ext4 fs and fill it with the contents of the
         # tree we are operating on.
-        subprocess.run(["mkfs.ext4", "-d", tree, "-U", root_fs_uuid, "-E", f"offset={partition_offset}", image,
+        subprocess.run(["mkfs.ext4", "-U", root_fs_uuid, "-E", f"offset={partition_offset}", image,
                         f"{int(partition_size / 1024)}k"], input="y", encoding='utf-8', check=True)
 
         # Mount the created image as a loopback device
         with loop_device(loop_client, image, partition_offset) as loop_block, \
             loop_device(loop_client, image, partition_size, partition_offset) as loop_part, \
             mount(loop_part, mountpoint):
+            # Copy the tree into the target image
+            subprocess.run(["cp", "-a", f"{tree}/.", mountpoint], check=True)
             # Install grub2 into the boot sector of the image, and copy the grub2 imagise into /boot/grub2
             with mount_api(mountpoint):
                 subprocess.run(["chroot", mountpoint, "grub2-install", "--no-floppy",

--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -33,15 +33,30 @@
       }
     },
     {
-      "name": "org.osbuild.selinux",
+      "name": "org.osbuild.fstab",
       "options": {
-        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        "filesystems": [
+          {
+            "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "vfs_type": "ext4",
+            "path": "/",
+            "freq": "1",
+            "passno": "1"
+          }
+        ]
       }
     },
     {
       "name": "org.osbuild.grub2",
       "options": {
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0 console=ttyS0,115200"
+      }
+    },
+    {
+      "name": "org.osbuild.selinux",
+      "options": {
+        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
       }
     },
     {

--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -5,6 +5,7 @@
       "name": "org.osbuild.dnf",
       "options": {
         "releasever": "30",
+        "install_weak_deps": true,
         "repos": {
           "fedora": {
             "name": "Fedora",
@@ -14,8 +15,14 @@
         },
         "packages": [
           "@Core",
+          "chrony",
+          "kernel",
           "selinux-policy-targeted",
-          "grub2-pc"
+          "grub2-pc",
+          "spice-vdagent",
+          "qemu-guest-agent",
+          "xen-libs",
+          "langpacks-en"
         ]
       }
     },

--- a/stages/org.osbuild.dnf
+++ b/stages/org.osbuild.dnf
@@ -10,6 +10,7 @@ def main(tree, options):
     packages = options["packages"]
     releasever = options["releasever"]
     operation = options.get("operation", "install")
+    weak_deps = options.get("install_weak_deps", True)
 
     with open("/tmp/dnf.conf", "w") as conf:
         for repoid, repo in repos.items():
@@ -45,7 +46,7 @@ def main(tree, options):
         "dnf", "-yv",
         "--installroot", tree,
         "--setopt", "reposdir=",
-        "--setopt", "install_weak_deps=False",
+        "--setopt", f"install_weak_deps={weak_deps}",
         "--releasever", releasever,
         "--disableplugin=generate_completion_cache", # supress error that completion db can't be opened
         "--config", "/tmp/dnf.conf",

--- a/stages/org.osbuild.dnf
+++ b/stages/org.osbuild.dnf
@@ -10,7 +10,6 @@ def main(tree, options):
     packages = options["packages"]
     releasever = options["releasever"]
     operation = options.get("operation", "install")
-    verbosity = options.get("verbosity", "info")
 
     with open("/tmp/dnf.conf", "w") as conf:
         for repoid, repo in repos.items():
@@ -48,7 +47,6 @@ def main(tree, options):
         "--setopt", "reposdir=",
         "--setopt", "install_weak_deps=False",
         "--releasever", releasever,
-        "--rpmverbosity", verbosity,
         "--disableplugin=generate_completion_cache", # supress error that completion db can't be opened
         "--config", "/tmp/dnf.conf",
         operation

--- a/stages/org.osbuild.fstab
+++ b/stages/org.osbuild.fstab
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+import json
+import sys
+
+
+def main(tree, options):
+    filesystems = options["filesystems"]
+
+    with open(f"{tree}/etc/fstab", "w") as f:
+        for filesystem in filesystems:
+            uuid = filesystem["uuid"]
+            path = filesystem["path"]
+            vfs_type = filesystem.get("vfs_type", "none")
+            options = filesystem.get("options", "defaults")
+            freq = filesystem.get("freq", "0")
+            passno = filesystem.get("passno", "0")
+
+            f.write(f"UUID={uuid}\t{path}\t{vfs_type}\t{options}\t{freq}\t{passno}\n")
+
+
+if __name__ == '__main__':
+    args = json.load(sys.stdin)
+    r = main(args["tree"], args["options"])
+    sys.exit(r)

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -20,7 +20,7 @@ def main(tree, options):
         env.write("# GRUB Environment Block\n"
                   f"GRUB2_ROOT_FS_UUID={root_fs_uuid}\n"
                   f"GRUB2_BOOT_FS_UUID={root_fs_uuid}\n"
-                  f"kernelopts=root=UUID={root_fs_uuid} rw {kernel_opts}\n")
+                  f"kernelopts=root=UUID={root_fs_uuid} {kernel_opts}\n")
     with open(f"{tree}/boot/grub2/grub.cfg", "w") as cfg:
         cfg.write("set timeout=0\n"
                   "load_env\n"

--- a/test/pipelines/web-server.json
+++ b/test/pipelines/web-server.json
@@ -46,7 +46,8 @@
     {
       "name": "org.osbuild.grub2",
       "options": {
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "kernel_opts": "rw"
       }
     }
   ],


### PR DESCRIPTION
In particular, we are now able to boot with selinux enabled.

See individual commits for details.

Also includes some minor cleanups throughout.