### PR TITLE
stages: add test stage

### DIFF
--- a/samples/base-test.json
+++ b/samples/base-test.json
@@ -54,6 +54,12 @@
       }
     },
     {
+      "name": "org.osbuild.test",
+      "options": {
+        "script": "/usr/bin/systemctl is-system-running --wait"
+      }
+    },
+    {
       "name": "org.osbuild.selinux",
       "options": {
         "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/stages/org.osbuild.test
+++ b/stages/org.osbuild.test
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+
+import json
+import os
+import sys
+
+
+def main(tree, options):
+    script = options["script"]
+
+    unit = f"""
+[Unit]
+Description=Boot Test
+Wants=dev-vport0p1.device
+After=dev-vport0p1.device
+
+[Service]
+StandardOutput=file:/dev/vport0p1
+ExecStart={script}
+ExecStopPost=/usr/bin/systemctl poweroff
+"""
+    with open(f"{tree}/etc/systemd/system/osbuild-test.service", "w") as f:
+        f.write(unit)
+
+    os.symlink("../osbuild-test.service",
+               f"{tree}/etc/systemd/system/multi-user.target.wants/osbuild-test.service")
+
+    return 0
+
+
+if __name__ == '__main__':
+    args = json.load(sys.stdin)
+    r = main(args["tree"], args["options"])
+    sys.exit(r)


### PR DESCRIPTION
Adds a new systemd unit to the image that will be pulled in by default,
run a given command, forward the output to a virtio serial port and
shutdown the machine.

We add a sample that uses this to verify that systemd conciders the
machine successfully booted. A simple way to run this test from the
commandline is to use
  `$ socat UNIX-LISTEN:qemu.sock -`
to listen for either `running` for success or `degraded` or
`maintenance` for failure.

The image should then be booted using something like
  `$ qemu-kvm -m 1024 -nographic -monitor none -serial none -chardev socket,path=qemu.sock,id=char0 -device virtio-serial -device virtserialport,chardev=char0,id=test0 -snapshot  base.qcow2`

Signed-off-by: Tom Gundersen <teg@jklm.no>