### PR TITLE
Set up continuous delivery for Fedora Rawhide/30

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,10 +6,29 @@ synced_files:
   - .packit.yaml
 upstream_project_name: osbuild
 downstream_package_name: osbuild
+create_tarball_command: ["make", "tarball"]
+current_version_command: ["python3", "setup.py", "--version"]
 jobs:
+  # trigger a COPR build for push events in open PRs
   - job: copr_build
     trigger: pull_request
     metadata:
       targets:
       - fedora-30-x86_64
       - fedora-rawhide-x86_64
+  # this is triggered by a commit on src.fedoraproject.org, not Github!
+  # e.g. in case of mass rebuild or automated changes of spec file (e.g. Python packagers)
+  # it will create a PR on Github with changes in synchronized files
+  - job: sync_from_downstream
+    trigger: commit
+  # create a PR on src.fedoraproject.org containing updated spec file and new sources (tarball)
+  # triggered by Github release
+  - job: propose_downstream
+    trigger: release
+    metadata:
+      dist-git-branch: master
+  # The same as above only for f30
+  - job: propose_downstream
+    trigger: release
+    metadata:
+      dist-git-branch: f30

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE_NAME = osbuild
-VERSION = $$(rpmspec -q --qf '%{version}\n' osbuild.spec | head -1)
+VERSION = $$(python3 setup.py --version)
 
 .PHONY: sdist tarball srpm rpm copy-rpms-to-test check-working-directory vagrant-test vagrant-test-keep-running
 
@@ -9,6 +9,9 @@ sdist:
 
 tarball:
 	git archive --prefix=osbuild-$(VERSION)/ --format=tar.gz HEAD > $(PACKAGE_NAME)-$(VERSION).tar.gz
+
+tarball-alternative:
+	git archive --prefix=osbuild-$(VERSION)/ --format=tar.gz HEAD > $(VERSION).tar.gz
 
 srpm: $(PACKAGE_NAME).spec tarball
 	/usr/bin/rpmbuild -bs \


### PR DESCRIPTION
This is achieved using "jobs" from packit-as-a-service, more
specifically the propose_downstream job. Furthermore
sync_from_downstream job is configured to keep the spec file
synchronized and prevent merge conflicts for new releases.

Also a small change in Makefile was necessary as it does not reflect the
current state of the spec file in Fedora dist-git (tarball name is
different). The spec file itself is not modified in this commit, because
it will be synchronized automatically using Packit.