### PR TITLE
assemblers/qcow2: Pass size explicitly and clean up tmp handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ assembles it into an image. Pipelines are defined as JSON files like this one:
     }
   ],
   "assembler": {
-    "name": "io.weldr.qcow2",
+    "name": "org.osbuild.qcow2",
     "options": {
       "filename": "example.qcow2",
-      "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+      "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+      "size": 3221225472
     }
   }
 }

--- a/assemblers/org.osbuild.qcow2
+++ b/assemblers/org.osbuild.qcow2
@@ -2,20 +2,11 @@
 
 import contextlib
 import json
-import math
 import os
 import socket
 import subprocess
 import sys
 import osbuild.remoteloop as remoteloop
-
-def tree_size(tree):
-    size = 0
-    for root, dirs, files in os.walk(tree):
-        for entry in files + dirs:
-            path = os.path.join(root, entry)
-            size += os.stat(path, follow_symlinks=False).st_size
-    return size
 
 @contextlib.contextmanager
 def mount(source, dest, *options):
@@ -48,12 +39,16 @@ def loop_device(loop_client, image, size, offset=0):
 def main(tree, output_dir, options, loop_client):
     filename = options["filename"]
     root_fs_uuid = options["root_fs_uuid"]
+    size = options["size"]
+
+    # sfdisk works on sectors of 512 bytes and ignores excess space - be explicit about this
+    if size % 512 != 0:
+        raise ValueError("`size` must be a multiple of sector size (512)")
 
     image = f"/tmp/osbuild-image.raw"
     mountpoint = f"/tmp/osbuild-mnt"
 
-    # Create an empty image file of the right size
-    size = int(math.ceil(tree_size(tree) * 1.2 / 512) * 512)
+    # Create an empty image file
     subprocess.run(["truncate", "--size", str(size), image], check=True)
 
     # Set up the partition table of the image

--- a/assemblers/org.osbuild.qcow2
+++ b/assemblers/org.osbuild.qcow2
@@ -7,7 +7,6 @@ import os
 import socket
 import subprocess
 import sys
-import tempfile
 import osbuild.remoteloop as remoteloop
 
 def tree_size(tree):
@@ -50,42 +49,39 @@ def main(tree, output_dir, options, loop_client):
     filename = options["filename"]
     root_fs_uuid = options["root_fs_uuid"]
 
-    # Create a working directory on a tmpfs, maybe we should implicitly
-    # always do this.
-    with tempfile.TemporaryDirectory() as workdir:
-        image = f"{workdir}/image.raw"
-        mountpoint = f"{workdir}/mnt"
+    image = f"/tmp/osbuild-image.raw"
+    mountpoint = f"/tmp/osbuild-mnt"
 
-        # Create an empty image file of the right size
-        size = int(math.ceil(tree_size(tree) * 1.2 / 512) * 512)
-        subprocess.run(["truncate", "--size", str(size), image], check=True)
+    # Create an empty image file of the right size
+    size = int(math.ceil(tree_size(tree) * 1.2 / 512) * 512)
+    subprocess.run(["truncate", "--size", str(size), image], check=True)
 
-        # Set up the partition table of the image
-        partition_table = "label: mbr\nbootable, type=83"
-        subprocess.run(["sfdisk", "-q", image], input=partition_table, encoding='utf-8', check=True)
-        r = subprocess.run(["sfdisk", "--json", image], stdout=subprocess.PIPE, encoding='utf-8', check=True)
-        partition_table = json.loads(r.stdout)
-        partition = partition_table["partitiontable"]["partitions"][0]
-        partition_offset = partition["start"] * 512
-        partition_size = partition["size"] * 512
+    # Set up the partition table of the image
+    partition_table = "label: mbr\nbootable, type=83"
+    subprocess.run(["sfdisk", "-q", image], input=partition_table, encoding='utf-8', check=True)
+    r = subprocess.run(["sfdisk", "--json", image], stdout=subprocess.PIPE, encoding='utf-8', check=True)
+    partition_table = json.loads(r.stdout)
+    partition = partition_table["partitiontable"]["partitions"][0]
+    partition_offset = partition["start"] * 512
+    partition_size = partition["size"] * 512
 
-        # Populate the first partition of the image with an ext4 fs and fill it with the contents of the
-        # tree we are operating on.
-        subprocess.run(["mkfs.ext4", "-U", root_fs_uuid, "-E", f"offset={partition_offset}", image,
-                        f"{int(partition_size / 1024)}k"], input="y", encoding='utf-8', check=True)
+    # Populate the first partition of the image with an ext4 fs and fill it with the contents of the
+    # tree we are operating on.
+    subprocess.run(["mkfs.ext4", "-U", root_fs_uuid, "-E", f"offset={partition_offset}", image,
+                    f"{int(partition_size / 1024)}k"], input="y", encoding='utf-8', check=True)
 
-        # Mount the created image as a loopback device
-        with loop_device(loop_client, image, partition_offset) as loop_block, \
-            loop_device(loop_client, image, partition_size, partition_offset) as loop_part, \
-            mount(loop_part, mountpoint):
-            # Copy the tree into the target image
-            subprocess.run(["cp", "-a", f"{tree}/.", mountpoint], check=True)
-            # Install grub2 into the boot sector of the image, and copy the grub2 imagise into /boot/grub2
-            with mount_api(mountpoint):
-                subprocess.run(["chroot", mountpoint, "grub2-install", "--no-floppy",
-                                "--modules=part_msdos", "--target=i386-pc", loop_block], check=True)
+    # Mount the created image as a loopback device
+    with loop_device(loop_client, image, partition_offset) as loop_block, \
+        loop_device(loop_client, image, partition_size, partition_offset) as loop_part, \
+        mount(loop_part, mountpoint):
+        # Copy the tree into the target image
+        subprocess.run(["cp", "-a", f"{tree}/.", mountpoint], check=True)
+        # Install grub2 into the boot sector of the image, and copy the grub2 imagise into /boot/grub2
+        with mount_api(mountpoint):
+            subprocess.run(["chroot", mountpoint, "grub2-install", "--no-floppy",
+                            "--modules=part_msdos", "--target=i386-pc", loop_block], check=True)
 
-        subprocess.run(["qemu-img", "convert", "-O", "qcow2", "-c", image, f"{output_dir}/{filename}"], check=True)
+    subprocess.run(["qemu-img", "convert", "-O", "qcow2", "-c", image, f"{output_dir}/{filename}"], check=True)
 
 if __name__ == '__main__':
     args = json.load(sys.stdin)

--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -67,8 +67,9 @@
     {
       "name": "org.osbuild.qcow2",
       "options": {
-	"filename": "base.qcow2",
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+        "filename": "base.qcow2",
+        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "size": 3221225472
       }
     }
 }

--- a/test/pipelines/f30-boot.json
+++ b/test/pipelines/f30-boot.json
@@ -100,7 +100,8 @@
       "name": "org.osbuild.qcow2",
       "options": {
 	"filename": "f30-boot.qcow2",
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac"
+        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "size": 3221225472
       }
     }
 }


### PR DESCRIPTION
See individual commits.

Is "block size" correct for the error message? Why did we round to the nearest 512 bytes in the first place?