### PR TITLE
Optimize memory usage in assembler stage

### DIFF
--- a/assemblers/org.osbuild.qcow2
+++ b/assemblers/org.osbuild.qcow2
@@ -45,7 +45,7 @@ def main(tree, output_dir, options, loop_client):
     if size % 512 != 0:
         raise ValueError("`size` must be a multiple of sector size (512)")
 
-    image = f"/tmp/osbuild-image.raw"
+    image = f"/var/tmp/osbuild-image.raw"
     mountpoint = f"/tmp/osbuild-mnt"
 
     # Create an empty image file


### PR DESCRIPTION
Two steps are required:

1) Introduce persistent storage in build root.
2) Move temporary image in assembler to the new storage.

We've decided to link containers' `/var` to host's `/var/tmp` (actually temporary dir in there) to have some kind of persistent storage in build root.

See individual commits for details.