### PR TITLE
osbuild: Change default value of --store to just .osbuild

### DIFF
--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -17,7 +17,7 @@ def main():
     parser.add_argument("--build-pipeline", metavar="PIPELINE", type=os.path.abspath,
                         help="json file containing the pipeline to create a build environment")
     parser.add_argument("--store", metavar="DIRECTORY", type=os.path.abspath,
-                        default=".osbuild/store",
+                        default=".osbuild",
                         help="the directory where intermediary os trees are stored")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath,
                         help="the directory containing stages, assemblers, and the osbuild library")


### PR DESCRIPTION
This commit changes the default value of --store argument from
.osbuild/store to just .osbuild. The reason is just to make the path
shorter.