### PR TITLE
Refactor locale stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 __pycache__
 
 /.osbuild
+/.osbuild-test
 /output
+/output-test
 
 /test/.vagrant

--- a/stages/org.osbuild.locale
+++ b/stages/org.osbuild.locale
@@ -1,19 +1,25 @@
 #!/usr/bin/python3
 
 import json
+import subprocess
 import sys
+import os
+
 
 def main(tree, options):
     language = options["language"]
-    vc_keymap = options.get("vc_keymap")
 
-    with open(f"{tree}/etc/locale.conf", "w") as f:
-        f.write(f'LANG="{language}"\n')
+    # We need to remove the /etc/locale.conf file first, because it is created while we install RPM packages.
+    # systemd-firstboot expects that if /etc/locale.conf exists it is a user-defined value and does not change it, but
+    # the assumption is wrong, because it contains a default value from RPM package.
+    try:
+        os.remove(f"{tree}/etc/locale.conf")
+        print("/etc/locale.conf already exists. Replacing.")
+    except FileNotFoundError:
+        pass
 
-    if vc_keymap:
-        with open(f"{tree}/etc/vconsole.conf", "w") as f:
-            f.write(f'KEYMAP="{vc_keymap}"\n')
-            f.write(f'FONT="eurlatgr"\n')
+    subprocess.run(["systemd-firstboot", f"--root={tree}", f"--locale={language}"], check=True)
+
 
 if __name__ == '__main__':
     args = json.load(sys.stdin)

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -28,6 +28,12 @@ def test_firewall(extract_dir):
         assert 'port port="88" protocol="udp"' in content
 
 
+def test_locale(extract_dir):
+    with open(f"{extract_dir}/etc/locale.conf") as f:
+        content = f.read()
+        assert 'LANG=nn_NO.utf8' in content
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Run integration tests')
     parser.add_argument('--list', dest='list', action='store_true', help='list test cases')
@@ -64,8 +70,16 @@ if __name__ == '__main__':
         test_cases=[test_firewall],
         type=IntegrationTestType.EXTRACT
     )
+    locale = IntegrationTestCase(
+        name="locale",
+        pipeline="locale.json",
+        build_pipeline=args.build_pipeline,
+        output_image="locale.tar.xz",
+        test_cases=[test_locale],
+        type=IntegrationTestType.EXTRACT
+    )
 
-    cases = [f30_boot, timezone, firewall]
+    cases = [f30_boot, timezone, firewall, locale]
 
     if args.list:
         print("Available test cases:")

--- a/test/integration_tests/__init__.py
+++ b/test/integration_tests/__init__.py
@@ -3,7 +3,10 @@ from .config import *
 
 def evaluate_test(test, arg=None, name=None):
     try:
-        test(arg)
+        if arg:
+            test(arg)
+        else:
+            test()
         print(f"{RESET}{BOLD}{name or test.__name__}: Success{RESET}")
     except AssertionError as e:
         print(f"{RESET}{BOLD}{name or test.__name__}: {RESET}{RED}Fail{RESET}")

--- a/test/integration_tests/run.py
+++ b/test/integration_tests/run.py
@@ -1,7 +1,7 @@
 import contextlib
 import logging
 import subprocess
-import time
+from os import path
 
 from .config import *
 
@@ -19,7 +19,8 @@ def run_image(file_name: str):
 @contextlib.contextmanager
 def extract_image(file_name: str):
     extract_dir = tempfile.mkdtemp(prefix="osbuild-")
-    subprocess.run(["tar", "xf", f"{OUTPUT_DIR}/{file_name}"], cwd=extract_dir, check=True)
+    archive = path.join(os.getcwd(), OUTPUT_DIR, file_name)
+    subprocess.run(["tar", "xf", archive], cwd=extract_dir, check=True)
     try:
         yield extract_dir
     finally:

--- a/test/pipelines/locale.json
+++ b/test/pipelines/locale.json
@@ -1,0 +1,32 @@
+{
+  "name": "Example Image",
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "repos": {
+          "fedora": {
+            "name": "Fedora",
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch"
+          }
+        },
+        "packages": ["@Core"]
+	}
+    },
+    {
+      "name": "org.osbuild.locale",
+      "options": {
+        "language": "nn_NO.utf8"
+      }
+    }
+  ],
+  "assembler": {
+    "name": "org.osbuild.tar",
+    "options": {
+      "filename": "locale.tar.xz",
+      "compression": "xz"
+    }
+  }
+}


### PR DESCRIPTION
Locale stage has been changed so that:

1) It is not used to change the keymap (use keymap stage).
2) It looks like similar stages. `systemd-firstboot` is now used to set the locale.

Also, I've fixed the integration tests. The fix will collide with #83 , but I've felt we need to have integration tests working in master asap.