### PR TITLE
Drop the compression from tar assembler in tests

### DIFF
--- a/assemblers/org.osbuild.tar
+++ b/assemblers/org.osbuild.tar
@@ -7,13 +7,18 @@ import sys
 
 def main(tree, output_dir, options):
     filename = options["filename"]
-    compression = options["compression"]
+    compression = options.get("compression")
 
-    if compression not in {"bzip2", "xz", "lzip", "lzma", "lzop", "gzip"}:
-        return 1
+    command = ["tar", "-cf", f"{output_dir}/{filename}", "-C", tree]
 
-    subprocess.run(["tar", f"--{compression}", "-cf", f"{output_dir}/{filename}", "-C", tree, "."],
-                   stdout=subprocess.DEVNULL, check=True)
+    if compression is not None:
+        if compression not in {"bzip2", "xz", "lzip", "lzma", "lzop", "gzip"}:
+            return 1
+        command.append(f"--{compression}")
+
+    command.append(".")
+
+    subprocess.run(command, stdout=subprocess.DEVNULL, check=True)
     return 0
 
 

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         name="timezone",
         pipeline="timezone.json",
         build_pipeline=args.build_pipeline,
-        output_image="timezone.tar.xz",
+        output_image="timezone.tar",
         test_cases=[test_timezone],
         type=IntegrationTestType.EXTRACT
     )
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         name="firewall",
         pipeline="firewall.json",
         build_pipeline=args.build_pipeline,
-        output_image="firewall.tar.xz",
+        output_image="firewall.tar",
         test_cases=[test_firewall],
         type=IntegrationTestType.EXTRACT
     )
@@ -74,7 +74,7 @@ if __name__ == '__main__':
         name="locale",
         pipeline="locale.json",
         build_pipeline=args.build_pipeline,
-        output_image="locale.tar.xz",
+        output_image="locale.tar",
         test_cases=[test_locale],
         type=IntegrationTestType.EXTRACT
     )

--- a/test/pipelines/firewall.json
+++ b/test/pipelines/firewall.json
@@ -27,8 +27,7 @@
   "assembler": {
     "name": "org.osbuild.tar",
     "options": {
-      "filename": "firewall.tar.xz",
-      "compression": "xz"
+      "filename": "firewall.tar"
     }
   }
 }

--- a/test/pipelines/locale.json
+++ b/test/pipelines/locale.json
@@ -25,8 +25,7 @@
   "assembler": {
     "name": "org.osbuild.tar",
     "options": {
-      "filename": "locale.tar.xz",
-      "compression": "xz"
+      "filename": "locale.tar"
     }
   }
 }

--- a/test/pipelines/timezone.json
+++ b/test/pipelines/timezone.json
@@ -25,8 +25,7 @@
   "assembler": {
     "name": "org.osbuild.tar",
     "options": {
-      "filename": "timezone.tar.xz",
-      "compression": "xz"
+      "filename": "timezone.tar"
     }
   }
 }


### PR DESCRIPTION
This PR make two things:

1) Introduces option for tar assembler not to use any compression at all.
2) Drop the compression from all tests to speed up their running times.