### PR TITLE
run timezone and firewall tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,12 @@ jobs:
     - name: f30-boot
       before_install: sudo apt-get install -y systemd-container yum qemu-kvm
       script: sudo env "PATH=$PATH" python3 -m test --case f30-boot --build-pipeline samples/build-from-yum.json
+    - name: timezone
+      before_install: sudo apt-get install -y systemd-container yum tar
+      script: sudo env "PATH=$PATH" python3 -m test --case timezone --build-pipeline samples/build-from-yum.json
+    - name: firewall
+      before_install: sudo apt-get install -y systemd-container yum tar
+      script: sudo env "PATH=$PATH" python3 -m test --case firewall --build-pipeline samples/build-from-yum.json  
+    - name: locale
+      before_install: sudo apt-get install -y systemd-container yum tar
+      script: sudo env "PATH=$PATH" python3 -m test --case locale --build-pipeline samples/build-from-yum.json  

--- a/samples/build-from-yum.json
+++ b/samples/build-from-yum.json
@@ -14,7 +14,8 @@
         },
         "packages": [
           "dnf",
-          "systemd"
+          "systemd",
+          "tar"
         ]
       }
     }


### PR DESCRIPTION
Both tests work in CI just fine so we should run them every time. I
introduce them as a separate jobs because jobs run in parallel so it
takes less time even though it does not share object store.