### PR TITLE
remove custom tarball command from packit configuration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,7 +6,6 @@ synced_files:
   - .packit.yaml
 upstream_project_name: osbuild
 downstream_package_name: osbuild
-create_tarball_command: ["make", "tarball"]
 current_version_command: ["python3", "setup.py", "--version"]
 jobs:
   # trigger a COPR build for push events in open PRs


### PR DESCRIPTION
It makes packit fail. Although I'm not sure this will work for new
releases, it should work for COPR builds. See upstream issue for more
information:
https://github.com/packit-service/packit/issues/532