### PR TITLE
packit: use default tarball and version behavior

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,8 +6,6 @@ synced_files:
   - .packit.yaml
 upstream_project_name: osbuild
 downstream_package_name: osbuild
-create_tarball_command: ["make", "tarball"]
-current_version_command: ["python3", "setup.py", "--version"]
 jobs:
   # trigger a COPR build for push events in open PRs
   - job: copr_build


### PR DESCRIPTION
With packit 0.6, you no longer need to redefine archive and version commands,
packit now updates %[auto]setup line to correctly unpack the archive

`packit srpm`:
```
11:38:13.452 upstream.py       DEBUG  Wrote: /home/tt/g/osbuild/osbuild/osbuild-1.72.gc082222-1.fc30.src.rpm
SRPM is /home/tt/g/osbuild/osbuild/osbuild-1.72.gc082222-1.fc30.src.rpm
SRPM: /home/tt/g/osbuild/osbuild/osbuild-1.72.gc082222-1.fc30.src.rpm
```

`rpmbuild --rebuild $SRPM`:
```
Provides: python3-osbuild = 1.72.gc082222-1.fc30 python3.7dist(osbuild) = 1 python3dist(osbuild) = 1
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires: python(abi) = 3.7 python3.7dist(setuptools)
Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/tt/rpmbuild/BUILDROOT/osbuild-1.72.gc082222-1.fc30.x86_64
Wrote: /home/tt/rpmbuild/RPMS/noarch/osbuild-1.72.gc082222-1.fc30.noarch.rpm
Wrote: /home/tt/rpmbuild/RPMS/noarch/python3-osbuild-1.72.gc082222-1.fc30.noarch.rpm
```

If you are trying this locally, please make sure you are on packit 0.6.1:
```
packit-0.6.1-1.fc30.noarch
```

Fixes https://github.com/packit-service/packit/issues/532