### PR TITLE
travis: disable python's output buffering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: bionic
 language: python
 python:
   - "3.7"
+env:
+  - PYTHONUNBUFFERED=1
 jobs:
   include:
     - name: pylint


### PR DESCRIPTION
Python buffers stdout and stderr if they're not connected to the
terminal. This messes with the ordering of osbuild and stage output,
becasue stages produce output more quickly.

Globally disable output buffering on travis.