### PR TITLE
travis: pin the pylint version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   include:
     - name: pylint
-      install: pip install pylint
+      install: pip install pylint==2.4.1
       script: pylint osbuild osbuild-run assemblers/* stages/*
     - name: unit-tests
       script: python3 -m unittest test.test_osbuild


### PR DESCRIPTION
We only want to upgrade to a new version of pip after explicitly
opting in. Otherwise, PRs may randmly start failing just because
pylint was upgraded, but unrelated to the code change.

Signed-off-by: Tom Gundersen <teg@jklm.no>