### PR TITLE
test: refactor boot test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
         - sudo env "PATH=$PATH" python3 -m osbuild --libdir . samples/noop.json
     - name: f30-boot
       before_install: sudo apt-get install -y systemd-container yum qemu-kvm
-      script: sudo env "PATH=$PATH" python3 -m test --case f30-boot --build-pipeline samples/build-from-yum.json
+      script: sudo env "PATH=$PATH" "OSBUILD_TEST_BUILD_PIPELINE=samples/build-from-yum.json" python3 -m unittest test.test_boot
     - name: timezone
       before_install: sudo apt-get install -y systemd-container yum tar
       script: sudo env "PATH=$PATH" python3 -m test --case timezone --build-pipeline samples/build-from-yum.json

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -45,14 +45,6 @@ if __name__ == '__main__':
     logging.info(f"Using {OBJECTS} for objects storage.")
     logging.info(f"Using {OSBUILD} for building images.")
 
-    f30_boot = IntegrationTestCase(
-        name="f30-boot",
-        pipeline="f30-boot.json",
-        build_pipeline=args.build_pipeline,
-        output_image="f30-boot.qcow2",
-        test_cases=[test_is_system_running],
-        type=IntegrationTestType.BOOT_WITH_QEMU
-    )
     timezone = IntegrationTestCase(
         name="timezone",
         pipeline="timezone.json",
@@ -78,7 +70,7 @@ if __name__ == '__main__':
         type=IntegrationTestType.EXTRACT
     )
 
-    cases = [f30_boot, timezone, firewall, locale]
+    cases = [timezone, firewall, locale]
 
     if args.list:
         print("Available test cases:")

--- a/test/osbuildtest.py
+++ b/test/osbuildtest.py
@@ -1,0 +1,21 @@
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+
+class TestCase(unittest.TestCase):
+    def run_osbuild(self, pipeline, store):
+            osbuild_cmd = ["python3", "-m", "osbuild", "--json", "--store", store, "--libdir", ".", pipeline]
+
+            build_pipeline = os.getenv("OSBUILD_TEST_BUILD_PIPELINE", None)
+            if build_pipeline:
+                osbuild_cmd.append("--build-pipeline")
+                osbuild_cmd.append(build_pipeline)
+
+            r = subprocess.run(osbuild_cmd, encoding="utf-8", stdout=subprocess.PIPE, check=True)
+
+            result = json.loads(r.stdout)
+            return result["tree_id"], result["output_id"]

--- a/test/test_boot.py
+++ b/test/test_boot.py
@@ -1,0 +1,31 @@
+
+import subprocess
+import tempfile
+import unittest
+from . import osbuildtest
+
+
+class TestBoot(osbuildtest.TestCase):
+    def test_boot(self):
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as store:
+            _, output_id = self.run_osbuild("test/pipelines/f30-boot.json", store=store)
+
+            r = subprocess.run(["qemu-system-x86_64",
+                "-snapshot",
+                "-m", "1024",
+                "-accel", "kvm:hvf:tcg",
+
+                # be silent
+                "-nographic",
+                "-monitor", "none",
+                "-serial", "none",
+
+                # create /dev/vport0p1
+                "-chardev", "stdio,id=stdio",
+                "-device", "virtio-serial",
+                "-device", "virtserialport,chardev=stdio",
+
+                f"{store}/refs/{output_id}/f30-boot.qcow2"
+            ], encoding="utf-8", capture_output=True, check=True)
+
+            self.assertEqual(r.stdout.strip(), "running")


### PR DESCRIPTION
Use the unittest module from the standard library. Also, ensure that
separate runs of this test don't share a osbuild store and clean up
after themselves.

With contributions from Ondřej Budai and Tom Gundersen.