### PR TITLE
assembler: rename qcow2 to qemu and add support for more formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ assembles it into an image. Pipelines are defined as JSON files like this one:
     }
   ],
   "assembler": {
-    "name": "org.osbuild.qcow2",
+    "name": "org.osbuild.qemu",
     "options": {
+      "format": "qcow2",
       "filename": "example.qcow2",
       "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
       "size": 3221225472

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -37,6 +37,7 @@ def loop_device(loop_client, image, size, offset=0):
         os.unlink(path)
 
 def main(tree, output_dir, options, loop_client):
+    fmt = options["format"]
     filename = options["filename"]
     root_fs_uuid = options["root_fs_uuid"]
     size = options["size"]
@@ -44,6 +45,9 @@ def main(tree, output_dir, options, loop_client):
     # sfdisk works on sectors of 512 bytes and ignores excess space - be explicit about this
     if size % 512 != 0:
         raise ValueError("`size` must be a multiple of sector size (512)")
+
+    if fmt not in ["raw", "qcow2", "vdi", "vmdk"]:
+        raise ValueError("`format` must be one of raw, qcow, vdi, vmdk")
 
     image = f"/var/tmp/osbuild-image.raw"
     mountpoint = f"/tmp/osbuild-mnt"
@@ -76,7 +80,7 @@ def main(tree, output_dir, options, loop_client):
             subprocess.run(["chroot", mountpoint, "grub2-install", "--no-floppy",
                             "--modules=part_msdos", "--target=i386-pc", loop_block], check=True)
 
-    subprocess.run(["qemu-img", "convert", "-O", "qcow2", "-c", image, f"{output_dir}/{filename}"], check=True)
+    subprocess.run(["qemu-img", "convert", "-O", fmt, "-c", image, f"{output_dir}/{filename}"], check=True)
 
 if __name__ == '__main__':
     args = json.load(sys.stdin)

--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -66,8 +66,9 @@
   ],
   "assembler":
     {
-      "name": "org.osbuild.qcow2",
+      "name": "org.osbuild.qemu",
       "options": {
+        "format": "qcow2",
         "filename": "base.qcow2",
         "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
         "size": 3221225472

--- a/test/pipelines/f30-boot.json
+++ b/test/pipelines/f30-boot.json
@@ -99,8 +99,9 @@
   ],
   "assembler":
     {
-      "name": "org.osbuild.qcow2",
+      "name": "org.osbuild.qemu",
       "options": {
+        "format": "qcow2",
 	"filename": "f30-boot.qcow2",
         "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
         "size": 3221225472


### PR DESCRIPTION
Make the assembler more generic, and update all the in-tree users.