### PR TITLE
stages/dnf: support --exclude

### DIFF
--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -23,6 +23,9 @@
           "qemu-guest-agent",
           "xen-libs",
           "langpacks-en"
+        ],
+        "exclude-packages": [
+          "dracut-config-rescue"
         ]
       }
     },

--- a/stages/org.osbuild.dnf
+++ b/stages/org.osbuild.dnf
@@ -60,6 +60,7 @@ def main(tree, options):
     basearch = options["basearch"]
     operation = options.get("operation", "install")
     weak_deps = options.get("install_weak_deps", True)
+    exclude_packages = options.get("exclude-packages", [])
 
     with open("/tmp/dnf.conf", "w") as conf:
         for repoid, repo in enumerate(repos):
@@ -101,6 +102,8 @@ def main(tree, options):
     ]
 
     cmd = base_cmd + [operation] + packages
+    for x in exclude_packages:
+        cmd += ["--exclude", x]
     print(" ".join(cmd), flush=True)
     subprocess.run(cmd, check=True)
 


### PR DESCRIPTION
This allows given packages to be excluded from the transaction. This
is useful if you want to install a group with certain exceptions.

A common thing to do in kicktstart files is:
```
rm -f /boot/*-rescue*
```

By instead excluding the dracut-rescue-config package we end up
with:
```
"deleted_files": [
  "/etc/kernel/postinst.d",
  "/usr/lib/dracut/dracut.conf.d/02-rescue.conf",
  "/usr/lib/kernel/install.d/51-dracut-rescue.install",
  "/boot/initramfs-0-rescue-ffffffffffffffffffffffffffffffff.img",
  "/boot/vmlinuz-0-rescue-ffffffffffffffffffffffffffffffff"
],
```

Signed-off-by: Tom Gundersen <teg@jklm.no>