### PR TITLE
move files from /usr/libexec to /usr/lib

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -47,13 +47,13 @@ A build system for OS images
 %install
 %py3_install
 
-mkdir -p %{buildroot}%{_libexecdir}/%{pypi_name}/stages
-install -p -m 0755 $(find stages -type f) %{buildroot}%{_libexecdir}/%{pypi_name}/stages/
+mkdir -p %{buildroot}%{_libdir}/%{pypi_name}/stages
+install -p -m 0755 $(find stages -type f) %{buildroot}%{_libdir}/%{pypi_name}/stages/
 
-mkdir -p %{buildroot}%{_libexecdir}/%{pypi_name}/assemblers
-install -p -m 0755 $(find assemblers -type f) %{buildroot}%{_libexecdir}/%{pypi_name}/assemblers/
+mkdir -p %{buildroot}%{_libdir}/%{pypi_name}/assemblers
+install -p -m 0755 $(find assemblers -type f) %{buildroot}%{_libdir}/%{pypi_name}/assemblers/
 
-install -p -m 0755 osbuild-run %{buildroot}%{_libexecdir}/%{pypi_name}/
+install -p -m 0755 osbuild-run %{buildroot}%{_libdir}/%{pypi_name}/
 
 %check
 exit 0
@@ -63,7 +63,7 @@ exit 0
 %files
 %license LICENSE
 %{_bindir}/osbuild
-%{_libexecdir}/%{pypi_name}
+%{_libdir}/%{pypi_name}
 
 %files -n     python3-%{pypi_name}
 %license LICENSE

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -65,7 +65,7 @@ class Stage:
                 "options": self.options,
             }
 
-            path = "/run/osbuild/lib" if libdir else "/usr/libexec/osbuild"
+            path = "/run/osbuild/lib" if libdir else "/usr/lib/osbuild"
             r = build_root.run(
                 [f"{path}/osbuild-run", f"{path}/stages/{self.name}"],
                 binds=[f"{tree}:/run/osbuild/tree"],
@@ -113,7 +113,7 @@ class Assembler:
                 binds.append(f"{output_dir}:/run/osbuild/output")
                 args["output_dir"] = "/run/osbuild/output"
 
-            path = "/run/osbuild/lib" if libdir else "/usr/libexec/osbuild"
+            path = "/run/osbuild/lib" if libdir else "/usr/lib/osbuild"
             with build_root.bound_socket("remoteloop") as sock, \
                 remoteloop.LoopServer(sock):
                 r = build_root.run(


### PR DESCRIPTION
There is no real difference in these two directories. Composer already
uses /usr/lib, so OSBuild should use the same as well.