### PR TITLE
Introduce stage testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,14 @@ jobs:
       script: sudo env "PATH=$PATH" python3 -m test --case timezone --build-pipeline samples/build-from-yum.json
     - name: firewall
       before_install: sudo apt-get install -y systemd-container yum tar
-      script: sudo env "PATH=$PATH" python3 -m test --case firewall --build-pipeline samples/build-from-yum.json  
+      script: sudo env "PATH=$PATH" python3 -m test --case firewall --build-pipeline samples/build-from-yum.json
     - name: locale
       before_install: sudo apt-get install -y systemd-container yum tar
-      script: sudo env "PATH=$PATH" python3 -m test --case locale --build-pipeline samples/build-from-yum.json  
+      script: sudo env "PATH=$PATH" python3 -m test --case locale --build-pipeline samples/build-from-yum.json
     - name: assemblers
       before_install: sudo apt-get install -y systemd-container yum tar
       script: sudo env "PATH=$PATH" "OSBUILD_TEST_BUILD_PIPELINE=samples/build-from-yum.json" python3 -m unittest test.test_assemblers
+    - name: stage-tests
+      before_install: sudo apt-get install -y systemd-container yum
+      script: sudo env "PATH=$PATH" "OSBUILD_TEST_BUILD_PIPELINE=samples/build-from-yum.json" python3 -m unittest test.test_stages
+

--- a/test/osbuildtest.py
+++ b/test/osbuildtest.py
@@ -1,5 +1,8 @@
+import difflib
+
 import json
 import os
+import pprint
 import shutil
 import subprocess
 import tempfile
@@ -42,3 +45,84 @@ class TestCase(unittest.TestCase):
 
         result = json.loads(r.stdout)
         return result["tree_id"], result["output_id"]
+
+    def run_tree_diff(self, tree1, tree2):
+        tree_diff_cmd = ["./tree-diff", tree1, tree2]
+
+        r = subprocess.run(tree_diff_cmd, encoding="utf-8", stdout=subprocess.PIPE, check=True)
+
+        return json.loads(r.stdout)
+
+    def get_path_to_store(self, tree_id):
+        return f"{self.store}/refs/{tree_id}"
+
+    def assertTreeDiffsEqual(self, tree_diff1, tree_diff2):
+        """
+        Asserts two tree diffs for equality.
+
+        Before assertion, the two trees are sorted, therefore order of files
+        doesn't matter.
+
+        There's a special rule for asserting differences where we don't
+        know the exact before/after value. This is useful for example if
+        the content of file is dependant on current datetime. You can use this
+        feature by putting null value in difference you don't care about.
+
+        Example:
+            "/etc/shadow": {content: ["sha256:xxx", null]}
+
+            In this case the after content of /etc/shadow doesn't matter.
+            The only thing that matters is the before content and that
+            the content modification happened.
+        """
+        tree_diff1 = _sorted_tree(tree_diff1)
+        tree_diff2 = _sorted_tree(tree_diff2)
+
+        def raise_assertion(msg):
+            raise TreeAssertionError(msg, tree_diff1, tree_diff2)
+
+        self.assertEqual(tree_diff1['added_files'], tree_diff2['added_files'])
+        self.assertEqual(tree_diff1['deleted_files'], tree_diff2['deleted_files'])
+
+        if len(tree_diff1['differences']) != len(tree_diff2['differences']):
+            raise_assertion('length of differences different')
+
+        for (file1, differences1), (file2, differences2) in \
+                zip(tree_diff1['differences'].items(), tree_diff2['differences'].items()):
+
+            if file1 != file2:
+                raise_assertion(f"filename different: {file1}, {file2}")
+
+            if len(differences1) != len(differences2):
+                raise_assertion("length of file differences different")
+
+            for (difference1_kind, difference1_values), (difference2_kind, difference2_values) in \
+                    zip(differences1.items(), differences2.items()):
+                if difference1_kind != difference2_kind:
+                    raise_assertion(f"different difference kinds: {difference1_kind}, {difference2_kind}")
+
+                if difference1_values[0] is not None \
+                        and difference2_values[0] is not None \
+                        and difference1_values[0] != difference2_values[0]:
+                    raise_assertion(f"before values are different: {difference1_values[0]}, {difference2_values[0]}")
+
+                if difference1_values[1] is not None \
+                        and difference2_values[1] is not None \
+                        and difference1_values[1] != difference2_values[1]:
+                    raise_assertion(f"after values are different: {difference1_values[1]}, {difference2_values[1]}")
+
+
+def _sorted_tree(tree):
+    sorted_tree = json.loads(json.dumps(tree, sort_keys=True))
+    sorted_tree["added_files"] = sorted(sorted_tree["added_files"])
+    sorted_tree["deleted_files"] = sorted(sorted_tree["deleted_files"])
+
+    return sorted_tree
+
+
+class TreeAssertionError(AssertionError):
+    def __init__(self, msg, tree_diff1, tree_diff2):
+        diff = ('\n'.join(difflib.ndiff(
+            pprint.pformat(tree_diff1).splitlines(),
+            pprint.pformat(tree_diff2).splitlines())))
+        super().__init__(f"{msg}\n\n{diff}")

--- a/test/osbuildtest.py
+++ b/test/osbuildtest.py
@@ -13,21 +13,24 @@ class TestCase(unittest.TestCase):
     """A TestCase to test running the osbuild program.
 
     Each test case can use `self.run_osbuild()` to run osbuild. A temporary
-    store is used, which can be accessed through `self.store`.
+    store is used, which can be accessed through `self.store`. The store is
+    persistent for whole test class due to performance concerns.
 
     To speed up local development, OSBUILD_TEST_STORE can be set to an existing
     store. Note that this might make tests dependant of each other. Do not use
     it for actual testing.
     """
 
-    def setUp(self):
-        self.store = os.getenv("OSBUILD_TEST_STORE")
-        if not self.store:
-            self.store = tempfile.mkdtemp(dir="/var/tmp")
+    @classmethod
+    def setUpClass(cls):
+        cls.store = os.getenv("OSBUILD_TEST_STORE")
+        if not cls.store:
+            cls.store = tempfile.mkdtemp(dir="/var/tmp")
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         if not os.getenv("OSBUILD_TEST_STORE"):
-            shutil.rmtree(self.store)
+            shutil.rmtree(cls.store)
 
     def run_osbuild(self, pipeline, input=None):
         osbuild_cmd = ["python3", "-m", "osbuild", "--json", "--store", self.store, "--libdir", ".", pipeline]

--- a/test/stages_tests/firewall/a.json
+++ b/test/stages_tests/firewall/a.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    }
+  ]
+}

--- a/test/stages_tests/firewall/b.json
+++ b/test/stages_tests/firewall/b.json
@@ -1,0 +1,61 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.firewall",
+      "options": {
+        "ports": [
+          "53:tcp",
+          "88:udp"
+        ],
+        "enabled_services": [
+          "http",
+          "ftp"
+        ],
+        "disabled_services": [
+          "telnet"
+        ]
+      }
+    }
+  ]
+}
+
+

--- a/test/stages_tests/firewall/diff.json
+++ b/test/stages_tests/firewall/diff.json
@@ -1,0 +1,8 @@
+{
+  "added_files": [
+    "/etc/firewalld/zones/public.xml",
+    "/etc/firewalld/zones/public.xml.old"
+  ],
+  "deleted_files": [],
+  "differences": {}
+}

--- a/test/stages_tests/fstab/a.json
+++ b/test/stages_tests/fstab/a.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    }
+  ]
+}

--- a/test/stages_tests/fstab/b.json
+++ b/test/stages_tests/fstab/b.json
@@ -1,0 +1,58 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.fstab",
+      "options": {
+        "filesystems": [
+          {
+            "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "vfs_type": "ext4",
+            "path": "/",
+            "freq": "1",
+            "passno": "1"
+          }
+        ]
+      }
+    }  ]
+}
+
+

--- a/test/stages_tests/fstab/diff.json
+++ b/test/stages_tests/fstab/diff.json
@@ -1,0 +1,7 @@
+{
+  "added_files": [
+    "/etc/fstab"
+  ],
+  "deleted_files": [],
+  "differences": {}
+}

--- a/test/stages_tests/hostname/a.json
+++ b/test/stages_tests/hostname/a.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    }
+  ]
+}

--- a/test/stages_tests/hostname/b.json
+++ b/test/stages_tests/hostname/b.json
@@ -1,0 +1,51 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.hostname",
+      "options": {
+        "hostname": "testing.hostname.local"
+      }
+    }
+  ]
+}
+
+

--- a/test/stages_tests/hostname/diff.json
+++ b/test/stages_tests/hostname/diff.json
@@ -1,0 +1,7 @@
+{
+  "added_files": [
+    "/etc/hostname"
+  ],
+  "deleted_files": [],
+  "differences": {}
+}

--- a/test/stages_tests/keymap/a.json
+++ b/test/stages_tests/keymap/a.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    }
+  ]
+}

--- a/test/stages_tests/keymap/b.json
+++ b/test/stages_tests/keymap/b.json
@@ -1,0 +1,51 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.keymap",
+      "options": {
+        "keymap": "se-dvorak"
+      }
+    }
+  ]
+}
+
+

--- a/test/stages_tests/keymap/diff.json
+++ b/test/stages_tests/keymap/diff.json
@@ -1,0 +1,7 @@
+{
+  "added_files": [
+    "/etc/vconsole.conf"
+  ],
+  "deleted_files": [],
+  "differences": {}
+}

--- a/test/stages_tests/locale/a.json
+++ b/test/stages_tests/locale/a.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    }
+  ]
+}

--- a/test/stages_tests/locale/b.json
+++ b/test/stages_tests/locale/b.json
@@ -1,0 +1,51 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.locale",
+      "options": {
+        "language": "nn_NO.utf8"
+      }
+    }
+  ]
+}
+
+

--- a/test/stages_tests/locale/diff.json
+++ b/test/stages_tests/locale/diff.json
@@ -1,0 +1,7 @@
+{
+  "added_files": [
+    "/etc/locale.conf"
+  ],
+  "deleted_files": [],
+  "differences": {}
+}

--- a/test/stages_tests/systemd/a.json
+++ b/test/stages_tests/systemd/a.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    }
+  ]
+}

--- a/test/stages_tests/systemd/b.json
+++ b/test/stages_tests/systemd/b.json
@@ -1,0 +1,52 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.systemd",
+      "options": {
+        "enabled_services": ["nftables"],
+        "disabled_services": ["sshd"]
+      }
+    }
+  ]
+}
+
+

--- a/test/stages_tests/systemd/diff.json
+++ b/test/stages_tests/systemd/diff.json
@@ -1,0 +1,9 @@
+{
+  "added_files": [
+    "/etc/systemd/system/multi-user.target.wants/nftables.service"
+  ],
+  "deleted_files": [
+    "/etc/systemd/system/multi-user.target.wants/sshd.service"
+  ],
+  "differences": {}
+}

--- a/test/stages_tests/timezone/a.json
+++ b/test/stages_tests/timezone/a.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    }
+  ]
+}

--- a/test/stages_tests/timezone/b.json
+++ b/test/stages_tests/timezone/b.json
@@ -1,0 +1,51 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.timezone",
+      "options": {
+        "zone": "Europe/Prague"
+      }
+    }
+  ]
+}
+
+

--- a/test/stages_tests/timezone/diff.json
+++ b/test/stages_tests/timezone/diff.json
@@ -1,0 +1,12 @@
+{
+  "added_files": [],
+  "deleted_files": [],
+  "differences": {
+    "/etc/localtime": {
+      "symlink": [
+        "../usr/share/zoneinfo/UTC",
+        "../usr/share/zoneinfo/Europe/Prague"
+      ]
+    }
+  }
+}

--- a/test/stages_tests/users/a.json
+++ b/test/stages_tests/users/a.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    }
+  ]
+}

--- a/test/stages_tests/users/b.json
+++ b/test/stages_tests/users/b.json
@@ -1,0 +1,55 @@
+{
+  "build": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": false,
+          "repos": [
+            {
+              "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+              "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+              "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+            }
+          ],
+          "packages": [
+            "dnf"
+          ]
+        }
+      }
+    ]
+  },
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "@Core"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.users",
+      "options": {
+        "users": {
+          "test": {
+            "password": "$6$s06sY2/bZbmuyE4a$JTn/Ki2jbNG.wGeCvt6mcjaIZ2HV.H8VjLzIMZs7f2G48NMFlcB2/OhbHZ6HhZAOcb.CmUb2qywSW2DkKe6gn0"
+          }
+        }
+      }
+    }
+  ]
+}
+
+

--- a/test/stages_tests/users/diff.json
+++ b/test/stages_tests/users/diff.json
@@ -1,0 +1,80 @@
+{
+  "added_files": [
+    "/etc/subgid-",
+    "/etc/subuid-",
+    "/home/test",
+    "/home/test/.bash_logout",
+    "/home/test/.bashrc",
+    "/home/test/.bash_profile",
+    "/var/spool/mail/test"
+  ],
+  "deleted_files": [],
+  "differences": {
+    "/etc/shadow-": {
+      "content": [
+        null,
+        null
+      ]
+    },
+    "/etc/passwd": {
+      "content": [
+        "sha256:9f38297afcc8f09e9e313db2628402f4448b92f5e5c41fdef8a859063703b09f",
+        "sha256:323c887dd9cc7f6ec7a2cb70daf54b56d74054153a8759983d84e92dc2393127"
+      ]
+    },
+    "/etc/group": {
+      "content": [
+        "sha256:302bff1ff0e98dfee5bddea461138a3f584695aceb590f8452e11e343e5eea2d",
+        "sha256:1bfe88ec0b2125a00a6e423bed2fbd562f426ddcb7cd28a27e21df90ee516bee"
+      ]
+    },
+    "/etc/gshadow": {
+      "content": [
+        null,
+        null
+      ]
+    },
+    "/etc/subuid": {
+      "content": [
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "sha256:26d48e295489c012dd33c13df566059d0f97215e1990d80192026e5a162dc3a0"
+      ]
+    },
+    "/etc/group-": {
+      "content": [
+        "sha256:ca63b6808736bb195f8a0576d0ed96a1d290a5e95da53beba9841ad59e17edc8",
+        "sha256:302bff1ff0e98dfee5bddea461138a3f584695aceb590f8452e11e343e5eea2d"
+      ]
+    },
+    "/etc/passwd-": {
+      "content": [
+        "sha256:8feaad3131f7f2842a96c2b4c054e2e32c8d2472de26fb29d7beb2b603753d53",
+        "sha256:9f38297afcc8f09e9e313db2628402f4448b92f5e5c41fdef8a859063703b09f"
+      ]
+    },
+    "/etc/gshadow-": {
+      "content": [
+        null,
+        null
+      ]
+    },
+    "/etc/subgid": {
+      "content": [
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "sha256:26d48e295489c012dd33c13df566059d0f97215e1990d80192026e5a162dc3a0"
+      ]
+    },
+    "/etc/shadow": {
+      "content": [
+        null,
+        null
+      ]
+    },
+    "/var/log/lastlog": {
+      "content": [
+        "sha256:a29839a75996714fe64f0d3dc9e21b58a66f8465a0e1a248ef76fcc822b1d078",
+        "sha256:d1024fa7ebf79a2dd6d553fef19bf1d1234616885979e533b345b7c54968079b"
+      ]
+    }
+  }
+}

--- a/test/test_boot.py
+++ b/test/test_boot.py
@@ -23,7 +23,7 @@ class TestBoot(osbuildtest.TestCase):
             "-device", "virtio-serial",
             "-device", "virtserialport,chardev=stdio",
 
-            f"{self.store}/refs/{output_id}/f30-boot.qcow2"
+            f"{self.get_path_to_store(output_id)}/f30-boot.qcow2"
         ], encoding="utf-8", stdout=subprocess.PIPE, check=True)
 
         self.assertEqual(r.stdout.strip(), "running")

--- a/test/test_stages.py
+++ b/test/test_stages.py
@@ -1,0 +1,36 @@
+import json
+import os
+
+from test import osbuildtest
+
+
+class TestDescriptions(osbuildtest.TestCase):
+
+    def run_stage_test(self, test_dir: str):
+        pipeline1 = f"{test_dir}/a.json"
+        pipeline2 = f"{test_dir}/b.json"
+        tree_id1, _ = self.run_osbuild(pipeline1)
+        tree_id2, _ = self.run_osbuild(pipeline2)
+
+        actual_diff = self.run_tree_diff(self.get_path_to_store(tree_id1), self.get_path_to_store(tree_id2))
+
+        with open(f"{test_dir}/diff.json") as f:
+            expected_diff = json.load(f)
+
+        self.assertTreeDiffsEqual(expected_diff, actual_diff)
+
+
+def generate_test_case(test):
+    def test_case(self):
+        self.run_stage_test(test)
+
+    return test_case
+
+
+def init_tests():
+    test_dir = 'test/stages_tests'
+    for test in os.listdir(test_dir):
+        setattr(TestDescriptions, f"test_{test}", generate_test_case(f"{test_dir}/{test}"))
+
+
+init_tests()

--- a/tree-diff
+++ b/tree-diff
@@ -39,7 +39,7 @@ def selinux_diff(path1, path2, path, differences):
         return True
     if label1 != label2:
         props = differences.setdefault(path, {})
-        props["selinux"] = [os.fsdecode(label1), os.fsdecode(label2)]
+        props["selinux"] = [label1.strip('\n\0'), label2.strip('\n\0')]
         return False
     return True
 

--- a/tree-diff
+++ b/tree-diff
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 
 import argparse
+import hashlib
 import json
 import os
+
+
+def hash_file(fd):
+    BLOCK_SIZE = 4096
+    hasher = hashlib.sha256()
+    buf = os.read(fd, BLOCK_SIZE)
+    while len(buf) > 0:
+        hasher.update(buf)
+        buf = os.read(fd, BLOCK_SIZE)
+
+    return f"sha256:{hasher.hexdigest()}"
 
 
 def stat_diff(stat1, stat2, path, differences):
@@ -32,11 +44,7 @@ def selinux_diff(path1, path2, path, differences):
     return True
 
 
-def content_diff(name, dir_fd1, dir_fd2, size1, size2, path, differences):
-    if size1 != size2:
-        props = differences.setdefault(path, {})
-        props["content"] = "different"
-        return
+def content_diff(name, dir_fd1, dir_fd2, path, differences):
     try:
         fd1 = os.open(name, flags=os.O_RDONLY, dir_fd=dir_fd1)
     except OSError:
@@ -47,12 +55,12 @@ def content_diff(name, dir_fd1, dir_fd2, size1, size2, path, differences):
         os.close(fd1)
         return
     try:
-        for (byte_block1, byte_block2) in zip(iter(lambda f=fd1: os.read(f, 4096), b""),
-                                              iter(lambda f=fd2: os.read(f, 4096), b"")):
-            if byte_block1 != byte_block2:
-                props = differences.setdefault(path, {})
-                props["content"] = "different"
-                break
+        hash1 = hash_file(fd1)
+        hash2 = hash_file(fd2)
+
+        if hash1 != hash2:
+            props = differences.setdefault(path, {})
+            props["content"] = [hash1, hash2]
     finally:
         os.close(fd1)
         os.close(fd2)
@@ -106,8 +114,6 @@ def diff_aux(dir_fd1, dir_fd2, path, report):
                 content_diff(dirent.name,
                              dir_fd1,
                              dir_fd2,
-                             stat1.st_size,
-                             stat2.st_size,
                              os.path.join(path, dirent.name),
                              report["differences"])
             elif dirent.is_dir(follow_symlinks=False):

--- a/tree-diff
+++ b/tree-diff
@@ -77,6 +77,13 @@ def diff_aux(dir_fd1, dir_fd2, path, report):
                 stat2 = os.stat(dirent.name, dir_fd=dir_fd2, follow_symlinks=False)
             except FileNotFoundError:
                 report["deleted_files"] += [os.path.join(path, dirent.name)]
+                if dirent.is_dir(follow_symlinks=False):
+                    try:
+                        child_fd = os.open(dirent.name, os.O_DIRECTORY, dir_fd=dir_fd1)
+                    except OSError:
+                        continue
+                    list_dir(child_fd, os.path.join(path, dirent.name), report["deleted_files"])
+                    os.close(child_fd)
                 continue
             entries1.add(dirent.name)
             stat1 = dirent.stat(follow_symlinks=False)
@@ -120,6 +127,13 @@ def diff_aux(dir_fd1, dir_fd2, path, report):
         for dirent in it:
             if dirent.name not in entries1:
                 report["added_files"] += [os.path.join(path, dirent.name)]
+                if dirent.is_dir(follow_symlinks=False):
+                    try:
+                        child_fd = os.open(dirent.name, os.O_DIRECTORY, dir_fd=dir_fd2)
+                    except OSError:
+                        continue
+                    list_dir(child_fd, os.path.join(path, dirent.name), report["added_files"])
+                    os.close(child_fd)
 
 
 def diff(dir_fd1, dir_fd2, report):
@@ -128,6 +142,20 @@ def diff(dir_fd1, dir_fd2, report):
     selinux_diff(f"/proc/self/fd/{dir_fd1}", f"/proc/self/fd/{dir_fd2}", "/", report["differences"])
     stat_diff(stat1, stat2, "/", report["differences"])
     diff_aux(dir_fd1, dir_fd2, "/", report)
+
+
+def list_dir(dir_fd, path, target_list):
+    with os.scandir(dir_fd) as it:
+        for dirent in it:
+            p = os.path.join(path, dirent.name)
+            target_list.append(p)
+            if dirent.is_dir(follow_symlinks=False):
+                try:
+                    child_fd = os.open(dirent.name, os.O_DIRECTORY, dir_fd=dir_fd)
+                except OSError:
+                    continue
+                list_dir(child_fd, p, target_list)
+                os.close(child_fd)
 
 
 def main():


### PR DESCRIPTION
Greetings, this a pretty huge PR, grab yourself a cup of coffee and hear my words!

This PR introduces stage tests: The stage testing is based on an output from the tree-diff tool. During one test two pipelines are run and their outputs are compared using tree-diff. The diff is then compared with expected diff included in the repository.

There are currently some issues with this PR I would like to discuss. **One of them is blocker and we shall not merge this PR before it's solved.**

## Blocker
### SELinux
SELinux works differently on Fedora host than on Ubuntu host. On Fedora users and timezone stages change selinux labels on some files. On Ubuntu it doesn't happen. See also #89

We need to investigate what's exactly happening: Why Fedora changes the labels and why it doesn't happen on Ubuntu.

**Currently, there's a diff from Fedora, which causes the tests to fail on CI (which is running Ubuntu)**. But if you run the tests on Fedora, everything is alright. I will investigate images built on Ubuntu to see how selinux labels are applied there.

## Discussions
### How should diffs be "deep"
I've changed the behaviour of `tree-diff` to dump the whole added/deleted subtree instead of just its root. This is imho good, because we can detect more stuff. However, we are not currently not dumping anything else than file names. Therefore we are not able to check for content/permissions/selinux when file is added (or deleted, but doesn't make any sense, I guess?).

Should we dump more information about added (deleted) files?

## Testing of dnf stage
The dnf stage test is weird, the diff is huge... What can we do about that? Install only a small package on top of @<!-- -->Core image (pipeline with dnf stage installing @<!-- -->Core packages)? Currently, it feels to me like we are testing the dnf itself...

## Preserving store between tests
Preserving store between tests sounds bad. Unfortunately, it takes **1 hour (!!)** to run the current 9 stage tests without preserving the store. So, I've changed the tests to preserve the store between them. This works right now, but can have unexpected consequences in future mainly due to not ideal reproducibility of osbuild pipelines. Possible solutions:

1) Just don't install @<!-- -->Core every time!
    Yeah, that would probably speed up the tests drastically. But do we want to test the other stages on empty image? Doesn't sound like a realistic usecase of stage...

2) Introduce some kind of base image, which all stage tests should use (core packages + selinux maybe?).
   Seems like an interesting idea for me, the only downside is that test framework will be probably a little bit more complex? Or not?

3) Leave as it is in current PR
   Yeah, it works, but I'm scared it will break sometime and debugging might be hard.

4) 1 hour test? We don't mind!
   I mind! It's just too much.