### PR TITLE
test: introduce OSBUILD_TEST_STORE

### DIFF
--- a/test/osbuildtest.py
+++ b/test/osbuildtest.py
@@ -13,13 +13,20 @@ class TestCase(unittest.TestCase):
 
     Each test case can use `self.run_osbuild()` to run osbuild. A temporary
     store is used, which can be accessed through `self.store`.
+
+    To speed up local development, OSBUILD_TEST_STORE can be set to an existing
+    store. Note that this might make tests dependant of each other. Do not use
+    it for actual testing.
     """
 
     def setUp(self):
-        self.store = tempfile.mkdtemp(dir="/var/tmp")
+        self.store = os.getenv("OSBUILD_TEST_STORE")
+        if not self.store:
+            self.store = tempfile.mkdtemp(dir="/var/tmp")
 
     def tearDown(self):
-        shutil.rmtree(self.store)
+        if not os.getenv("OSBUILD_TEST_STORE"):
+            shutil.rmtree(self.store)
 
     def run_osbuild(self, pipeline):
             osbuild_cmd = ["python3", "-m", "osbuild", "--json", "--store", self.store, "--libdir", ".", pipeline]


### PR DESCRIPTION
The testosbuild.TestCase class creates a fresh store for each test,
because tests should run independent of each other.

This can lead to long waiting times while developing a new test case.

Allow overriding the store used with OSBUILD_TEST_STORE. This should
never be used where tests are actually run. It is a development-only
feature.