### PR TITLE
Introduce cloud-base sample

### DIFF
--- a/samples/cloud-base.json
+++ b/samples/cloud-base.json
@@ -1,0 +1,83 @@
+{
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "install_weak_deps": true,
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "gpgkey": "F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          }
+        ],
+        "packages": [
+          "kernel-core",
+	  "@Fedora Cloud Server",
+	  "chrony",
+	  "polkit",
+	  "systemd-udev",
+          "selinux-policy-targeted",
+          "grub2-pc",
+          "langpacks-en"
+        ],
+        "exclude_packages": [
+          "dracut-config-rescue",
+	  "etables",
+	  "firewalld",
+	  "gobject-introspection",
+	  "plymouth"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.locale",
+      "options": {
+        "language": "en_US"
+      }
+    },
+    {
+      "name": "org.osbuild.fstab",
+      "options": {
+        "filesystems": [
+          {
+            "uuid": "ea711a29-e460-4879-9d70-9da99ae021f9",
+            "vfs_type": "ext4",
+            "path": "/",
+            "freq": "1",
+            "passno": "1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.grub2",
+      "options": {
+        "root_fs_uuid": "ea711a29-e460-4879-9d70-9da99ae021f9",
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0"
+      }
+    },
+    {
+      "name": "org.osbuild.selinux",
+      "options": {
+        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+      }
+    },
+    {
+      "name": "org.osbuild.fix-bls"
+    }
+  ],
+  "assembler":
+    {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "format": "qcow2",
+        "filename": "base.qcow2",
+        "ptuuid": "0x14fc63d2",
+        "root_fs_uuid": "ea711a29-e460-4879-9d70-9da99ae021f9",
+        "size": 3221225472
+      }
+    }
+}


### PR DESCRIPTION
It is similar to the official Fedora cloud base image except for few
minor differences. The reason for this divergence is that we don't want
to include all hacks that are currently present in the official
kickstart file. You can see it here as a reference:
https://pagure.io/fedora-kickstarts/blob/master/f/fedora-cloud-base.ks#_149

#### Differences:

* partition-table-id
* partition size

These are differences where I'm not sure we should even "fix" them:

 * RPM verify throws much more errors with the official image (most of them are missing in `/usr/share/locale/`). This difference comes from [this line in cloud base ks](https://pagure.io/fedora-kickstarts/blob/master/f/fedora-cloud-base.ks#_149)
 * Official image does not contain `linux-firmware` which is dependency of `kernel-core` and therefore cannot be removed using `exclude_packages`
 * Official image does not contain `gpg-pubkey` ?