### PR TITLE
test: give osbuild time to clean up on SIGINT

### DIFF
--- a/test/osbuildtest.py
+++ b/test/osbuildtest.py
@@ -25,7 +25,7 @@ class TestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.store = os.getenv("OSBUILD_TEST_STORE")
         if not cls.store:
-            cls.store = tempfile.mkdtemp(dir="/var/tmp")
+            cls.store = tempfile.mkdtemp(prefix="osbuild-test-", dir="/var/tmp")
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
When the test runner receives SIGINT, osbuild's mounts stay around.
osbuild handles SIGING correctly, but it doesn't have time before being
killed because it's parent went away.

Fix this by waiting on it explicitly in the test runner.