### PR TITLE
osbuild: add --version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,16 +2,12 @@
 
 ## Manual version using Packit
 
-```
-$ ./bump-version.sh
-```
-Check that the spec file is correctly modified.
-Create new commit from this change; this commit will become the new tag.
+Increase the `__version__` variable in `osbuild/__init__.py`. Make a commit
+with only that change and tag and push it:
 ```
 $ git tag -a <version-number> -m <some description>
 $ git push origin <version-number>
 ```
-
 
 Create new release on Github containing the number of this release as a
 name, the same number as a tag, and description copied from the previous

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-current_version=$(python3 setup.py --version)
-new_version=$(expr "${current_version}" + 1)
-
-sed -i "s|Version:\s*${current_version}|Version:\\t${new_version}|" osbuild.spec
-sed -i "s|Release:\s*[[:digit:]]\+|Release:\\t1|" osbuild.spec
-sed -i "s|version=\"${current_version}\"|version=\"${new_version}\"|" setup.py

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -1,9 +1,9 @@
 %global         pypi_name osbuild
-%global 	pkgdir %{_prefix}/lib/%{pypi_name}
+%global         pkgdir %{_prefix}/lib/%{pypi_name}
 
 Name:           %{pypi_name}
-Version:	3
-Release:	1%{?dist}
+Version:        %(python3 %{S:setup.py} --version)
+Release:        1%{?dist}
 License:        ASL 2.0
 
 URL:            https://github.com/osbuild/osbuild

--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -1,6 +1,7 @@
 
 from .pipeline import Assembler, AssemblerFailed, load, Pipeline, Stage, StageFailed
 
+__version__ = "3"
 
 __all__ = [
     "Assembler",

--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -12,6 +12,7 @@ RED = "\033[31m"
 
 def main():
     parser = argparse.ArgumentParser(description="Build operating system images")
+    parser.add_argument("-v", "--version", action="version", version=osbuild.__version__)
     parser.add_argument("pipeline_path", metavar="PIPELINE",
                         help="json file containing the pipeline that should be built, or a '-' to read from stdin")
     parser.add_argument("--build-pipeline", metavar="PIPELINE", type=os.path.abspath,

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 import glob
 import setuptools
+import osbuild
 
 setuptools.setup(
     name="osbuild",
-    version="3",
+    version=osbuild.__version__,
     description="A build system for OS images",
     packages=["osbuild"],
     license='Apache-2.0',


### PR DESCRIPTION
Add a `__version__` field to the osbuild package, so that it can be
accessed from `__main__.py`.

This can serve as a single point of truth for the version number:
setup.py and osbuild.spec source it from there, making `bump-version.sh`
unnecessary.