### PR TITLE
fix execv /usr/lib/osbuild/osbuild-run does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ sdist:
 tarball:
 	git archive --prefix=osbuild-$(VERSION)/ --format=tar.gz HEAD > $(VERSION).tar.gz
 
-srpm: $(PACKAGE_NAME).spec tarball
+srpm: $(PACKAGE_NAME).spec check-working-directory tarball
 	/usr/bin/rpmbuild -bs \
 	  --define "_sourcedir $(CURDIR)" \
 	  --define "_srcrpmdir $(CURDIR)" \
 	  $(PACKAGE_NAME).spec
 
-rpm: $(PACKAGE_NAME).spec tarball
+rpm: $(PACKAGE_NAME).spec check-working-directory tarball 
 	- rm -r "`pwd`/output"
 	mkdir -p "`pwd`/output"
 	mkdir -p "`pwd`/rpmbuild"

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -69,11 +69,11 @@ class Stage:
                 "options": self.options,
             }
 
-            path = "/run/osbuild/lib" if libdir else "/usr/lib/osbuild"
+            path = "/run/osbuild/lib"
             r = build_root.run(
                 [f"{path}/osbuild-run", f"{path}/stages/{self.name}"],
                 binds=[f"{tree}:/run/osbuild/tree"],
-                readonly_binds=[f"{libdir}:{path}"] if libdir else [],
+                readonly_binds=[f"{libdir}:{path}"] if libdir else [f"/usr/lib/osbuild:{path}"],
                 encoding="utf-8",
                 input=json.dumps(args),
                 stdout=None if interactive else subprocess.PIPE,
@@ -124,13 +124,15 @@ class Assembler:
                 binds.append(f"{output_dir}:/run/osbuild/output")
                 args["output_dir"] = "/run/osbuild/output"
 
-            path = "/run/osbuild/lib" if libdir else "/usr/lib/osbuild"
+            path = "/run/osbuild/lib"
             with build_root.bound_socket("remoteloop") as sock, \
                 remoteloop.LoopServer(sock):
                 r = build_root.run(
                     [f"{path}/osbuild-run", f"{path}/assemblers/{self.name}"],
                     binds=binds,
-                    readonly_binds=[f"{tree}:/run/osbuild/tree"] + ([f"{libdir}:{path}"] if libdir else []),
+                    readonly_binds=[f"{tree}:/run/osbuild/tree"] +
+                                   ([f"{libdir}:{path}"] if libdir else [f"/usr/lib/osbuild:{path}",
+                                   f"/usr/lib/python3.7/site-packages/osbuild:{path}/assemblers/osbuild"]),
                     encoding="utf-8",
                     input=json.dumps(args),
                     stdout=None if interactive else subprocess.PIPE,


### PR DESCRIPTION
In case osbuild is invoked without libdir parameter, the osbuild files
are not propagated into the buildroot container and therefore all
pipelines containing buildroot fail.

Example:
```
$ sudo osbuild --store /var/osbuild/ qcow2-pipeline.json
...
execv(/usr/lib/osbuild/osbuild-run) failed: No such file or directory
```

Unfortunately this is only the first error. Once you fix it, you realize
that also the symlink from "assemblers" directory is missing and
therefore you cannot import osbuild because it is not available anywhere
in the path. This is why I had to bind the osbuild module from host to
the build container.