### PR TITLE
stages/users: set authorized_keys file permissions to 600

### DIFF
--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -68,6 +68,7 @@ def add_ssh_key(root, user, key):
         f.write(f"{key}\n")
 
     os.chown(authorized_keys, int(uid), int(gid))
+    os.chmod(authorized_keys, 0o600)
 
 
 def main(tree, options):


### PR DESCRIPTION
Otherwise user may be unable to login. More information:
https://stackoverflow.com/questions/6377009/adding-public-key-to-ssh-authorized-keys-does-not-log-me-in-automatically