### PR TITLE
buildroot: configure nspawn's stdio setup, if needed

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -22,7 +22,7 @@ Requires: glibc
 Requires: policycoreutils
 Requires: qemu-img
 Requires: systemd
-Requires: systemd-container
+Requires: systemd-container >= 242
 Requires: tar
 Requires: util-linux
 Requires: python3-%{pypi_name}

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -75,6 +75,7 @@ class BuildRoot:
             "--quiet",
             "--register=no",
             "--as-pid2",
+            "--console=pipe",
             "--link-journal=no",
             "--property=DeviceAllow=block-loop rw",
             f"--directory={self.root}",


### PR DESCRIPTION
With version 242 [systemd-nspawn(5)](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html) [gained](https://github.com/systemd/systemd/commit/de40a3037af944f6803375f2f5269cffc4247f56#diff-db6b16c9ade7e951e3bb793bec110098R229) the --console argument to control how stdin, stdout, stderr is set up; with this change the behavior of systemd-nspawn also changed. Before, only when nspawn detected that stdio were ttys it would setup stdio as (pseudo-)terminal. After that change, it will do so if the console mode is not 'pipe', which needs to be explicitly specified, because the default, i.e. if stdio is not a tty and nothing is specified, is 'read-only'. This specifically also means that no input is passed as stdin to the container. But some stages, e.g. dnf, require data to be delivered via stdin and thus this change breaks those stages.
Revert back to the old behavior of systemd by passing '--console=pipe' but only if systemd is version greater than 241.

Closes #152 NB: the systemd version check is done quite ad hoc, maybe that should go into its own function somewhere else