### PR TITLE
RFC: container-runtime independent stdio setup for the container

### DIFF
--- a/osbuild-run
+++ b/osbuild-run
@@ -1,10 +1,23 @@
 #!/usr/bin/python3
 
+import array
+import json
 import shutil
 import os
+import socket
 import subprocess
 import sys
 
+
+# copied from remoteloop.py
+def load_fds(sock, msglen):
+    fds = array.array("i")   # Array of ints
+    msg, ancdata, _, addr = sock.recvmsg(msglen, socket.CMSG_LEN(253 * fds.itemsize))
+    for cmsg_level, cmsg_type, cmsg_data in ancdata:
+        if (cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS):
+            # Append data, ignoring any truncated integers at the end.
+            fds.frombytes(cmsg_data[:len(cmsg_data) - (len(cmsg_data) % fds.itemsize)])
+    return json.loads(msg), list(fds), addr
 
 def ldconfig():
     # ld.so.conf must exist, or `ldconfig` throws a warning
@@ -72,7 +85,22 @@ def nsswitch():
         pass
 
 
+def setup_stdio():
+    with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_PASSCRED, 1)
+        sock.connect("/run/osbuild/api/osbuild")
+        req = {'method': 'setup-stdio'}
+        sock.send(json.dumps(req).encode('utf-8'))
+        msg, fds, _ = load_fds(sock, 1024)
+        for io in ['stdin', 'stdout', 'stderr']:
+            target = getattr(sys, io)
+            source = fds[msg[io]]
+            os.dup2(source, target.fileno())
+            os.close(source)
+
+
 if __name__ == "__main__":
+    setup_stdio()
     ldconfig()
     sysusers()
     update_ca_trust()

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -1,0 +1,75 @@
+import array
+import asyncio
+import json
+import os
+import tempfile
+import threading
+import sys
+
+
+from . import remoteloop
+
+
+class API:
+    def __init__(self, sock, args, interactive):
+        self.sock = sock
+        self.input = args
+        self.interactive = interactive
+        self._output = None
+        self.event_loop = asyncio.new_event_loop()
+        self.event_loop.add_reader(self.sock, self._dispatch)
+        self.thread = threading.Thread(target=self._run_event_loop)
+
+    @property
+    def output(self):
+        return self._output and self._output.read()
+
+    def _prepare_input(self):
+        with tempfile.TemporaryFile() as fd:
+            fd.write(json.dumps(self.input).encode('utf-8'))
+            # re-open the file to get a read-only file descriptor
+            return open(f"/proc/self/fd/{fd.fileno()}", "r")
+
+    def _prepare_output(self):
+        if self.interactive:
+            return os.fdopen(os.dup(sys.stdout.fileno()), 'w')
+        out = tempfile.TemporaryFile(mode="wb")
+        fd = os.open(f"/proc/self/fd/{out.fileno()}", os.O_RDONLY|os.O_CLOEXEC)
+        self._output = os.fdopen(fd)
+        return out
+
+    def _setup_stdio(self, addr):
+        with self._prepare_input() as stdin, \
+             self._prepare_output() as stdout:
+            msg = {}
+            fds = array.array("i")
+            fds.append(stdin.fileno())
+            msg['stdin'] = 0
+            fds.append(stdout.fileno())
+            msg['stdout'] = 1
+            fds.append(stdout.fileno())
+            msg['stderr'] = 2
+            remoteloop.dump_fds(self.sock, msg, fds, addr=addr)
+
+    def __del__(self):
+        self.sock.close()
+
+    def _dispatch(self):
+        msg, addr = self.sock.recvfrom(1024)
+        args = json.loads(msg)
+        if args["method"] == 'setup-stdio':
+            self._setup_stdio(addr)
+
+    def _run_event_loop(self):
+        # Set the thread-local event loop
+        asyncio.set_event_loop(self.event_loop)
+        # Run event loop until stopped
+        self.event_loop.run_forever()
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *args):
+        self.event_loop.call_soon_threadsafe(self.event_loop.stop)
+        self.thread.join()

--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -25,8 +25,9 @@ def load_fds(sock, msglen):
     return json.loads(msg), list(fds), addr
 
 
-def dump_fds(sock, obj, fds):
-    sock.sendmsg([json.dumps(obj).encode('utf-8')], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds))])
+def dump_fds(sock, obj, fds, flags=0, addr=None):
+    ancillary = [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds))]
+    sock.sendmsg([json.dumps(obj).encode('utf-8')], ancillary, flags, addr)
 
 
 class LoopServer:

--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -21,7 +21,7 @@ def load_fds(sock, msglen):
     for cmsg_level, cmsg_type, cmsg_data in ancdata:
         if (cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS):
             # Append data, ignoring any truncated integers at the end.
-            fds.fromstring(cmsg_data[:len(cmsg_data) - (len(cmsg_data) % fds.itemsize)])
+            fds.frombytes(cmsg_data[:len(cmsg_data) - (len(cmsg_data) % fds.itemsize)])
     return json.loads(msg), list(fds), addr
 
 


### PR DESCRIPTION
Introduce a new osbuild-`API` through which the container, i.e. `osbuild-run`, can setup input and output (stdio) for the stage. Currently this is done passing fds over the API socket (when requested via `setup-stdio`). Input (the stdin for the container/stage) is a file-backed temp "buffer" to the json data. output (i.e. stdout of the container/stage) is either just the host's `stdin` or another file-backed temp buffer.
The buffer file is reopend for the container to get an independent file descriptor so writes and reads (and file modes) are independent.

This is a RFC, to make sure that is the right direction. If so I will clean the commits up and re-arrange them. I was also thinking of encapsulating that file-backed temp "buffer" code into its own small object (`FileBuffer` or some such.).