### PR TITLE
Safe tempfiles, rpm cleanups

### DIFF
--- a/stages/org.osbuild.dnf
+++ b/stages/org.osbuild.dnf
@@ -6,9 +6,10 @@ import os
 import pathlib
 import subprocess
 import sys
+import tempfile
 
 
-def write_repofile(f, repoid, repo):
+def write_repofile(f, repoid, repo, keydir):
     f.write(f"[{repoid}]\n")
 
     def write_option(key, value):
@@ -23,7 +24,7 @@ def write_repofile(f, repoid, repo):
             write_option(key, value)
 
     if "gpgkey" in repo:
-        keyfile = f"/tmp/{repoid}.asc"
+        keyfile = f"{keydir}/{repoid}.asc"
         with open(keyfile, "w") as key:
             key.write(repo["gpgkey"])
         write_option("gpgcheck", 1)
@@ -62,10 +63,6 @@ def main(tree, options):
     weak_deps = options.get("install_weak_deps", True)
     exclude_packages = options.get("exclude_packages", [])
 
-    with open("/tmp/dnf.conf", "w") as conf:
-        for repoid, repo in enumerate(repos):
-            write_repofile(conf, f"repo{repoid}", repo)
-
     script = f"""
         set -e
         mkdir -p {tree}/dev {tree}/sys {tree}/proc
@@ -90,22 +87,29 @@ def main(tree, options):
         print(f"setting up API VFS in target tree failed: {err.returncode}")
         return err.returncode
 
-    base_cmd = [
-        "dnf", "-yv",
-        "--installroot", tree,
-        "--forcearch", basearch,
-        "--setopt", "reposdir=",
-        "--setopt", f"install_weak_deps={weak_deps}",
-        "--releasever", releasever,
-        "--disableplugin=generate_completion_cache", # supress error that completion db can't be opened
-        "--config", "/tmp/dnf.conf"
-    ]
+    with tempfile.TemporaryDirectory(prefix="org.osbuild.dnf.") as confdir:
+        dnfconf = f"{confdir}/dnf.conf"
 
-    cmd = base_cmd + [operation] + packages
-    for x in exclude_packages:
-        cmd += ["--exclude", x]
-    print(" ".join(cmd), flush=True)
-    subprocess.run(cmd, check=True)
+        with open(dnfconf, "w") as conf:
+            for num, repo in enumerate(repos):
+                write_repofile(conf, f"repo{num}", repo, confdir)
+
+        base_cmd = [
+            "dnf", "-yv",
+            "--installroot", tree,
+            "--forcearch", basearch,
+            "--setopt", "reposdir=",
+            "--setopt", f"install_weak_deps={weak_deps}",
+            "--releasever", releasever,
+            "--disableplugin=generate_completion_cache", # supress error that completion db can't be opened
+            "--config", dnfconf
+        ]
+
+        cmd = base_cmd + [operation] + packages
+        for x in exclude_packages:
+            cmd += ["--exclude", x]
+        print(" ".join(cmd), flush=True)
+        subprocess.run(cmd, check=True)
 
     # verify metadata checksum
     for repoid, repo in enumerate(repos):

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -7,6 +7,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import tempfile
 
 
 RPM_CACHE_DIR = "/var/cache/org.osbuild.rpm"
@@ -55,12 +56,11 @@ def download_package(pkg):
 
 
 def main(tree, options):
-    for key in  options.get("gpgkeys", []):
-        keyfile = "/tmp/key.asc"
-        with open(keyfile, "w") as f:
-            f.write(key)
-        subprocess.run(["rpmkeys", "--import", keyfile], check=True)
-        os.remove(keyfile)
+    for key in options.get("gpgkeys", []):
+        with tempfile.NamedTemporaryFile(prefix="gpgkey.") as keyfile:
+            keyfile.write(key)
+            keyfile.flush()
+            subprocess.run(["rpmkeys", "--import", keyfile.name], check=True)
 
     os.makedirs(RPM_CACHE_DIR)
 
@@ -87,10 +87,14 @@ def main(tree, options):
 
     subprocess.run(["/bin/sh", "-c", script], check=True)
 
-    with open("/tmp/manifest", "w") as f:
-        f.write("\n".join(packages))
-
-    subprocess.run(["rpm", "--root", tree, "--install", "/tmp/manifest"], cwd=RPM_CACHE_DIR, check=True)
+    with tempfile.NamedTemporaryFile(prefix="manifest.", mode='w') as manifest:
+        manifest.writelines(p+'\n' for p in packages)
+        manifest.flush()
+        subprocess.run([
+            "rpm",
+            "--root", tree,
+            "--install", manifest.name
+        ], cwd=RPM_CACHE_DIR, check=True)
 
     # remove temporary machine ID if it was created by us
     if not machine_id_set_previously:

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -31,9 +31,9 @@ def download_package(pkg):
             filename = curl.stdout.strip()
             break
     else:
-        raise RuntimeError("Error downloading " + pkg["url"])
+        raise RuntimeError(f"Error downloading {pkg['url']}")
 
-    algorithm, checksum = pkg["checksum"].split(":", 1)
+    algorithm, checksum = pkg["checksum"].strip().split(":", 1)
     if algorithm not in ("md5", "sha1", "sha256", "sha384", "sha512"):
         raise RuntimeError(f"Unsupported checksum algorithm: {algorithm}")
 
@@ -45,12 +45,6 @@ def download_package(pkg):
         encoding="utf-8",
         check=True)
 
-    # check signature, because `rpm --install` doesn't
-    subprocess.run(
-        ["rpmkeys", "--checksig", filename],
-        cwd=RPM_CACHE_DIR,
-        stdout=subprocess.DEVNULL,
-        check=True)
 
     return filename
 
@@ -93,6 +87,9 @@ def main(tree, options):
         subprocess.run([
             "rpm",
             "--root", tree,
+            # Make rpm require valid signatures & digests on packages.
+            # (see /usr/lib/rpm/macros for more info)
+            "--define", "_pkgverify_level all",
             "--install", manifest.name
         ], cwd=RPM_CACHE_DIR, check=True)
 

--- a/stages/org.osbuild.yum
+++ b/stages/org.osbuild.yum
@@ -3,9 +3,9 @@
 import json
 import subprocess
 import sys
+import tempfile
 
-
-def write_repofile(f, repoid, repo):
+def write_repofile(f, repoid, repo, keydir):
     f.write(f"[{repoid}]\n")
 
     def write_option(key, value):
@@ -20,7 +20,7 @@ def write_repofile(f, repoid, repo):
             write_option(key, value)
 
     if "gpgkey" in repo:
-        keyfile = f"/tmp/{repoid}.asc"
+        keyfile = f"{keydir}/{repoid}.asc"
         with open(keyfile, "w") as key:
             key.write(repo["gpgkey"])
         write_option("gpgcheck", 1)
@@ -33,10 +33,6 @@ def main(tree, options):
     releasever = options["releasever"]
     operation = options.get("operation", "install")
     verbosity = options.get("verbosity", "info")
-
-    with open("/tmp/yum.conf", "w") as conf:
-        for repoid, repo in enumerate(repos):
-            write_repofile(conf, f"repo{repoid}", repo)
 
     script = f"""
         set -e
@@ -51,18 +47,24 @@ def main(tree, options):
         print(f"setting up API VFS in target tree failed: {err.returncode}")
         return err.returncode
 
-    cmd = [
-        "yum", "--assumeyes",
-        f"--installroot={tree}",
-        "--setopt=\"reposdir=\"",
-        f"--releasever={releasever}",
-        f"--rpmverbosity={verbosity}",
-        "--config=/tmp/yum.conf",
-        operation
-    ] + packages
+    with tempfile.TemporaryDirectory(prefix="org.osbuild.yum.") as confdir:
+        yumconf = f"{confdir}/yum.conf"
+        with open(yumconf, "w") as conf:
+            for num, repo in enumerate(repos):
+                write_repofile(conf, f"repo{num}", repo, confdir)
 
-    print(" ".join(cmd), flush=True)
-    return subprocess.run(cmd, check=False).returncode
+        cmd = [
+            "yum", "--assumeyes",
+            f"--installroot={tree}",
+            "--setopt=\"reposdir=\"",
+            f"--releasever={releasever}",
+            f"--rpmverbosity={verbosity}",
+            f"--config={yumconf}",
+            operation
+        ] + packages
+
+        print(" ".join(cmd), flush=True)
+        return subprocess.run(cmd, check=False).returncode
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Three stages (`org.osbuild.dnf`, `org.osbuild.yum`, `org.osbuild.rpm`) were writing files with predictable names in `/tmp`, which is generally a Bad Idea. (It makes me especially nervous when that's how they're handling GPG keys..)

So: the first two commits should make those stages use proper tempfiles / temporary directory to store keys and config files.

As an added bonus, the third commit should make `rpm --install` actually check & require valid package signatures so we don't have to manually check them.