### PR TITLE
pipeline: introduce host runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__
 /output-test
 
 /test/.vagrant
+
+/runners/org.osbuild.host

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -61,6 +61,14 @@ install -p -m 0755 $(find runners -type f) %{buildroot}%{pkgdir}/runners
 mkdir -p %{buildroot}%{pkgdir}/stages/osbuild
 mkdir -p %{buildroot}%{pkgdir}/assemblers/osbuild
 
+# install host runner
+%if 0%{?fc30}
+ln -s org.osbuild.fedora30 %{buildroot}%{pkgdir}/runners/org.osbuild.host
+%endif
+%if 0%{?el8}
+ln -s org.osbuild.rhel82 %{buildroot}%{pkgdir}/runners/org.osbuild.host
+%endif
+
 %check
 exit 0
 # We have some integration tests, but those require running a VM, so that would

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -270,7 +270,7 @@ def load(description):
     if build:
         build_pipeline, runner = load_build(build)
     else:
-        build_pipeline, runner = None, None
+        build_pipeline, runner = None, "org.osbuild.host"
 
     pipeline = Pipeline(runner, build_pipeline)
 


### PR DESCRIPTION
osbuild currently throws an error when not passing a build environment
on the command line, because the runner is unset. This is annoying on
hosts which only need a runner set, but no build pipeline.

To simplify running osbuild in this common case, introduce
`org.osbuild.host`, which is a runner that is defined to work on the
host that osbuild is installed on. Use this runner by default and
include a symlink to the right runner in the Fedora and RHEL packages.

Also add `runners/org.osbuild.host` to `.gitignore`, so that developers
can set the symlink when running osbuild from the source directory.

Fixes #171