### PR TITLE
WIP: Add support for building a UEFI bootable disk image

### DIFF
--- a/assemblers/org.osbuild.uefi
+++ b/assemblers/org.osbuild.uefi
@@ -1,0 +1,158 @@
+#!/usr/bin/python3
+
+import contextlib
+import json
+import socket
+import subprocess
+import sys
+import tempfile
+import osbuild.remoteloop as remoteloop
+
+STAGE_DESC = "Assemble a UEFI bootable partitioned disk image with qemu-img"
+STAGE_INFO = """
+Assemble a UEFI bootable partitioned disk image using `qemu-img`.
+
+Creates a sparse GPT-partitioned disk image of the given `size`, with the last
+partition containing an ext4 root filesystem. The image is configured so that
+can boot on UEFI based systems.
+
+Copies the tree contents into the root filesystem and then converts the raw
+sparse image into the format requested with the `fmt` option.
+
+Buildhost commands used: `truncate`, `mount`, `umount`, `sfdisk`,
+`mkfs.ext4`, `mkfs.vfat`, `qemu-img`.
+
+This assembler assumes that the UEFI packages and configuration have already
+been written to the tree. (see the org.osbuild.uefi-bls stage)
+
+The esp_fs_id is a 32-bit hex number that must match the fstab entry for
+/boot/efi where it must be of the form 'ABCD-0123' but for mkfs.vfat it must be
+ABCD0123. This assembler accepts it in either form, stripping any '-' from it
+before passing it to mkfs.vfat
+"""
+STAGE_OPTS = """
+"required": ["format", "filename", "ptuuid", "esp_fs_id", "root_fs_uuid", "size"],
+"properties": {
+  "format": {
+    "description": "Image file format to use",
+    "type": "string",
+    "enum": ["raw", "qcow2", "vdi", "vmdk"]
+  },
+  "filename": {
+    "description": "Image filename",
+    "type": "string"
+  },
+  "ptuuid": {
+    "description": "UUID for the disk image's partition table",
+    "type": "string"
+  },
+  "esp_fs_id": {
+    "description": "32-bit hex Volume ID for the EFI System Partition filesystem",
+    "type": "string"
+  },
+  "root_fs_uuid": {
+    "description": "UUID for the root filesystem",
+    "type": "string"
+  },
+  "size": {
+    "description": "Virtual disk size",
+    "type": "string"
+  }
+}
+"""
+
+@contextlib.contextmanager
+def mount(source):
+    with tempfile.TemporaryDirectory(prefix="osbuild-mnt") as dest:
+        subprocess.run(["mount", source, dest], check=True)
+        try:
+            yield dest
+        finally:
+            subprocess.run(["umount", "-R", dest], check=True)
+
+
+@contextlib.contextmanager
+def mount_path(source, dest):
+    subprocess.run(["mount", source, dest], check=True)
+    try:
+        yield dest
+    finally:
+        subprocess.run(["umount", "-R", dest], check=True)
+
+
+def main(tree, output_dir, options, loop_client):
+    fmt = options["format"]
+    filename = options["filename"]
+    ptuuid = options["ptuuid"]
+
+    # Allow 32 bit hex value to also contain a '-' which is required by the fstab entry
+    esp_fs_id = options["esp_fs_id"].replace("-", "")
+    root_fs_uuid = options["root_fs_uuid"]
+    size = options["size"]
+
+    # sfdisk works on sectors of 512 bytes and ignores excess space - be explicit about this
+    if size % 512 != 0:
+        raise ValueError("`size` must be a multiple of sector size (512)")
+
+    if fmt not in ["raw", "qcow2", "vdi", "vmdk"]:
+        raise ValueError("`format` must be one of raw, qcow, vdi, vmdk")
+
+    image = "/var/tmp/osbuild-image.raw"
+
+    # Create an empty image file
+    subprocess.run(["truncate", "--size", str(size), image], check=True)
+
+    # Set up the partition table of the image
+    # p1 is the EFI System Partition
+    # p2 is the / filesystem
+    partition_table = f"label: gpt\nlabel-id: {ptuuid}\n" \
+                       "2048 972800 C12A7328-F81F-11D2-BA4B-00A0C93EC93B\n" \
+                       "976896"
+    subprocess.run(["sfdisk", "-q", image], input=partition_table, encoding='utf-8', check=True)
+
+    r = subprocess.run(["sfdisk", "--json", image], stdout=subprocess.PIPE, encoding='utf-8', check=True)
+    partition_table = json.loads(r.stdout)
+
+    esp_partition = partition_table["partitiontable"]["partitions"][0]
+    esp_offset = esp_partition["start"] * 512
+    esp_size = esp_partition["size"] * 512
+
+    root_partition = partition_table["partitiontable"]["partitions"][1]
+    root_offset = root_partition["start"] * 512
+    root_size = root_partition["size"] * 512
+
+    with loop_client.device(image, root_offset, root_size) as loop:
+        # Populate the root partition of the image with an ext4 fs
+        subprocess.run(["mkfs.ext4", "-U", root_fs_uuid, loop],
+                       input="y", encoding='utf-8', check=True)
+
+        # Mount the root partition and create the UEFI System Partition at /boot/efi/
+        with mount(loop) as mountpoint:
+            with loop_client.device(image, esp_offset, esp_size) as esp_loop:
+                # Format and mount the ESP at /boot/efi/
+                subprocess.run(["mkfs.vfat", "-n", "EFI System Partition", "-i", esp_fs_id, esp_loop],
+                               encoding='utf-8', check=True)
+
+                # EFI/BOOT goes under /boot/efi/
+                subprocess.run(["mkdir", "-p", mountpoint+"/boot/efi/"], check=True)
+                with mount_path(esp_loop, mountpoint+"/boot/efi"):
+                    # Copy the tree into the target image
+                    subprocess.run(["cp", "-a", f"{tree}/.", mountpoint], check=True)
+
+    extra_args = []
+
+    # raw and vdi don't suppport compression
+    if fmt not in ("raw", "vdi"):
+        extra_args.append("-c")
+
+    subprocess.run(["qemu-img", "convert", "-O", fmt, *extra_args, image, f"{output_dir}/{filename}"], check=True)
+
+if __name__ == '__main__':
+    args = json.load(sys.stdin)
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_PASSCRED, 1)
+        sock.connect("/run/osbuild/api/remoteloop")
+        ret = main(args["tree"], args["output_dir"], args["options"], remoteloop.LoopClient(sock))
+
+    sys.exit(ret)

--- a/samples/f30-base-uefi.json
+++ b/samples/f30-base-uefi.json
@@ -1,0 +1,107 @@
+{
+  "runner": "org.osbuild.fedora30",
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "install_weak_deps": true,
+        "repos": [
+          {
+            "baseurl": "http://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/x86_64/os/",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97",
+            "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n"
+          }
+        ],
+        "packages": [
+          "@Core",
+          "chrony",
+          "kernel",
+          "selinux-policy-targeted",
+          "grub2-pc",
+          "spice-vdagent",
+          "qemu-guest-agent",
+          "xen-libs",
+          "langpacks-en",
+          "grub2-efi-ia32",
+          "shim-ia32",
+          "grub2-efi-x64",
+          "shim-x64",
+          "efibootmgr",
+          "grub2-tools"
+        ],
+        "exclude_packages": [
+          "dracut-config-rescue"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.locale",
+      "options": {
+        "language": "en_US"
+      }
+    },
+    {
+      "name": "org.osbuild.users",
+      "options": {
+        "users": {
+          "root": {"password": "$6$LsodJXg8kj9G7sbe$8o6ZfPR4UMKE4MLcXTLukatY.YYXRuR4h9hV162numzgAZhn1Gb9Hkuua1s5unC1P0FMj47dGy9uxSdS3fhsX."}
+        }
+      }
+    },
+    {
+      "name": "org.osbuild.fstab",
+      "options": {
+        "filesystems": [
+          {
+            "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+            "vfs_type": "ext4",
+            "path": "/",
+            "freq": "1",
+            "passno": "1"
+          },
+          {
+            "uuid": "46BB-8120",
+            "vfs_type": "vfat",
+            "path": "/boot/efi",
+            "options": "umask=0077,shortname=winnt",
+            "freq": "0",
+            "passno": "2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.grub2",
+      "options": {
+        "root_fs_uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0 console=ttyS0 console=tty1"
+      }
+    },
+    {
+      "name": "org.osbuild.selinux",
+      "options": {
+        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+      }
+    },
+    {
+      "name": "org.osbuild.fix-bls"
+    },
+    {
+      "name": "org.osbuild.uefi-bls"
+    }
+  ],
+  "assembler":
+    {
+      "name": "org.osbuild.uefi",
+      "options": {
+        "format": "raw",
+        "filename": "base.img",
+        "ptuuid": "29579f67-d390-43e7-bd96-dc8f5461171e",
+        "esp_fs_id": "46BB-8120",
+        "root_fs_uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+        "size": 3221225472
+      }
+    }
+}

--- a/stages/org.osbuild.uefi-bls
+++ b/stages/org.osbuild.uefi-bls
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+import glob
+import json
+import os
+import sys
+import subprocess
+
+STAGE_DESC = "Setup paths for UEFI booting with blscfg"
+STAGE_INFO = """
+This stage copies the configuration files needed to boot on UEFI systems using
+the blscfg module.
+
+This stage must be run after org.stage.grub2 and org.stage.fix-bls so that the correct
+files are available.
+"""
+STAGE_OPTS = ""
+
+
+def main(tree, _options):
+    """Copy configuration files needed for UEFI blscfg booting
+    """
+    # A minimal grub.cfg has already been written, it needs to be copied to the
+    # distribution specific EFI directory (eg. /boot/efi/EFI/fedora)
+    # The grubenv file contains the UUID of the filesystem to read the bls entries
+    # from.
+    # It may already exist in this path, this makes sure that it is present.
+    for d in glob.glob(f"{tree}/boot/efi/EFI/*"):
+        # Skip the fallback loader
+        if d.endswith("BOOT"):
+            continue
+        # Copy config files if they don't already exist
+        for file in ["grubenv", "grub.cfg"]:
+            if not os.path.exists(f"{d}/{file}"):
+                subprocess.run(["cp", f"{tree}/boot/grub2/{file}", d], check=True)
+    return 0
+
+
+if __name__ == '__main__':
+    args = json.load(sys.stdin)
+    r = main(args["tree"], args["options"])
+    sys.exit(r)


### PR DESCRIPTION
This adds a new stage, org.osbuild.uefi-bls, which copies configuration
files to the UEFI directories and configures the image so that UEFI will
use the bls entries.

It also adds a new assembler, org.osbuild.uefi, which creates a UEFI
disk image that will be booted using the grub2 blscfg command.

Included is a f30 sample that demonstrates building a UEFI bootable
raw image.