### PR TITLE
mulit-arch: add aarch64 support

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -73,6 +73,10 @@ STAGE_OPTS = """
           "type": "object",
           "required": ["mountpoint", "type", "uuid"],
           "properties": {
+            "label": {
+              "description": "Label for the filesystem",
+              "type": "string"
+            },
             "mountpoint": {
               "description": "Where to mount the partition",
               "type": "string"
@@ -126,23 +130,31 @@ def mount(source, dest):
         subprocess.run(["umount", "-R", dest], check=True)
 
 
-def mkfs_ext4(device, uuid):
-    subprocess.run(["mkfs.ext4", "-U", uuid, device], input="y", encoding='utf-8', check=True)
+def mkfs_ext4(device, uuid, label):
+    opts = []
+    if label:
+        opts = ["-L", label]
+    subprocess.run(["mkfs.ext4", "-U", uuid] + opts + [device],
+                   input="y", encoding='utf-8', check=True)
 
 
-def mkfs_xfs(device, uuid):
-    subprocess.run(["mkfs.xfs", "-m", f"uuid={uuid}", device], encoding='utf-8', check=True)
+def mkfs_xfs(device, uuid, label):
+    opts = []
+    if label:
+        opts = ["-L", label]
+    subprocess.run(["mkfs.xfs", "-m", f"uuid={uuid}"] + opts + [device],
+                   encoding='utf-8', check=True)
 
 
-def mkfs_vfat(device, uuid, name=None):
+def mkfs_vfat(device, uuid, label):
     volid = uuid.replace('-', '')
     opts = []
-    if name:
-        opts = ["-n", name]
+    if label:
+        opts = ["-n", label]
     subprocess.run(["mkfs.vfat", "-i", volid] + opts + [device], encoding='utf-8', check=True)
 
 
-def mkfs_for_type(device, uuid, fs_type):
+def mkfs_for_type(device, uuid, fs_type, label):
     if fs_type == "ext4":
         maker = mkfs_ext4
     elif fs_type == "xfs":
@@ -151,7 +163,7 @@ def mkfs_for_type(device, uuid, fs_type):
         maker = mkfs_vfat
     else:
         raise ValueError(f"Unknown filesystem type '{fs_type}'")
-    maker(device, uuid)
+    maker(device, uuid, label)
 
 
 def create_partition_table_legacy(image, options):
@@ -301,7 +313,8 @@ def main(tree, output_dir, options, loop_client):
             filesystem = partition["filesystem"]
             loop = cm.enter_context(loop_client.device(image, offset, size))
             # make the specified filesystem
-            mkfs_for_type(loop, filesystem["uuid"], filesystem["type"])
+            fs_label = filesystem.get("label")
+            mkfs_for_type(loop, filesystem["uuid"], filesystem["type"], fs_label)
             # now mount it
             mountpoint = os.path.normpath(f"{root}/{filesystem['mountpoint']}")
             os.makedirs(mountpoint, exist_ok=True)

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -77,14 +77,30 @@ def mkfs_xfs(device, uuid):
     subprocess.run(["mkfs.xfs", "-m", f"uuid={uuid}", device], encoding='utf-8', check=True)
 
 
-def create_partition_table(image, ptuuid):
+def create_partition_table(image, options):
     """Set up the partition table of the image"""
+    ptuuid = options["ptuuid"]
+    root_fs_uuid = options["root_fs_uuid"]
+    root_fs_type = options.get("root_fs_type", "ext4")
+
     partition_table = f"label: mbr\nlabel-id: {ptuuid}\nbootable, type=83"
     subprocess.run(["sfdisk", "-q", image], input=partition_table, encoding='utf-8', check=True)
 
     r = subprocess.run(["sfdisk", "--json", image], stdout=subprocess.PIPE, encoding='utf-8', check=True)
     partition_table = json.loads(r.stdout)
-    return partition_table
+
+    partition = partition_table["partitiontable"]["partitions"][0]
+    partitions = [{
+        "start": partition["start"] * 512,
+        "size": partition["size"] * 512,
+        "filesystem": {
+            "type": root_fs_type,
+            "uuid": root_fs_uuid,
+            "mountpoint": "/"
+        }
+    }]
+
+    return partitions
 
 
 def install_grub2(image, fs_module, partition_offset):
@@ -154,10 +170,9 @@ def main(tree, output_dir, options, loop_client):
     subprocess.run(["truncate", "--size", str(size), image], check=True)
 
     # The partition table
-    partition_table = create_partition_table(image, ptuuid)
-    partition = partition_table["partitiontable"]["partitions"][0]
-    partition_offset = partition["start"] * 512
-    partition_size = partition["size"] * 512
+    partitions = create_partition_table(image, options)
+    partition_offset = partitions[0]["start"]
+    partition_size = partitions[0]["size"]
 
     # Create the level-2 bootloader
     install_grub2(image, grub2_fs_module, partition_offset)

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -82,7 +82,7 @@ def mkfs_for_type(device, uuid, fs_type):
     elif fs_type == "xfs":
         maker = mkfs_xfs
     else:
-        raise ValueError("Unknown filesystem type")
+        raise ValueError(f"Unknown filesystem type '{fs_type}'")
     maker(device, uuid)
 
 
@@ -112,9 +112,22 @@ def create_partition_table(image, options):
     return partitions
 
 
-def install_grub2(image, fs_module, partition_offset):
+def install_grub2(image, partitions):
     """Install grub2 to image"""
     grub2_core = "/var/tmp/grub2-core.img"
+
+    root_fs_type = "unknown"
+    for p in partitions:
+        if p["filesystem"]["mountpoint"] == "/":
+            root_fs_type = p["filesystem"]["type"]
+            break
+
+    if root_fs_type == "ext4":
+        fs_module = "ext2"
+    elif root_fs_type == "xfs":
+        fs_module = "xfs"
+    else:
+        raise ValueError(f"unknown root filesystem type: '{root_fs_type}'")
 
     # Create the level-2 bootloader
     # The purpose of this is to find the grub modules and configuration
@@ -130,6 +143,7 @@ def install_grub2(image, fs_module, partition_offset):
                     "part_msdos", fs_module, "biosdisk"],
                    check=True)
 
+    partition_offset = partitions[0]["start"]
     assert os.path.getsize(grub2_core) < partition_offset - 512
 
     with open(image, "rb+") as image_f:
@@ -153,7 +167,6 @@ def main(tree, output_dir, options, loop_client):
     fmt = options["format"]
     filename = options["filename"]
     size = options["size"]
-    root_fs_type = options.get("root_fs_type", "ext4")
 
     # sfdisk works on sectors of 512 bytes and ignores excess space - be explicit about this
     if size % 512 != 0:
@@ -162,15 +175,6 @@ def main(tree, output_dir, options, loop_client):
     if fmt not in ["raw", "raw.xz", "qcow2", "vdi", "vmdk", "vpc"]:
         raise ValueError("`format` must be one of raw, qcow, vdi, vmdk, vpc")
 
-    if root_fs_type == "ext4":
-        mkfs = mkfs_ext4
-        grub2_fs_module = "ext2"
-    elif root_fs_type == "xfs":
-        mkfs = mkfs_xfs
-        grub2_fs_module = "xfs"
-    else:
-        raise ValueError("`root_fs_type` must be either ext4 or xfs")
-
     image = "/var/tmp/osbuild-image.raw"
 
     # Create an empty image file
@@ -178,10 +182,9 @@ def main(tree, output_dir, options, loop_client):
 
     # The partition table
     partitions = create_partition_table(image, options)
-    partition_offset = partitions[0]["start"]
 
     # Create the level-2 bootloader
-    install_grub2(image, grub2_fs_module, partition_offset)
+    install_grub2(image, partitions)
 
     # Now assemble the filesystem hierarchy and copy the tree into the image
     with contextlib.ExitStack() as cm:

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -14,11 +14,13 @@ STAGE_DESC = "Assemble a bootable partitioned disk image with qemu-img"
 STAGE_INFO = """
 Assemble a bootable partitioned disk image using `qemu-img`.
 
-Creates a sparse MBR-partitioned disk image of the given `size`, with a single
-bootable partition containing the root filesystem.
+Creates a sparse partitioned disk image of type `pttype` of a given `size`,
+with a partition table according to `partitions` or a MBR partitioned disk
+having a single bootable partition containing the root filesystem if the
+`pttype` property is absent.
 
-Installs GRUB2 (using the buildhost's `/usr/lib/grub/i386-pc/boot.img` etc.) as
-the bootloader.
+If the partition type is MBR it installs GRUB2 (using the buildhost's
+`/usr/lib/grub/i386-pc/boot.img` etc.) as the bootloader.
 
 Copies the tree contents into the root filesystem and then converts the raw
 sparse image into the format requested with the `fmt` option.
@@ -27,7 +29,12 @@ Buildhost commands used: `truncate`, `mount`, `umount`, `sfdisk`,
 `grub2-mkimage`, `mkfs.ext4` or `mkfs.xfs`, `qemu-img`.
 """
 STAGE_OPTS = """
-"required": ["format", "filename", "ptuuid", "root_fs_uuid", "size"],
+"required": ["format", "filename", "ptuuid", "size"],
+"oneOf": [{
+  "required": ["root_fs_uuid"]
+},{
+  "required": ["pttype", "partitions"]
+}],
 "properties": {
   "format": {
     "description": "Image file format to use",
@@ -38,9 +45,60 @@ STAGE_OPTS = """
     "description": "Image filename",
     "type": "string"
   },
+  "partitions": {
+    "description": "Partition layout ",
+    "type": "array",
+    "items": {
+      "description": "Description of one partition",
+      "type": "object",
+      "properties": {
+        "bootable": {
+          "description": "Mark the partition as bootable (MBR)",
+          "type": "boolean"
+        },
+        "size": {
+          "description": "The size of this partition",
+          "type": "integer"
+        },
+        "start": {
+          "description": "The start offset of this partition",
+          "type": "integer"
+        },
+        "type": {
+          "description": "The partition type (UUID or identifier)",
+          "type": "string"
+        },
+        "filesystem": {
+          "description": "Description of the filesystem",
+          "type": "object",
+          "required": ["mountpoint", "type", "uuid"],
+          "properties": {
+            "mountpoint": {
+              "description": "Where to mount the partition",
+              "type": "string"
+            },
+            "type": {
+              "description": "Type of the filesystem",
+              "type": "string",
+              "enum": ["ext4", "xfs"]
+            },
+            "uuid": {
+              "description": "UUID for the filesystem",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
   "ptuuid": {
     "description": "UUID for the disk image's partition table",
     "type": "string"
+  },
+  "pttype": {
+    "description": "The type of the partition table",
+    "type": "string",
+    "enum": ["mbr", "gpt"]
   },
   "root_fs_uuid": {
     "description": "UUID for the root filesystem",
@@ -86,8 +144,7 @@ def mkfs_for_type(device, uuid, fs_type):
     maker(device, uuid)
 
 
-def create_partition_table(image, options):
-    """Set up the partition table of the image"""
+def create_partition_table_legacy(image, options):
     ptuuid = options["ptuuid"]
     root_fs_uuid = options["root_fs_uuid"]
     root_fs_type = options.get("root_fs_type", "ext4")
@@ -108,6 +165,44 @@ def create_partition_table(image, options):
             "mountpoint": "/"
         }
     }]
+
+    return partitions
+
+
+def create_partition_table(image, options):
+    """Set up the partition table of the image"""
+    ptuuid = options["ptuuid"]
+    pttype = options.get("pttype")
+
+    # if 'pttype' is missing, we are in legacy mode
+    if pttype is None:
+        return create_partition_table_legacy(image, options)
+
+    # new mode
+    partitions = options["partitions"]
+
+    # generate the command for sfdisk to create the table
+    command = f"label: {pttype}\nlabel-id: {ptuuid}"
+    for partition in partitions:
+        fields = []
+        for field in ["start", "size", "type"]:
+            if field in partition:
+                fields += [f'{field}="{partition[field]}"']
+        if "bootable" in partition and partition["bootable"]:
+            fields += ["bootable"]
+        command += "\n" + ", ".join(fields)
+
+    subprocess.run(["sfdisk", "-q", image], input=command, encoding='utf-8', check=True)
+
+    # read the actual dimensions back
+    r = subprocess.run(["sfdisk", "--json", image], stdout=subprocess.PIPE, encoding='utf-8', check=True)
+    disk_table = json.loads(r.stdout)["partitiontable"]
+    disk_partitions = disk_table["partitions"]
+
+    assert len(disk_partitions) == len(partitions)
+    for i, partition in enumerate(partitions):
+        partition["start"] = disk_partitions[i]["start"] * 512
+        partition["size"] = disk_partitions[i]["size"] * 512
 
     return partitions
 

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -80,7 +80,7 @@ STAGE_OPTS = """
             "type": {
               "description": "Type of the filesystem",
               "type": "string",
-              "enum": ["ext4", "xfs"]
+              "enum": ["ext4", "xfs", "vfat"]
             },
             "uuid": {
               "description": "UUID for the filesystem",
@@ -134,11 +134,21 @@ def mkfs_xfs(device, uuid):
     subprocess.run(["mkfs.xfs", "-m", f"uuid={uuid}", device], encoding='utf-8', check=True)
 
 
+def mkfs_vfat(device, uuid, name=None):
+    volid = uuid.replace('-', '')
+    opts = []
+    if name:
+        opts = ["-n", name]
+    subprocess.run(["mkfs.vfat", "-i", volid] + opts + [device], encoding='utf-8', check=True)
+
+
 def mkfs_for_type(device, uuid, fs_type):
     if fs_type == "ext4":
         maker = mkfs_ext4
     elif fs_type == "xfs":
         maker = mkfs_xfs
+    elif fs_type == "vfat":
+        maker = mkfs_vfat
     else:
         raise ValueError(f"Unknown filesystem type '{fs_type}'")
     maker(device, uuid)
@@ -166,7 +176,7 @@ def create_partition_table_legacy(image, options):
         }
     }]
 
-    return partitions
+    return "mbr", partitions
 
 
 def create_partition_table(image, options):
@@ -204,7 +214,7 @@ def create_partition_table(image, options):
         partition["start"] = disk_partitions[i]["start"] * 512
         partition["size"] = disk_partitions[i]["size"] * 512
 
-    return partitions
+    return pttype, partitions
 
 
 def install_grub2(image, partitions):
@@ -276,10 +286,11 @@ def main(tree, output_dir, options, loop_client):
     subprocess.run(["truncate", "--size", str(size), image], check=True)
 
     # The partition table
-    partitions = create_partition_table(image, options)
+    pttype, partitions = create_partition_table(image, options)
 
     # Create the level-2 bootloader
-    install_grub2(image, partitions)
+    if pttype == "mbr":
+        install_grub2(image, partitions)
 
     # Now assemble the filesystem hierarchy and copy the tree into the image
     with contextlib.ExitStack() as cm:

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -60,13 +60,12 @@ STAGE_OPTS = """
 """
 
 @contextlib.contextmanager
-def mount(source):
-    with tempfile.TemporaryDirectory(prefix="osbuild-mnt") as dest:
-        subprocess.run(["mount", source, dest], check=True)
-        try:
-            yield dest
-        finally:
-            subprocess.run(["umount", "-R", dest], check=True)
+def mount(source, dest):
+    subprocess.run(["mount", source, dest], check=True)
+    try:
+        yield dest
+    finally:
+        subprocess.run(["umount", "-R", dest], check=True)
 
 
 def mkfs_ext4(device, uuid):
@@ -75,6 +74,16 @@ def mkfs_ext4(device, uuid):
 
 def mkfs_xfs(device, uuid):
     subprocess.run(["mkfs.xfs", "-m", f"uuid={uuid}", device], encoding='utf-8', check=True)
+
+
+def mkfs_for_type(device, uuid, fs_type):
+    if fs_type == "ext4":
+        maker = mkfs_ext4
+    elif fs_type == "xfs":
+        maker = mkfs_xfs
+    else:
+        raise ValueError("Unknown filesystem type")
+    maker(device, uuid)
 
 
 def create_partition_table(image, options):
@@ -143,8 +152,6 @@ def install_grub2(image, fs_module, partition_offset):
 def main(tree, output_dir, options, loop_client):
     fmt = options["format"]
     filename = options["filename"]
-    ptuuid = options["ptuuid"]
-    root_fs_uuid = options["root_fs_uuid"]
     size = options["size"]
     root_fs_type = options.get("root_fs_type", "ext4")
 
@@ -172,17 +179,27 @@ def main(tree, output_dir, options, loop_client):
     # The partition table
     partitions = create_partition_table(image, options)
     partition_offset = partitions[0]["start"]
-    partition_size = partitions[0]["size"]
 
     # Create the level-2 bootloader
     install_grub2(image, grub2_fs_module, partition_offset)
 
-    with loop_client.device(image, partition_offset, partition_size) as loop:
-        # Populate the first partition of the image with a filesystem
-        mkfs(loop, root_fs_uuid)
-        # Copy the tree into the target image
-        with mount(loop) as mountpoint:
-            subprocess.run(["cp", "-a", f"{tree}/.", mountpoint], check=True)
+    # Now assemble the filesystem hierarchy and copy the tree into the image
+    with contextlib.ExitStack() as cm:
+        root = cm.enter_context(tempfile.TemporaryDirectory(prefix="osbuild-mnt"))
+        # sort the partition according to their position in the filesystem tree
+        for partition in sorted(partitions, key=lambda p: len(p["filesystem"]["mountpoint"])):
+            offset, size = partition["start"], partition["size"]
+            filesystem = partition["filesystem"]
+            loop = cm.enter_context(loop_client.device(image, offset, size))
+            # make the specified filesystem
+            mkfs_for_type(loop, filesystem["uuid"], filesystem["type"])
+            # now mount it
+            mountpoint = os.path.normpath(f"{root}/{filesystem['mountpoint']}")
+            os.makedirs(mountpoint, exist_ok=True)
+            cm.enter_context(mount(loop, mountpoint))
+        # the filesystem tree should now be properly setup,
+        # copy the tree into the target image
+        subprocess.run(["cp", "-a", f"{tree}/.", root], check=True)
 
     if fmt == "raw":
         subprocess.run(["cp", image, f"{output_dir}/{filename}"], check=True)

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -77,6 +77,53 @@ def mkfs_xfs(device, uuid):
     subprocess.run(["mkfs.xfs", "-m", f"uuid={uuid}", device], encoding='utf-8', check=True)
 
 
+def create_partition_table(image, ptuuid):
+    """Set up the partition table of the image"""
+    partition_table = f"label: mbr\nlabel-id: {ptuuid}\nbootable, type=83"
+    subprocess.run(["sfdisk", "-q", image], input=partition_table, encoding='utf-8', check=True)
+
+    r = subprocess.run(["sfdisk", "--json", image], stdout=subprocess.PIPE, encoding='utf-8', check=True)
+    partition_table = json.loads(r.stdout)
+    return partition_table
+
+
+def install_grub2(image, fs_module, partition_offset):
+    """Install grub2 to image"""
+    grub2_core = "/var/tmp/grub2-core.img"
+
+    # Create the level-2 bootloader
+    # The purpose of this is to find the grub modules and configuration
+    # to be able to start the level-3 bootloader. It contains the modules
+    # necessary to do this, but nothing else.
+    subprocess.run(["grub2-mkimage",
+                    "--verbose",
+                    "--directory", "/usr/lib/grub/i386-pc",
+                    "--prefix", "(,msdos1)/boot/grub2",
+                    "--format", "i386-pc",
+                    "--compression", "auto",
+                    "--output", grub2_core,
+                    "part_msdos", fs_module, "biosdisk"],
+                   check=True)
+
+    assert os.path.getsize(grub2_core) < partition_offset - 512
+
+    with open(image, "rb+") as image_f:
+        # Install the level-1 bootloader into the start of the MBR
+        # The purpose of this is simply to jump into the level-2 bootloader.
+        with open("/usr/lib/grub/i386-pc/boot.img", "rb") as boot_f:
+            # The boot.img file is 512 bytes, but we must only copy the first 440
+            # bytes, as these contain the bootstrapping code. The rest of the
+            # first sector contains the partition table, and must not be
+            # overwritten.
+            image_f.write(boot_f.read(440))
+
+        # Install the level-2 bootloader into the space after the MBR, before
+        # the first partition.
+        with open(grub2_core, "rb") as core_f:
+            image_f.seek(512)
+            shutil.copyfileobj(core_f, image_f)
+
+
 def main(tree, output_dir, options, loop_client):
     fmt = options["format"]
     filename = options["filename"]
@@ -102,52 +149,18 @@ def main(tree, output_dir, options, loop_client):
         raise ValueError("`root_fs_type` must be either ext4 or xfs")
 
     image = "/var/tmp/osbuild-image.raw"
-    grub2_core = "/var/tmp/grub2-core.img"
 
     # Create an empty image file
     subprocess.run(["truncate", "--size", str(size), image], check=True)
 
-    # Set up the partition table of the image
-    partition_table = f"label: mbr\nlabel-id: {ptuuid}\nbootable, type=83"
-    subprocess.run(["sfdisk", "-q", image], input=partition_table, encoding='utf-8', check=True)
-
-    r = subprocess.run(["sfdisk", "--json", image], stdout=subprocess.PIPE, encoding='utf-8', check=True)
-    partition_table = json.loads(r.stdout)
+    # The partition table
+    partition_table = create_partition_table(image, ptuuid)
     partition = partition_table["partitiontable"]["partitions"][0]
     partition_offset = partition["start"] * 512
     partition_size = partition["size"] * 512
 
     # Create the level-2 bootloader
-    # The purpose of this is to find the grub modules and configuration
-    # to be able to start the level-3 bootloader. It contains the modules
-    # necessary to do this, but nothing else.
-    subprocess.run(["grub2-mkimage",
-                    "--verbose",
-                    "--directory", "/usr/lib/grub/i386-pc",
-                    "--prefix", "(,msdos1)/boot/grub2",
-                    "--format", "i386-pc",
-                    "--compression", "auto",
-                    "--output", grub2_core,
-                    "part_msdos", grub2_fs_module, "biosdisk"],
-                   check=True)
-
-    assert os.path.getsize(grub2_core) < partition_offset - 512
-
-    with open(image, "rb+") as image_f:
-        # Install the level-1 bootloader into the start of the MBR
-        # The purpose of this is simply to jump into the level-2 bootloader.
-        with open("/usr/lib/grub/i386-pc/boot.img", "rb") as boot_f:
-            # The boot.img file is 512 bytes, but we must only copy the first 440
-            # bytes, as these contain the bootstrapping code. The rest of the
-            # first sector contains the partition table, and must not be
-            # overwritten.
-            image_f.write(boot_f.read(440))
-
-        # Install the level-2 bootloader into the space after the MBR, before
-        # the first partition.
-        with open(grub2_core, "rb") as core_f:
-            image_f.seek(512)
-            shutil.copyfileobj(core_f, image_f)
+    install_grub2(image, grub2_fs_module, partition_offset)
 
     with loop_client.device(image, partition_offset, partition_size) as loop:
         # Populate the first partition of the image with a filesystem

--- a/samples/f30-aarch64.json
+++ b/samples/f30-aarch64.json
@@ -99,7 +99,7 @@
         "pttype": "gpt",
         "partitions": [
           {"start": 2048, "size": 972800, "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-           "filesystem": {"type": "vfat", "uuid": "46BB-8120",
+           "filesystem": {"type": "vfat", "uuid": "46BB-8120", "label": "EFI System Partition",
                           "mountpoint": "/boot/efi"}},
           {"start": 976896,
            "filesystem": {"type": "ext4", "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",

--- a/samples/f30-aarch64.json
+++ b/samples/f30-aarch64.json
@@ -1,0 +1,110 @@
+{
+  "runner": "org.osbuild.fedora30",
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "aarch64",
+        "install_weak_deps": true,
+        "repos": [
+          {
+            "baseurl": "http://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/",
+            "checksum": "sha256:46f9d7fee4416eb6975903ce9650348e0b40e35503fe953bcdc12bb18db06bac",
+            "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n"
+          }
+        ],
+        "packages": [
+          "@Core",
+          "chrony",
+          "dracut-config-generic",
+          "efibootmgr",
+          "grub2-efi-aa64",
+          "grub2-tools"
+          "kernel",
+          "langpacks-en",
+          "qemu-guest-agent",
+          "selinux-policy-targeted",
+          "shim-aa64",
+          "spice-vdagent",
+          "xen-libs",
+        ],
+        "exclude_packages": [
+          "dracut-config-rescue"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.locale",
+      "options": {
+        "language": "en_US"
+      }
+    },
+    {
+      "name": "org.osbuild.users",
+      "options": {
+        "users": {
+          "root": {"password": "$6$LsodJXg8kj9G7sbe$8o6ZfPR4UMKE4MLcXTLukatY.YYXRuR4h9hV162numzgAZhn1Gb9Hkuua1s5unC1P0FMj47dGy9uxSdS3fhsX."}
+        }
+      }
+    },
+    {
+      "name": "org.osbuild.fstab",
+      "options": {
+        "filesystems": [
+          {
+            "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+            "vfs_type": "ext4",
+            "path": "/",
+            "freq": "1",
+            "passno": "1"
+          },
+          {
+            "uuid": "46BB-8120",
+            "vfs_type": "vfat",
+            "path": "/boot/efi",
+            "options": "umask=0077,shortname=winnt",
+            "freq": "0",
+            "passno": "2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.grub2",
+      "options": {
+        "root_fs_uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0 console=ttyS0 console=tty1",
+        "uefi": {"vendor": "fedora"}
+      }
+    },
+    {
+      "name": "org.osbuild.selinux",
+      "options": {
+        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+      }
+    },
+    {
+      "name": "org.osbuild.fix-bls"
+    }
+  ],
+  "assembler":
+    {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "format": "qcow2",
+        "filename": "base.qcow2",
+        "size": 3221225472,
+        "ptuuid": "29579f67-d390-43e7-bd96-dc8f5461171e",
+        "pttype": "gpt",
+        "partitions": [
+          {"start": 2048, "size": 972800, "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+           "filesystem": {"type": "vfat", "uuid": "46BB-8120",
+                          "mountpoint": "/boot/efi"}},
+          {"start": 976896,
+           "filesystem": {"type": "ext4", "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+                          "mountpoint": "/"}}
+        ]
+      }
+    }
+}

--- a/samples/f30-base-uefi.json
+++ b/samples/f30-base-uefi.json
@@ -101,7 +101,7 @@
         "pttype": "gpt",
         "partitions": [
           {"start": 2048, "size": 972800, "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
-           "filesystem": {"type": "vfat", "uuid": "46BB-8120",
+           "filesystem": {"type": "vfat", "uuid": "46BB-8120", "label": "EFI System Partition",
                           "mountpoint": "/boot/efi"}},
           {"start": 976896,
            "filesystem": {"type": "ext4", "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",

--- a/samples/f30-base-uefi.json
+++ b/samples/f30-base-uefi.json
@@ -1,0 +1,112 @@
+{
+  "runner": "org.osbuild.fedora30",
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "install_weak_deps": true,
+        "repos": [
+          {
+            "baseurl": "http://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/x86_64/os/",
+            "checksum": "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97",
+            "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n"
+          }
+        ],
+        "packages": [
+          "@Core",
+          "chrony",
+          "kernel",
+          "selinux-policy-targeted",
+          "grub2-pc",
+          "spice-vdagent",
+          "qemu-guest-agent",
+          "xen-libs",
+          "langpacks-en",
+          "grub2-efi-ia32",
+          "shim-ia32",
+          "grub2-efi-x64",
+          "shim-x64",
+          "efibootmgr",
+          "grub2-tools"
+        ],
+        "exclude_packages": [
+          "dracut-config-rescue"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.locale",
+      "options": {
+        "language": "en_US"
+      }
+    },
+    {
+      "name": "org.osbuild.users",
+      "options": {
+        "users": {
+          "root": {"password": "$6$LsodJXg8kj9G7sbe$8o6ZfPR4UMKE4MLcXTLukatY.YYXRuR4h9hV162numzgAZhn1Gb9Hkuua1s5unC1P0FMj47dGy9uxSdS3fhsX."}
+        }
+      }
+    },
+    {
+      "name": "org.osbuild.fstab",
+      "options": {
+        "filesystems": [
+          {
+            "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+            "vfs_type": "ext4",
+            "path": "/",
+            "freq": "1",
+            "passno": "1"
+          },
+          {
+            "uuid": "46BB-8120",
+            "vfs_type": "vfat",
+            "path": "/boot/efi",
+            "options": "umask=0077,shortname=winnt",
+            "freq": "0",
+            "passno": "2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.grub2",
+      "options": {
+        "root_fs_uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0 console=ttyS0 console=tty1",
+        "uefi": {"vendor": "fedora"}
+      }
+    },
+    {
+      "name": "org.osbuild.selinux",
+      "options": {
+        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+      }
+    },
+    {
+      "name": "org.osbuild.fix-bls"
+    }
+  ],
+  "assembler":
+    {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "format": "qcow2",
+        "filename": "base.qcow2",
+        "size": 3221225472,
+        "ptuuid": "29579f67-d390-43e7-bd96-dc8f5461171e",
+        "pttype": "gpt",
+        "partitions": [
+          {"start": 2048, "size": 972800, "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+           "filesystem": {"type": "vfat", "uuid": "46BB-8120",
+                          "mountpoint": "/boot/efi"}},
+          {"start": 976896,
+           "filesystem": {"type": "ext4", "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+                          "mountpoint": "/"}}
+        ]
+      }
+    }
+}

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -61,6 +61,12 @@ def copy_modules(tree):
         shutil.copy2(f"/usr/lib/grub/i386-pc/{dirent.name}", f"{tree}/boot/grub2/i386-pc/")
 
 
+def copy_font(tree):
+    """Copy a unicode font into /boot"""
+    os.makedirs(f"{tree}/boot/grub2/fonts", exist_ok=True)
+    shutil.copy2("/usr/share/grub/unicode.pf2", f"{tree}/boot/grub2/fonts/")
+
+
 def main(tree, options):
     root_fs_uuid = options["root_fs_uuid"]
     kernel_opts = options.get("kernel_opts", "")
@@ -88,10 +94,7 @@ def main(tree, options):
                   "blscfg\n")
 
     copy_modules(tree)
-
-    # Copy a unicode font into /boot
-    os.makedirs(f"{tree}/boot/grub2/fonts", exist_ok=True)
-    shutil.copy2("/usr/share/grub/unicode.pf2", f"{tree}/boot/grub2/fonts/")
+    copy_font(tree)
 
     return 0
 

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -67,6 +67,19 @@ def copy_font(tree):
     shutil.copy2("/usr/share/grub/unicode.pf2", f"{tree}/boot/grub2/fonts/")
 
 
+def write_grub_cfg(tree, path):
+    """Write the grub config"""
+    with open(os.path.join(tree, path), "w") as cfg:
+        cfg.write("set timeout=0\n"
+                  "load_env\n"
+                  "search --no-floppy --fs-uuid --set=root ${GRUB2_ROOT_FS_UUID}\n"
+                  "search --no-floppy --fs-uuid --set=boot ${GRUB2_BOOT_FS_UUID}\n"
+                  "function load_video {\n"
+                  "  insmod all_video\n"
+                  "}\n"
+                  "blscfg\n")
+
+
 def main(tree, options):
     root_fs_uuid = options["root_fs_uuid"]
     kernel_opts = options.get("kernel_opts", "")
@@ -83,16 +96,8 @@ def main(tree, options):
                   f"GRUB2_ROOT_FS_UUID={root_fs_uuid}\n"
                   f"GRUB2_BOOT_FS_UUID={root_fs_uuid}\n"
                   f"kernelopts=root=UUID={root_fs_uuid} {kernel_opts}\n")
-    with open(f"{tree}/boot/grub2/grub.cfg", "w") as cfg:
-        cfg.write("set timeout=0\n"
-                  "load_env\n"
-                  "search --no-floppy --fs-uuid --set=root ${GRUB2_ROOT_FS_UUID}\n"
-                  "search --no-floppy --fs-uuid --set=boot ${GRUB2_BOOT_FS_UUID}\n"
-                  "function load_video {\n"
-                  "  insmod all_video\n"
-                  "}\n"
-                  "blscfg\n")
 
+    write_grub_cfg(tree, "boot/grub2/grub.cfg")
     copy_modules(tree)
     copy_font(tree)
 

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -19,13 +19,20 @@ behavior in Fedora 30 and later.
 This stage will overwrite `/etc/default/grub`, `/boot/grub2/grubenv`, and
 `/boot/grub2/grub.cfg`. (Leading directories will be created if not present.)
 
-This stage also copies GRUB2 files from the buildhost into the target tree:
+If Legacy boot support is requested (the default, or explicitly via `legacy`)
+this stage will also overwrite `/boot/grub2/grub.cfg` and will copy the
+GRUB2 files from the buildhost into the target tree:
 * `/usr/share/grub/unicode.pf2`       -> `/boot/grub2/fonts/`
 * `/usr/lib/grub/i386-pc/*.{mod,lst}` -> `/boot/grub2/i386-pc/`
   * NOTE: skips `fdt.lst`, which is an empty file
 
-This stage will fail if the buildhost doesn't have `/usr/lib/grub/i386-pc/`
-and `/usr/share/grub/unicode.pf2`.
+NB: with legacy support enabled, this stage will fail if the buildhost
+doesn't have `/usr/lib/grub/i386-pc/` and `/usr/share/grub/unicode.pf2`.
+
+If UEFI support is enabled via `uefi: {"vendor": "<vendor>"}` this stage will
+also write the `grub.cfg` to `boot/efi/EFI/<vendor>/grub.cfg`.
+
+Both UEFI and Legacy can be specified at the same time.
 """
 STAGE_OPTS = """
 "required": ["root_fs_uuid"],
@@ -44,6 +51,24 @@ STAGE_OPTS = """
     "description": "Additional kernel boot options",
     "type": "string",
     "default": ""
+  },
+  "legacy": {
+    "description": "Include legacy boot support",
+    "type": "boolean",
+    "default": true
+  },
+  "uefi": {
+    "description": "Include UEFI boot support",
+    "type": "object",
+    "required": ["vendor"],
+      "properties": {
+        "vendor": {
+          "type": "string",
+           "description": "The vendor of the UEFI binaries (this is us)",
+           "examples": ["fedora"],
+           "pattern": "^(.+)$"
+         }
+      }
   }
 }
 """
@@ -83,6 +108,8 @@ def write_grub_cfg(tree, path):
 def main(tree, options):
     root_fs_uuid = options["root_fs_uuid"]
     kernel_opts = options.get("kernel_opts", "")
+    legacy = options.get("legacy", True)
+    uefi = options.get("uefi", None)
 
     # Create the configuration file that determines how grub.cfg is generated.
     os.makedirs(f"{tree}/etc/default", exist_ok=True)
@@ -97,9 +124,20 @@ def main(tree, options):
                   f"GRUB2_BOOT_FS_UUID={root_fs_uuid}\n"
                   f"kernelopts=root=UUID={root_fs_uuid} {kernel_opts}\n")
 
-    write_grub_cfg(tree, "boot/grub2/grub.cfg")
-    copy_modules(tree)
-    copy_font(tree)
+    if legacy:
+        write_grub_cfg(tree, "boot/grub2/grub.cfg")
+        copy_modules(tree)
+        copy_font(tree)
+
+    if uefi is not None:
+        # UEFI support:
+        # The following files are needed for UEFI support:
+        # /boot/efi/EFI/<vendor>/{grubenv, grub.cfg}
+        # - grubenv should have been written to via the link from
+        #     /boot/grub2/grubenv created by grub2-efi-{x64, ia32}.rpm
+        # - grub.cfg needs to be generated
+        vendor = uefi["vendor"]
+        write_grub_cfg(tree, f"boot/efi/EFI/{vendor}/grub.cfg")
 
     return 0
 

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -48,6 +48,19 @@ STAGE_OPTS = """
 }
 """
 
+
+def copy_modules(tree):
+    """Copy all modules from the build image to /boot"""
+    os.makedirs(f"{tree}/boot/grub2/i386-pc", exist_ok=True)
+    for dirent in os.scandir("/usr/lib/grub/i386-pc"):
+        (_, ext) = os.path.splitext(dirent.name)
+        if ext not in ('.mod', '.lst'):
+            continue
+        if dirent.name == "fdt.lst":
+            continue
+        shutil.copy2(f"/usr/lib/grub/i386-pc/{dirent.name}", f"{tree}/boot/grub2/i386-pc/")
+
+
 def main(tree, options):
     root_fs_uuid = options["root_fs_uuid"]
     kernel_opts = options.get("kernel_opts", "")
@@ -74,15 +87,7 @@ def main(tree, options):
                   "}\n"
                   "blscfg\n")
 
-    # Copy all modules from the build image to /boot
-    os.makedirs(f"{tree}/boot/grub2/i386-pc", exist_ok=True)
-    for dirent in os.scandir("/usr/lib/grub/i386-pc"):
-        (_, ext) = os.path.splitext(dirent.name)
-        if ext not in ('.mod', '.lst'):
-            continue
-        if dirent.name == "fdt.lst":
-            continue
-        shutil.copy2(f"/usr/lib/grub/i386-pc/{dirent.name}", f"{tree}/boot/grub2/i386-pc/")
+    copy_modules(tree)
 
     # Copy a unicode font into /boot
     os.makedirs(f"{tree}/boot/grub2/fonts", exist_ok=True)


### PR DESCRIPTION
Since aarch64 is booted via UEFI & grub2 this is based on PR #173 from @bcl with the difference that I dropped the `org.osbuild.uefi-bls` stage and instead added (optional) support for UEFI to the grub2 stage. Also the copying of the grub modules can deal with the case that those are not available (as it is on aarch64). The rest is just adding the right grub2/shim packages. 

The one difference I noted compared to the fedora (rhel) guest images are the entries in `/boot/grub/*` created by anaconda:
```
# Create grub.conf for EC2. This used to be done by appliance creator but
# anaconda doesn't do it. And, in case appliance-creator is used, we're
# overriding it here so that both cases get the exact same file.
# Note that the console line is different -- that's because EC2 provides
# different virtual hardware, and this is a convenient way to act differently
echo -n "Creating grub.conf for pvgrub"
rootuuid=$( awk '$2=="/" { print $1 };'  /etc/fstab )
mkdir /boot/grub
echo -e 'default=0\ntimeout=0\n\n' > /boot/grub/grub.conf
for kv in $( ls -1v /boot/vmlinuz* |grep -v rescue |sed s/.*vmlinuz-//  ); do
  echo "title Fedora ($kv)" >> /boot/grub/grub.conf
  echo -e "\troot (hd0,0)" >> /boot/grub/grub.conf
  echo -e "\tkernel /boot/vmlinuz-$kv ro root=$rootuuid no_timer_check console=hvc0 LANG=en_US.UTF-8" >> /boot/grub/grub.conf
  echo -e "\tinitrd /boot/initramfs-$kv.img" >> /boot/grub/grub.conf
  echo
done
```
I tested a `x86_64` UEFI build with the `org.osbuild.grub2` stage changes using the `f30-base-uefi.json` file. It also successfully builds on my rPI, successfully boots but then gets stuck mounting the rootfs (or fsck). [Image info](https://github.com/osbuild/osbuild/files/3938492/aarch64.info.txt) looks fine though.

