### PR TITLE
assemblers/tar: fix compression

### DIFF
--- a/assemblers/org.osbuild.tar
+++ b/assemblers/org.osbuild.tar
@@ -40,16 +40,15 @@ def main(tree, output_dir, options):
     filename = options["filename"]
     compression = options.get("compression")
 
-    command = ["tar", "-cf", f"{output_dir}/{filename}", "-C", tree]
-
+    extra_args = []
     if compression is not None:
         if compression not in {"bzip2", "xz", "lzip", "lzma", "lzop", "gzip"}:
             return 1
-        command.append(f"--{compression}")
+        extra_args.append(f"--{compression}")
 
-    command.append(".")
+    subprocess.run(["tar", *extra_args, "-cf", f"{output_dir}/{filename}", "-C", tree, "."],
+                   stdout=subprocess.DEVNULL, check=True)
 
-    subprocess.run(command, stdout=subprocess.DEVNULL, check=True)
     return 0
 
 

--- a/test/pipelines/f30-base.json
+++ b/test/pipelines/f30-base.json
@@ -21,7 +21,8 @@
               "grub2-pc",
               "policycoreutils",
               "qemu-img",
-              "systemd"
+              "systemd",
+              "tar"
             ]
           }
         }

--- a/test/test_assemblers.py
+++ b/test/test_assemblers.py
@@ -102,6 +102,22 @@ class TestAssemblers(osbuildtest.TestCase):
                                      1024 * 1024)
                     self.assertFilesystem(device + "p1", options["root_fs_uuid"], "ext4", tree_id)
 
+    def test_tar(self):
+        cases = [
+            ("tree.tar.gz", None, ["application/x-tar"]),
+            ("tree.tar.gz", "gzip", ["application/x-gzip", "application/gzip"])
+        ]
+        for filename, compression, expected_mimetypes in cases:
+            options = {
+                    "filename": filename,
+                    "compression": compression
+            }
+            tree_id, output_id = self.run_assembler("org.osbuild.tar", options)
+            image = f"{self.store}/refs/{output_id}/{filename}"
+            output = subprocess.check_output(["file", "--mime-type", image], encoding="utf-8")
+            _, mimetype = output.strip().split(": ") # "filename: mimetype"
+            self.assertIn(mimetype, expected_mimetypes)
+
 
 @contextlib.contextmanager
 def mount(device):


### PR DESCRIPTION
Commit 283281f broke compression by appending the argument last to the
tar command line. It needs to appear before the file.

Fix that and add a test.