### PR TITLE
Work around an systemd-nspawn not creating /lib64 links on s390x/ppc64le 

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -39,10 +39,11 @@ class BuildRoot:
                 raise
             self.mounts.append(target)
 
-        if platform.machine() == "s390x":
+        if platform.machine() == "s390x" or platform.machine() == "ppc64le":
             # work around a combination of systemd not creating the link from
             # /lib64 -> /usr/lib64 (see systemd issue #14311) and the dynamic
             # linker is being set to (/lib/ld64.so.1 -> /lib64/ld64.so.1)
+            # on s390x or /lib64/ld64.so.2 on ppc64le
             # Therefore we manually create the link before calling nspawn
             os.symlink("/usr/lib64", f"{self.root}/lib64")
 

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -1,6 +1,7 @@
 
 import contextlib
 import os
+import platform
 import socket
 import shutil
 import subprocess
@@ -37,6 +38,13 @@ class BuildRoot:
                 self.unmount()
                 raise
             self.mounts.append(target)
+
+        if platform.machine() == "s390x":
+            # work around a combination of systemd not creating the link from
+            # /lib64 -> /usr/lib64 (see systemd issue #14311) and the dynamic
+            # linker is being set to (/lib/ld64.so.1 -> /lib64/ld64.so.1)
+            # Therefore we manually create the link before calling nspawn
+            os.symlink("/usr/lib64", f"{self.root}/lib64")
 
     def mount_var(self):
         target = os.path.join(self.root, "var")


### PR DESCRIPTION
Together with the `/lib/ld64.so.1 -> /lib64/ld64.so.1` (or `/lib64/ld64.so.2`) being the default on s390x (ppc64le), `systemd-nspawn` not creatling the (`lib64` -> `/usr/lib64` [#14311](https://github.com/systemd/systemd/issues/14311)) leads to the container being broken (no executables can be executed). So for those to platforms we create the missing link ourselves.