### PR TITLE
pipeline: return logs in --json mode

### DIFF
--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -1,13 +1,11 @@
 
-from .pipeline import Assembler, AssemblerFailed, load, load_build, Pipeline, Stage, StageFailed
+from .pipeline import Assembler, load, load_build, Pipeline, Stage
 
 
 __all__ = [
     "Assembler",
-    "AssemblerFailed",
     "load",
     "load_build",
     "Pipeline",
     "Stage",
-    "StageFailed",
 ]

--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -38,29 +38,24 @@ def main():
         pipeline.prepend_build_env(build_pipeline, runner)
 
     try:
-        pipeline.run(args.store, interactive=not args.json, libdir=args.libdir)
+        r = pipeline.run(args.store, interactive=not args.json, libdir=args.libdir)
     except KeyboardInterrupt:
         print()
         print(f"{RESET}{BOLD}{RED}Aborted{RESET}")
         return 130
-    except (osbuild.StageFailed, osbuild.AssemblerFailed) as error:
-        print()
-        print(f"{RESET}{BOLD}{RED}{error.name} failed with code {error.returncode}{RESET}")
-        if args.json:
-            print(error.output)
-        return 1
 
     if args.json:
-        json.dump({
-            "tree_id": pipeline.tree_id,
-            "output_id": pipeline.output_id,
-        }, sys.stdout)
+        json.dump(r, sys.stdout)
         sys.stdout.write("\n")
     else:
-        print("tree id:", pipeline.tree_id)
-        print("output id:", pipeline.output_id)
+        if r["success"]:
+            print("tree id:", pipeline.tree_id)
+            print("output id:", pipeline.output_id)
+        else:
+            print()
+            print(f"{RESET}{BOLD}{RED}Failed{RESET}")
 
-    return 0
+    return 0 if r["success"] else 1
 
 
 if __name__ == "__main__":

--- a/test/osbuildtest.py
+++ b/test/osbuildtest.py
@@ -42,23 +42,19 @@ class TestCase(unittest.TestCase):
 
         stdin = subprocess.PIPE if input else None
 
-        p = subprocess.Popen(osbuild_cmd, encoding="utf-8", stdin=stdin, stdout=subprocess.PIPE)
-        if input:
-            p.stdin.write(input)
-            p.stdin.close()
+        p = subprocess.Popen(osbuild_cmd, encoding="utf-8", stdin=stdin, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         try:
-            r = p.wait()
-            if r != 0:
-                print(p.stdout.read())
-            self.assertEqual(r, 0)
+            output, _ = p.communicate(input)
+            if p.returncode != 0:
+                print(output)
+            self.assertEqual(p.returncode, 0)
         except KeyboardInterrupt:
             # explicitly wait again to let osbuild clean up
             p.wait()
             raise
 
-        result = json.load(p.stdout)
-        p.stdout.close()
-        return result["tree_id"], result["output_id"]
+        result = json.loads(output)
+        return result.get("tree_id"), result.get("output_id")
 
     def run_tree_diff(self, tree1, tree2):
         tree_diff_cmd = ["./tree-diff", tree1, tree2]


### PR DESCRIPTION
A pipeline run only returned logs in the `StageFailed` and
`AssemblerFailed` exceptions. Remove those and always return structured
data instead.

It only returns data for stages that actually ran (i.e., didn't come
from the cache). This is similar to the output in interactive mode.