### PR TITLE
api and remoteloop: don't close the passed-in socket

### DIFF
--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -51,9 +51,6 @@ class API:
             msg['stderr'] = 2
             remoteloop.dump_fds(self.sock, msg, fds, addr=addr)
 
-    def __del__(self):
-        self.sock.close()
-
     def _dispatch(self):
         msg, addr = self.sock.recvfrom(1024)
         args = json.loads(msg)

--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -62,9 +62,6 @@ class LoopServer:
         self.event_loop.add_reader(self.sock, self._dispatch)
         self.thread = threading.Thread(target=self._run_event_loop)
 
-    def __del__(self):
-        self.sock.close()
-
     def _create_device(self, fd, dir_fd, offset=None, sizelimit=None):
         while True:
             # Getting an unbound loopback device and attaching a backing


### PR DESCRIPTION
The socket that the osbuild and loop apis should talk on are passed into
their `__init__` function. The caller should be responsible for closing
those sockets.

This already happens in all current callers.

This fixes a non-fatal error on RHEL's python 3.6, because it was
calling `socket.close` on an already-closed socket:

    Traceback (most recent call last):
      File "/usr/lib64/python3.6/asyncio/base_events.py", line 529, in __del__
        self.close()
      File "/usr/lib64/python3.6/asyncio/unix_events.py", line 63, in close
        super().close()
      File "/usr/lib64/python3.6/asyncio/selector_events.py", line 99, in close
        self._close_self_pipe()
      File "/usr/lib64/python3.6/asyncio/selector_events.py", line 109, in _close_self_pipe
        self._remove_reader(self._ssock.fileno())
      File "/usr/lib64/python3.6/asyncio/selector_events.py", line 268, in _remove_reader
        key = self._selector.get_key(fd)
      File "/usr/lib64/python3.6/selectors.py", line 189, in get_key
        return mapping[fileobj]
      File "/usr/lib64/python3.6/selectors.py", line 70, in __getitem__
        fd = self._selector._fileobj_lookup(fileobj)
      File "/usr/lib64/python3.6/selectors.py", line 224, in _fileobj_lookup
        return _fileobj_to_fd(fileobj)
      File "/usr/lib64/python3.6/selectors.py", line 41, in _fileobj_to_fd
        raise ValueError("Invalid file descriptor: {}".format(fd))
    ValueError: Invalid file descriptor: -1