### PR TITLE
pipeline: proper object cleanup on errors

### DIFF
--- a/samples/error.json
+++ b/samples/error.json
@@ -1,0 +1,10 @@
+{
+  "stages": [
+    {
+      "name": "org.osbuild.error"
+    }
+  ],
+  "assembler": {
+    "name": "org.osbuild.noop"
+  }
+}

--- a/stages/org.osbuild.error
+++ b/stages/org.osbuild.error
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+
+import json
+import sys
+
+STAGE_DESC = "Return an error"
+STAGE_INFO = """
+Error stage. Return the given error. Useful for testing, debugging, and
+wasting time.
+"""
+STAGE_OPTS = """
+"properties": {
+  "returncode": {
+    "description": "What to return code to use"
+    "type": "number",
+    "default": 255
+  }
+}
+"""
+
+
+def main(_tree, options):
+    errno = options.get("returncode", 255)
+    print(f"Error stage will now return error: {errno}")
+    return errno
+
+
+if __name__ == '__main__':
+    args = json.load(sys.stdin)
+    r = main(args["tree"], args.get("options", {}))
+    sys.exit(r)


### PR DESCRIPTION
The recent changes (#184) removed the {Assembler,Stage}Failed exceptions, which includes them being thrown from Stage.run and Assembler.run. Instead result dictionaries are returned even on errors. But the object store, used as a context manager, relies on exceptions to detect the error case and thus needs them to cleanup the temporary objects. Without those exceptions the temporary objects end up in the store even when the sage or assembler failed. Restore the old behavior by throwing a generic BuildError exception from the Stage and Assembler, which will be caught directly in the pipeline and converted to a result dict.

Fixes #188 