### PR TITLE
multi-arch: add support for ppc64le (open-firmware)

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -248,6 +248,14 @@ class PartitionTable:
                 return p
         return None
 
+    def partition_containing_boot(self) -> Partition:
+        """Return the partition containing /boot"""
+        for p in self.partitions_with_filesystems():
+            if p.mountpoint == "/boot":
+                return p
+        # fallback to the root partition
+        return self.partition_containing_root()
+
     def write_to(self, target, sync=True):
         """Write the partition table to disk"""
         # generate the command for sfdisk to create the table
@@ -341,19 +349,21 @@ def install_grub2(image: str, pt: PartitionTable):
     # read the partition and its filesystem containing said modules
     # and the grub configuration [NB: efi systems work differently]
 
+    # find the partition containing /boot/grub2
+    boot_part = pt.partition_containing_boot()
+
     # modules: access the disk and read the partition table
     modules = ["biosdisk", "part_msdos"]
 
-    # modules: grubs needs to access the filesystems
-    root_part = pt.partition_containing_root()
-    root_fs_type = root_part.fs_type or "unknown"
+    # modules: grubs needs to access the filesystems of /boot/grub2
+    fs_type = boot_part.fs_type or "unknown"
 
-    if root_fs_type == "ext4":
+    if fs_type == "ext4":
         modules += ["ext2"]
-    elif root_fs_type == "xfs":
+    elif fs_type == "xfs":
         modules += ["xfs"]
     else:
-        raise ValueError(f"unknown root filesystem type: '{root_fs_type}'")
+        raise ValueError(f"unknown boot filesystem type: '{fs_type}'")
 
     # now created the core image
     subprocess.run(["grub2-mkimage",

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -257,6 +257,18 @@ class PartitionTable:
         # fallback to the root partition
         return self.partition_containing_root()
 
+    def find_prep_partition(self) -> Partition:
+        """Find the PReP partition'"""
+        if self.label == "dos":
+            prep_type = "41"
+        elif self.label == "gpt":
+            prep_type = "9E1A2D38-C612-4316-AA26-8B49521E5A8B"
+
+        for part in self.partitions:
+            if part.type.upper() == prep_type:
+                return part
+        return None
+
     def write_to(self, target, sync=True):
         """Write the partition table to disk"""
         # generate the command for sfdisk to create the table
@@ -353,8 +365,29 @@ def grub2_write_core_mbrgap(core_f: BinaryIO,
     shutil.copyfileobj(core_f, image_f)
 
 
+def grub2_write_core_prep_part(core_f: BinaryIO,
+                               image_f: BinaryIO,
+                               pt: PartitionTable):
+    """Write the core to the prep partition"""
+    # On ppc64le with Open Firmware a special partition called
+    # 'PrEP partition' is used the store the grub2 core; the
+    # firmware looks for this partition and directly loads and
+    # executes the core form it.
+    prep_part = pt.find_prep_partition()
+    if prep_part is None:
+        raise ValueError("PrEP partition missing")
+
+    core_size = os.fstat(core_f.fileno()).st_size
+    assert core_size < prep_part.size_in_bytes - 512
+    image_f.seek(prep_part.start_in_bytes)
+    shutil.copyfileobj(core_f, image_f)
+
+
 def install_grub2(image: str, pt: PartitionTable, options):
     """Install grub2 to image"""
+    platform = options.get("platform", "i386-pc")
+
+    boot_path = f"/usr/lib/grub/{platform}/boot.img"
     core_path = "/var/tmp/grub2-core.img"
 
     # Create the level-2 & 3 stages of the bootloader, aka the core
@@ -369,8 +402,15 @@ def install_grub2(image: str, pt: PartitionTable, options):
     # find the partition containing /boot/grub2
     boot_part = pt.partition_containing_boot()
 
-    # modules: access the disk and read the partition table
-    modules = ["biosdisk", "part_msdos"]
+    # modules: access the disk and read the partition table:
+    # on x86 'biosdisk' is used to access the disk, on ppc64le
+    # with "Open Firmware" the latter is directly loading core
+    if platform == "i386-pc":
+        modules = ["biosdisk"]
+    else:
+        modules = []
+
+    modules += ["part_msdos"]
 
     # modules: grubs needs to access the filesystems of /boot/grub2
     fs_type = boot_part.fs_type or "unknown"
@@ -391,27 +431,33 @@ def install_grub2(image: str, pt: PartitionTable, options):
     # now created the core image
     subprocess.run(["grub2-mkimage",
                     "--verbose",
-                    "--directory", "/usr/lib/grub/i386-pc",
-                    "--format", "i386-pc",
+                    "--directory", f"/usr/lib/grub/{platform}",
                     "--prefix", f"(,{partid})/boot/grub2",
+                    "--format", platform,
                     "--compression", "auto",
-                    "--output", grub2_core] +
+                    "--output", core_path] +
                    modules,
                    check=True)
 
     with open(image, "rb+") as image_f:
-        # Install the level-1 bootloader into the start of the MBR
-        # The purpose of this is simply to jump into the level-2 bootloader.
-        with open("/usr/lib/grub/i386-pc/boot.img", "rb") as boot_f:
-            # The boot.img file is 512 bytes, but we must only copy the first 440
-            # bytes, as these contain the bootstrapping code. The rest of the
-            # first sector contains the partition table, and must not be
-            # overwritten.
-            image_f.write(boot_f.read(440))
+        if platform == "i386-pc":
+            # On x86, install the level-1 bootloader into the start of the MBR
+            # The purpose of this is simply to jump into the stage-2 bootloader.
+            # On ppc64le & Open Firmware stage-2 is loaded by the firmware
+            with open(boot_path, "rb") as boot_f:
+                # The boot.img file is 512 bytes, but we must only copy the first 440
+                # bytes, as these contain the bootstrapping code. The rest of the
+                # first sector contains the partition table, and must not be
+                # overwritten.
+                image_f.write(boot_f.read(440))
 
         with open(core_path, "rb") as core_f:
-            # Embed the core in the gap between the MBR and the fist partition
-            grub2_write_core_mbrgap(core_f, image_f, pt)
+            if platform == "powerpc-ieee1275":
+                # write the core to the PrEP partition
+                grub2_write_core_prep_part(core_f, image_f, pt)
+            else:
+                # embed the core in the MBR gap
+                grub2_write_core_mbrgap(core_f, image_f, pt)
 
 
 def main(tree, output_dir, options, loop_client):

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -197,6 +197,7 @@ class Partition:
         self.bootable = bootable
         self.name = name
         self.filesystem = filesystem
+        self.index = None
 
     @property
     def start_in_bytes(self):
@@ -289,6 +290,7 @@ class PartitionTable:
 
         assert len(disk_parts) == len(self.partitions)
         for i, part in enumerate(self.partitions):
+            part.index = i
             part.start = disk_parts[i]["start"]
             part.size = disk_parts[i]["size"]
             part.type = disk_parts[i].get("type")
@@ -365,12 +367,18 @@ def install_grub2(image: str, pt: PartitionTable):
     else:
         raise ValueError(f"unknown boot filesystem type: '{fs_type}'")
 
+    # identify the partition containing boot for grub2
+    if pt.label == "dos":
+        partid = "msdos" + str(boot_part.index + 1)
+    else:
+        raise ValueError(f"unsupported partition type: '{pt.label}'")
+
     # now created the core image
     subprocess.run(["grub2-mkimage",
                     "--verbose",
                     "--directory", "/usr/lib/grub/i386-pc",
-                    "--prefix", "(,msdos1)/boot/grub2",
                     "--format", "i386-pc",
+                    "--prefix", f"(,{partid})/boot/grub2",
                     "--compression", "auto",
                     "--output", grub2_core] +
                    modules,

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -338,7 +338,7 @@ def partition_table_from_options(options) -> PartitionTable:
     return PartitionTable(pttype, ptuuid, parts)
 
 
-def install_grub2(image: str, pt: PartitionTable):
+def install_grub2(image: str, pt: PartitionTable, options):
     """Install grub2 to image"""
     grub2_core = "/var/tmp/grub2-core.img"
 
@@ -410,6 +410,7 @@ def main(tree, output_dir, options, loop_client):
     fmt = options["format"]
     filename = options["filename"]
     size = options["size"]
+    bootloader = options.get("bootloader", {"type": "grub2"})
 
     # sfdisk works on sectors of 512 bytes and ignores excess space - be explicit about this
     if size % 512 != 0:
@@ -427,9 +428,9 @@ def main(tree, output_dir, options, loop_client):
     pt = partition_table_from_options(options)
     pt.write_to(image)
 
-    # Create the level-2 bootloader
-    if pt.label == "dos":
-        install_grub2(image, pt)
+    # Install the bootloader
+    if bootloader["type"] == "grub2":
+        install_grub2(image, pt, bootloader)
 
     # Now assemble the filesystem hierarchy and copy the tree into the image
     with contextlib.ExitStack() as cm:

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -332,32 +332,39 @@ def install_grub2(image: str, pt: PartitionTable):
     """Install grub2 to image"""
     grub2_core = "/var/tmp/grub2-core.img"
 
+    # Create the level-2 & 3 stages of the bootloader, aka the core
+    # it consists of the kernel plus the core modules required to
+    # to locate and load the rest of the grub modules, specifically
+    # the "normal.mod" (Stage 4) module.
+    # The exact list of modules required to be built into the core
+    # depends on the system: it is the minimal set needed to find
+    # read the partition and its filesystem containing said modules
+    # and the grub configuration [NB: efi systems work differently]
+
+    # modules: access the disk and read the partition table
+    modules = ["biosdisk", "part_msdos"]
+
+    # modules: grubs needs to access the filesystems
     root_part = pt.partition_containing_root()
     root_fs_type = root_part.fs_type or "unknown"
 
     if root_fs_type == "ext4":
-        fs_module = "ext2"
+        modules += ["ext2"]
     elif root_fs_type == "xfs":
-        fs_module = "xfs"
+        modules += ["xfs"]
     else:
         raise ValueError(f"unknown root filesystem type: '{root_fs_type}'")
 
-    # Create the level-2 bootloader
-    # The purpose of this is to find the grub modules and configuration
-    # to be able to start the level-3 bootloader. It contains the modules
-    # necessary to do this, but nothing else.
+    # now created the core image
     subprocess.run(["grub2-mkimage",
                     "--verbose",
                     "--directory", "/usr/lib/grub/i386-pc",
                     "--prefix", "(,msdos1)/boot/grub2",
                     "--format", "i386-pc",
                     "--compression", "auto",
-                    "--output", grub2_core,
-                    "part_msdos", fs_module, "biosdisk"],
+                    "--output", grub2_core] +
+                   modules,
                    check=True)
-
-    partition_offset = pt[0].start_in_bytes
-    assert os.path.getsize(grub2_core) < partition_offset - 512
 
     with open(image, "rb+") as image_f:
         # Install the level-1 bootloader into the start of the MBR
@@ -369,8 +376,13 @@ def install_grub2(image: str, pt: PartitionTable):
             # overwritten.
             image_f.write(boot_f.read(440))
 
-        # Install the level-2 bootloader into the space after the MBR, before
-        # the first partition.
+        # Embed Stage-2 in the MBR gap
+        # For historic and performance reasons the first partition
+        # is aligned to a specific sector number (used to be 64,
+        # now it is 2048), which leaves a gap between it and the MBR,
+        # where the core image can be embedded in; also check it fits
+        partition_offset = pt[0].start_in_bytes
+        assert os.path.getsize(grub2_core) < partition_offset - 512
         with open(grub2_core, "rb") as core_f:
             image_f.seek(512)
             shutil.copyfileobj(core_f, image_f)

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import List
+from typing import List, BinaryIO
 import osbuild.remoteloop as remoteloop
 
 STAGE_DESC = "Assemble a bootable partitioned disk image with qemu-img"
@@ -338,9 +338,24 @@ def partition_table_from_options(options) -> PartitionTable:
     return PartitionTable(pttype, ptuuid, parts)
 
 
+def grub2_write_core_mbrgap(core_f: BinaryIO,
+                            image_f: BinaryIO,
+                            pt: PartitionTable):
+    """Write the core into the MBR gap"""
+    # For historic and performance reasons the first partition
+    # is aligned to a specific sector number (used to be 64,
+    # now it is 2048), which leaves a gap between it and the MBR,
+    # where the core image can be embedded in; also check it fits
+    core_size = os.fstat(core_f.fileno()).st_size
+    partition_offset = pt[0].start_in_bytes
+    assert core_size < partition_offset - 512
+    image_f.seek(512)
+    shutil.copyfileobj(core_f, image_f)
+
+
 def install_grub2(image: str, pt: PartitionTable, options):
     """Install grub2 to image"""
-    grub2_core = "/var/tmp/grub2-core.img"
+    core_path = "/var/tmp/grub2-core.img"
 
     # Create the level-2 & 3 stages of the bootloader, aka the core
     # it consists of the kernel plus the core modules required to
@@ -394,16 +409,9 @@ def install_grub2(image: str, pt: PartitionTable, options):
             # overwritten.
             image_f.write(boot_f.read(440))
 
-        # Embed Stage-2 in the MBR gap
-        # For historic and performance reasons the first partition
-        # is aligned to a specific sector number (used to be 64,
-        # now it is 2048), which leaves a gap between it and the MBR,
-        # where the core image can be embedded in; also check it fits
-        partition_offset = pt[0].start_in_bytes
-        assert os.path.getsize(grub2_core) < partition_offset - 512
-        with open(grub2_core, "rb") as core_f:
-            image_f.seek(512)
-            shutil.copyfileobj(core_f, image_f)
+        with open(core_path, "rb") as core_f:
+            # Embed the core in the gap between the MBR and the fist partition
+            grub2_write_core_mbrgap(core_f, image_f, pt)
 
 
 def main(tree, output_dir, options, loop_client):

--- a/samples/f30-ppc64le.json
+++ b/samples/f30-ppc64le.json
@@ -1,0 +1,93 @@
+{
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "ppc64le",
+        "install_weak_deps": true,
+        "repos": [
+          {
+            "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch",
+            "checksum": "sha256:48cb7d1bfee69cccf0e644bbe0f37c50032cb1c35a7af384b9acac90d1c217d7",
+            "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm\nbbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75\nL+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy\nKJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R\nn7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO\n4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53\n2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc\nYKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq\nSDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ\ng0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3\nDlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB\ntDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac\ng9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8\nf79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va\nN9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D\nK07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ\nOx5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o\n8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml\nSMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7\n+zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7\nCxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O\npMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==\n=BfZ/\n-----END PGP PUBLIC KEY BLOCK-----\n"
+          }
+        ],
+        "packages": [
+          "@Core",
+          "chrony",
+          "coreutils",
+          "dracut-config-generic",
+          "grub2",
+          "kernel",
+          "langpacks-en",
+          "powerpc-utils",
+          "qemu-guest-agent",
+          "selinux-policy-targeted",
+          "spice-vdagent"
+        ],
+        "exclude_packages": [
+          "dracut-config-rescue"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.locale",
+      "options": {
+        "language": "en_US"
+      }
+    },
+    {
+      "name": "org.osbuild.fstab",
+      "options": {
+        "filesystems": [
+          {
+            "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "vfs_type": "ext4",
+            "path": "/",
+            "freq": "1",
+            "passno": "1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.grub2",
+      "options": {
+        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "kernel_opts": "ro console=ttyS0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
+        "legacy": "powerpc-ieee1275"
+      }
+    },
+    {
+      "name": "org.osbuild.selinux",
+      "options": {
+        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+      }
+    },
+    {
+      "name": "org.osbuild.fix-bls"
+    }
+  ],
+  "assembler":
+    {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "bootloader": {
+          "type": "grub2",
+          "platform": "powerpc-ieee1275"
+        },
+        "format": "qcow2",
+        "filename": "base.qcow2",
+        "size": 3221225472,
+        "ptuuid": "29579f67-d390-43e7-bd96-dc8f5461171e",
+        "pttype": "dos",
+        "partitions": [
+          {"size": 8192, "type": "41", "bootable": true},
+          {"start": 10240,
+            "filesystem": {"type": "ext4", "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                          "mountpoint": "/"}}
+        ]
+      }
+    }
+}

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -22,12 +22,14 @@ This stage will overwrite `/etc/default/grub`, `/boot/grub2/grubenv`, and
 If Legacy boot support is requested (the default, or explicitly via `legacy`)
 this stage will also overwrite `/boot/grub2/grub.cfg` and will copy the
 GRUB2 files from the buildhost into the target tree:
-* `/usr/share/grub/unicode.pf2`       -> `/boot/grub2/fonts/`
-* `/usr/lib/grub/i386-pc/*.{mod,lst}` -> `/boot/grub2/i386-pc/`
+* `/usr/share/grub/unicode.pf2`          -> `/boot/grub2/fonts/`
+* `/usr/lib/grub/$platform/*.{mod,lst}` -> `/boot/grub2/$platform/`
   * NOTE: skips `fdt.lst`, which is an empty file
+The $platform variable (default: i386-pc) refers to target platform
+that grub2 is mean to ran on (see grub-install(1)'s `--target`)
 
 NB: with legacy support enabled, this stage will fail if the buildhost
-doesn't have `/usr/lib/grub/i386-pc/` and `/usr/share/grub/unicode.pf2`.
+doesn't have `/usr/lib/grub/$platform/` and `/usr/share/grub/unicode.pf2`.
 
 If UEFI support is enabled via `uefi: {"vendor": "<vendor>"}` this stage will
 also write the `grub.cfg` to `boot/efi/EFI/<vendor>/grub.cfg`.
@@ -67,23 +69,26 @@ STAGE_OPTS = """
            "description": "The vendor of the UEFI binaries (this is us)",
            "examples": ["fedora"],
            "pattern": "^(.+)$"
-         }
+        }
       }
+    }
   }
 }
 """
 
 
-def copy_modules(tree):
+def copy_modules(tree, platform):
     """Copy all modules from the build image to /boot"""
-    os.makedirs(f"{tree}/boot/grub2/i386-pc", exist_ok=True)
-    for dirent in os.scandir("/usr/lib/grub/i386-pc"):
+    target = f"{tree}/boot/grub2/{platform}"
+    source = f"/usr/lib/grub/{platform}"
+    os.makedirs(target, exist_ok=True)
+    for dirent in os.scandir(source):
         (_, ext) = os.path.splitext(dirent.name)
         if ext not in ('.mod', '.lst'):
             continue
         if dirent.name == "fdt.lst":
             continue
-        shutil.copy2(f"/usr/lib/grub/i386-pc/{dirent.name}", f"{tree}/boot/grub2/i386-pc/")
+        shutil.copy2(f"/{source}/{dirent.name}", target)
 
 
 def copy_font(tree):
@@ -111,6 +116,10 @@ def main(tree, options):
     legacy = options.get("legacy", True)
     uefi = options.get("uefi", None)
 
+    # legacy boolean means the
+    if isinstance(legacy, bool):
+        legacy = "i386-pc"
+
     # Create the configuration file that determines how grub.cfg is generated.
     os.makedirs(f"{tree}/etc/default", exist_ok=True)
     with open(f"{tree}/etc/default/grub", "w") as default:
@@ -126,7 +135,7 @@ def main(tree, options):
 
     if legacy:
         write_grub_cfg(tree, "boot/grub2/grub.cfg")
-        copy_modules(tree)
+        copy_modules(tree, legacy)
         copy_font(tree)
 
     if uefi is not None:

--- a/test/test_assemblers.py
+++ b/test/test_assemblers.py
@@ -98,7 +98,7 @@ class TestAssemblers(osbuildtest.TestCase):
                     self.assertPartitionTable(device, "dos", options["ptuuid"], 1, boot_partition=1)
                     self.assertGRUB2(device,
                                      "26e3327c6b5ac9b5e21d8b86f19ff7cb4d12fb2d0406713f936997d9d89de3ee",
-                                     "1ebb35399388ba4007cee817a066570db948c450da911a3db67dba8083be247d",
+                                     "18031c9465e3f9ccb9aeb9c8e59dec6b82e91376e2628c8100b5461af62ad67c",
                                      1024 * 1024)
                     self.assertFilesystem(device + "p1", options["root_fs_uuid"], "ext4", tree_id)
 


### PR DESCRIPTION
This includes the necessary changes to the `grub2` stage as well as the `qemu` assembler.
The `grub2` stage has the `legacy` option (keeping compatibility) changed from a boolean to a string, specifying the target platform the legacy modules are being installed for. In the `qemu` the main difference to x86 legacy, i.e. non-efi, is that no stage 1 is required because the core image is stored on a special 'PReP' partition, which must be marked as bootable. The firmware then looks for that partition and directly loads the core from there and executes it. Introduce a `platform` parameter for the grub installer code which controls various platform depended aspects, including a) the path for the modules, b) what modules are compiled into the core, c) if the boot image is written to the MBR and 4) where to write the core image, i.e. mbr-gap or PReP partition.
It does compose the resulting image successfully boots. 
