### PR TITLE
osbuild: create API sockets in the thread they're used in

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -1,8 +1,6 @@
 
-import contextlib
 import os
 import platform
-import socket
 import shutil
 import subprocess
 import tempfile
@@ -94,17 +92,6 @@ class BuildRoot:
             *[f"--bind-ro={b}" for b in [f"{self.api}:/run/osbuild/api"] + (readonly_binds or [])],
             f"/run/osbuild/lib/runners/{self.runner}"
             ] + argv, check=check, **kwargs)
-
-    @contextlib.contextmanager
-    def bound_socket(self, name):
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-        sock_path = os.path.join(self.api, name)
-        sock.bind(os.path.join(self.api, name))
-        try:
-            yield sock
-        finally:
-            os.unlink(sock_path)
-            sock.close()
 
     def __del__(self):
         self.unmount()

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -80,10 +80,8 @@ class Stage:
 
             sources_dir = f"{libdir}/sources" if libdir else "/usr/lib/osbuild/sources"
 
-            with build_root.bound_socket("osbuild") as osbuild_sock, \
-                build_root.bound_socket("sources") as sources_sock, \
-                API(osbuild_sock, args, interactive) as api, \
-                sources.SourcesServer(sources_sock, sources_dir, source_options or {}):
+            with API(f"{build_root.api}/osbuild", args, interactive) as api, \
+                sources.SourcesServer(f"{build_root.api}/sources", sources_dir, source_options or {}):
                 r = build_root.run(
                     [f"/run/osbuild/lib/stages/{self.name}"],
                     binds=[f"{tree}:/run/osbuild/tree"],
@@ -141,10 +139,8 @@ class Assembler:
                 # buildroot we should remove this because it includes code from the host in the buildroot thus
                 # violating our effort of reproducibility.
                 ro_binds.append(f"{osbuild_module_path}:/run/osbuild/lib/assemblers/osbuild")
-            with build_root.bound_socket("remoteloop") as loop_sock, \
-                build_root.bound_socket("osbuild") as osbuild_sock, \
-                remoteloop.LoopServer(loop_sock), \
-                API(osbuild_sock, args, interactive) as api:
+            with remoteloop.LoopServer(f"{build_root.api}/remoteloop"), \
+                API(f"{build_root.api}/osbuild", args, interactive) as api:
                 r = build_root.run(
                     [f"/run/osbuild/lib/assemblers/{self.name}"],
                     binds=binds,


### PR DESCRIPTION
This might (hopefully) fix a race in destructing the asyncio.EventLoop
that's used in all API classes, which leads to warnings about unhandled
exceptions on CI.

This also puts their creation closer to where the client-side sockets
are created.