### PR TITLE
Support grub2 booting with GPT layout via BIOS boot partition

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -5,6 +5,7 @@ import json
 import os
 import socket
 import shutil
+import struct
 import subprocess
 import sys
 import tempfile
@@ -269,6 +270,14 @@ class PartitionTable:
                 return part
         return None
 
+    def find_bios_boot_partition(self) -> Partition:
+        """Find the BIOS-boot Partition"""
+        bb_type = "21686148-6449-6E6F-744E-656564454649"
+        for part in self.partitions:
+            if part.type.upper() == bb_type:
+                return part
+        return None
+
     def write_to(self, target, sync=True):
         """Write the partition table to disk"""
         # generate the command for sfdisk to create the table
@@ -394,6 +403,51 @@ def grub2_write_core_prep_part(core_f: BinaryIO,
     shutil.copyfileobj(core_f, image_f)
 
 
+def grub2_write_core_bios_boot(core_f: BinaryIO,
+                               image_f: BinaryIO,
+                               pt: PartitionTable):
+    """Write the core to the bios boot partition"""
+    bb = pt.find_bios_boot_partition()
+    if bb is None:
+        raise ValueError("BIOS-boot partition missing")
+    core_size = os.fstat(core_f.fileno()).st_size
+    if bb.size_in_bytes < core_size:
+        raise ValueError("BIOS-boot partition too small")
+
+    image_f.seek(bb.start_in_bytes)
+    shutil.copyfileobj(core_f, image_f)
+
+    # The core image needs to know from where to load its
+    # second sector so that information needs to be embedded
+    # into the image itself at the right location, i.e.
+    # the "sector start parameter" ("size .long 2, 0"):
+    # 0x200 - GRUB_BOOT_MACHINE_LIST_SIZE (12) = 0x1F4 = 500
+    image_f.seek(bb.start_in_bytes + 500)
+    image_f.write(struct.pack("<Q", bb.start + 1))
+
+    # Additionally, write the location (in sectors) of
+    # the grub core image, into the boot image, so the
+    # latter can find the former. To exact location is
+    # taken from grub2's "boot.S"":
+    #  GRUB_BOOT_MACHINE_KERNEL_SECTOR 0x5c (= 92)
+    image_f.seek(0x5c)
+    image_f.write(struct.pack("<Q", bb.start))
+
+
+def grub2_partition_id(pt: PartitionTable):
+    """grub2 partition identifier for the partition table"""
+
+    label2grub = {
+        "dos": "msdos",
+        "gpt": "gpt"
+    }
+
+    if pt.label not in label2grub:
+        raise ValueError(f"Unknown partition type: {pt.label}")
+
+    return label2grub[pt.label]
+
+
 def install_grub2(image: str, pt: PartitionTable, options):
     """Install grub2 to image"""
     platform = options.get("platform", "i386-pc")
@@ -421,7 +475,10 @@ def install_grub2(image: str, pt: PartitionTable, options):
     else:
         modules = []
 
-    modules += ["part_msdos"]
+    if pt.label == "dos":
+        modules += ["part_msdos"]
+    elif pt.label == "gpt":
+        modules += ["part_gpt"]
 
     # modules: grubs needs to access the filesystems of /boot/grub2
     fs_type = boot_part.fs_type or "unknown"
@@ -434,10 +491,8 @@ def install_grub2(image: str, pt: PartitionTable, options):
         raise ValueError(f"unknown boot filesystem type: '{fs_type}'")
 
     # identify the partition containing boot for grub2
-    if pt.label == "dos":
-        partid = "msdos" + str(boot_part.index + 1)
-    else:
-        raise ValueError(f"unsupported partition type: '{pt.label}'")
+    partid = grub2_partition_id(pt) + str(boot_part.index + 1)
+    print(f"grub2 prefix {partid}")
 
     # now created the core image
     subprocess.run(["grub2-mkimage",
@@ -462,6 +517,9 @@ def install_grub2(image: str, pt: PartitionTable, options):
             if platform == "powerpc-ieee1275":
                 # write the core to the PrEP partition
                 grub2_write_core_prep_part(core_f, image_f, pt)
+            elif pt.label == "gpt":
+                # gpt requires a bios-boot partition
+                grub2_write_core_bios_boot(core_f, image_f, pt)
             else:
                 # embed the core in the MBR gap
                 grub2_write_core_mbrgap(core_f, image_f, pt)

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -350,6 +350,17 @@ def partition_table_from_options(options) -> PartitionTable:
     return PartitionTable(pttype, ptuuid, parts)
 
 
+def grub2_write_boot_image(boot_f: BinaryIO,
+                           image_f: BinaryIO):
+    """Write the boot image (grub2 stage 1) to the MBR"""
+
+    # The boot.img file is 512 bytes, but we must only copy the first 440
+    # bytes, as these contain the bootstrapping code. The rest of the
+    # first sector contains the partition table, and must not be
+    # overwritten.
+    image_f.write(boot_f.read(440))
+
+
 def grub2_write_core_mbrgap(core_f: BinaryIO,
                             image_f: BinaryIO,
                             pt: PartitionTable):
@@ -445,11 +456,7 @@ def install_grub2(image: str, pt: PartitionTable, options):
             # The purpose of this is simply to jump into the stage-2 bootloader.
             # On ppc64le & Open Firmware stage-2 is loaded by the firmware
             with open(boot_path, "rb") as boot_f:
-                # The boot.img file is 512 bytes, but we must only copy the first 440
-                # bytes, as these contain the bootstrapping code. The rest of the
-                # first sector contains the partition table, and must not be
-                # overwritten.
-                image_f.write(boot_f.read(440))
+                grub2_write_boot_image(boot_f, image_f)
 
         with open(core_path, "rb") as core_f:
             if platform == "powerpc-ieee1275":

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -360,14 +360,24 @@ def partition_table_from_options(options) -> PartitionTable:
 
 
 def grub2_write_boot_image(boot_f: BinaryIO,
-                           image_f: BinaryIO):
+                           image_f: BinaryIO,
+                           core_location: int):
     """Write the boot image (grub2 stage 1) to the MBR"""
 
     # The boot.img file is 512 bytes, but we must only copy the first 440
     # bytes, as these contain the bootstrapping code. The rest of the
     # first sector contains the partition table, and must not be
     # overwritten.
+    image_f.seek(0)
     image_f.write(boot_f.read(440))
+
+    # Additionally, write the location (in sectors) of
+    # the grub core image, into the boot image, so the
+    # latter can find the former. To exact location is
+    # taken from grub2's "boot.S":
+    #  GRUB_BOOT_MACHINE_KERNEL_SECTOR 0x5c (= 92)
+    image_f.seek(0x5c)
+    image_f.write(struct.pack("<Q", core_location))
 
 
 def grub2_write_core_mbrgap(core_f: BinaryIO,
@@ -383,6 +393,8 @@ def grub2_write_core_mbrgap(core_f: BinaryIO,
     assert core_size < partition_offset - 512
     image_f.seek(512)
     shutil.copyfileobj(core_f, image_f)
+
+    return 1  # the location of the core image in sectors
 
 
 def grub2_write_core_prep_part(core_f: BinaryIO,
@@ -401,6 +413,8 @@ def grub2_write_core_prep_part(core_f: BinaryIO,
     assert core_size < prep_part.size_in_bytes - 512
     image_f.seek(prep_part.start_in_bytes)
     shutil.copyfileobj(core_f, image_f)
+
+    return prep_part.start
 
 
 def grub2_write_core_bios_boot(core_f: BinaryIO,
@@ -425,13 +439,7 @@ def grub2_write_core_bios_boot(core_f: BinaryIO,
     image_f.seek(bb.start_in_bytes + 500)
     image_f.write(struct.pack("<Q", bb.start + 1))
 
-    # Additionally, write the location (in sectors) of
-    # the grub core image, into the boot image, so the
-    # latter can find the former. To exact location is
-    # taken from grub2's "boot.S"":
-    #  GRUB_BOOT_MACHINE_KERNEL_SECTOR 0x5c (= 92)
-    image_f.seek(0x5c)
-    image_f.write(struct.pack("<Q", bb.start))
+    return bb.start
 
 
 def grub2_partition_id(pt: PartitionTable):
@@ -506,23 +514,25 @@ def install_grub2(image: str, pt: PartitionTable, options):
                    check=True)
 
     with open(image, "rb+") as image_f:
-        if platform == "i386-pc":
-            # On x86, install the level-1 bootloader into the start of the MBR
-            # The purpose of this is simply to jump into the stage-2 bootloader.
-            # On ppc64le & Open Firmware stage-2 is loaded by the firmware
-            with open(boot_path, "rb") as boot_f:
-                grub2_write_boot_image(boot_f, image_f)
-
+        # Write the newly created grub2 core to the image
         with open(core_path, "rb") as core_f:
             if platform == "powerpc-ieee1275":
                 # write the core to the PrEP partition
-                grub2_write_core_prep_part(core_f, image_f, pt)
+                core_loc = grub2_write_core_prep_part(core_f, image_f, pt)
             elif pt.label == "gpt":
                 # gpt requires a bios-boot partition
-                grub2_write_core_bios_boot(core_f, image_f, pt)
+                core_loc = grub2_write_core_bios_boot(core_f, image_f, pt)
             else:
                 # embed the core in the MBR gap
-                grub2_write_core_mbrgap(core_f, image_f, pt)
+                core_loc = grub2_write_core_mbrgap(core_f, image_f, pt)
+
+        # On certain platforms (x86) a level 1 boot loader is required
+        # to load to the core image (on ppc64le & Open Firmware this is
+        # done by the firmware itself)
+        if platform == "i386-pc":
+            # On x86, the boot image just jumps to core image
+            with open(boot_path, "rb") as boot_f:
+                grub2_write_boot_image(boot_f, image_f, core_loc)
 
 
 def main(tree, output_dir, options, loop_client):

--- a/samples/f30-qcow2-gpt.json
+++ b/samples/f30-qcow2-gpt.json
@@ -1,0 +1,99 @@
+{
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "install_weak_deps": true,
+        "repos": [
+            "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+        ],
+        "packages": [
+          "@Fedora Cloud Server",
+          "chrony",
+          "kernel",
+          "selinux-policy-targeted",
+          "grub2-pc",
+          "spice-vdagent",
+          "qemu-guest-agent",
+          "xen-libs",
+          "langpacks-en"
+        ],
+        "exclude_packages": [
+          "dracut-config-rescue"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.systemd",
+      "options": {
+        "enabled_services": [
+          "cloud-config",
+          "cloud-final",
+          "cloud-init",
+          "cloud-init-local"]
+      }
+    },
+    {
+      "name": "org.osbuild.locale",
+      "options": {
+        "language": "en_US"
+      }
+    },
+    {
+      "name": "org.osbuild.fstab",
+      "options": {
+        "filesystems": [
+          {
+            "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+            "vfs_type": "ext4",
+            "path": "/",
+            "freq": "1",
+            "passno": "1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.grub2",
+      "options": {
+        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0"
+      }
+    },
+    {
+      "name": "org.osbuild.selinux",
+      "options": {
+        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+      }
+    },
+    {
+      "name": "org.osbuild.fix-bls"
+    }
+  ],
+  "assembler":
+    {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "format": "qcow2",
+        "filename": "base.qcow2",
+        "ptuuid": "29579f67-d390-43e7-bd96-dc8f5461171e",
+        "pttype": "gpt",
+        "partitions": [
+          {
+            "size": 8192, "type": "21686148-6449-6E6F-744E-656564454649", "bootable": true
+          },
+          {
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "filesystem": {
+              "type": "ext4",
+              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+              "mountpoint": "/"
+            }
+          }
+        ],
+        "size": 3221225472
+      }
+    }
+}


### PR DESCRIPTION
Normally, when using Master Boot Record (MBR) partition layout and the grub2 (in non-efi mode) bootloader, the grub2 `core` image is located in the gap between the MBR and the first partition, which exists for history and performance reasons. When the partition layout is GPT this gap does not exist in that predictable way. Instead a specialized (small) partition is used is used, called the [`BIOS boot` partition](https://en.wikipedia.org/wiki/BIOS_boot_partition). The initial grub stage, as well as the gurb `core` image need to be adjusted when this partition is used.

A sample demonstrating the usage is included (`samples/f30-qcow2-gpt.json`). 

It successfully boots but there is one slight delay and a rather big one in grub2 execution. The former at `kern/fs.c:56; Detecting ext2` and the latter at `lib/relocator.c: 1410: chunks = 0x7fd8c140`. I will have a look at this later. 
![grub2_delay_relocator](https://user-images.githubusercontent.com/2040/71557992-7b241780-2a4e-11ea-8680-7db13bf62c88.png)
