### PR TITLE
Introduce secrets

### DIFF
--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -21,6 +21,8 @@ def main():
                         help="the directory where intermediary os trees are stored")
     parser.add_argument("--sources", metavar="SOURCES", type=os.path.abspath,
                         help="json file containing a dictionary of source configuration")
+    parser.add_argument("--secrets", metavar="SECRETS", type=os.path.abspath,
+                        help="json file containing a dictionary of secrets that are passed to sources")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath,
                         help="the directory containing stages, assemblers, and the osbuild library")
     parser.add_argument("--json", action="store_true",
@@ -44,8 +46,19 @@ def main():
         with open(args.sources) as f:
             source_options = json.load(f)
 
+    secrets = {}
+    if args.secrets:
+        with open(args.secrets) as f:
+            secrets = json.load(f)
+
     try:
-        r = pipeline.run(args.store, interactive=not args.json, libdir=args.libdir, source_options=source_options)
+        r = pipeline.run(
+            args.store,
+            interactive=not args.json,
+            libdir=args.libdir,
+            source_options=source_options,
+            secrets=secrets
+        )
     except KeyboardInterrupt:
         print()
         print(f"{RESET}{BOLD}{RED}Aborted{RESET}")

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -26,7 +26,10 @@ class SourcesServer:
             encoding="utf-8",
             check=False)
 
-        return json.loads(r.stdout)
+        try:
+            return json.loads(r.stdout)
+        except ValueError:
+            return {"error": f"source returned malformed json: {r.stdout}"}
 
     def _dispatch(self, sock):
         msg, addr = sock.recvfrom(8182)

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -34,7 +34,7 @@ class SourcesServer:
             return {"error": f"source returned malformed json: {r.stdout}"}
 
     def _dispatch(self, sock):
-        msg, addr = sock.recvfrom(8182)
+        msg, addr = sock.recvfrom(65536)
         request = json.loads(msg)
         reply = self._run_source(request["source"], request["checksums"])
         msg = json.dumps(reply).encode("utf-8")
@@ -67,7 +67,7 @@ def get(source, checksums):
             "checksums": checksums
         }
         sock.sendall(json.dumps(msg).encode('utf-8'))
-        reply = json.loads(sock.recv(8192))
+        reply = json.loads(sock.recv(65536))
         if "error" in reply:
             raise RuntimeError(f"{source}: " + reply["error"])
         return reply

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -6,16 +6,18 @@ import threading
 
 
 class SourcesServer:
-    def __init__(self, socket_address, sources_dir, source_options):
+    def __init__(self, socket_address, sources_dir, source_options, secrets=None):
         self.socket_address = socket_address
         self.sources_dir = sources_dir
-        self.source_options = source_options
+        self.source_options = source_options or {}
+        self.secrets = secrets or {}
         self.event_loop = asyncio.new_event_loop()
         self.thread = threading.Thread(target=self._run_event_loop)
 
     def _run_source(self, source, checksums):
         msg = {
             "options": self.source_options.get(source, {}),
+            "secrets": self.secrets.get(source, {}),
             "checksums": checksums
         }
 

--- a/sources/org.osbuild.dnf
+++ b/sources/org.osbuild.dnf
@@ -4,19 +4,41 @@ import json
 import sys
 
 
-def main(options, sources):
+def main(options, sources, secrets):
     repos = options.get("repos", {})
+    repo_secrets = secrets.get("repos", {})
 
     reply = []
-    for s in sources:
+    for checksum in sources:
         try:
-            repo = {
-                "checksum": s,
-                **repos[s]
-            }
+            source_repo = repos[checksum]
+            source_repo_secrets = repo_secrets.get(checksum, {})
         except KeyError:
-            json.dump({"error": f"source unknown: {s}"}, sys.stdout)
+            json.dump({"error": f"source unknown: {checksum}"}, sys.stdout)
             return 1
+
+        repo = {"checksum": checksum}
+
+        if "baseurl" in source_repo:
+            repo["baseurl"] = source_repo["baseurl"]
+        elif "mirrorlist" in source_repo:
+            repo["mirrorlist"] = source_repo["mirrorlist"]
+        elif "metalink" in source_repo:
+            repo["metalink"] = source_repo["metalink"]
+        else:
+            json.dump({"error": f"repo {checksum} is missing baseurl, mirrorlist, or metalink key"}, sys.stdout)
+
+        if "sslcacert" in source_repo:
+            repo["sslcacert"] = source_repo["sslcacert"]
+
+        if "gpgkey" in source_repo:
+            repo["gpgkey"] = source_repo["gpgkey"]
+
+        if "sslclientcert" in source_repo_secrets:
+            repo["sslclientcert"] = source_repo_secrets["sslclientcert"]
+
+        if "sslclientkey" in source_repo_secrets:
+            repo["sslclientkey"] = source_repo_secrets["sslclientkey"]
 
         reply.append(repo)
 
@@ -26,5 +48,5 @@ def main(options, sources):
 
 if __name__ == '__main__':
     args = json.load(sys.stdin)
-    r = main(args["options"], args["checksums"])
+    r = main(args["options"], args["checksums"], args.get("secrets", {}))
     sys.exit(r)

--- a/stages/org.osbuild.dnf
+++ b/stages/org.osbuild.dnf
@@ -165,6 +165,13 @@ def write_repofile(f, repoid, repo, keydir):
         if value:
             write_option(key, value)
 
+    for cert in ("sslcacert", "sslclientcert", "sslclientkey"):
+        if cert in repo:
+            path = f"{keydir}/{cert}.pem"
+            with open(path, "w") as certfile:
+                certfile.write(repo[cert])
+            write_option(cert, path)
+
     if "gpgkey" in repo:
         keyfile = f"{keydir}/{repoid}.asc"
         with open(keyfile, "w") as key:

--- a/stages/org.osbuild.dnf
+++ b/stages/org.osbuild.dnf
@@ -213,8 +213,6 @@ def main(tree, options):
     exclude_packages = options.get("exclude_packages", [])
     module_platform_id = options.get("module_platform_id", None)
 
-    print("Repositories: {}\n".format(json.dumps(repos, indent=2)))
-
     script = f"""
         set -e
         mkdir -p {tree}/dev {tree}/sys {tree}/proc

--- a/stages/org.osbuild.dnf
+++ b/stages/org.osbuild.dnf
@@ -253,6 +253,7 @@ def main(tree, options):
             "--forcearch", basearch,
             "--setopt", "reposdir=",
             "--setopt", f"install_weak_deps={weak_deps}",
+            "--setopt", f"skip_if_unavailable=false",
             "--releasever", releasever,
             "--noplugins",
             "--config", dnfconf


### PR DESCRIPTION
Secrets are an extension of sources: a JSON object for each source that contains sensitive data which can be stored and passed separately and should not appear in logs.

Also includes a patch that makes use of secrets by adding support for the `sslcacert`, `sslclientcert`, and `sslclientkey` dnf options.

See individual commits for details.