### PR TITLE
Revert changed defaults for the qemu assembler and grub2 stage

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -539,7 +539,7 @@ def main(tree, output_dir, options, loop_client):
     fmt = options["format"]
     filename = options["filename"]
     size = options["size"]
-    bootloader = options.get("bootloader", {"type": "grub2"})
+    bootloader = options.get("bootloader", {"type": "none"})
 
     # sfdisk works on sectors of 512 bytes and ignores excess space - be explicit about this
     if size % 512 != 0:
@@ -556,6 +556,11 @@ def main(tree, output_dir, options, loop_client):
     # The partition table
     pt = partition_table_from_options(options)
     pt.write_to(image)
+
+    # For backwards comparability assume that if bootloader is not
+    # set and partition scheme is dos (MBR) grub2 is being used
+    if bootloader["type"] == "none" and pt.label == "dos":
+        bootloader["type"] = "grub2"
 
     # Install the bootloader
     if bootloader["type"] == "grub2":

--- a/samples/f30-qcow2-gpt.json
+++ b/samples/f30-qcow2-gpt.json
@@ -76,6 +76,7 @@
     {
       "name": "org.osbuild.qemu",
       "options": {
+        "bootloader": {"type": "grub2"},
         "format": "qcow2",
         "filename": "base.qcow2",
         "ptuuid": "29579f67-d390-43e7-bd96-dc8f5461171e",

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -117,7 +117,7 @@ def main(tree, options):
     uefi = options.get("uefi", None)
 
     # legacy boolean means the
-    if isinstance(legacy, bool):
+    if isinstance(legacy, bool) and legacy:
         legacy = "i386-pc"
 
     # Create the configuration file that determines how grub.cfg is generated.


### PR DESCRIPTION
With the introduction of the `bootloader` (`qemu` assembler) option as well as the change of the `i386-legacy` option (`grub2` stage) the defaults changed, which broke at least the `f30-base-uefi.json` sample. Restore the old defaults.