### PR TITLE
Hybrid boot support: one image can be booted via UEFI and legacy

### DIFF
--- a/samples/f30-qcow2-hybrid.json
+++ b/samples/f30-qcow2-hybrid.json
@@ -1,0 +1,130 @@
+{
+  "runner": "org.osbuild.fedora30",
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "install_weak_deps": true,
+        "repos": [
+          "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+        ],
+        "packages": [
+          "@Fedora Cloud Server",
+          "chrony",
+          "kernel",
+          "selinux-policy-targeted",
+          "grub2-pc",
+          "spice-vdagent",
+          "qemu-guest-agent",
+          "xen-libs",
+          "langpacks-en",
+          "grub2-efi-ia32",
+          "shim-ia32",
+          "grub2-efi-x64",
+          "shim-x64",
+          "efibootmgr",
+          "grub2-tools"
+        ],
+        "exclude_packages": [
+          "dracut-config-rescue"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.systemd",
+      "options": {
+        "enabled_services": [
+          "cloud-config",
+          "cloud-final",
+          "cloud-init",
+          "cloud-init-local"]
+      }
+    },
+    {
+      "name": "org.osbuild.locale",
+      "options": {
+        "language": "en_US"
+      }
+    },
+    {
+      "name": "org.osbuild.fstab",
+      "options": {
+        "filesystems": [
+          {
+            "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+            "vfs_type": "ext4",
+            "path": "/",
+            "freq": "1",
+            "passno": "1"
+          },
+          {
+            "uuid": "46BB-8120",
+            "vfs_type": "vfat",
+            "path": "/boot/efi",
+            "options": "umask=0077,shortname=winnt",
+            "freq": "0",
+            "passno": "2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.grub2",
+      "options": {
+        "root_fs_uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0 console=ttyS0 console=tty1",
+        "uefi": {
+          "vendor": "fedora"
+        },
+        "legacy": "i386-pc"
+      }
+    },
+    {
+      "name": "org.osbuild.fix-bls"
+    },
+    {
+      "name": "org.osbuild.selinux",
+      "options": {
+        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+      }
+    }
+  ],
+  "assembler": {
+    "name": "org.osbuild.qemu",
+    "options": {
+      "bootloader": {"type": "grub2"},
+      "format": "qcow2",
+      "filename": "base.qcow2",
+      "size": 3221225472,
+      "ptuuid": "29579f67-d390-43e7-bd96-dc8f5461171e",
+      "pttype": "gpt",
+      "partitions": [
+        {
+          "size": 8192,
+          "type": "21686148-6449-6E6F-744E-656564454649",
+          "bootable": true
+        },
+        {
+          "size": 972800,
+          "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+          "filesystem": {
+            "type": "vfat",
+            "uuid": "46BB-8120",
+            "label": "EFI System Partition",
+            "mountpoint": "/boot/efi"
+          }
+        },
+        {
+          "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+          "filesystem": {
+            "type": "ext4",
+            "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+            "mountpoint": "/"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -110,6 +110,15 @@ def write_grub_cfg(tree, path):
                   "blscfg\n")
 
 
+def write_grub_cfg_redirect(tree, path):
+    """Write a grub config pointing to the other cfg"""
+    print("hybrid boot support enabled. Writing alias grub config")
+    with open(os.path.join(tree, path), "w") as cfg:
+        cfg.write("search --no-floppy --set prefix --file /boot/grub2/grub.cfg\n"
+                  "set prefix=($prefix)/boot/grub2\n"
+                  "configfile $prefix/grub.cfg\n")
+
+
 def main(tree, options):
     root_fs_uuid = options["root_fs_uuid"]
     kernel_opts = options.get("kernel_opts", "")
@@ -120,33 +129,59 @@ def main(tree, options):
     if isinstance(legacy, bool) and legacy:
         legacy = "i386-pc"
 
+    # Check if hybrid boot support is requested, i.e. the resulting image
+    # should support booting via legacy and also UEFI. In that case the
+    # canonical grub.cfg and the grubenv will be in /boot/grub2. The ESP
+    # will only contain a small config file redirecting to the one in
+    # /boot/grub2 and will not have a grubenv itself.
+    hybrid = uefi and legacy
+
     # Create the configuration file that determines how grub.cfg is generated.
     os.makedirs(f"{tree}/etc/default", exist_ok=True)
     with open(f"{tree}/etc/default/grub", "w") as default:
         default.write("GRUB_TIMEOUT=0\n"
                       "GRUB_ENABLE_BLSCFG=true\n")
 
+
     os.makedirs(f"{tree}/boot/grub2", exist_ok=True)
-    with open(f"{tree}/boot/grub2/grubenv", "w") as env:
+    grubenv = f"{tree}/boot/grub2/grubenv"
+
+    if hybrid:
+        # The rpm grub2-efi package will have installed a symlink from
+        # /boot/grub2/grubenv to the ESP. In the case of hybrid boot we
+        # want a single grubenv in /boot/grub2; therefore remove the link
+        try:
+            os.unlink(grubenv)
+        except FileNotFoundError:
+            pass
+
+    with open(grubenv, "w") as env:
         env.write("# GRUB Environment Block\n"
                   f"GRUB2_ROOT_FS_UUID={root_fs_uuid}\n"
                   f"GRUB2_BOOT_FS_UUID={root_fs_uuid}\n"
                   f"kernelopts=root=UUID={root_fs_uuid} {kernel_opts}\n")
 
+    if uefi is not None:
+        # UEFI support:
+        # The following files are needed for UEFI support:
+        # /boot/efi/EFI/<vendor>/
+        # - grubenv: in the case of non-hybrid boot it should have
+        #     been written to via the link from /boot/grub2/grubenv
+        #     created by grub2-efi-{x64, ia32}.rpm
+        # - grub.cfg: needs to be generated, either the canonical one
+        #     or a shim one that redirects to the canonical one in
+        #     /boot/grub2 in case of hybrid boot (see above)
+        vendor = uefi["vendor"]
+        grubcfg = f"boot/efi/EFI/{vendor}/grub.cfg"
+        if hybrid:
+            write_grub_cfg_redirect(tree, grubcfg)
+        else:
+            write_grub_cfg(tree, grubcfg)
+
     if legacy:
         write_grub_cfg(tree, "boot/grub2/grub.cfg")
         copy_modules(tree, legacy)
         copy_font(tree)
-
-    if uefi is not None:
-        # UEFI support:
-        # The following files are needed for UEFI support:
-        # /boot/efi/EFI/<vendor>/{grubenv, grub.cfg}
-        # - grubenv should have been written to via the link from
-        #     /boot/grub2/grubenv created by grub2-efi-{x64, ia32}.rpm
-        # - grub.cfg needs to be generated
-        vendor = uefi["vendor"]
-        write_grub_cfg(tree, f"boot/efi/EFI/{vendor}/grub.cfg")
 
     return 0
 


### PR DESCRIPTION
Currently an image is either booted via UEFI (GPT partition layput and the grub2 efi binary in a dedicated EFI partition) or legacy boot (grub2 boot and core image on a mbr partition scheme). But, on single image can be made bootable via both methods with by having both a ESP partition (EFI) and the BIOS boot partition for legacy grub2 (see #198). The question was how to structure the configuration, i.e. how to make it so there is only one `grubenv` and main `grub.cfg` that are not duplicated. After talking to @vathpela and @martinezjavier the route chosen was to have the `grubenv` and canonical `grub.cfg` always in `/boot/grub2` and if (and only if) hybrid boot is requested install a small `grub.cfg` on the ESP that finds the canonical one and then loads that.
