### PR TITLE
Support for a separate boot partition

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -513,11 +513,14 @@ def install_grub2(image: str, pt: PartitionTable, options):
     partid = grub2_partition_id(pt) + str(boot_part.index + 1)
     print(f"grub2 prefix {partid}")
 
+    # the path containing the grub files relative partition
+    grub_path = os.path.relpath("/boot/grub2", boot_part.mountpoint)
+
     # now created the core image
     subprocess.run(["grub2-mkimage",
                     "--verbose",
                     "--directory", f"/usr/lib/grub/{platform}",
-                    "--prefix", f"(,{partid})/boot/grub2",
+                    "--prefix", f"(,{partid})/{grub_path}",
                     "--format", platform,
                     "--compression", "auto",
                     "--output", core_path] +

--- a/samples/f30-bootpart-hybrid.json
+++ b/samples/f30-bootpart-hybrid.json
@@ -1,0 +1,150 @@
+{
+  "runner": "org.osbuild.fedora30",
+  "stages": [
+    {
+      "name": "org.osbuild.dnf",
+      "options": {
+        "releasever": "30",
+        "basearch": "x86_64",
+        "install_weak_deps": true,
+        "repos": [
+          "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+        ],
+        "packages": [
+          "@Fedora Cloud Server",
+          "chrony",
+          "kernel",
+          "selinux-policy-targeted",
+          "grub2-pc",
+          "spice-vdagent",
+          "qemu-guest-agent",
+          "xen-libs",
+          "langpacks-en",
+          "grub2-efi-ia32",
+          "shim-ia32",
+          "grub2-efi-x64",
+          "shim-x64",
+          "efibootmgr",
+          "grub2-tools"
+        ],
+        "exclude_packages": [
+          "dracut-config-rescue"
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.systemd",
+      "options": {
+        "enabled_services": [
+          "cloud-config",
+          "cloud-final",
+          "cloud-init",
+          "cloud-init-local"]
+      }
+    },
+    {
+      "name": "org.osbuild.locale",
+      "options": {
+        "language": "en_US"
+      }
+    },
+    {
+      "name": "org.osbuild.fstab",
+      "options": {
+        "filesystems": [
+          {
+            "uuid": "08a41983-3328-4d1a-ae3c-1699e6d2a806",
+            "vfs_type": "ext4",
+            "path": "/boot",
+            "freq": "1",
+            "passno": "1"
+          },
+          {
+            "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+            "vfs_type": "ext4",
+            "path": "/",
+            "freq": "1",
+            "passno": "1"
+          },
+          {
+            "uuid": "46BB-8120",
+            "vfs_type": "vfat",
+            "path": "/boot/efi",
+            "options": "umask=0077,shortname=winnt",
+            "freq": "0",
+            "passno": "2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "org.osbuild.grub2",
+      "options": {
+        "root_fs_uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+        "boot_fs_uuid": "08a41983-3328-4d1a-ae3c-1699e6d2a806",
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0 console=ttyS0 console=tty1",
+        "uefi": {
+          "vendor": "fedora"
+        },
+        "legacy": "i386-pc"
+      }
+    },
+    {
+      "name": "org.osbuild.fix-bls",
+      "options": {
+        "prefix": "/"
+      }
+    },
+    {
+      "name": "org.osbuild.selinux",
+      "options": {
+        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+      }
+    }
+  ],
+  "assembler": {
+    "name": "org.osbuild.qemu",
+    "options": {
+      "bootloader": {"type": "grub2"},
+      "format": "qcow2",
+      "filename": "base.qcow2",
+      "size": 3221225472,
+      "ptuuid": "29579f67-d390-43e7-bd96-dc8f5461171e",
+      "pttype": "gpt",
+      "partitions": [
+        {
+          "size": 786432,
+          "filesystem": {
+            "type": "ext4",
+            "uuid": "08a41983-3328-4d1a-ae3c-1699e6d2a806",
+            "label": "boot",
+            "mountpoint": "/boot"
+          }
+        },
+        {
+          "size": 972800,
+          "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+          "filesystem": {
+            "type": "vfat",
+            "uuid": "46BB-8120",
+            "label": "EFI System Partition",
+            "mountpoint": "/boot/efi"
+          }
+        },
+        {
+          "size": 8192,
+          "type": "21686148-6449-6E6F-744E-656564454649",
+          "bootable": true
+        },
+        {
+          "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+          "filesystem": {
+            "type": "ext4",
+            "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
+            "mountpoint": "/"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/stages/org.osbuild.fix-bls
+++ b/stages/org.osbuild.fix-bls
@@ -18,13 +18,14 @@ This stage reads and (re)writes all .conf files in /boot/loader/entries.
 STAGE_OPTS = ""
 
 
-def main(tree, _options):
+def main(tree, options):
     """Fix broken paths in /boot/loader/entries.
 
     grub2-mkrelpath uses /proc/self/mountinfo to find the source of the file
     system it is installed to. This breaks in a container, because we
     bind-mount the tree from the host.
     """
+    prefix = options.get("prefix", "/boot")
 
     path_re = re.compile(r"(/.*)+/boot")
 
@@ -34,7 +35,7 @@ def main(tree, _options):
 
         with open(name, "w") as f:
             for line in entry:
-                f.write(path_re.sub("/boot", line))
+                f.write(path_re.sub(prefix, line))
 
     return 0
 

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -113,7 +113,7 @@ def write_grub_cfg(tree, path):
         cfg.write("set timeout=0\n"
                   "load_env\n"
                   "search --no-floppy --fs-uuid --set=root ${GRUB2_ROOT_FS_UUID}\n"
-                  "search --no-floppy --fs-uuid --set=boot ${GRUB2_BOOT_FS_UUID}\n"
+                  "set boot=${root}\n"
                   "function load_video {\n"
                   "  insmod all_video\n"
                   "}\n"
@@ -158,7 +158,6 @@ def main(tree, options):
         default.write("GRUB_TIMEOUT=0\n"
                       "GRUB_ENABLE_BLSCFG=true\n")
 
-
     os.makedirs(f"{tree}/boot/grub2", exist_ok=True)
     grubenv = f"{tree}/boot/grub2/grubenv"
 
@@ -174,7 +173,6 @@ def main(tree, options):
     with open(grubenv, "w") as env:
         env.write("# GRUB Environment Block\n"
                   f"GRUB2_ROOT_FS_UUID={grub_fs_uuid}\n"
-                  f"GRUB2_BOOT_FS_UUID={grub_fs_uuid}\n"
                   f"kernelopts=root=UUID={root_fs_uuid} {kernel_opts}\n")
 
     if uefi is not None:

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -49,6 +49,16 @@ STAGE_OPTS = """
         "examples": ["6699-AFB5"] }
     ]
   },
+  "boot_fs_uuid": {
+    "description": "UUID of the boot filesystem, if /boot is separated",
+    "type": "string",
+    "oneOf": [
+      { "pattern": "^[0-9A-Za-z]{8}(-[0-9A-Za-z]{4}){3}-[0-9A-Za-z]{12}$",
+        "examples": ["9c6ae55b-cf88-45b8-84e8-64990759f39d"] },
+      { "pattern": "^[0-9A-Za-z]{4}-[0-9A-Za-z]{4}$",
+        "examples": ["6699-AFB5"] }
+    ]
+  },
   "kernel_opts": {
     "description": "Additional kernel boot options",
     "type": "string",
@@ -110,17 +120,19 @@ def write_grub_cfg(tree, path):
                   "blscfg\n")
 
 
-def write_grub_cfg_redirect(tree, path):
+def write_grub_cfg_redirect(tree, path, separate_boot):
     """Write a grub config pointing to the other cfg"""
     print("hybrid boot support enabled. Writing alias grub config")
+    root = "/" if separate_boot else "/boot/"
     with open(os.path.join(tree, path), "w") as cfg:
-        cfg.write("search --no-floppy --set prefix --file /boot/grub2/grub.cfg\n"
-                  "set prefix=($prefix)/boot/grub2\n"
+        cfg.write(f"search --no-floppy --set prefix --file {root}grub2/grub.cfg\n"
+                  f"set prefix=($prefix){root}grub2\n"
                   "configfile $prefix/grub.cfg\n")
 
 
 def main(tree, options):
     root_fs_uuid = options["root_fs_uuid"]
+    boot_fs_uuid = options.get("boot_fs_uuid", None)
     kernel_opts = options.get("kernel_opts", "")
     legacy = options.get("legacy", True)
     uefi = options.get("uefi", None)
@@ -135,6 +147,10 @@ def main(tree, options):
     # will only contain a small config file redirecting to the one in
     # /boot/grub2 and will not have a grubenv itself.
     hybrid = uefi and legacy
+
+    # grub_fs_uuid points to the filesystem containing the grub files
+    grub_fs_uuid = boot_fs_uuid or root_fs_uuid
+    separate_boot = boot_fs_uuid is not None
 
     # Create the configuration file that determines how grub.cfg is generated.
     os.makedirs(f"{tree}/etc/default", exist_ok=True)
@@ -157,8 +173,8 @@ def main(tree, options):
 
     with open(grubenv, "w") as env:
         env.write("# GRUB Environment Block\n"
-                  f"GRUB2_ROOT_FS_UUID={root_fs_uuid}\n"
-                  f"GRUB2_BOOT_FS_UUID={root_fs_uuid}\n"
+                  f"GRUB2_ROOT_FS_UUID={grub_fs_uuid}\n"
+                  f"GRUB2_BOOT_FS_UUID={grub_fs_uuid}\n"
                   f"kernelopts=root=UUID={root_fs_uuid} {kernel_opts}\n")
 
     if uefi is not None:
@@ -174,7 +190,7 @@ def main(tree, options):
         vendor = uefi["vendor"]
         grubcfg = f"boot/efi/EFI/{vendor}/grub.cfg"
         if hybrid:
-            write_grub_cfg_redirect(tree, grubcfg)
+            write_grub_cfg_redirect(tree, grubcfg, separate_boot)
         else:
             write_grub_cfg(tree, grubcfg)
 


### PR DESCRIPTION
Introduce options for the `org.osbuild.grub2` and `org.osbuild.fix-bls` stage so that they support `/boot` being on a separate partition. The basic change for most of the changes in both stages is that if paths need to be specified relative to the root of the filesystem of the partition which is `/boot/...` if `/boot` is on root or `/...` if `/boot` is separate.
Includes a "kitchen-sink" example that supports hybrid boot with `/boot` being on separate partition. 

Maybe the awesome @martinezjavier could have a look? ;D

Closes #208 