### PR TITLE
osbuild.spec: actually install runners symlinks

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -55,7 +55,7 @@ mkdir -p %{buildroot}%{pkgdir}/assemblers
 install -p -m 0755 $(find assemblers -type f) %{buildroot}%{pkgdir}/assemblers/
 
 mkdir -p %{buildroot}%{pkgdir}/runners
-install -p -m 0755 $(find runners -type f) %{buildroot}%{pkgdir}/runners
+install -p -m 0755 $(find runners -type f -or -type l) %{buildroot}%{pkgdir}/runners
 
 mkdir -p %{buildroot}%{pkgdir}/sources
 install -p -m 0755 $(find sources -type f) %{buildroot}%{pkgdir}/sources


### PR DESCRIPTION
The Fedora 31 and Fedora 32 runners are symlinks but the spec file only looked for files and not symlinks. Fix that.

Follow up by `6a14ba40f7ef206e8ea577bd8ff8d0f9ca28b186`. Found by @larskarlitski .

NB: This will install the symlinks as actual files, which might not be the worst idea, but not 100% sure that is what we want.