### PR TITLE
Move installation of the osbuild files into setup.py

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -48,22 +48,6 @@ A build system for OS images
 %install
 %py3_install
 
-mkdir -p %{buildroot}%{pkgdir}/stages
-install -p -m 0755 $(find stages -type f) %{buildroot}%{pkgdir}/stages/
-
-mkdir -p %{buildroot}%{pkgdir}/assemblers
-install -p -m 0755 $(find assemblers -type f) %{buildroot}%{pkgdir}/assemblers/
-
-mkdir -p %{buildroot}%{pkgdir}/runners
-install -p -m 0755 $(find runners -type f) %{buildroot}%{pkgdir}/runners
-
-mkdir -p %{buildroot}%{pkgdir}/sources
-install -p -m 0755 $(find sources -type f) %{buildroot}%{pkgdir}/sources
-
-# mount points for bind mounting the osbuild library
-mkdir -p %{buildroot}%{pkgdir}/stages/osbuild
-mkdir -p %{buildroot}%{pkgdir}/assemblers/osbuild
-
 # install host runner
 %if 0%{?fc30}
 ln -s org.osbuild.fedora30 %{buildroot}%{pkgdir}/runners/org.osbuild.host

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,14 @@
-import glob
+import os
 import setuptools
+
+# Mountpoints for osbuild library
+data_files = [("/usr/lib/osbuild/stages/osbuild", []),
+              ("/usr/lib/osbuild/assemblers/osbuild", [])]
+# Copy the osbuild files
+for d in ["stages", "assemblers", "runners", "sources"]:
+    for root, dnames, fnames in os.walk(d):
+        if fnames:
+            data_files.append((f"/usr/lib/osbuild/{root}", [f"{root}/{f}" for f in fnames]))
 
 setuptools.setup(
     name="osbuild",
@@ -10,4 +19,5 @@ setuptools.setup(
     entry_points={
         "console_scripts": ["osbuild = osbuild.__main__:main"]
     },
+    data_files=data_files,
 )


### PR DESCRIPTION
This keeps installation all in one place, and makes it easier to install
from source without needing to first build an rpm.