### PR TITLE
Add support for checkpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ jobs:
       install: pip install pylint==2.4.1
       script: pylint osbuild runners/* assemblers/* stages/* sources/*
     - name: unit-tests
-      script: python3 -m unittest test.test_osbuild
+      script:
+        - python3 -m unittest test.test_osbuild
+        - python3 -m unittest test.test_objectstore
     - name: rpm
       before_install:
         - sudo apt-get install -y rpm python3-setuptools

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -40,15 +40,20 @@ class TreeObject:
     @property
     def treesum(self) -> str:
         """Calculate the treesum of the tree"""
-        fd = os.open(self.path, os.O_DIRECTORY)
-        try:
+        with self.open() as fd:
             m = hashlib.sha256()
             treesum.treesum(m, fd)
             treesum_hash = m.hexdigest()
+            return treesum_hash
+
+    @contextlib.contextmanager
+    def open(self):
+        """Open the directory and return the file descriptor"""
+        try:
+            fd = os.open(self.path, os.O_DIRECTORY)
+            yield fd
         finally:
             os.close(fd)
-
-        return treesum_hash
 
     def move(self, destination: str):
         """Move the tree to destination

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -144,7 +144,7 @@ class ObjectStore:
         output_tree = f"{self.objects}/{treesum_hash}"
 
         # if a tree with the same treesum already exist, use that
-        with suppress_oserror(errno.ENOTEMPTY):
+        with suppress_oserror(errno.ENOTEMPTY, errno.EEXIST):
             os.rename(tree.path, output_tree)
         tree.path = output_tree
 

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -106,6 +106,24 @@ class ObjectStore:
             # left to do is to commit it to the object store
             self.commit(tree, object_id)
 
+    def snapshot(self, tree_path: str, object_id: str) -> str:
+        """Commit `tree_path` to store and ref it as `object_id`
+
+        Create a snapshot of `tree_path` and store it via its
+        content hash in the object directory; additionally
+        create a new reference to it via `object_id` in the
+        reference directory.
+
+        Returns: The treesum of the snapshot
+        """
+        # Make a new temporary directory and TreeObject; initialize
+        # the latter with the contents of `tree_path` and commit
+        # it to the store
+        with tempfile.TemporaryDirectory(dir=self.store) as tmp:
+            tree = TreeObject(f"{tmp}/tree")
+            tree.init(tree_path)
+            return self.commit(tree, object_id)
+
     def commit(self, tree: TreeObject, object_id: str) -> str:
         """Commits a TreeObject to the object store
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -51,6 +51,7 @@ class Stage:
         self.build = build
         self.base = base
         self.options = options
+        self.checkpoint = False
 
     @property
     def id(self):
@@ -253,6 +254,8 @@ class Pipeline:
                                               libdir=libdir,
                                               source_options=source_options,
                                               secrets=secrets)
+                                if stage.checkpoint:
+                                    object_store.snapshot(tree, stage.id)
                                 results["stages"].append(r.as_dict())
                     except BuildError as err:
                         results["stages"].append(err.as_dict())

--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -20,6 +20,33 @@ class TestObjectStore(unittest.TestCase):
         if not os.getenv("OSBUILD_TEST_STORE"):
             shutil.rmtree(cls.store)
 
+    def test_basic(self):
+        # always use a temporary store so item counting works
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+            object_store = objectstore.ObjectStore(tmp)
+            with object_store.new("a") as tree:
+                p = Path(f"{tree}/A")
+                p.touch()
+
+            assert os.path.exists(f"{object_store.refs}/a")
+            assert os.path.exists(f"{object_store.refs}/a/A")
+            assert len(os.listdir(object_store.refs)) == 1
+            assert len(os.listdir(object_store.objects)) == 1
+            assert len(os.listdir(f"{object_store.refs}/a/")) == 1
+
+            with object_store.new("b") as tree:
+                p = Path(f"{tree}/A")
+                p.touch()
+                p = Path(f"{tree}/B")
+                p.touch()
+
+            assert os.path.exists(f"{object_store.refs}/b")
+            assert os.path.exists(f"{object_store.refs}/b/B")
+
+            assert len(os.listdir(object_store.refs)) == 2
+            assert len(os.listdir(object_store.objects)) == 2
+            assert len(os.listdir(f"{object_store.refs}/b/")) == 2
+
     def test_snapshot(self):
         object_store = objectstore.ObjectStore(self.store)
         with object_store.new("b") as tree:

--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -47,6 +47,26 @@ class TestObjectStore(unittest.TestCase):
             assert len(os.listdir(object_store.objects)) == 2
             assert len(os.listdir(f"{object_store.refs}/b/")) == 2
 
+    def test_duplicate(self):
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+            object_store = objectstore.ObjectStore(tmp)
+            with object_store.new("a") as tree:
+                p = Path(f"{tree}/A")
+                p.touch()
+
+            with object_store.new("b") as tree:
+                shutil.copy2(f"{object_store.refs}/a/A",
+                             f"{tree}/A")
+
+            assert os.path.exists(f"{object_store.refs}/a")
+            assert os.path.exists(f"{object_store.refs}/a/A")
+            assert os.path.exists(f"{object_store.refs}/b/A")
+
+            assert len(os.listdir(object_store.refs)) == 2
+            assert len(os.listdir(object_store.objects)) == 1
+            assert len(os.listdir(f"{object_store.refs}/a/")) == 1
+            assert len(os.listdir(f"{object_store.refs}/b/")) == 1
+
     def test_snapshot(self):
         object_store = objectstore.ObjectStore(self.store)
         with object_store.new("b") as tree:

--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from pathlib import Path
+from osbuild import objectstore
+
+
+class TestObjectStore(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.store = os.getenv("OSBUILD_TEST_STORE")
+        if not cls.store:
+            cls.store = tempfile.mkdtemp(prefix="osbuild-test-", dir="/var/tmp")
+
+    @classmethod
+    def tearDownClass(cls):
+        if not os.getenv("OSBUILD_TEST_STORE"):
+            shutil.rmtree(cls.store)
+
+    def test_snapshot(self):
+        object_store = objectstore.ObjectStore(self.store)
+        with object_store.new("b") as tree:
+            p = Path(f"{tree}/A")
+            p.touch()
+            object_store.snapshot(tree, "a")
+            p = Path(f"{tree}/B")
+            p.touch()
+
+        # check the references exist
+        assert os.path.exists(f"{object_store.refs}/a")
+        assert os.path.exists(f"{object_store.refs}/b")
+
+        # check the contents of the trees
+        assert os.path.exists(f"{object_store.refs}/a/A")
+        assert not os.path.exists(f"{object_store.refs}/a/B")
+
+        assert os.path.exists(f"{object_store.refs}/b/A")
+        assert os.path.exists(f"{object_store.refs}/b/B")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
During `osbuild` development of a certain stage, it very often is the case that one wants to to cache the result of everything up to that stage. This is already currently possible by creating an identical pipeline up to that stage and running that but that is somewhat inconvenient.

Therefore this PR adds support for a new `--checkpoint` option to `osbuild` which can be used to create checkpoints of the tree at arbitrary points in the pipeline. 

The argument to `--checkpoint` will be matched against the stage identifier and supports file name matching a la `fnmatch`. The stage identifier consists of a prefix and the stage name, where the prefix is `"/"` for the main stages or `"build/"` for stage in the build pipeline. Examples:
 
-  ` "*"`        will match all stages
-   `"/*"`      will only match main stages
-  `"build/*"`  will match all build stages
-  `"/*grub2"`  will match the main grub2 stage
-  `"*dnf"`     will match all dnf stages

Comments on the names (`checkpoint` vs `snapshot`) and also the matching are welcome.