### PR TITLE
Add a unit test to verify `STAGE_OPTS` has valid json

### DIFF
--- a/stages/org.osbuild.dnf
+++ b/stages/org.osbuild.dnf
@@ -132,7 +132,7 @@ STAGE_OPTS = """
   "module_platform_id": {
     "description": "DNF's module_platform_id option. Corresponds to PLATFORM_ID from /etc/os-release",
     "type": "string"
-  },
+  }
 }
 """
 

--- a/stages/org.osbuild.error
+++ b/stages/org.osbuild.error
@@ -11,7 +11,7 @@ wasting time.
 STAGE_OPTS = """
 "properties": {
   "returncode": {
-    "description": "What to return code to use"
+    "description": "What to return code to use",
     "type": "number",
     "default": 255
   }

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -73,13 +73,12 @@ STAGE_OPTS = """
     "description": "Include UEFI boot support",
     "type": "object",
     "required": ["vendor"],
-      "properties": {
-        "vendor": {
-          "type": "string",
-           "description": "The vendor of the UEFI binaries (this is us)",
-           "examples": ["fedora"],
-           "pattern": "^(.+)$"
-        }
+    "properties": {
+      "vendor": {
+        "type": "string",
+         "description": "The vendor of the UEFI binaries (this is us)",
+         "examples": ["fedora"],
+         "pattern": "^(.+)$"
       }
     }
   }


### PR DESCRIPTION
Loads `stages` and `assembler` stages as modules and tries to load the json and fail if that fails. Fix the invalid json in `STAGE_OPTS` of the stages that the test discovered.