### PR TITLE
osbuild: ability to validate stage options

### DIFF
--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -31,6 +31,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Install Python Packages
+      run: pip install jsonschema
     - name: "Run Pipeline Tests"
       run: sudo env "PATH=$PATH" make test-runtime
 
@@ -49,6 +51,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Install Python Packages
+      run: pip install jsonschema
     - name: "Run Noop-Pipeline Tests"
       run: |
         for i in {0..2} ; do
@@ -75,6 +79,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Install Python Packages
+      run: pip install jsonschema
     - name: "Run Assembler Tests"
       run: sudo env "PATH=$PATH" python3 -m unittest -v test.test_assemblers
 
@@ -95,5 +101,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Install Python Packages
+      run: pip install jsonschema
     - name: "Run Stage Tests"
       run: sudo env "PATH=$PATH" python3 -m unittest -v test.test_stages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,28 @@ jobs:
           cd osbuild
           python3 -m unittest -v test.test_objectstore
 
+  sample_validation:
+    name: "sample validation"
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/library/python:3.7
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          path: osbuild
+
+      - name: Install Dependencies
+        run: |
+          pip install jsonschema
+
+      - name: Validate the samples
+        run: |
+          cd osbuild
+          for f in samples/*; do
+            python3 -m osbuild --libdir . --inspect "$f" > /dev/null
+          done
+
   rpm_build:
     name: "📦 RPM"
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     container: docker.io/library/python:3.7
     steps:
       - name: Install pylint
-        run: pip install pylint==2.4.1
+        run: pip install pylint==2.4.1 jsonschema
       - name: Clone repository
         uses: actions/checkout@v2
       - name: Run pylint
@@ -66,6 +66,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: osbuild
+
+      - name: Install Dependencies
+        run: pip install jsonschema
 
       - name: Run test_osbuild
         run: |

--- a/assemblers/org.osbuild.noop
+++ b/assemblers/org.osbuild.noop
@@ -8,7 +8,9 @@ STAGE_INFO = """
 No-op assembler. Produces no output, just prints a JSON dump of its options
 and then exits.
 """
-STAGE_OPTS = ""
+STAGE_OPTS = """
+"additionalProperties": false
+"""
 def main(_tree, _output_dir, options):
     print("Not doing anything with these options:", json.dumps(options))
 

--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -22,6 +22,7 @@ the commit id and the compose information respectively.
 [1] https://ostree.readthedocs.io/en/stable/manual/adapting-existing/
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["ref"],
 "properties": {
   "ref": {

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -51,7 +51,7 @@ STAGE_OPTS = """
   "format": {
     "description": "Image file format to use",
     "type": "string",
-    "enum": ["raw", "qcow2", "vdi", "vmdk", "vpc", "vhdx"]
+    "enum": ["raw", "raw.xz", "qcow2", "vdi", "vmdk", "vpc", "vhdx"]
   },
   "filename": {
     "description": "Image filename",

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -30,6 +30,7 @@ Buildhost commands used: `truncate`, `mount`, `umount`, `sfdisk`,
 `grub2-mkimage`, `mkfs.ext4` or `mkfs.xfs`, `qemu-img`.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["format", "filename", "ptuuid", "size"],
 "oneOf": [{
   "required": ["root_fs_uuid"]

--- a/assemblers/org.osbuild.rawfs
+++ b/assemblers/org.osbuild.rawfs
@@ -26,6 +26,7 @@ generate with uuid.uuid4() in Python, `uuidgen(1)` in a shell script, or
 read from `/proc/sys/kernel/random/uuid` if your kernel provides it.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["filename", "root_fs_uuid", "size"],
 "properties": {
   "filename": {

--- a/assemblers/org.osbuild.tar
+++ b/assemblers/org.osbuild.tar
@@ -22,6 +22,7 @@ caller is responsible for making sure that `compression` and `filename` match.
 Buildhost commands used: `tar` and any named `compression` program.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["filename"],
 "properties": {
   "filename": {

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -92,6 +92,11 @@ ln -s ../osbuild %{buildroot}%{pkgdir}/sources/osbuild
 # mount point for bind mounting the osbuild library
 mkdir -p %{buildroot}%{pkgdir}/osbuild
 
+# schemata
+mkdir -p %{buildroot}%{_datadir}/osbuild/schemas
+install -p -m 0755 $(find schemas/*.json) %{buildroot}%{_datadir}/osbuild/schemas
+ln -s %{_datadir}/osbuild/schemas %{buildroot}%{pkgdir}/schemas
+
 # documentation
 mkdir -p %{buildroot}%{_mandir}/man1
 mkdir -p %{buildroot}%{_mandir}/man5
@@ -108,6 +113,7 @@ exit 0
 %{_bindir}/osbuild
 %{_mandir}/man1/%{name}.1*
 %{_mandir}/man5/%{name}-manifest.5*
+%{_datadir}/osbuild/schemas
 %{pkgdir}
 # the following files are in the ostree sub-package
 %exclude %{pkgdir}/assemblers/org.osbuild.ostree.commit

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -36,6 +36,7 @@ def mark_checkpoints(pipeline, checkpoints):
     mark_pipeline(pipeline)
     return points
 
+
 def parse_manifest(path):
     if path == "-":
         manifest = json.load(sys.stdin)
@@ -44,6 +45,7 @@ def parse_manifest(path):
             manifest = json.load(f)
 
     return manifest
+
 
 def parse_arguments(sys_argv):
     parser = argparse.ArgumentParser(description="Build operating system images")
@@ -69,6 +71,7 @@ def parse_arguments(sys_argv):
                         help="directory where result objects are stored")
 
     return parser.parse_args(sys_argv[1:])
+
 
 def osbuild_cli(*, sys_argv=[]):
     args = parse_arguments(sys_argv)

--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -1,0 +1,426 @@
+"""Introspection and validation for osbuild
+
+This module contains utilities that help to introspect parts
+that constitute the inner parts of osbuild, i.e. its stages
+and assembler (which is also considered a type of stage in
+this context). Additionally, it provides classes and functions
+to do schema validation of OSBuild manifests and stage options.
+
+A central `Index` class can be used to obtain stage and schema
+information. For the former a `StageInfo` class is returned via
+`Index.get_stage_info`, which contains meta-information about
+the individual stages. Schemata, obtained via `Index.get_schema`
+is represented via a `Schema` class that can in turn be used
+to validate the individual components.
+
+The high level `validate` function can be used to check a given
+manifest (parsed form JSON input in dictionary form) against all
+available schemata. The result is a `ValidationResult` which
+contains a single `ValidationError` for each error detected in
+the manifest. See the individual documentation for details.
+"""
+import ast
+import contextlib
+import copy
+import os
+import json
+from collections import deque
+from typing import Dict, Iterable, Optional
+
+import jsonschema
+
+
+FAILED_TITLE = "JSON Schema validation failed"
+FAILED_TYPEURI = "https://osbuild.org/validation-error"
+
+
+class ValidationError:
+    """Describes a single failed validation
+
+    Consists of a `message` member describing the error
+    that occurred and a `path` that points to the element
+    that caused the error.
+    Implements hashing, equality and less-than and thus
+    can be sorted and used in sets and dictionaries.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        self.path = deque()
+
+    @classmethod
+    def from_exception(cls, ex):
+        err = cls(ex.message)
+        err.path = ex.absolute_path
+        return err
+
+    @property
+    def id(self):
+        if not self.path:
+            return "."
+
+        result = ""
+        for p in self.path:
+            if isinstance(p, str):
+                if " " in p:
+                    p = f"'{p}'"
+                result += "." + p
+            elif isinstance(p, int):
+                result += f"[{p}]"
+            else:
+                assert "new type"
+
+        return result
+
+    def as_dict(self):
+        """Serializes this object as a dictionary
+
+        The `path` member will be serialized as a list of
+        components (string or integer) and `message` the
+        human readable message string.
+        """
+        return {
+            "message": self.message,
+            "path": list(self.path)
+        }
+
+    def rebase(self, path: Iterable[str]):
+        """Prepend the `path` to `self.path`"""
+        rev = reversed(path)
+        self.path.extendleft(rev)
+
+    def __hash__(self):
+        return hash((self.id, self.message))
+
+    def __eq__(self, other: "ValidationError"):
+        if not isinstance(other, ValidationError):
+            raise ValueError("Need ValidationError")
+
+        if self.id != other.id:
+            return False
+        return self.message == other.message
+
+    def __lt__(self, other: "ValidationError"):
+        if not isinstance(other, ValidationError):
+            raise ValueError("Need ValidationError")
+
+        return self.id < other.id
+
+    def __str__(self):
+        return f"ValidationError: {self.message} [{self.id}]"
+
+
+class ValidationResult:
+    """Result of a JSON Schema validation"""
+
+    def __init__(self, origin: Optional[str]):
+        self.origin = origin
+        self.errors = set()
+
+    def fail(self, msg: str) -> ValidationError:
+        """Add a new `ValidationError` with `msg` as message"""
+        err = ValidationError(msg)
+        self.errors.add(err)
+        return err
+
+    def add(self, err: ValidationError):
+        """Add a `ValidationError` to the set of errors"""
+        self.errors.add(err)
+        return self
+
+    def merge(self, result: "ValidationResult", *, path=[]):
+        """Merge all errors of `result` into this
+
+        Merge all the errors of in `result` into this,
+        adjusting their the paths be pre-pending the
+        supplied `path`.
+        """
+        for err in result:
+            err = copy.deepcopy(err)
+            err.rebase(path)
+            self.errors.add(err)
+
+    def as_dict(self):
+        """Represent this result as a dictionary
+
+        If there are not errors, returns an empty dict;
+        otherwise it will contain a `type`, `title` and
+        `errors` field. The `title` is a human readable
+        description, the `type` is a URI identifying
+        the validation error type and errors is a list
+        of `ValueErrors`, in turn serialized as dict.
+        Additionally, a `success` member is provided to
+        be compatible with pipeline build results.
+        """
+        errors = [e.as_dict() for e in self]
+        if not errors:
+            return {}
+
+        return {
+            "type": FAILED_TYPEURI,
+            "title": FAILED_TITLE,
+            "success": False,
+            "errors": errors
+        }
+
+    @property
+    def valid(self):
+        """Returns `True` if there are zero errors"""
+        return len(self) == 0
+
+    def __iadd__(self, error: ValidationError):
+        return self.add(error)
+
+    def __bool__(self):
+        return self.valid
+
+    def __len__(self):
+        return len(self.errors)
+
+    def __iter__(self):
+        return iter(sorted(self.errors))
+
+    def __str__(self):
+        return f"ValidationResult: {len(self)} error(s)"
+
+    def __getitem__(self, key):
+        if not isinstance(key, str):
+            raise ValueError("Only string keys allowed")
+
+        lst = list(filter(lambda e: e.id == key, self))
+        if not lst:
+            raise IndexError(f"{key} not found")
+
+        return lst
+
+
+class Schema:
+    """JSON Schema representation
+
+    Class that represents a JSON schema. The `data` attribute
+    contains the actual schema data itself. The `klass` and
+    (optional) `name` refer to entity this schema belongs to.
+    The schema information can be used to validate data via
+    the `validate` method.
+
+    The class can be created with empty schema data. In that
+    case it represents missing schema information. Any call
+    to `validate` will then result in a failure.
+
+    The truth value of this objects corresponds to it having
+    schema data.
+    """
+
+    def __init__(self, schema: str, name: Optional[str] = None):
+        self.data = schema
+        self.name = name
+        if schema:
+            self._validator = jsonschema.Draft7Validator(schema)
+
+    def validate(self, target) -> ValidationResult:
+        """Validate the `target` against this schema
+
+        If the schema information itself is missing, it
+        will return a `ValidationResult` in failed state,
+        with 'missing schema information' as the reason.
+        """
+        res = ValidationResult(self.name)
+
+        if not self.data:
+            return res.fail("missing schema information")
+
+        for error in self._validator.iter_errors(target):
+            res += ValidationError.from_exception(error)
+
+        return res
+
+    def __bool__(self):
+        return self.data
+
+
+class StageInfo:
+    """Meta information about a stage
+
+    Represents the information about a osbuild pipeline
+    stage or assembler (here also considered to be a stage).
+    Contains the short description (`desc`), a longer
+    description (`info`) and the JSON schema of valid options
+    (`opts`). The `validate` method will check a the options
+    of a stage instance against the JSON schema.
+
+    Normally this class is instantiated via its `load` method.
+    """
+
+    def __init__(self, klass: str, name: str, info: str):
+        self.name = name
+        self.type = klass
+
+        opts = info.get("STAGE_OPTS") or ""
+        self.info = info.get("STAGE_INFO")
+        self.desc = info.get("STAGE_DESC")
+        self.opts = info.get("STAGE_OPTS")
+        self.opts = json.loads("{" + opts + "}")
+
+    @property
+    def schema(self):
+        schema = {
+            "title": f"Pipeline {self.type}",
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "name": {"type": "string"},
+                "options": {
+                    "type": "object",
+                    **self.opts
+                }
+            },
+            "required": ["name"]
+        }
+
+        # if there are is a definitions node, it needs to be at
+        # the top level schema node, since the schema inside the
+        # stages is written as-if they were the root node and
+        # so are the references
+        definitions = self.opts.get("definitions")
+        if definitions:
+            schema["definitions"] = definitions
+            del schema["properties"]["options"]["definitions"]
+
+        return schema
+
+    @classmethod
+    def load(cls, root, klass, name) -> Optional["StageInfo"]:
+        names = ['STAGE_INFO', 'STAGE_DESC', 'STAGE_OPTS']
+
+        def value(a):
+            v = a.value
+            if isinstance(v, ast.Str):
+                return v.s
+            return ""
+
+        def filter_type(lst, target):
+            return [x for x in lst if isinstance(x, target)]
+
+        def targets(a):
+            return [t.id for t in filter_type(a.targets, ast.Name)]
+
+        mapping = {
+            "Stage": "stages",
+            "Assembler": "assemblers"
+        }
+
+        if klass not in mapping:
+            raise ValueError(f"Unsupported type: {klass}")
+
+        base = mapping[klass]
+
+        path = os.path.join(root, base, name)
+        try:
+            with open(path) as f:
+                data = f.read()
+        except FileNotFoundError:
+            return None
+
+        tree = ast.parse(data, name)
+        assigns = filter_type(tree.body, ast.Assign)
+        targets = [(t, a) for a in assigns for t in targets(a)]
+        info = {k: value(v) for k, v in targets if k in names}
+        return cls(klass, name, info)
+
+
+class Index:
+    """Index of stages and assemblers
+
+    Class that can be used to get the meta information about
+    osbuild stages and assemblers as well as JSON schemata.
+    """
+
+    def __init__(self, path: str):
+        self.path = path
+        self._stage_info = {}
+        self._schemata = {}
+
+    def get_stage_info(self, klass, name) -> Optional[StageInfo]:
+        """Obtain `StageInfo` for a given stage or assembler"""
+
+        if (klass, name) not in self._stage_info:
+
+            info = StageInfo.load(self.path, klass, name)
+            self._stage_info[(klass, name)] = info
+
+        return self._stage_info[(klass, name)]
+
+    def get_schema(self, klass, name=None) -> Schema:
+        """Obtain a `Schema` for `klass` and `name` (optional)
+
+        Returns a `Schema` for the entity identified via `klass`
+        and `name` (if given). Always returns a `Schema` even if
+        no schema information could be found for the entity. In
+        that case the actual schema data for `Schema` will be
+        `None` and any validation will fail.
+        """
+        schema = self._schemata.get((klass, name))
+        if schema is not None:
+            return schema
+
+        if klass == "Manifest":
+            path = f"{self.path}/schemas/osbuild1.json"
+            with contextlib.suppress(FileNotFoundError):
+                with open(path, "r") as f:
+                    schema = json.load(f)
+        elif klass in ["Stage", "Assembler"]:
+            info = self.get_stage_info(klass, name)
+            if info:
+                schema = info.schema
+        else:
+            raise ValueError(f"Unknown klass: {klass}")
+
+        schema = Schema(schema, name or klass)
+        self._schemata[(klass, name)] = schema
+
+        return schema
+
+
+def validate(manifest: Dict, index: Index) -> ValidationResult:
+    """Validate a OSBuild manifest
+
+    This function will validate a OSBuild manifest, including
+    all its stages and assembler and build manifests. It will
+    try to validate as much as possible and not stop on errors.
+    The result is a `ValidationResult` object that can be used
+    to check the overall validation status and iterate all the
+    individual validation errors.
+    """
+
+    schema = index.get_schema("Manifest")
+    result = schema.validate(manifest)
+
+    # main pipeline
+    pipeline = manifest.get("pipeline", {})
+
+    # recursively validate the build pipeline  as a "normal"
+    # pipeline in order to validate its stages and assembler
+    # options; for this it is being re-parented in a new plain
+    # {"pipeline": ...} dictionary. NB: Any nested structural
+    # errors might be detected twice, but de-duplicated by the
+    # `ValidationResult.merge` call
+    build = pipeline.get("build", {}).get("pipeline")
+    if build:
+        res = validate({"pipeline": build}, index=index)
+        result.merge(res, path=["pipeline", "build"])
+
+    stages = pipeline.get("stages", [])
+    for i, stage in enumerate(stages):
+        name = stage["name"]
+        schema = index.get_schema("Stage", name)
+        res = schema.validate(stage)
+        result.merge(res, path=["pipeline", "stages", i])
+
+    asm = pipeline.get("assembler", {})
+    if asm:
+        name = asm["name"]
+        schema = index.get_schema("Assembler", name)
+        res = schema.validate(asm)
+        result.merge(res, path=["pipeline", "assembler"])
+
+    return result

--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -257,7 +257,7 @@ class Schema:
         return res
 
     def __bool__(self):
-        return self.data
+        return self.check().valid
 
 
 class StageInfo:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -58,11 +58,12 @@ class Stage:
         m.update(json.dumps(self.options, sort_keys=True).encode())
         return m.hexdigest()
 
-    def description(self):
-        description = {}
-        description["name"] = self.name
+    def description(self, *, with_id=False):
+        description = {"name": self.name}
         if self.options:
             description["options"] = self.options
+        if with_id:
+            description["id"] = self.id
         return description
 
     def run(self,
@@ -121,11 +122,12 @@ class Assembler:
         m.update(json.dumps(self.options, sort_keys=True).encode())
         return m.hexdigest()
 
-    def description(self):
-        description = {}
-        description["name"] = self.name
+    def description(self, *, with_id=False):
+        description = {"name": self.name}
         if self.options:
             description["options"] = self.options
+        if with_id:
+            description["id"] = self.id
         return description
 
     def run(self, tree, runner, build_tree, output_dir=None, interactive=False, libdir=None, var="/var/tmp"):
@@ -190,17 +192,28 @@ class Pipeline:
         pipeline.build = build_pipeline
         pipeline.runner = runner
 
-    def description(self):
+    def description(self, *, with_id=False):
         description = {}
         if self.build:
             description["build"] = {
-                "pipeline": self.build.description(),
+                "pipeline": self.build.description(with_id=with_id),
                 "runner": self.runner
             }
         if self.stages:
-            description["stages"] = [s.description() for s in self.stages]
+            stages = [s.description(with_id=with_id) for s in self.stages]
+            description["stages"] = stages
         if self.assembler:
-            description["assembler"] = self.assembler.description()
+            assembler = self.assembler.description(with_id=with_id)
+            description["assembler"] = assembler
+
+        if with_id:
+            tree_id = self.tree_id
+            if tree_id:
+                description["tree_id"] = tree_id
+            output_id = self.output_id
+            if output_id:
+                description["output_id"] = tree_id
+
         return description
 
     def build_stages(self, object_store, interactive, libdir, secrets):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema

--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -914,8 +914,8 @@
               "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
               "vfs_type": "ext4",
               "path": "/",
-              "freq": "1",
-              "passno": "1"
+              "freq": 1,
+              "passno": 1
             }
           ]
         }

--- a/samples/f30-aarch64.json
+++ b/samples/f30-aarch64.json
@@ -337,7 +337,6 @@
     }
   },
   "pipeline": {
-    "runner": "org.osbuild.fedora30",
     "stages": [
       {
         "name": "org.osbuild.rpm",

--- a/samples/f30-base-uefi.json
+++ b/samples/f30-base-uefi.json
@@ -339,7 +339,6 @@
     }
   },
   "pipeline": {
-    "runner": "org.osbuild.fedora30",
     "stages": [
       {
         "name": "org.osbuild.rpm",

--- a/samples/f30-bootpart-hybrid.json
+++ b/samples/f30-bootpart-hybrid.json
@@ -390,7 +390,6 @@
     }
   },
   "pipeline": {
-    "runner": "org.osbuild.fedora30",
     "stages": [
       {
         "name": "org.osbuild.rpm",

--- a/samples/f30-qcow2-hybrid.json
+++ b/samples/f30-qcow2-hybrid.json
@@ -390,7 +390,6 @@
     }
   },
   "pipeline": {
-    "runner": "org.osbuild.fedora30",
     "stages": [
       {
         "name": "org.osbuild.rpm",

--- a/schemas/osbuild1.json
+++ b/schemas/osbuild1.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://osbuild.org/schemas/osbuild1.json",
 
   "title": "OSBuild Manifest",

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ setuptools.setup(
     description="A build system for OS images",
     packages=["osbuild", "osbuild.util"],
     license='Apache-2.0',
+    install_requires=[
+        "jsonschema",
+    ],
     entry_points={
         "console_scripts": [
             "osbuild = osbuild.main_cli:main_cli"

--- a/stages/org.osbuild.chrony
+++ b/stages/org.osbuild.chrony
@@ -11,6 +11,7 @@ Modifies /etc/chrony.conf, removing all "server" or "pool" lines and adding
 a "server" line for each server listed in `timeservers`.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["timeservers"],
 "properties": {
   "timeservers": {

--- a/stages/org.osbuild.chrony
+++ b/stages/org.osbuild.chrony
@@ -11,6 +11,7 @@ Modifies /etc/chrony.conf, removing all "server" or "pool" lines and adding
 a "server" line for each server listed in `timeservers`.
 """
 STAGE_OPTS = """
+"required": ["timeservers"],
 "properties": {
   "timeservers": {
     "type": "array",

--- a/stages/org.osbuild.debug-shell
+++ b/stages/org.osbuild.debug-shell
@@ -12,6 +12,7 @@ which starts an early-boot root shell on the given `tty`.
 Also symlinks the service file into /etc/systemd/system/sysinit.target.wants/.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["tty"],
 "properties": {
   "tty": {

--- a/stages/org.osbuild.error
+++ b/stages/org.osbuild.error
@@ -9,6 +9,7 @@ Error stage. Return the given error. Useful for testing, debugging, and
 wasting time.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "properties": {
   "returncode": {
     "description": "What to return code to use",

--- a/stages/org.osbuild.firewall
+++ b/stages/org.osbuild.firewall
@@ -29,6 +29,7 @@ target tree, which means it may fail unexpectedly when the buildhost and target
 are different arches or OSes.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "properties": {
   "ports": {
     "description": "Ports (or port ranges) to open",

--- a/stages/org.osbuild.first-boot
+++ b/stages/org.osbuild.first-boot
@@ -19,6 +19,7 @@ If the flag-file cannot be removed, the service fails without executing
 any further first-boot commands.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["commands"],
 "properties": {
   "commands": {

--- a/stages/org.osbuild.first-boot
+++ b/stages/org.osbuild.first-boot
@@ -29,7 +29,7 @@ STAGE_OPTS = """
     }
   },
   "wait_for_network": {
-    "type": "bool",
+    "type": "boolean",
     "description": "Wait for the network to be up before executing",
     "default": false
   }

--- a/stages/org.osbuild.fix-bls
+++ b/stages/org.osbuild.fix-bls
@@ -13,9 +13,23 @@ This happens because some boot loader config tools (e.g. grub2-mkrelpath)
 examine /proc/self/mountinfo to find the "real" path to /boot, and find the
 path to the osbuild tree - which won't be valid at boot time for this image.
 
+The paths in the Bootloader Specification are relative to the partition
+they are located on, i.e. `/boot/loader/...` if `/boot` is on the root
+file-system partition. If `/boot` is on a separate partition, the correct
+path would be `/loader/.../` The `prefix` can be used to adjust for that.
+By default it is `/boot`, i.e. assumes `/boot` is on the root file-system.
+
 This stage reads and (re)writes all .conf files in /boot/loader/entries.
 """
-STAGE_OPTS = ""
+STAGE_OPTS = """
+"properties": {
+  "prefix": {
+    "description": "Prefix to use, normally `/boot`",
+    "type": "string",
+    "default": "/boot"
+  }
+}
+"""
 
 
 def main(tree, options):

--- a/stages/org.osbuild.fix-bls
+++ b/stages/org.osbuild.fix-bls
@@ -22,6 +22,7 @@ By default it is `/boot`, i.e. assumes `/boot` is on the root file-system.
 This stage reads and (re)writes all .conf files in /boot/loader/entries.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "properties": {
   "prefix": {
     "description": "Prefix to use, normally `/boot`",

--- a/stages/org.osbuild.fstab
+++ b/stages/org.osbuild.fstab
@@ -13,6 +13,7 @@ a `path` (mount point).
 This stage replaces /etc/fstab, removing any existing entries.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["filesystems"],
 "properties": {
   "filesystems": {

--- a/stages/org.osbuild.fstab
+++ b/stages/org.osbuild.fstab
@@ -74,8 +74,8 @@ def main(tree, options):
             label = filesystem.get("label")
             vfs_type = filesystem.get("vfs_type", "none")
             options = filesystem.get("options", "defaults")
-            freq = filesystem.get("freq", "0")
-            passno = filesystem.get("passno", "0")
+            freq = filesystem.get("freq", 0)
+            passno = filesystem.get("passno", 0)
 
             if uuid:
                 fs_spec = f"UUID={uuid}"

--- a/stages/org.osbuild.groups
+++ b/stages/org.osbuild.groups
@@ -13,6 +13,7 @@ If no `gid` is given, `groupadd` will choose one.
 If the specified group name or GID is already in use, this stage will fail.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "properties": {
   "groups": {
     "type": "object",

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -42,6 +42,7 @@ and accompanying data can be installed from the built root via `uefi.install`.
 Both UEFI and Legacy can be specified at the same time.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "oneOf": [{
   "required": ["root_fs_uuid"]
 }, {

--- a/stages/org.osbuild.hostname
+++ b/stages/org.osbuild.hostname
@@ -14,6 +14,7 @@ buildhost with `--hostname={hostname}`, which checks the validity of the
 hostname and writes it to /etc/hostname.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["hostname"],
 "properties": {
   "hostname": {

--- a/stages/org.osbuild.kernel-cmdline
+++ b/stages/org.osbuild.kernel-cmdline
@@ -11,6 +11,7 @@ command line.
 https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "properties": {
   "root_fs_uuid": {
     "description": "UUID of the root filesystem image",

--- a/stages/org.osbuild.keymap
+++ b/stages/org.osbuild.keymap
@@ -15,6 +15,7 @@ Removes any existing /etc/vconsole.conf, then runs `systemd-firstboot` with the
 Valid keymaps are generally found in /lib/kbd/keymaps.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["keymap"],
 "properties": {
   "keymap": {

--- a/stages/org.osbuild.locale
+++ b/stages/org.osbuild.locale
@@ -15,6 +15,7 @@ with the `--locale` flag, which will write a new `/etc/locale.conf` in the
 target system with `LANG={language}`.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["language"],
 "properties": {
   "language": {

--- a/stages/org.osbuild.noop
+++ b/stages/org.osbuild.noop
@@ -8,7 +8,9 @@ STAGE_INFO = """
 No-op stage. Prints a JSON dump of the options passed into this stage and
 leaves the tree untouched. Useful for testing, debugging, and wasting time.
 """
-STAGE_OPTS = ""
+STAGE_OPTS = """
+"additionalProperties": false
+"""
 
 def main(_tree, options):
     print("Not doing anything with these options:", json.dumps(options))

--- a/stages/org.osbuild.ostree
+++ b/stages/org.osbuild.ostree
@@ -30,8 +30,12 @@ the sysroot and the deployments. Additional kernel options can be passed via
 [1] https://ostree.readthedocs.io/en/latest/manual/deployment/
 """
 STAGE_OPTS = """
-"required": ["rootfs"],
+"required": ["commit", "osname", "rootfs"],
 "properties": {
+  "commit": {
+    "description": "checksum of the OSTree commit",
+    "type": "string"
+  },
   "mounts": {
     "description": "Mount points of the final file system",
     "type": "array",
@@ -51,6 +55,10 @@ STAGE_OPTS = """
         }
       }
     }
+  },
+  "osname": {
+    "description": "Name of the stateroot to be used in the deployment",
+    "type": "string"
   },
   "kernel_opts": {
     "description": "Additional kernel command line options",

--- a/stages/org.osbuild.ostree
+++ b/stages/org.osbuild.ostree
@@ -54,7 +54,11 @@ STAGE_OPTS = """
   },
   "kernel_opts": {
     "description": "Additional kernel command line options",
-    "type": "string"
+    "type": "array",
+    "items": {
+      "description": "A single kernel command line option",
+      "type": "string"
+    }
   },
   "ref": {
     "description": "OStree ref to create and use for deployment",

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -34,6 +34,7 @@ Uses the following binaries from the host:
     * `rpm` to install packages into the target tree
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "properties": {
   "gpgkeys": {
     "description": "Array of GPG key contents to import",

--- a/stages/org.osbuild.rpm-ostree
+++ b/stages/org.osbuild.rpm-ostree
@@ -38,6 +38,7 @@ human users need to be part of.
 [2] https://rpm-ostree.readthedocs.io/en/latest/manual/treefile/
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "properties": {
   "etc_group_members": {
     "description": "Array of group names to still keep in /etc/group",

--- a/stages/org.osbuild.rpm-ostree
+++ b/stages/org.osbuild.rpm-ostree
@@ -38,7 +38,6 @@ human users need to be part of.
 [2] https://rpm-ostree.readthedocs.io/en/latest/manual/treefile/
 """
 STAGE_OPTS = """
-"required": ["enabled_services"],
 "properties": {
   "etc_group_members": {
     "description": "Array of group names to still keep in /etc/group",

--- a/stages/org.osbuild.script
+++ b/stages/org.osbuild.script
@@ -25,6 +25,7 @@ through `/bin/sh` in that case, so it might still work, but that behavior is
 not guaranteed.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["script"],
 "properties": {
   "script": {

--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -24,6 +24,7 @@ labels for newly-created files are determined by the host's SELinux policy and
 may not match the tree's policy.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["file_contexts"],
 "properties": {
   "file_contexts": {

--- a/stages/org.osbuild.systemd
+++ b/stages/org.osbuild.systemd
@@ -16,6 +16,7 @@ items, which will delete _all_ symlinks to the named services.
 Uses `systemctl` from the buildhost.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["enabled_services"],
 "properties": {
   "enabled_services": {

--- a/stages/org.osbuild.test
+++ b/stages/org.osbuild.test
@@ -13,6 +13,7 @@ Creates `/etc/systemd/system/osbuild-test.service`, and a symlink to it in
 `/etc/systemd/system/multi-user.target.wants/`.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["script"],
 "properties": {
   "script": {

--- a/stages/org.osbuild.timezone
+++ b/stages/org.osbuild.timezone
@@ -14,6 +14,7 @@ Removes `/etc/localtime`, then runs the host's `systemd-firstboot` binary with
 the `--timezone` option, which will re-create `/etc/localtime`.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "required": ["zone"],
 "properties": {
   "zone": {

--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -15,6 +15,7 @@ misbehave if the `usermod`/`useradd` binary inside the tree makes incorrect
 assumptions about its host system.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "properties": {
   "users": {
     "type": "object",

--- a/stages/org.osbuild.zipl
+++ b/stages/org.osbuild.zipl
@@ -10,6 +10,7 @@ Configures `zipl` with a minimal config so it can be used in
 the assembler to write the bootmap and bootloader code.
 """
 STAGE_OPTS = """
+"additionalProperties": false,
 "properties": {
   "timeout": {
     "description": "Boot loader timeout value",

--- a/stages/org.osbuild.zipl
+++ b/stages/org.osbuild.zipl
@@ -10,6 +10,12 @@ Configures `zipl` with a minimal config so it can be used in
 the assembler to write the bootmap and bootloader code.
 """
 STAGE_OPTS = """
+"properties": {
+  "timeout": {
+    "description": "Boot loader timeout value",
+    "type": "number"
+  }
+}
 """
 
 

--- a/test/pipelines/f30-boot.json
+++ b/test/pipelines/f30-boot.json
@@ -914,8 +914,8 @@
               "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
               "vfs_type": "ext4",
               "path": "/",
-              "freq": "1",
-              "passno": "1"
+              "freq": 1,
+              "passno": 1
             }
           ]
         }

--- a/test/stages_tests/fstab/b.json
+++ b/test/stages_tests/fstab/b.json
@@ -828,8 +828,8 @@
               "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
               "vfs_type": "ext4",
               "path": "/",
-              "freq": "1",
-              "passno": "1"
+              "freq": 1,
+              "passno": 1
             }
           ]
         }

--- a/test/stages_tests/groups/b.json
+++ b/test/stages_tests/groups/b.json
@@ -825,7 +825,7 @@
         "options": {
           "groups": {
             "testgroup": {
-              "gid": "42042"
+              "gid": 42042
             }
           }
         }

--- a/test/test_assemblers.py
+++ b/test/test_assemblers.py
@@ -107,10 +107,9 @@ class TestAssemblers(osbuildtest.TestCase):
             ("tree.tar.gz", "gzip", ["application/x-gzip", "application/gzip"])
         ]
         for filename, compression, expected_mimetypes in cases:
-            options = {
-                "filename": filename,
-                "compression": compression
-            }
+            options = {"filename": filename}
+            if compression:
+                options["compression"] = compression
             _, output_id = self.run_assembler("org.osbuild.tar", options)
             image = f"{self.store}/refs/{output_id}/{filename}"
             output = subprocess.check_output(["file", "--mime-type", image], encoding="utf-8")

--- a/test/test_osbuild.py
+++ b/test/test_osbuild.py
@@ -97,6 +97,23 @@ class TestDescriptions(unittest.TestCase):
                 msg = f"{klass} '{name}' has invalid STAGE_OPTS\n\t" + str(e)
                 self.fail(msg)
 
+    def test_schema(self):
+        schema = osbuild.meta.Schema(None)
+        self.assertFalse(schema)
+
+        schema = osbuild.meta.Schema({"type": "bool"})  # should be 'boolean'
+        self.assertFalse(schema.check().valid)
+        self.assertFalse(schema)
+
+        schema = osbuild.meta.Schema({"type": "array", "minItems": 3})
+        self.assertTrue(schema.check().valid)
+        self.assertTrue(schema)
+
+        res = schema.validate([1, 2])
+        self.assertFalse(res)
+        res = schema.validate([1, 2, 3])
+        self.assertTrue(res)
+
     def test_validation(self):
         index = osbuild.meta.Index(os.curdir)
 

--- a/test/test_osbuild.py
+++ b/test/test_osbuild.py
@@ -1,4 +1,3 @@
-import importlib.util
 import json
 import os
 import unittest
@@ -79,26 +78,18 @@ class TestDescriptions(unittest.TestCase):
             })
 
     def test_stageinfo(self):
-        def list_stages(base):
-            return [(base, f) for f in os.listdir(base) if f.startswith("org.osbuild")]
+        def list_stages(base, klass):
+            return [(klass, f) for f in os.listdir(base) if f.startswith("org.osbuild")]
 
-        def load_module(base, name):
-            loader = importlib.machinery.SourceFileLoader(name, f"{base}/{name}")
-            spec = importlib.util.spec_from_loader(loader.name, loader)
-            mod = importlib.util.module_from_spec(spec)
-            loader.exec_module(mod)
-            return mod
-
-        stages = list_stages("stages")
-        stages += list_stages("assemblers")
+        stages = list_stages("stages", "Stage")
+        stages += list_stages("assemblers", "Assembler")
 
         for stage in stages:
-            base, name = stage
-            m = load_module(base, name)
+            klass, name = stage
             try:
-                json.loads("{" + m.STAGE_OPTS + "}")
+                osbuild.meta.StageInfo.load(os.curdir, klass, name)
             except json.decoder.JSONDecodeError as e:
-                msg = f"Stage '{base}/{name}' has invalid STAGE_OPTS\n\t" + str(e)
+                msg = f"{klass} '{name}' has invalid STAGE_OPTS\n\t" + str(e)
                 self.fail(msg)
 
     def test_validation(self):

--- a/test/test_osbuild.py
+++ b/test/test_osbuild.py
@@ -87,7 +87,12 @@ class TestDescriptions(unittest.TestCase):
         for stage in stages:
             klass, name = stage
             try:
-                osbuild.meta.StageInfo.load(os.curdir, klass, name)
+                info = osbuild.meta.StageInfo.load(os.curdir, klass, name)
+                schema = osbuild.meta.Schema(info.schema, name)
+                res = schema.check()
+                if not res:
+                    err = "\n  ".join(str(e) for e in res)
+                    self.fail(str(res) + "\n  " + err)
             except json.decoder.JSONDecodeError as e:
                 msg = f"{klass} '{name}' has invalid STAGE_OPTS\n\t" + str(e)
                 self.fail(msg)


### PR DESCRIPTION
Add a `--validate` option to the osbuild command that will validate the options of the stages, including the build pipeline and the assembler, against the json schema of the corresponding stages.

Will abort if any errors are found and print the corresponding messages, optionally in form of json if `--json` was passed as an command line option.

I was thinking of moving the actual validation code, including the `StageInfo` class to a new `osbuild/meta.py`. Opinions?