### PR TITLE
Small fixes for the json schemata and the samples

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -127,7 +127,7 @@ STAGE_OPTS = """
   },
   "size": {
     "description": "Virtual disk size",
-    "type": "string"
+    "type": "integer"
   },
   "root_fs_type": {
     "description": "Type of the root filesystem",

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -119,7 +119,7 @@ STAGE_OPTS = """
   "pttype": {
     "description": "The type of the partition table",
     "type": "string",
-    "enum": ["mbr", "gpt"]
+    "enum": ["mbr", "dos", "gpt"]
   },
   "root_fs_uuid": {
     "description": "UUID for the root filesystem",

--- a/assemblers/org.osbuild.rawfs
+++ b/assemblers/org.osbuild.rawfs
@@ -41,8 +41,7 @@ STAGE_OPTS = """
   },
   "size": {
     "description": "Maximum size of the filesystem",
-    "type": "string",
-    "examples": ["500M", "20GB"]
+    "type": "integer"
   },
   "fs_type": {
     "description": "Filesystem type",

--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -39,8 +39,8 @@
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           }
         ]
       }

--- a/samples/base-rawfs.json
+++ b/samples/base-rawfs.json
@@ -40,8 +40,8 @@
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           }
         ]
       }

--- a/samples/base-rpm-qcow2.json
+++ b/samples/base-rpm-qcow2.json
@@ -1320,8 +1320,8 @@
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           }
         ]
       }

--- a/samples/cloud-base.json
+++ b/samples/cloud-base.json
@@ -42,8 +42,8 @@
             "uuid": "ea711a29-e460-4879-9d70-9da99ae021f9",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           }
         ]
       }

--- a/samples/f30-aarch64.json
+++ b/samples/f30-aarch64.json
@@ -54,16 +54,16 @@
             "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           },
           {
             "uuid": "46BB-8120",
             "vfs_type": "vfat",
             "path": "/boot/efi",
             "options": "umask=0077,shortname=winnt",
-            "freq": "0",
-            "passno": "2"
+            "freq": 0,
+            "passno": 2
           }
         ]
       }

--- a/samples/f30-base-uefi.json
+++ b/samples/f30-base-uefi.json
@@ -56,16 +56,16 @@
             "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           },
           {
             "uuid": "46BB-8120",
             "vfs_type": "vfat",
             "path": "/boot/efi",
             "options": "umask=0077,shortname=winnt",
-            "freq": "0",
-            "passno": "2"
+            "freq": 0,
+            "passno": 2
           }
         ]
       }

--- a/samples/f30-bootpart-hybrid.json
+++ b/samples/f30-bootpart-hybrid.json
@@ -56,23 +56,23 @@
             "uuid": "08a41983-3328-4d1a-ae3c-1699e6d2a806",
             "vfs_type": "ext4",
             "path": "/boot",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           },
           {
             "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           },
           {
             "uuid": "46BB-8120",
             "vfs_type": "vfat",
             "path": "/boot/efi",
             "options": "umask=0077,shortname=winnt",
-            "freq": "0",
-            "passno": "2"
+            "freq": 0,
+            "passno": 2
           }
         ]
       }

--- a/samples/f30-ppc64le.json
+++ b/samples/f30-ppc64le.json
@@ -45,8 +45,8 @@
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           }
         ]
       }

--- a/samples/f30-qcow2-gpt.json
+++ b/samples/f30-qcow2-gpt.json
@@ -49,8 +49,8 @@
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           }
         ]
       }

--- a/samples/f30-qcow2-hybrid.json
+++ b/samples/f30-qcow2-hybrid.json
@@ -56,16 +56,16 @@
             "uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           },
           {
             "uuid": "46BB-8120",
             "vfs_type": "vfat",
             "path": "/boot/efi",
             "options": "umask=0077,shortname=winnt",
-            "freq": "0",
-            "passno": "2"
+            "freq": 0,
+            "passno": 2
           }
         ]
       }

--- a/samples/f30-s390x.json
+++ b/samples/f30-s390x.json
@@ -57,8 +57,8 @@
             "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
             "vfs_type": "ext4",
             "path": "/",
-            "freq": "1",
-            "passno": "1"
+            "freq": 1,
+            "passno": 1
           }
         ]
       }

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -66,8 +66,10 @@ STAGE_OPTS = """
   },
   "legacy": {
     "description": "Include legacy boot support",
-    "type": "boolean",
-    "default": true
+    "oneOf": [
+      {"type": "boolean", "default": true},
+      {"type": "string", "default": "i386-pc"}
+    ]
   },
   "uefi": {
     "description": "Include UEFI boot support",


### PR DESCRIPTION
For the `qemu` and `rawfs` assemblers the image `size` attribute was wrongly declared as `string`. The `qemu` assembler also was missing the `dos` option as an alias for `mbr`. The `grub2` stage allows `legacy` to be a `boolean` or a `string`.

All the samples had wrong types for `org.osbuild.fstab.{freq, passno}` (were `string`, should be `integer`).

