### PR TITLE
Remove unused GitLab CI configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,0 @@
-stages:
-  - test
-
-unit_test:
-  stage: test
-  image: python:3.7-alpine
-  script:
-    - python3 -m unittest test.test_osbuild


### PR DESCRIPTION
We're not using the GitLab CI integration yet and we will need to
rethink how to implement it anyway.

Signed-off-by: Major Hayden <major@redhat.com>