### PR TITLE
No automatic commits for the last stage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: docker.io/library/python:3.7
+      options: --privileged  # Needed for bind mounts in unit tests
     steps:
       - name: Clone repository
         uses: actions/checkout@v2

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -210,18 +210,10 @@ class ObjectStore:
 
     @contextlib.contextmanager
     def get(self, object_id):
-        with self.tempdir() as tmp:
-            if object_id:
-                path = self.resolve_ref(object_id)
-                mount(path, tmp)
-                try:
-                    yield tmp
-                finally:
-                    umount(tmp)
-            else:
-                # None was given as object_id, just return an empty directory
-                yield tmp
-
+        with Object(self) as obj:
+            obj.base = object_id
+            with obj.read() as path:
+                yield path
 
     @contextlib.contextmanager
     def new(self, object_id, base_id=None):

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -129,8 +129,8 @@ class Object:
     @contextlib.contextmanager
     def _open(self):
         """Open the directory and return the file descriptor"""
+        fd = os.open(self._path, os.O_DIRECTORY)
         try:
-            fd = os.open(self._path, os.O_DIRECTORY)
             yield fd
         finally:
             os.close(fd)

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -28,7 +28,8 @@ def suppress_oserror(*errnos):
 
 
 class Object:
-    def __init__(self, path: str):
+    def __init__(self, store: "ObjectStore", path: str):
+        self.store = store
         os.makedirs(path, mode=0o755, exist_ok=True)
         self.path = path
 
@@ -113,7 +114,7 @@ class ObjectStore:
         with tempfile.TemporaryDirectory(dir=self.store) as tmp:
             # the object that is yielded will be added to the content store
             # on success as object_id
-            obj = Object(f"{tmp}/tree")
+            obj = Object(self, f"{tmp}/tree")
 
             if base_id:
                 # the base, the working tree and the output dir are all
@@ -143,7 +144,7 @@ class ObjectStore:
         # the latter with the contents of `object_path` and commit
         # it to the store
         with tempfile.TemporaryDirectory(dir=self.store) as tmp:
-            obj = Object(f"{tmp}/tree")
+            obj = Object(self, f"{tmp}/tree")
             obj.init(object_path)
             return self.commit(obj, object_id)
 

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -59,7 +59,7 @@ class Object:
     @property
     def treesum(self) -> str:
         """Calculate the treesum of the object"""
-        with self.open() as fd:
+        with self._open() as fd:
             m = hashlib.sha256()
             treesum.treesum(m, fd)
             treesum_hash = m.hexdigest()
@@ -72,15 +72,6 @@ class Object:
         else:
             path = self._tree
         return path
-
-    @contextlib.contextmanager
-    def open(self):
-        """Open the directory and return the file descriptor"""
-        try:
-            fd = os.open(self._path, os.O_DIRECTORY)
-            yield fd
-        finally:
-            os.close(fd)
 
     def write(self) -> str:
         """Return a path that can be written to"""
@@ -110,6 +101,15 @@ class Object:
         if self._workdir:
             self._workdir.cleanup()
             self._workdir = None
+
+    @contextlib.contextmanager
+    def _open(self):
+        """Open the directory and return the file descriptor"""
+        try:
+            fd = os.open(self._path, os.O_DIRECTORY)
+            yield fd
+        finally:
+            os.close(fd)
 
     def __enter__(self):
         return self

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -62,15 +62,16 @@ class Object:
         finally:
             os.close(fd)
 
-    def move(self, destination: str):
-        """Move the object to destination
+    def store_tree(self, destination: str):
+        """Store the tree at destination and reset itself
 
-        Does so atomically by using rename(2). If the
-        target already exist, use that instead
+        Moves the tree atomically by using rename(2). If the
+        target already exist, does nothing. Afterwards it
+        resets itself and can be used as if it was new.
         """
         with suppress_oserror(errno.ENOTEMPTY, errno.EEXIST):
             os.rename(self.path, destination)
-        self._tree = destination
+        self.reset()
 
     def reset(self):
         self.cleanup()
@@ -194,7 +195,7 @@ class ObjectStore:
         # will always produce the same content hash, but that is not
         # guaranteed. If an object with the same treesum already exist, us
         # the existing one instead
-        obj.move(f"{self.objects}/{treesum_hash}")
+        obj.store_tree(f"{self.objects}/{treesum_hash}")
 
         # symlink the object_id (config hash) in the refs directory to the
         # treesum (content hash) in the objects directory. If a symlink by

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -105,11 +105,11 @@ class ObjectStore:
 
     @contextlib.contextmanager
     def new(self, object_id, base_id=None):
-        """Creates a new directory for `object_id`.
+        """Creates a new `Object` for `object_id`.
 
-        This method must be used as a context manager. It returns a path to a
-        temporary directory and only commits it when the context completes
-        without raising an exception.
+        This method must be used as a context manager. It returns a new
+        temporary instance of `Object`. It will only be committed to the
+        store if the context completes without raising an exception.
         """
         with tempfile.TemporaryDirectory(dir=self.store) as tmp:
             # the object that is yielded will be added to the content store
@@ -122,7 +122,7 @@ class ObjectStore:
                 # fs supports it
                 obj.init(self.resolve_ref(base_id))
 
-            yield obj.path
+            yield obj
 
             # if the yield above raises an exception, the working tree
             # is cleaned up by tempfile, otherwise, the it the content

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -160,22 +160,22 @@ class ObjectStore:
             # left to do is to commit it to the object store
             self.commit(obj, object_id)
 
-    def snapshot(self, object_path: str, object_id: str) -> str:
-        """Commit `object_path` to store and ref it as `object_id`
+    def snapshot(self, obj: str, object_id: str) -> str:
+        """Commit `obj` to store and ref it as `object_id`
 
-        Create a snapshot of `object_path` and store it via its
-        content hash in the object directory; additionally
+        Create a snapshot of the object `obj` and store it via
+        its content hash in the object directory; additionally
         create a new reference to it via `object_id` in the
         reference directory.
 
         Returns: The treesum of the snapshot
         """
         # Make a new temporary directory and Object; initialize
-        # the latter with the contents of `object_path` and commit
+        # the latter with the contents of `obj.path` and commit
         # it to the store
-        with Object(self) as obj:
-            obj.init(object_path)
-            return self.commit(obj, object_id)
+        with Object(self) as tmp:
+            tmp.init(obj.path)
+            return self.commit(tmp, object_id)
 
     def commit(self, obj: Object, object_id: str) -> str:
         """Commits a Object to the object store

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -73,11 +73,21 @@ class Object:
     @contextlib.contextmanager
     def open(self):
         """Open the directory and return the file descriptor"""
+        if self._base_path and not self._init:
+            path = self._base_path
+        else:
+            path = self._tree
+
         try:
-            fd = os.open(self.path, os.O_DIRECTORY)
+            fd = os.open(path, os.O_DIRECTORY)
             yield fd
         finally:
             os.close(fd)
+
+    def write(self) -> str:
+        """Return a path that can be written to"""
+        self.init()
+        return self._tree
 
     def store_tree(self, destination: str):
         """Store the tree at destination and reset itself
@@ -167,8 +177,8 @@ class ObjectStore:
             if base_id:
                 # if we were given a base id, resolve its path and set it
                 # as the base_path of the object
+                # NB: `obj` does not get initialized explicitly here
                 obj.base_path = self.resolve_ref(base_id)
-                obj.init()
 
             yield obj
 

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -150,7 +150,7 @@ class ObjectStore:
         with self.tempdir() as tmp:
             if object_id:
                 path = self.resolve_ref(object_id)
-                subprocess.run(["mount", "-o", "bind,ro,mode=0755", path, tmp], check=True)
+                subprocess.run(["mount", "--make-private", "-o", "bind,ro,mode=0755", path, tmp], check=True)
                 try:
                     yield tmp
                 finally:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -281,7 +281,7 @@ class Pipeline:
                                               var=store,
                                               secrets=secrets)
                                 if stage.checkpoint:
-                                    object_store.snapshot(tree.path, stage.id)
+                                    object_store.snapshot(tree, stage.id)
                                 results["stages"].append(r.as_dict())
                     except BuildError as err:
                         results["stages"].append(err.as_dict())

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -281,7 +281,7 @@ class Pipeline:
                                               var=store,
                                               secrets=secrets)
                                 if stage.checkpoint:
-                                    object_store.snapshot(tree, stage.id)
+                                    object_store.commit(tree, stage.id)
                                 results["stages"].append(r.as_dict())
                     except BuildError as err:
                         results["stages"].append(err.as_dict())

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -272,7 +272,7 @@ class Pipeline:
                     try:
                         with object_store.new(self.tree_id, base_id=base) as tree:
                             for stage in self.stages[base_idx + 1:]:
-                                r = stage.run(tree,
+                                r = stage.run(tree.path,
                                               self.runner,
                                               build_tree,
                                               store,
@@ -281,7 +281,7 @@ class Pipeline:
                                               var=store,
                                               secrets=secrets)
                                 if stage.checkpoint:
-                                    object_store.snapshot(tree, stage.id)
+                                    object_store.snapshot(tree.path, stage.id)
                                 results["stages"].append(r.as_dict())
                     except BuildError as err:
                         results["stages"].append(err.as_dict())
@@ -298,7 +298,7 @@ class Pipeline:
                             r = self.assembler.run(tree,
                                                    self.runner,
                                                    build_tree,
-                                                   output_dir=output_dir,
+                                                   output_dir=output_dir.path,
                                                    interactive=interactive,
                                                    libdir=libdir,
                                                    var=store)

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -272,7 +272,7 @@ class Pipeline:
                     try:
                         with object_store.new(self.tree_id, base_id=base) as tree:
                             for stage in self.stages[base_idx + 1:]:
-                                r = stage.run(tree.path,
+                                r = stage.run(tree.write(),
                                               self.runner,
                                               build_tree,
                                               store,
@@ -298,7 +298,7 @@ class Pipeline:
                             r = self.assembler.run(tree,
                                                    self.runner,
                                                    build_tree,
-                                                   output_dir=output_dir.path,
+                                                   output_dir=output_dir.write(),
                                                    interactive=interactive,
                                                    libdir=libdir,
                                                    var=store)

--- a/test/osbuildtest.py
+++ b/test/osbuildtest.py
@@ -8,6 +8,8 @@ import subprocess
 import tempfile
 import unittest
 
+import osbuild
+
 
 class TestCase(unittest.TestCase):
     """A TestCase to test running the osbuild program.
@@ -43,6 +45,20 @@ class TestCase(unittest.TestCase):
         if sources:
             osbuild_cmd.append("--sources")
             osbuild_cmd.append(sources)
+
+        # Create a checkpoint at the last stage, i.e.
+        # commit the final tree to the store, so that
+        # tests can use it to compare against
+        if input:
+            manifest = json.loads(input)
+        else:
+            with open(pipeline, "r") as f:
+                manifest = json.load(f)
+
+        parsed = osbuild.load(manifest, {})
+        if parsed.tree_id:
+            osbuild_cmd.append("--checkpoint")
+            osbuild_cmd.append(parsed.tree_id)
 
         stdin = subprocess.PIPE if input else None
 

--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -25,7 +25,8 @@ class TestObjectStore(unittest.TestCase):
         with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
             object_store = objectstore.ObjectStore(tmp)
             with object_store.new("a") as tree:
-                p = Path(f"{tree.path}/A")
+                path = tree.write()
+                p = Path(f"{path}/A")
                 p.touch()
 
             assert os.path.exists(f"{object_store.refs}/a")
@@ -35,9 +36,10 @@ class TestObjectStore(unittest.TestCase):
             assert len(os.listdir(f"{object_store.refs}/a/")) == 1
 
             with object_store.new("b") as tree:
-                p = Path(f"{tree.path}/A")
+                path = tree.write()
+                p = Path(f"{path}/A")
                 p.touch()
-                p = Path(f"{tree.path}/B")
+                p = Path(f"{path}/B")
                 p.touch()
 
             assert os.path.exists(f"{object_store.refs}/b")
@@ -51,12 +53,14 @@ class TestObjectStore(unittest.TestCase):
         with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
             object_store = objectstore.ObjectStore(tmp)
             with object_store.new("a") as tree:
-                p = Path(f"{tree.path}/A")
+                path = tree.write()
+                p = Path(f"{path}/A")
                 p.touch()
 
             with object_store.new("b") as tree:
+                path = tree.write()
                 shutil.copy2(f"{object_store.refs}/a/A",
-                             f"{tree.path}/A")
+                             f"{path}/A")
 
             assert os.path.exists(f"{object_store.refs}/a")
             assert os.path.exists(f"{object_store.refs}/a/A")
@@ -70,10 +74,12 @@ class TestObjectStore(unittest.TestCase):
     def test_snapshot(self):
         object_store = objectstore.ObjectStore(self.store)
         with object_store.new("b") as tree:
-            p = Path(f"{tree.path}/A")
+            path = tree.write()
+            p = Path(f"{path}/A")
             p.touch()
             object_store.snapshot(tree, "a")
-            p = Path(f"{tree.path}/B")
+            path = tree.write()
+            p = Path(f"{path}/B")
             p.touch()
 
         # check the references exist

--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -72,7 +72,7 @@ class TestObjectStore(unittest.TestCase):
         with object_store.new("b") as tree:
             p = Path(f"{tree.path}/A")
             p.touch()
-            object_store.snapshot(tree.path, "a")
+            object_store.snapshot(tree, "a")
             p = Path(f"{tree.path}/B")
             p.touch()
 

--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -77,7 +77,7 @@ class TestObjectStore(unittest.TestCase):
             path = tree.write()
             p = Path(f"{path}/A")
             p.touch()
-            object_store.snapshot(tree, "a")
+            object_store.commit(tree, "a")
             path = tree.write()
             p = Path(f"{path}/B")
             p.touch()

--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -25,7 +25,7 @@ class TestObjectStore(unittest.TestCase):
         with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
             object_store = objectstore.ObjectStore(tmp)
             with object_store.new("a") as tree:
-                p = Path(f"{tree}/A")
+                p = Path(f"{tree.path}/A")
                 p.touch()
 
             assert os.path.exists(f"{object_store.refs}/a")
@@ -35,9 +35,9 @@ class TestObjectStore(unittest.TestCase):
             assert len(os.listdir(f"{object_store.refs}/a/")) == 1
 
             with object_store.new("b") as tree:
-                p = Path(f"{tree}/A")
+                p = Path(f"{tree.path}/A")
                 p.touch()
-                p = Path(f"{tree}/B")
+                p = Path(f"{tree.path}/B")
                 p.touch()
 
             assert os.path.exists(f"{object_store.refs}/b")
@@ -51,12 +51,12 @@ class TestObjectStore(unittest.TestCase):
         with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
             object_store = objectstore.ObjectStore(tmp)
             with object_store.new("a") as tree:
-                p = Path(f"{tree}/A")
+                p = Path(f"{tree.path}/A")
                 p.touch()
 
             with object_store.new("b") as tree:
                 shutil.copy2(f"{object_store.refs}/a/A",
-                             f"{tree}/A")
+                             f"{tree.path}/A")
 
             assert os.path.exists(f"{object_store.refs}/a")
             assert os.path.exists(f"{object_store.refs}/a/A")
@@ -70,10 +70,10 @@ class TestObjectStore(unittest.TestCase):
     def test_snapshot(self):
         object_store = objectstore.ObjectStore(self.store)
         with object_store.new("b") as tree:
-            p = Path(f"{tree}/A")
+            p = Path(f"{tree.path}/A")
             p.touch()
-            object_store.snapshot(tree, "a")
-            p = Path(f"{tree}/B")
+            object_store.snapshot(tree.path, "a")
+            p = Path(f"{tree.path}/B")
             p.touch()
 
         # check the references exist


### PR DESCRIPTION
This series of commits does away with the automatic commit at the end of the last stage of the normal pipeline (for now the auto-commit of the last stage of the _build_ pipeline is kept).
It does that by channelling all read and write operations to the store via the object `Object` (renamed from `TreeObject`). This `Object` can have a _base_ (i.e. another `Object`, realisticly a tree) and implements Copy-On-Write semantics: read operations will be done directly from the _base_ directory, if no `write` operation has been done to the tree yet. On such a `write` op, the contents of _base_ will be coped to a temporary directory. When an `Object` is committed to the store, the contents of the temporary directory will be moved inside the store. The `Object` will then be reset (a new temporary tree created) and the _base_ of `Object` will be set to the newly created entry in the store. This ensures that even with two pipeline runs are racing and thus two `Objects` with the same content created only one will win, but both `Objects` will from then on use the same _base_ (tree) for all further stages.

TODO:
 - [x] commit messages
 - [x] tests