### PR TITLE
spec: use forgemeta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ sdist:
 	find `pwd`/dist -name '*.tar.gz' -printf '%f\n' -exec mv {} . \;
 
 tarball:
-	git archive --prefix=osbuild-$(VERSION)/ --format=tar.gz HEAD > $(VERSION).tar.gz
+	git archive --prefix=osbuild-$(VERSION)/ --format=tar.gz HEAD > osbuild-$(VERSION).tar.gz
 
 srpm: $(PACKAGE_NAME).spec check-working-directory tarball
 	/usr/bin/rpmbuild -bs \

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -1,14 +1,19 @@
+%global		forgeurl https://github.com/osbuild/osbuild
+
+Version:        7
+
+%forgemeta
+
 %global         pypi_name osbuild
 %global         pkgdir %{_prefix}/lib/%{pypi_name}
 
 Name:           %{pypi_name}
-Version:        7
 Release:        1%{?dist}
 License:        ASL 2.0
 
-URL:            https://github.com/osbuild/osbuild
+URL:            %{forgeurl}
 
-Source0:        https://github.com/osbuild/%{pypi_name}/archive/%{version}.tar.gz
+Source0:        %{forgesource}
 BuildArch:      noarch
 Summary:        A build system for OS images
 
@@ -41,7 +46,7 @@ Summary:        %{summary}
 A build system for OS images
 
 %prep
-%autosetup -n %{name}-%{version}
+%forgesetup
 
 %build
 %py3_build


### PR DESCRIPTION
This changes the name of the source tarball, but apart from that has
no effect as-is.

However, if the `commit` global is set, then the source tarball is
expected to be the standard git-archive at that commit, and the
release field is set to contain the date and the git sha. This is
useful for when we want to build rpms between releases.

This works analogously to how osbulid-composer currently works.

See <https://fedoraproject.org/wiki/Forge-hosted_projects_packaging_automation>
for details.

See <https://gist.github.com/teg/f9c267b2da7ba0aafda02a5b306d44ec> for how this could be used.