### PR TITLE
ci: run the rpm build tests in Fedora containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,18 @@ jobs:
       script:
         - python3 -m unittest test.test_osbuild
         - python3 -m unittest test.test_objectstore
-    - name: rpm
-      before_install:
-        - sudo apt-get install -y rpm python3-setuptools
-        - sudo wget --directory-prefix=/usr/lib/rpm/macros.d https://src.fedoraproject.org/rpms/python-rpm-macros/raw/master/f/macros.python-srpm
-        - sudo wget --directory-prefix=/usr/lib/rpm/macros.d https://src.fedoraproject.org/rpms/python-rpm-macros/raw/master/f/macros.python
-        - sudo wget --directory-prefix=/usr/lib/rpm/macros.d https://src.fedoraproject.org/rpms/python-rpm-macros/raw/master/f/macros.python3
-      script: make rpm-nodeps
+    - name: rpm-f31
+      services:
+        - docker
+      script: docker run --rm -v $(pwd):/src fedora:31 sh -c "cd /src && dnf install -y 'dnf-command(builddep)' make git rpm-build && dnf builddep -y osbuild.spec && make rpm"
+    - name: rpm-f32
+      services:
+        - docker
+      script: docker run --rm -v $(pwd):/src fedora:32 sh -c "cd /src && dnf install -y 'dnf-command(builddep)' make git rpm-build && dnf builddep -y osbuild.spec && make rpm"
+    - name: rpm-f33
+      services:
+        - docker
+      script: docker run --rm -v $(pwd):/src fedora:33 sh -c "cd /src && dnf install -y 'dnf-command(builddep)' make git rpm-build && dnf builddep -y osbuild.spec && make rpm"
     - name: pipeline-noop
       before_install: sudo apt-get install -y systemd-container
       script:

--- a/Makefile
+++ b/Makefile
@@ -16,27 +16,11 @@ srpm: $(PACKAGE_NAME).spec check-working-directory tarball
 	  --define "_srcrpmdir $(CURDIR)" \
 	  $(PACKAGE_NAME).spec
 
-rpm: $(PACKAGE_NAME).spec check-working-directory tarball 
+rpm: $(PACKAGE_NAME).spec check-working-directory tarball
 	- rm -r "`pwd`/output"
 	mkdir -p "`pwd`/output"
 	mkdir -p "`pwd`/rpmbuild"
 	/usr/bin/rpmbuild -bb \
-	  --define "_sourcedir `pwd`" \
-	  --define "_specdir `pwd`" \
-	  --define "_builddir `pwd`/rpmbuild" \
-	  --define "_srcrpmdir `pwd`" \
-	  --define "_rpmdir `pwd`/output" \
-	  --define "_buildrootdir `pwd`/build" \
-	  $(PACKAGE_NAME).spec
-	rm -r "`pwd`/rpmbuild"
-	rm -r "`pwd`/build"
-
-rpm-nodeps: $(PACKAGE_NAME).spec tarball
-	- rm -r "`pwd`/output"
-	mkdir -p "`pwd`/output"
-	mkdir -p "`pwd`/rpmbuild"
-	/usr/bin/rpmbuild -bb \
-	  --nodeps \
 	  --define "_sourcedir `pwd`" \
 	  --define "_specdir `pwd`" \
 	  --define "_builddir `pwd`/rpmbuild" \


### PR DESCRIPTION
Building rpm directly on Ubuntu is somewhat possible but it's fragile and
it cannot cover all quirks of rpm build. This commit switches the rpm build
tests to using fedora containers. This isn't also the best solution but
imho it's much better than the previous one.

I opened this PR because #226 is failing due to rpm macro failure which doesn't look like fun to fix. As our setup is kinda strange (building rpm directly on Ubuntu) I decided to rework it using Fedora containers. Packit might be a better solution but I'm not sure if we can rely on it currently and I don't mind having another independent rpm build check in Travis CI.

Also, I'm not sure if want to we to test the rpm build build against rawhide, it might be a bit fragile...