### PR TITLE
Build RPMs via GitHub Actions

### DIFF
--- a/.github/workflows/build_rpms.yml
+++ b/.github/workflows/build_rpms.yml
@@ -1,0 +1,57 @@
+name: RPM Build
+
+# NOTE(mhayden): Restricting branches prevents jobs from being doubled since
+# a push to a pull request triggers two events.
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - master
+
+jobs:
+  rpm_build:
+    name: "Build RPMs"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fedora_release: ["31", "32", "rawhide"]
+    container:
+      image: "docker.io/library/fedora:${{ matrix.fedora_release }}"
+    steps:
+      - name: Prepare container
+        run: |
+          echo "fastestmirror=1" >> /etc/dnf/dnf.conf
+          echo "install_weak_deps=0" >> /etc/dnf/dnf.conf
+          dnf -y upgrade
+          dnf -y install dnf-plugins-core git make rpm-build
+          mkdir rpms
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          path: osbuild
+
+      - name: Install RPM build dependencies
+        run: dnf -y builddep osbuild/osbuild.spec
+
+      - name: Build RPMs
+        run: |
+          pushd osbuild
+            make rpm
+          popd
+          cp -av osbuild/output/*/*.rpm rpms/
+          date > rpms/timestamp.txt
+
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v1
+        with:
+          name: Packages
+          path: rpms/
+
+      - name: Test RPM installation
+        run: |
+          pushd rpms
+            dnf -y install $(ls *.rpm)
+          popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,6 @@ jobs:
       script:
         - python3 -m unittest test.test_osbuild
         - python3 -m unittest test.test_objectstore
-    - name: rpm-f31
-      services:
-        - docker
-      script: docker run --rm -v $(pwd):/src fedora:31 sh -c "cd /src && dnf install -y 'dnf-command(builddep)' make git rpm-build && dnf builddep -y osbuild.spec && make rpm"
-    - name: rpm-f32
-      services:
-        - docker
-      script: docker run --rm -v $(pwd):/src fedora:32 sh -c "cd /src && dnf install -y 'dnf-command(builddep)' make git rpm-build && dnf builddep -y osbuild.spec && make rpm"
-    - name: rpm-f33
-      services:
-        - docker
-      script: docker run --rm -v $(pwd):/src fedora:33 sh -c "cd /src && dnf install -y 'dnf-command(builddep)' make git rpm-build && dnf builddep -y osbuild.spec && make rpm"
     - name: pipeline-noop
       before_install: sudo apt-get install -y systemd-container
       script:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name="osbuild",
-    version="7",
+    version="8",
     description="A build system for OS images",
     packages=["osbuild"],
     license='Apache-2.0',


### PR DESCRIPTION
* Bump `setup.py` to version 8 to match the spec file
* Build RPMs natively in Fedora 31, 32, and Rawhide containers via GitHub Actions
* Remove redundant RPM builds in Travis CI