### PR TITLE
github: use only specfile to build RPMs

### DIFF
--- a/.github/workflows/build_rpms.yml
+++ b/.github/workflows/build_rpms.yml
@@ -25,33 +25,51 @@ jobs:
           echo "fastestmirror=1" >> /etc/dnf/dnf.conf
           echo "install_weak_deps=0" >> /etc/dnf/dnf.conf
           dnf -y upgrade
-          dnf -y install dnf-plugins-core git make rpm-build
-          mkdir rpms
+          dnf -y install dnf-plugins-core rpm-build rpmdevtools
 
-      - name: Clone repository
-        uses: actions/checkout@v2
-        with:
-          path: osbuild
+      - name: Fetch .spec file
+        run: |
+          mkdir spec
+          # Fetch the spec file at the given commit, and prepend the commit sha to it
+          curl "https://raw.githubusercontent.com/osbuild/osbuild/${GITHUB_SHA}/osbuild.spec" -o osbuild.spec
+          echo "%global commit ${GITHUB_SHA}" | cat - osbuild.spec > spec/osbuild.spec
 
       - name: Install RPM build dependencies
-        run: dnf -y builddep osbuild/osbuild.spec
+        run: dnf -y builddep spec/osbuild.spec
+
+      - name: Fetch sources
+        run: |
+          mkdir sources
+          spectool -g spec/osbuild.spec -C sources/
+
+      - name: Build SRPM
+        run: |
+          mkdir srpms
+          rpmbuild -bs \
+            --define "_sourcedir sources" \
+            --define "_srcrpmdir srpms" \
+            spec/osbuild.spec
 
       - name: Build RPMs
         run: |
-          pushd osbuild
-            make rpm
-          popd
-          cp -av osbuild/output/*/*.rpm rpms/
-          date > rpms/timestamp.txt
+          mkdir rpmbuild rpms build
+          rpmbuild -bb \
+            --define "_sourcedir `pwd`/sources" \
+            --define "_specdir `pwd`/spec" \
+            --define "_builddir `pwd`/rpmbuild" \
+            --define "_srcrpmdir `pwd`/srpms" \
+            --define "_rpmdir `pwd`/rpms" \
+            --define "_buildrootdir `pwd`/build" \
+            spec/osbuild.spec
 
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v1
         with:
-          name: Packages
+          name: rpms
           path: rpms/
 
       - name: Test RPM installation
         run: |
-          pushd rpms
+          pushd rpms/noarch
             dnf -y install $(ls *.rpm)
           popd


### PR DESCRIPTION
Make RPM building more similar to how RPMs will be built in koji.

This downloads the specfile from github at the given commit, appends
the commit sha to the specfile and uses spectools to download the
correct sources from github.

This should be equivalent to what is done in the makefile, the only
behavioral difference is that the rpms are now versioned based on
the git sha they are built from.

The main purpose of this change is to avoid any differences between
the CI and the real RPMs due to bugs in the Makefile. Correctly
versioned RPMs will also be handy for testing/debugging/deployment.