### PR TITLE
Allow osbuild to run on rawhide (f33)

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -80,6 +80,9 @@ ln -s org.osbuild.fedora31 %{buildroot}%{pkgdir}/runners/org.osbuild.host
 %if 0%{?fc32}
 ln -s org.osbuild.fedora32 %{buildroot}%{pkgdir}/runners/org.osbuild.host
 %endif
+%if 0%{?fc33}
+ln -s org.osbuild.fedora33 %{buildroot}%{pkgdir}/runners/org.osbuild.host
+%endif
 %if 0%{?el8}
 ln -s org.osbuild.rhel82 %{buildroot}%{pkgdir}/runners/org.osbuild.host
 %endif

--- a/runners/org.osbuild.fedora33
+++ b/runners/org.osbuild.fedora33
@@ -1,0 +1,1 @@
+org.osbuild.fedora30


### PR DESCRIPTION
Add an additional symlink for Fedora Rawhide, which is currently set
as release 33.

Signed-off-by: Major Hayden <major@redhat.com>