### PR TITLE
🧨 Run all RPM builds even if one fails

### DIFF
--- a/.github/workflows/build_rpms.yml
+++ b/.github/workflows/build_rpms.yml
@@ -15,6 +15,7 @@ jobs:
     name: "Build RPMs"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         fedora_release: ["31", "32", "rawhide"]
     container:


### PR DESCRIPTION
By default, GitHub Actions stops running all RPM builds if one fails.
This means that a temporary repository issue (like what is happening
with F32 today) stops all RPM builds.

Set the `fail-fast` option to `false` to disable this behavior.

Signed-off-by: Major Hayden <major@redhat.com>