### PR TITLE
osbuild: make parameter identifiers more descriptive

### DIFF
--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -35,18 +35,18 @@ def main():
     parser = argparse.ArgumentParser(description="Build operating system images")
     parser.add_argument("pipeline_path", metavar="PIPELINE",
                         help="json file containing the pipeline that should be built, or a '-' to read from stdin")
-    parser.add_argument("--build-env", metavar="ENV", type=os.path.abspath,
+    parser.add_argument("--build-env", metavar="FILE", type=os.path.abspath,
                         help="json file containing a description of the build environment")
     parser.add_argument("--store", metavar="DIRECTORY", type=os.path.abspath,
                         default=".osbuild",
-                        help="the directory where intermediary os trees are stored")
-    parser.add_argument("--sources", metavar="SOURCES", type=os.path.abspath,
+                        help="directory where intermediary os trees are stored")
+    parser.add_argument("--sources", metavar="FILE", type=os.path.abspath,
                         help="json file containing a dictionary of source configuration")
-    parser.add_argument("--secrets", metavar="SECRETS", type=os.path.abspath,
+    parser.add_argument("--secrets", metavar="FILE", type=os.path.abspath,
                         help="json file containing a dictionary of secrets that are passed to sources")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath,
                         help="the directory containing stages, assemblers, and the osbuild library")
-    parser.add_argument("--checkpoint", metavar="CHECKPOINT", action="append", type=str, default=None,
+    parser.add_argument("--checkpoint", metavar="ID", action="append", type=str, default=None,
                         help="stage to commit to the object store during build (can be passed multiple times)")
     parser.add_argument("--json", action="store_true",
                         help="output results in JSON format")


### PR DESCRIPTION
(Copied from the commit-message:)

This modifies the help-strings for parameters in `osbuild --help`.
Rather than using the identifier to describe its purpose, make it
describe its type. That is, this changes:

  --sources=SOURCES         =>        --sources=FILE

The option-name should already describe the purpose, so lets use the
argument-name for the type. This also improves on the stuttering when
reading the output.

We already do that for options that take directories as arguments. For
some reasons, we did not do that for options that take file-paths.

It is arguable whether this should be `PATH` or `FILE`. The latter has
the advantage that it makes clear that it is not a directory. It should
be obvious that `FILE` allows all kinds of paths.

Lastly, this does not update the positional arguments (in our case just
`PIPELINE`), since I did not conclude on the best way to make it
self-documenting. `PIPELINE-FILE` sounds convoluted.