### PR TITLE
 Remove section about Packit from RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 ## Manual version using Packit
 
 ```
-$ ./bump-version.sh
+$ make bump-version
 ```
 Check that the spec file is correctly modified.
 Create new commit from this change; this commit will become the new tag.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,33 +17,6 @@ Create new release on Github containing the number of this release as a
 name, the same number as a tag, and description copied from the previous
 one.
 
-```
-$ packit status
-```
-This should show a new release available in upstream
-In order to execute this you will need a ~/.config/packit.yaml containing
-your FAS account, Pagure token, Github token, and valid Kerberos TGT for
-FEDORAPROJECT.ORG realm
-```
-$ packit propose-update
-```
-It will create a PR on src.fedoraproject.org.
-If everything looks fine, you can merge it.
-```
-$ packit build
-```
-Create new koji build
-```
-$ packit create-update
-```
-Create Bodhi update
 
-
-You can also repeat the procedure from 'propose-update' to the end with
-different branched of Fedora. You need to do it if you want to get new
-version into stable releases.
-```
-$ packit propose-update --dist-git-branch f31
-$ # other commands take the same switch
-```
-
+Once the Github release is available, follow the standard procedure for
+creating a Fedora update.


### PR DESCRIPTION
We don't use Packit any more, so just remove it from the RELEASE document. If we ever want to reintroduce it, feel free to simply revert this commit.