### PR TITLE
pipeline: don't commit checkpoints on error

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -270,12 +270,12 @@ class Pipeline:
                                           libdir=libdir,
                                           var=store,
                                           secrets=secrets)
-                        if stage.checkpoint:
-                            object_store.commit(tree, stage.id)
                         results["stages"].append(r.as_dict())
                         if not r.success:
                             results["success"] = False
                             return results
+                        if stage.checkpoint:
+                            object_store.commit(tree, stage.id)
                 results["tree_id"] = self.tree_id
 
             if self.assembler:
@@ -290,11 +290,11 @@ class Pipeline:
                                                    interactive=interactive,
                                                    libdir=libdir,
                                                    var=store)
-                        object_store.commit(output_tree, self.output_id)
                         results["assembler"] = r.as_dict()
                         if not r.success:
                             results["success"] = False
                             return results
+                        object_store.commit(output_tree, self.output_id)
 
                 results["output_id"] = self.output_id
 


### PR DESCRIPTION
Only commit checkpoints to the object store if the run of the stage or assembler was successful. Otherwise we commit a empty, corrupted or old tree to the store. Any subsequent run might then pick up that bogus tree as a starting point.