### PR TITLE
RELEASE.md: update to mention 'v' tag prefix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,19 +1,20 @@
 # How to create new release
 
-## Manual version using Packit
+Use the `bump-version` target to bump the version:
 
 ```
 $ make bump-version
 ```
 Check that the spec file is correctly modified.
 Create new commit from this change; this commit will become the new tag.
+The name of the tag should the be the new version number prefixed by `v`.
 ```
-$ git tag -a <version-number> -m <some description>
+$ git tag -a v<version-number> -m <some description>
 $ git push origin <version-number>
 ```
 
 
-Create new release on Github containing the number of this release as a
+Create new release on Github containing the number of this release as its
 name, the same number as a tag, and description copied from the previous
 one.
 


### PR DESCRIPTION
The rule for the tag name is to have a 'v' prefix, update the release instruction to reflect that.