### PR TITLE
Do not automatically commit build pipelines to the store

### DIFF
--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -207,9 +207,11 @@ class ObjectStore:
         self.store = store
         self.objects = f"{store}/objects"
         self.refs = f"{store}/refs"
+        self.tmp = f"{store}/tmp"
         os.makedirs(self.store, exist_ok=True)
         os.makedirs(self.objects, exist_ok=True)
         os.makedirs(self.refs, exist_ok=True)
+        os.makedirs(self.tmp, exist_ok=True)
 
     def contains(self, object_id):
         if not object_id:
@@ -224,7 +226,7 @@ class ObjectStore:
 
     def tempdir(self, prefix=None, suffix=None):
         """Return a tempfile.TemporaryDirectory within the store"""
-        return tempfile.TemporaryDirectory(dir=self.store,
+        return tempfile.TemporaryDirectory(dir=self.tmp,
                                            prefix=prefix,
                                            suffix=suffix)
 

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -235,28 +235,27 @@ class ObjectStore:
             with obj.read() as path:
                 yield path
 
-    @contextlib.contextmanager
     def new(self, base_id=None):
         """Creates a new temporary `Object`.
 
-        This method must be used as a context manager. It returns
-        a temporary instance of `Object`, which can then be used
-        for interaction with the store.
+        It returns a temporary instance of `Object`, the base
+        optionally set to `base_id`. It can be used to interact
+        with the store.
         If changes to the object's content were made (by calling
         `Object.write`), these must manually be committed to the
         store via `commit()`.
         """
 
-        with Object(self) as obj:
+        obj = Object(self)
 
-            if base_id:
-                # if we were given a base id then this is the base
-                # content for the new object
-                # NB: `Object` has copy-on-write semantics, so no
-                # copying of the data takes places at this point
-                obj.base = base_id
+        if base_id:
+            # if we were given a base id then this is the base
+            # content for the new object
+            # NB: `Object` has copy-on-write semantics, so no
+            # copying of the data takes places at this point
+            obj.base = base_id
 
-            yield obj
+        return obj
 
     def commit(self, obj: Object, object_id: str) -> str:
         """Commits a Object to the object store

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -203,6 +203,33 @@ class Object:
         return exc_type is None
 
 
+class HostTree:
+    """Read-only access to the host file system
+
+    An object that provides the same interface as
+    `objectstore.Object` that can be used to read
+    the host file-system.
+    """
+    def __init__(self, store):
+        self.store = store
+
+    @staticmethod
+    def write():
+        raise ValueError("Cannot write to host")
+
+    @contextlib.contextmanager
+    def read(self):
+        with self.store.tempdir() as tmp:
+            mount("/", tmp)
+            try:
+                yield tmp
+            finally:
+                umount(tmp)
+
+    def cleanup(self):
+        pass  # noop for the host
+
+
 class ObjectStore:
     def __init__(self, store):
         self.store = store

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -336,6 +336,17 @@ class Pipeline:
         results = {}
 
         with objectstore.ObjectStore(store) as object_store:
+            # if the final result is already in the store, exit
+            # early and don't attempt to build the tree, which
+            # in turn might not be in the store and would in that
+            # case be build but not be used
+            if object_store.contains(self.output_id):
+                results = {"output_id": self.output_id,
+                           "success": True}
+                if object_store.contains(self.tree_id):
+                    results["tree_id"] = self.tree_id
+                return results
+
             results, build_tree, tree = self.build_stages(object_store,
                                                           interactive,
                                                           libdir,

--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -263,6 +263,21 @@ class TestObjectStore(unittest.TestCase):
         assert os.path.exists(f"{object_store.refs}/b/A")
         assert os.path.exists(f"{object_store.refs}/b/B")
 
+    def test_host_tree(self):
+        object_store = objectstore.ObjectStore(self.store)
+        host = objectstore.HostTree(object_store)
+
+        # check we cannot call `write`
+        with self.assertRaises(ValueError):
+            with host.write() as _:
+                pass
+
+        # check we actually cannot write to the path
+        with host.read() as path:
+            p = Path(f"{path}/osbuild-test-file")
+            with self.assertRaises(OSError):
+                p.touch()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -61,6 +61,18 @@ class TestObjectStore(unittest.TestCase):
             self.assertEqual(object_store.resolve_ref("a"),
                              f"{object_store.refs}/a")
 
+    def test_cleanup(self):
+        # always use a temporary store so item counting works
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+            with objectstore.ObjectStore(tmp) as object_store:
+                tree = object_store.new()
+                self.assertEqual(len(os.listdir(object_store.tmp)), 1)
+                with tree.write() as path:
+                    p = Path(f"{path}/A")
+                    p.touch()
+            # there should be no temporary Objects dirs anymore
+            self.assertEqual(len(os.listdir(object_store.tmp)), 0)
+
     def test_duplicate(self):
         with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
             object_store = objectstore.ObjectStore(tmp)


### PR DESCRIPTION
Refactoring of the `Pipeline.run()` code so to not automatically commit the build pipelines to the store. 
 
Closes #259 