### PR TITLE
setup.py: remove unused import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import glob
 import setuptools
 
 setuptools.setup(


### PR DESCRIPTION
Remove the unused 'glob' import. Issue found by lgtm.com