### PR TITLE
Improve Build of Man-pages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,36 @@ jobs:
           cd osbuild
           pylint osbuild runners/* assemblers/* stages/* sources/*
 
+  documentation:
+    name: "📚 Documentation"
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/library/python:3.7
+    steps:
+      - name: Install Dependencies
+        run: |
+          pip install docutils
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          path: osbuild
+
+      - name: Generate Documentation
+        run: |
+          make \
+            -f osbuild/Makefile \
+            SRCDIR=osbuild \
+            BUILDDIR=build \
+            RST2MAN=rst2man.py \
+            man
+
+      - name: Verify Documentation
+        working-directory: build
+        run: |
+          test -d docs
+          test -f docs/osbuild.1
+
   unit_tests:
     name: "unit"
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@
 BUILDDIR ?= .
 SRCDIR ?= .
 
+RST2MAN ?= rst2man
+
 #
 # Automatic Variables
 #
@@ -88,9 +90,14 @@ $(BUILDDIR)/%/:
 # deployments to our website, as well as package manager scripts.
 #
 
+MANPAGES_RST = $(wildcard $(SRCDIR)/docs/*.[0123456789].rst)
+MANPAGES_TROFF = $(patsubst $(SRCDIR)/%.rst,$(BUILDDIR)/%,$(MANPAGES_RST))
+
+$(MANPAGES_TROFF): $(BUILDDIR)/docs/%: $(SRCDIR)/docs/%.rst | $(BUILDDIR)/docs/
+	$(RST2MAN) "$<" "$@"
+
 .PHONY: man
-man:
-	rst2man docs/osbuild.1.rst osbuild.1
+man: $(MANPAGES_TROFF)
 
 #
 # Building packages

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,96 @@
-VERSION := $(shell python3 setup.py --version)
-NEXT_VERSION := $(shell expr "$(VERSION)" + 1)
-COMMIT=$(shell git rev-parse HEAD)
+#
+# Maintenance Helpers
+#
+# This makefile contains targets used for development, as well as helpers to
+# aid automatization of maintenance. Unless a target is documented in
+# `make help`, it is not supported and is only meant to be used by developers
+# to aid their daily development work.
+#
+# All supported targets honor the `SRCDIR` variable to find the source-tree.
+# For most unsupported targets, you are expected to have the source-tree as
+# your working directory. To specify a different source-tree, simply override
+# the variable via `SRCDIR=<path>` on the commandline. While you can also
+# override `BUILDDIR`, you are usually expected to have the build output
+# directory as working directory.
+#
+
+BUILDDIR ?= .
+SRCDIR ?= .
+
+#
+# Automatic Variables
+#
+# This section contains a bunch of automatic variables used all over the place.
+# They mostly try to fetch information from the repository sources to avoid
+# hard-coding them in this makefile.
+#
+# Most of the variables here are pre-fetched so they will only ever be
+# evaluated once. This, however, means they are always executed regardless of
+# which target is run.
+#
+#     VERSION:
+#         This evaluates the `version` field of `setup.py`. Therefore, it will
+#         be set to the latest version number of this repository without any
+#         prefix (just a plain number).
+#
+#     COMMIT:
+#         This evaluates to the latest git commit sha. This will not work if
+#         the source is not a git checkout. Hence, this variable is not
+#         pre-fetched but evaluated at time of use.
+#
+
+VERSION := $(shell (cd "$(SRCDIR)" && python3 setup.py --version))
+COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
+
+#
+# Generic Targets
+#
+# The following is a set of generic targets used across the makefile. The
+# following targets are defined:
+#
+#     help
+#         This target prints all supported targets. It is meant as
+#         documentation of targets we support and might use outside of this
+#         repository.
+#         This is also the default target.
+#
+#     $(BUILDDIR)/
+#     $(BUILDDIR)/%/
+#         This target simply creates the specified directory. It is limited to
+#         the build-dir as a safety measure. Note that this requires you to use
+#         a trailing slash after the directory to not mix it up with regular
+#         files. Lastly, you mostly want this as order-only dependency, since
+#         timestamps on directories do not affect their content.
+#
+
+.PHONY: help
+help:
+	@echo "make [TARGETS...]"
+	@echo
+	@echo "This is the maintenance makefile of osbuild. The following"
+	@echo "targets are available:"
+	@echo
+	@echo "    help:               Print this usage information."
+	@echo "    man:                Generate all man-pages"
+
+$(BUILDDIR)/:
+	mkdir -p "$@"
+
+$(BUILDDIR)/%/:
+	mkdir -p "$@"
+
+#
+# Documentation
+#
+# The following targets build the included documentation. This includes the
+# packaged man-pages, but also all other kinds of documentation that needs to
+# be generated. Note that these targets are relied upon by automatic
+# deployments to our website, as well as package manager scripts.
+#
+
+.PHONY: man
+man:
+	rst2man docs/osbuild.1.rst osbuild.1
 
 #
 # Building packages
@@ -41,11 +131,10 @@ rpm: $(RPM_SPECFILE) $(RPM_TARBALL)
 # Releasing
 #
 
+NEXT_VERSION := $(shell expr "$(VERSION)" + 1)
+
 .PHONY: bump-version
 bump-version:
 	sed -i "s|Version:\(\s*\)$(VERSION)|Version:\1$(NEXT_VERSION)|" osbuild.spec
 	sed -i "s|Release:\(\s*\)[[:digit:]]\+|Release:\11|" osbuild.spec
 	sed -i "s|version=\"$(VERSION)\"|version=\"$(NEXT_VERSION)\"|" setup.py
-
-man:
-	rst2man docs/osbuild.1.rst osbuild.1

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -17,6 +17,7 @@ Source0:        %{forgesource}
 BuildArch:      noarch
 Summary:        A build system for OS images
 
+BuildRequires:  make
 BuildRequires:  python3-devel
 BuildRequires:  python3-docutils
 
@@ -51,7 +52,7 @@ A build system for OS images
 
 %build
 %py3_build
-rst2man docs/%{name}.1.rst %{name}.1
+make man
 
 %install
 %py3_install
@@ -74,7 +75,9 @@ mkdir -p %{buildroot}%{pkgdir}/assemblers/osbuild
 
 # documentation
 mkdir -p %{buildroot}%{_mandir}/man1
-install -m 644 osbuild.1 %{buildroot}%{_mandir}/man1/
+mkdir -p %{buildroot}%{_mandir}/man5
+install -p -m 0644 -t %{buildroot}%{_mandir}/man1/ docs/*.1
+install -p -m 0644 -t %{buildroot}%{_mandir}/man5/ docs/*.5
 
 %check
 exit 0
@@ -85,6 +88,7 @@ exit 0
 %license LICENSE
 %{_bindir}/osbuild
 %{_mandir}/man1/%{name}.1*
+%{_mandir}/man5/%{name}-manifest.5*
 %{pkgdir}
 
 %files -n       python3-%{pypi_name}

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -20,19 +20,19 @@ Summary:        A build system for OS images
 BuildRequires:  python3-devel
 BuildRequires:  python3-docutils
 
-Requires: bash
-Requires: coreutils
-Requires: curl
-Requires: dnf
-Requires: e2fsprogs
-Requires: glibc
-Requires: policycoreutils
-Requires: qemu-img
-Requires: systemd
-Requires: systemd-container
-Requires: tar
-Requires: util-linux
-Requires: python3-%{pypi_name}
+Requires:       bash
+Requires:       coreutils
+Requires:       curl
+Requires:       dnf
+Requires:       e2fsprogs
+Requires:       glibc
+Requires:       policycoreutils
+Requires:       qemu-img
+Requires:       systemd
+Requires:       systemd-container
+Requires:       tar
+Requires:       util-linux
+Requires:       python3-%{pypi_name}
 
 %{?python_enable_dependency_generator}
 
@@ -43,7 +43,7 @@ A build system for OS images
 Summary:        %{summary}
 %{?python_provide:%python_provide python3-%{pypi_name}}
 
-%description -n     python3-%{pypi_name}
+%description -n python3-%{pypi_name}
 A build system for OS images
 
 %prep
@@ -87,7 +87,7 @@ exit 0
 %{_mandir}/man1/%{name}.1*
 %{pkgdir}
 
-%files -n     python3-%{pypi_name}
+%files -n       python3-%{pypi_name}
 %license LICENSE
 %doc README.md
 %{python3_sitelib}/%{pypi_name}-*.egg-info/


### PR DESCRIPTION
This PR extends `make man`. See each commit for details. The driving force is to allow me to extend `osbuild.org` to automatically pull documentation from the respective osbuild repositories and deploy documentation to `osbuild.org`.

I know this touches Makefiles and, thus, triggers all our feelings. I tried to document everything, keep crazy features out, and just make sure the make-rules are solid and work under all circumstances. Ask me if anything is unclear.

Lastly, this extends the CI to actually build the man-pages. This will make us catch any formatting errors (or Makefile corruptions) much earlier. Yey!