### PR TITLE
docs: fix incorrect option-list formatting

### DIFF
--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -45,7 +45,7 @@ is not listed here, **osbuild** will deny startup and exit with an error.
                                 configuration
 --secrets=PATH                  json file containing a dictionary of secrets
                                 that are passed to sources
--l, --libdir=DIR                directory containing stages, assemblers, and
+-l DIR, --libdir=DIR            directory containing stages, assemblers, and
                                 the osbuild library
 --checkpoint=CHECKPOINT         stage to commit to the object store during
                                 build (can be passed multiple times)


### PR DESCRIPTION
The used format of `-X, --long=VALUE` is not a valid option-list entry,
even though it is very commonly used all over the linux man-pages. Use
the supported format of `-X VALUE, --long=VALUE`, which will format
correctly in the man-page and html outputs.

For reference, these formats are valid in RST option-lists:

        -a                      Short option
        -c arg                  Short option with arg.
        --long                  Long option.
        -2, --two               Aliases on a single line.
        -f FILE, --file=FILE    Aliases with arguments.
        /V                      VMS/DOS-style option.