### PR TITLE
build: fix `make release` contributor list without git tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,10 @@ release:
 	@echo "        * ..."
 	@echo
 	@echo -n "        Contributions from: "
-	@echo `git log --format='%an, ' v$(VERSION)..HEAD | sort -u | tr -d '\n' | sed 's/, $$//'`
+	# We omit the contributor list if `git log` fails. If you hit this,
+	# consider fetching missing tags via `git fetch --tags`, or just copy
+	# this command and remove the stderr-redirect.
+	@echo `( git log --format='%an, ' v$(VERSION)..HEAD 2>/dev/null | sort -u | tr -d '\n' | sed 's/, $$//' ) || echo`
 	@echo
 	@echo "        - Location, YYYY-MM-DD"
 	@echo "--------------------------------------------------------------------------------"


### PR DESCRIPTION
If the local checkout has no git tags, the contributor list cannot be
generated. Just omit the information in that case. We can try to be
more clever here, but lets fix this first. I could not come up with any
reasonable solution to improve on this easily. Hence, the source
includes a comment explaining that you might just have to fetch the git
tags first.