### PR TITLE
spec: include NEWS.md in docs

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -93,7 +93,7 @@ exit 0
 
 %files -n       python3-%{pypi_name}
 %license LICENSE
-%doc README.md
+%doc README.md NEWS.md
 %{python3_sitelib}/%{pypi_name}-*.egg-info/
 %{python3_sitelib}/%{pypi_name}/
 


### PR DESCRIPTION
We have some news for the world to read, therefore include the recently added `NEWS.md` file in the rpm package.