### PR TITLE
Make objectstore.Object delete its tree on cleanup

### DIFF
--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -2,9 +2,23 @@ import os
 import shutil
 import tempfile
 import unittest
+import subprocess
 
 from pathlib import Path
 from osbuild import objectstore
+
+
+def can_set_immutable():
+    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+        try:
+            os.makedirs(f"{tmp}/f")
+            # fist they give it ...
+            subprocess.run(["chattr", "+i", f"{tmp}/f"], check=True)
+            # ... then they take it away
+            subprocess.run(["chattr", "-i", f"{tmp}/f"], check=True)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
+        return True
 
 
 class TestObjectStore(unittest.TestCase):
@@ -72,6 +86,17 @@ class TestObjectStore(unittest.TestCase):
                     p.touch()
             # there should be no temporary Objects dirs anymore
             self.assertEqual(len(os.listdir(object_store.tmp)), 0)
+
+    @unittest.skipUnless(can_set_immutable(), "Need root permissions")
+    def test_cleanup_immutable(self):
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+            with objectstore.ObjectStore(tmp) as object_store:
+                tree = object_store.new()
+                with tree.write() as path:
+                    p = Path(f"{path}/A")
+                    p.touch()
+                    subprocess.run(["chattr", "+i", f"{path}/A"],
+                                   check=True)
 
     def test_duplicate(self):
         with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:


### PR DESCRIPTION
`objectstore.Object` is creating a temporary work dir and then the actual directory for the tree that is being used for write operations. Currently we rely on the cleanup mechanisms of the top level workdir, i.e. `Tempfiles.TemporaryDirectory.cleanup()`, to also remove all the child-directories, including the the `Object._tree` directory.
Internally Python 3 is using its `shutil.rmtree()`, with a custom `onerror` handler that will fixup permissions transparently. Sadly the current [version](https://github.com/python/cpython/blob/50e6e991781db761c496561a995541ca8d83ff87/Lib/tempfile.py#L795) of it will not reset the immutable file attribute (see `chattr(1)`). The result is that cleanup of trees that contain immutable files will fail. 
Therefore, roll a custom `onerror` handler that will also reset immutable flags and "manually" cleanup the `Object._tree` on `Object.cleanup()`.