### PR TITLE
Delay the cleanup of build trees in `build_stages`

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -17,6 +17,11 @@ RESET = "\033[0m"
 BOLD = "\033[1m"
 
 
+def cleanup(*objs):
+    """Call cleanup method for all objects, filters None values out"""
+    _ = map(lambda o: o.cleanup(), filter(None, objs))
+
+
 class BuildResult:
     def __init__(self, origin, returncode, output):
         self.name = origin.name
@@ -285,6 +290,7 @@ class Pipeline:
 
             results["stages"].append(r.as_dict())
             if not r.success:
+                cleanup(build_tree, tree)
                 results["success"] = False
                 return results, None, None
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -232,15 +232,15 @@ class Pipeline:
                                             interactive,
                                             libdir,
                                             secrets)
-            # Cleanup the build tree used to build `tree`
-            # which is not needed anymore
-            t.cleanup()
 
             results["build"] = r
             if not r["success"]:
-                tree.cleanup()
                 results["success"] = False
                 return results, None, None
+
+            # Cleanup the build tree (`t`) which was used to
+            # build `tree`; it is now not needed anymore
+            t.cleanup()
 
             build_tree = tree
 


### PR DESCRIPTION
Delay the cleanup of the build tree of the build pipeline, and first check the result and only cleanup the tree when the build did not fail, because in that case both returned trees will be `None` and trying to cleanup them up will result in an exception. Therefore, also don't clean up `tree` in the error case.

Closes #288 