### PR TITLE
pipeline: ensure the build tree is always built

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -217,11 +217,6 @@ class Pipeline:
     def build_stages(self, object_store, interactive, libdir, secrets):
         results = {"success": True}
 
-        if not self.stages:
-            build_tree = objectstore.HostTree(object_store)
-            tree = object_store.new()
-            return results, build_tree, tree
-
         # We need a build tree for the stages below, which is either
         # another tree that needs to be built with the build pipeline
         # or the host file system if no build pipeline is specified
@@ -248,6 +243,13 @@ class Pipeline:
             t.cleanup()
 
             build_tree = tree
+
+        # If there are no stages, just return build tree we just
+        # obtained and a new, clean `tree`
+        if not self.stages:
+            tree = object_store.new()
+            return results, build_tree, tree
+
 
         # Create a new tree. The base is our tree_id because if that
         # is already in the store, we can short-circuit directly and


### PR DESCRIPTION
If there is a build pipeline specified, always build it, even if there are no accompanying stages. If we short-circuit earlier and ignore the build pipeline section, errors in the build pipeline would not be caught at all.

Closes #289 