### PR TITLE
ci: convert more tests to github-actions

### DIFF
--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -1,0 +1,95 @@
+name: Runtime Tests
+
+on: [pull_request, push]
+
+#
+# We set `PYTHONUNBUFFERED` to get more immediate and ordered output from
+# python programs. This should not be necessary if all relevant output used the
+# unbuffered stderr, but that is not entirely under our control.
+#
+env:
+  PYTHONUNBUFFERED: 1
+
+jobs:
+  noop_pipeline_tests:
+    name: "Noop-Pipeline Tests"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Clone Repository"
+      uses: actions/checkout@v2
+    - name: "Install Dependencies"
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install \
+          systemd-container
+    - name: "Set up Python"
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: "Run Noop-Pipeline Tests"
+      run: |
+        for i in {0..2} ; do
+          sudo env "PATH=$PATH" python3 -m osbuild --libdir . samples/noop.json
+        done
+
+  source_tests:
+    name: "Source Tests"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Clone Repository"
+      uses: actions/checkout@v2
+    - name: "Install Dependencies"
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install \
+          rpm \
+          systemd-container
+    - name: "Set up Python"
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: "Run Source Tests"
+      run: sudo env "PATH=$PATH" python3 -m unittest -v test.test_sources
+
+  assembler_tests:
+    name: "Assembler Tests"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Clone Repository"
+      uses: actions/checkout@v2
+    - name: "Install Dependencies"
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install \
+          nbd-client \
+          qemu-utils \
+          rpm \
+          systemd-container \
+          tar \
+          yum
+    - name: "Set up Python"
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: "Run Assembler Tests"
+      run: sudo env "PATH=$PATH" python3 -m unittest -v test.test_assemblers
+
+  stage_tests:
+    name: "Stage Tests"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Clone Repository"
+      uses: actions/checkout@v2
+    - name: "Install Dependencies"
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install \
+          systemd-container \
+          tar \
+          yum
+    - name: "Set up Python"
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: "Run Stage Tests"
+      run: sudo env "PATH=$PATH" python3 -m unittest -v test.test_stages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,6 @@
 name: Tests
 
-# NOTE(mhayden): Restricting branches prevents jobs from being doubled since
-# a push to a pull request triggers two events.
-on:
-  pull_request:
-    branches:
-      - "*"
-  push:
-    branches:
-      - master
+on: [pull_request, push]
 
 jobs:
   pylint:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,6 @@ env:
   - PYTHONUNBUFFERED=1
 jobs:
   include:
-    - name: pipeline-noop
-      before_install: sudo apt-get install -y systemd-container
-      script:
-        - sudo env "PATH=$PATH" python3 -m osbuild --libdir . samples/noop.json
-        - sudo env "PATH=$PATH" python3 -m osbuild --libdir . samples/noop.json
-    - name: sources-tests
-      before_install: sudo apt-get install -y rpm
-      script: sudo env "PATH=$PATH" python3 -m unittest -v test.test_sources
     - name: f30-boot
       before_install: sudo apt-get install -y systemd-container yum qemu-kvm
       script: sudo env "PATH=$PATH" python3 -m unittest -v test.test_boot
-    - name: assemblers
-      before_install: sudo apt-get install -y systemd-container yum tar qemu-utils nbd-client
-      script: sudo env "PATH=$PATH" python3 -m unittest -v test.test_assemblers
-    - name: stage-tests
-      before_install: sudo apt-get install -y systemd-container yum
-      script: sudo env "PATH=$PATH" python3 -m unittest -v test.test_stages


### PR DESCRIPTION
Heyho

CC: @major 

This converts some more of the runtime tests to github actions. I decided to pick a separate workflow, so we can define globals that affect all jobs in the workflow. I only ended up doing this for the `PYTHONUNBUFFERED` thing, since github-actions is quite limited in its programmability and gives almost no tools to extract things into reusable functions. Anyway, I think this all works fine.

There is still one test left in Travis, since I cannot test it right now as it triggers kernel bugs for me. I will look at them once I figured that out.

Thanks
David