### PR TITLE
runners: drop os-release hack for rhel-8.2

### DIFF
--- a/runners/org.osbuild.rhel82
+++ b/runners/org.osbuild.rhel82
@@ -98,29 +98,6 @@ def setup_stdio():
             os.dup2(source, target.fileno())
             os.close(source)
 
-def os_release():
-    """/usr/lib/os-release doesn't exist. The `redhat-release` package
-    generates `/etc/os-release directly. To work around this, do the same here.
-
-    https://bugzilla.redhat.com/show_bug.cgi?id=1766754
-    """
-
-    # remove the symlink that systemd-nspawn creates
-    os.remove("/etc/os-release")
-    with open("/etc/os-release", "w") as f:
-        f.write('NAME="Red Hat Enterprise Linux"\n')
-        f.write('VERSION="8.2 (Ootpa)"\n')
-        f.write('ID="rhel"\n')
-        f.write('ID_LIKE="fedora"\n')
-        f.write('VERSION_ID="8.2"\n')
-        f.write('PLATFORM_ID="platform:el8"\n')
-        f.write('PRETTY_NAME="Red Hat Enterprise Linux 8.2 Beta (Ootpa)"\n')
-        f.write('ANSI_COLOR="0;31"\n')
-        f.write('CPE_NAME="cpe:/o:redhat:enterprise_linux:8.2:beta"\n')
-        f.write('HOME_URL="https://www.redhat.com/"\n')
-        f.write('BUG_REPORT_URL="https://bugzilla.redhat.com/"\n')
-
-
 def python_alternatives():
     """/usr/bin/python3 is a symlink to /etc/alternatives/python3, which points
     to /usr/bin/python3.6 by default. Recreate the link in /etc, so that
@@ -140,7 +117,6 @@ if __name__ == "__main__":
     update_ca_certificates()
     tmpfiles()
     nsswitch()
-    os_release()
     python_alternatives()
 
     r = subprocess.run(sys.argv[1:], check=False)


### PR DESCRIPTION
The bug was fixed upstream and is available in the latest 8.2 builds.
Since it is not yet released, we don't need to keep the hack around.

Fixes #294