### PR TITLE
spec: do not generate deps from internal files

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -35,6 +35,12 @@ Requires:       tar
 Requires:       util-linux
 Requires:       python3-%{pypi_name}
 
+# Turn off dependency generators for assemblers, runners and stages.
+# They run in a container, so there's no reason to generate dependencies
+# from them. As of 2020-03-25 this filters out python3.6 dependency generated
+# by rhel runner.
+%global __requires_exclude_from ^%{pkgdir}/(assemblers|runners|stages)/.*$
+
 %{?python_enable_dependency_generator}
 
 %description


### PR DESCRIPTION
RPM is smart about dependencies - it goes over all shebangs of packaged files
and adds Requires to them. Prior this commit osbuild package depended on
python 3.6, because rhel runner has /usr/bin/python3.6 as shebang.

This commit fixes it by turning off dependency generators for our internal
stuff: assemblers, runners, stages and sources. They run in a container,
so I think there's no reason generate dependencies from them.