### PR TITLE
test/boot: convert `-accel ...` -> `-M accel=...` for qemu

### DIFF
--- a/test/test_boot.py
+++ b/test/test_boot.py
@@ -11,7 +11,7 @@ class TestBoot(osbuildtest.TestCase):
         r = subprocess.run(["qemu-system-x86_64",
             "-snapshot",
             "-m", "1024",
-            "-accel", "kvm:hvf:tcg",
+            "-M", "accel=kvm:hvf:tcg",
 
             # be silent
             "-nographic",


### PR DESCRIPTION
Recent qemu version will warn with our current code:

    qemu-system-x86_64: -accel kvm:hvf:tcg: Don't use ':' with -accel,
                            use -M accel=... for now instead

Since this might result in hard-errors, lets just follow the advice and
use the `-M` switch.