### PR TITLE
osbuild: drop legacy input format

### DIFF
--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -59,13 +59,8 @@ def main():
     manifest = json.load(f)
     f.close()
 
-    if "pipeline" in manifest:
-        pipeline = manifest["pipeline"]
-        sources_options = manifest.get("sources", {})
-    else:
-        # backwards compatibility
-        pipeline = manifest
-        sources_options = {}
+    pipeline = manifest.get("pipeline", {})
+    sources_options = manifest.get("sources", {})
 
     if args.sources:
         with open(args.sources) as f:


### PR DESCRIPTION
This drops support for passing in non-manifest style pipelines
directly. It used to be that we directly pass in the pipeline
description, but it got changed to a proper manifest format in:

    commit e48c2f178cb047d3872ea494206788072f13594d
    Author: Tom Gundersen <teg@jklm.no>
    Date:   Thu Feb 13 17:44:54 2020 +0100

        osbuild: allow the sources to be passed in on stdin

With 2 releases in between, we are now far enough to drop the old
format. All code has been converted, our API guarantee is not in place,
yet, so lets just drop the legacy code and fully commit to the
manifest.

Fixes #265.

(I am completely unsure whether we fixed all tests. But CI will bail me out!)