### PR TITLE
pipeline: check assembler res outside context mgr

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -327,11 +327,11 @@ class Pipeline:
                                    libdir=libdir,
                                    var=object_store.store)
 
-            results["assembler"] = r.as_dict()
-            if not r.success:
-                output.cleanup()
-                results["success"] = False
-                return results
+        results["assembler"] = r.as_dict()
+        if not r.success:
+            output.cleanup()
+            results["success"] = False
+            return results
 
         object_store.commit(output, self.output_id)
         output.cleanup()


### PR DESCRIPTION
Move the whole result handling of the assembler outside the context manager; this includes the cleanup of the object in the error case which would conflict with the ongoing write operation inside the context manager and thus lead to a crash:

```
Traceback (most recent call last):
  File "/usr/bin/osbuild", line 11, in <module>;
    load_entry_point('osbuild==10', 'console_scripts', 'osbuild')()
  File "/usr/lib/python3.7/site-packages/osbuild/__main__.py", line 99, in main
    secrets=secrets
  File "/usr/lib/python3.7/site-packages/osbuild/pipeline.py", line 362, in run
    libdir)
  File "/usr/lib/python3.7/site-packages/osbuild/pipeline.py", line 324, in assemble
    output.cleanup()
  File "/usr/lib/python3.7/site-packages/osbuild/objectstore.py", line 160, in cleanup
    self._check_writer()
  File "/usr/lib/python3.7/site-packages/osbuild/objectstore.py", line 178, in _check_writer
    raise ValueError("Write operation is ongoing")
ValueError: Write operation is ongoing
```