### PR TITLE
assembler/qemu: support for GPT partition UUIDs 

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -85,6 +85,10 @@ STAGE_OPTS = """
           "description": "The partition type (UUID or identifier)",
           "type": "string"
         },
+        "uuid": {
+           "description": "UUID of the partition (GPT)",
+           "type": "string"
+        },
         "filesystem": {
           "description": "Description of the filesystem",
           "type": "object",
@@ -195,6 +199,7 @@ class Filesystem:
         maker(device, self.uuid, self.label)
 
 
+# pylint: disable=too-many-instance-attributes
 class Partition:
     def __init__(self,
                  pttype: str = None,
@@ -202,12 +207,14 @@ class Partition:
                  size: int = None,
                  bootable: bool = False,
                  name: str = None,
+                 uuid: str = None,
                  filesystem: Filesystem = None):
         self.type = pttype
         self.start = start
         self.size = size
         self.bootable = bootable
         self.name = name
+        self.uuid = uuid
         self.filesystem = filesystem
         self.index = None
 
@@ -295,7 +302,7 @@ class PartitionTable:
         command = f"label: {self.label}\nlabel-id: {self.uuid}"
         for partition in self.partitions:
             fields = []
-            for field in ["start", "size", "type", "name"]:
+            for field in ["start", "size", "type", "name", "uuid"]:
                 value = getattr(partition, field)
                 if value:
                     fields += [f'{field}="{value}"']
@@ -338,7 +345,8 @@ def partition_from_json(js) -> Partition:
                   start=js.get("start"),
                   size=js.get("size"),
                   bootable=js.get("bootable"),
-                  name=js.get("name"))
+                  name=js.get("name"),
+                  uuid=js.get("uuid"))
     fs = js.get("filesystem")
     if fs:
         p.filesystem = filesystem_from_json(fs)

--- a/samples/f30-qcow2-gpt.json
+++ b/samples/f30-qcow2-gpt.json
@@ -89,10 +89,12 @@
           {
             "size": 8192,
             "type": "21686148-6449-6E6F-744E-656564454649",
+            "uuid": "51db3fcc-a04a-406d-af53-4285e6766678",
             "bootable": true
           },
           {
             "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "uuid": "6cb708c1-c0e8-4614-8bbf-c6ebd39484a3",
             "filesystem": {
               "type": "ext4",
               "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",

--- a/samples/f30-qcow2-gpt.json
+++ b/samples/f30-qcow2-gpt.json
@@ -1,105 +1,107 @@
 {
-  "stages": [
-    {
-      "name": "org.osbuild.dnf",
-      "options": {
-        "releasever": "30",
-        "basearch": "x86_64",
-        "install_weak_deps": true,
-        "repos": [
-          "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
-        ],
-        "packages": [
-          "@Fedora Cloud Server",
-          "chrony",
-          "kernel",
-          "selinux-policy-targeted",
-          "grub2-pc",
-          "spice-vdagent",
-          "qemu-guest-agent",
-          "xen-libs",
-          "langpacks-en"
-        ],
-        "exclude_packages": [
-          "dracut-config-rescue"
-        ],
-        "module_platform_id": "platform:f30"
-      }
-    },
-    {
-      "name": "org.osbuild.systemd",
-      "options": {
-        "enabled_services": [
-          "cloud-config",
-          "cloud-final",
-          "cloud-init",
-          "cloud-init-local"
-        ]
-      }
-    },
-    {
-      "name": "org.osbuild.locale",
-      "options": {
-        "language": "en_US"
-      }
-    },
-    {
-      "name": "org.osbuild.fstab",
-      "options": {
-        "filesystems": [
-          {
-            "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "vfs_type": "ext4",
-            "path": "/",
-            "freq": 1,
-            "passno": 1
-          }
-        ]
-      }
-    },
-    {
-      "name": "org.osbuild.grub2",
-      "options": {
-        "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-        "kernel_opts": "ro biosdevname=0 net.ifnames=0"
-      }
-    },
-    {
-      "name": "org.osbuild.selinux",
-      "options": {
-        "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
-      }
-    },
-    {
-      "name": "org.osbuild.fix-bls"
-    }
-  ],
-  "assembler": {
-    "name": "org.osbuild.qemu",
-    "options": {
-      "bootloader": {
-        "type": "grub2"
-      },
-      "format": "qcow2",
-      "filename": "base.qcow2",
-      "ptuuid": "29579f67-d390-43e7-bd96-dc8f5461171e",
-      "pttype": "gpt",
-      "partitions": [
-        {
-          "size": 8192,
-          "type": "21686148-6449-6E6F-744E-656564454649",
-          "bootable": true
-        },
-        {
-          "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
-          "filesystem": {
-            "type": "ext4",
-            "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-            "mountpoint": "/"
-          }
+  "pipeline": {
+    "stages": [
+      {
+        "name": "org.osbuild.dnf",
+        "options": {
+          "releasever": "30",
+          "basearch": "x86_64",
+          "install_weak_deps": true,
+          "repos": [
+            "sha256:9f596e18f585bee30ac41c11fb11a83ed6b11d5b341c1cb56ca4015d7717cb97"
+          ],
+          "packages": [
+            "@Fedora Cloud Server",
+            "chrony",
+            "kernel",
+            "selinux-policy-targeted",
+            "grub2-pc",
+            "spice-vdagent",
+            "qemu-guest-agent",
+            "xen-libs",
+            "langpacks-en"
+          ],
+          "exclude_packages": [
+            "dracut-config-rescue"
+          ],
+          "module_platform_id": "platform:f30"
         }
-      ],
-      "size": 3221225472
+      },
+      {
+        "name": "org.osbuild.systemd",
+        "options": {
+          "enabled_services": [
+            "cloud-config",
+            "cloud-final",
+            "cloud-init",
+            "cloud-init-local"
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.locale",
+        "options": {
+          "language": "en_US"
+        }
+      },
+      {
+        "name": "org.osbuild.fstab",
+        "options": {
+          "filesystems": [
+            {
+              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+              "vfs_type": "ext4",
+              "path": "/",
+              "freq": 1,
+              "passno": 1
+            }
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.grub2",
+        "options": {
+          "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+          "kernel_opts": "ro biosdevname=0 net.ifnames=0"
+        }
+      },
+      {
+        "name": "org.osbuild.selinux",
+        "options": {
+          "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+        }
+      },
+      {
+        "name": "org.osbuild.fix-bls"
+      }
+    ],
+    "assembler": {
+      "name": "org.osbuild.qemu",
+      "options": {
+        "bootloader": {
+          "type": "grub2"
+        },
+        "format": "qcow2",
+        "filename": "base.qcow2",
+        "ptuuid": "29579f67-d390-43e7-bd96-dc8f5461171e",
+        "pttype": "gpt",
+        "partitions": [
+          {
+            "size": 8192,
+            "type": "21686148-6449-6E6F-744E-656564454649",
+            "bootable": true
+          },
+          {
+            "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+            "filesystem": {
+              "type": "ext4",
+              "uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+              "mountpoint": "/"
+            }
+          }
+        ],
+        "size": 3221225472
+      }
     }
   }
 }


### PR DESCRIPTION
The GUID Partition Table (GPT) layout supports assigning UUIDs for individual partitions. Add support for specifying those in the partition description.









