### PR TITLE
samples: set legacy to false in f30 aarch64 sample

### DIFF
--- a/samples/f30-aarch64.json
+++ b/samples/f30-aarch64.json
@@ -74,6 +74,7 @@
       "options": {
         "root_fs_uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
         "kernel_opts": "ro biosdevname=0 net.ifnames=0 console=ttyS0 console=tty1",
+        "legacy": false,
         "uefi": {
           "vendor": "fedora"
         }


### PR DESCRIPTION
The "legacy" option in stages/org.osbuild.grub2 defaults to True:
`legacy = options.get("legacy", True)`
If both legacy and uefi is enable, the stage will try to create a hybrid
image, but that fails for aarch64. This patch makes sure we use uefi
mode only which fixed this issue.

I tested the patch by hand together with the fix from this PR:
https://github.com/osbuild/osbuild/pull/308