### PR TITLE
[WIP] Utility Classes for the Cache Rework

### DIFF
--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -1,0 +1,139 @@
+"""Linux API Access
+
+This module provides access to linux system-calls and other APIs, in particular
+those not provided by the python standard library. The idea is to provide
+universal wrappers with broad access to linux APIs. Convenience helpers and
+higher-level abstractions are beyond the scope of this module.
+
+In some cases it is overly complex to provide universal access to a specifc
+API. Hence, the API might be restricted to a reduced subset of its
+functionality, just to make sure we can actually implement the wrappers in a
+reasonable manner.
+"""
+
+
+import fcntl
+import os
+import struct
+
+
+__all__ = [
+    "fcntl_flock",
+]
+
+
+def fcntl_flock(fd, lock_type):
+    """Perform File-locking Operation
+
+    This function performs a linux file-locking operation on the specified
+    file-descriptor. The specific type of lock must be specified by the caller.
+    This function does not allow to specify the byte-range of the file to lock.
+    Instead, it always applies the lock operations to the entire file.
+
+    For system-level documentation, see the `fcntl(2)` man-page, especially the
+    section about `struct flock` and the locking commands.
+
+    This function always uses the open-file-description locks provided by
+    modern linux kernels. This means, locks are tied to the
+    open-file-description. That is, they are shared between duplicated
+    file-descriptors. Furthermore, acquiring a lock while already holding a
+    lock will update the lock to the new specified lock type, rather than
+    acquiring a new lock.
+
+    So far, this function always performs try-lock operations. The blocking
+    mode is currently not exposed.
+
+    Parameters
+    ----------
+    fd : int
+        The file-descriptor to use for the locking operation.
+    lock_type : int
+        The type of lock to use. This can be one of: `fcntl.F_RDLCK`,
+        `fcntl.F_WRLCK`, `fcntl.F_UNLCK`.
+
+    Raises
+    ------
+    OSError
+        If the underlying `fcntl(2)` syscall fails, a matching `OSError` is
+        raised.
+    """
+
+
+    assert fd >= 0
+    valid_types = [fcntl.F_RDLCK, fcntl.F_WRLCK, fcntl.F_UNLCK]
+    assert any(lock_type == v for v in valid_types)
+
+    #
+    # The `OFD` constants are not available through the `fcntl` module, so we
+    # need to use their integer representations directly. They are the same
+    # across all linux ABIs:
+    #
+    #     F_OFD_SETLK = 36
+    #     F_OFD_SETLK = 37
+    #     F_OFD_SETLKW = 38
+    #
+
+    lock_cmd = 37
+
+    #
+    # We use the linux open-file-descriptor (OFD) version of the POSIX file
+    # locking operations. They attach locks to an open file description, rather
+    # than to a process. They have clear, useful semantics.
+    # This means, we need to use the `fcntl(2)` operation with `struct flock`,
+    # which is rather unfortunate, since it varies depending on compiler
+    # arguments used for the python library, as well as depends on the host
+    # architecture, etc.
+    #
+    # The structure layout of the locking argument is:
+    #
+    #     struct flock {
+    #         short int l_type;
+    #         short int l_whence;
+    #         off_t l_start;
+    #         off_t l_len;
+    #         pid_t int l_pid;
+    #     }
+    #
+    # The possible options for `l_whence` are `SEEK_SET`, `SEEK_CUR`, and
+    # `SEEK_END`. All are provided by the `fcntl` module. Same for the possible
+    # options for `l_type`, which are `L_RDLCK`, `L_WRLCK`, and `L_UNLCK`.
+    #
+    # Depending on which architecture you run on, but also depending on whether
+    # large-file mode was enabled to compile the python library, the values of
+    # the constants as well as the sizes of `off_t` can change. What we know is
+    # that `short int` is always 16-bit on linux, and we know that `fcntl(2)`
+    # does not take a `size` parameter. Therefore, the kernel will just fetch
+    # the structure from user-space with the correct size. The python wrapper
+    # `fcntl.fcntl()` always uses a 1024-bytes buffer and thus we can just pad
+    # our argument with trailing zeros to provide a valid argument to the
+    # kernel. Note that your libc might also do automatic translation to
+    # `fcntl64(2)` and `struct flock64` (if you run on 32bit machines with
+    # large-file support enabled). Also, random architectures change trailing
+    # padding of the structure (MIPS-ABI32 adds 128-byte trailing padding,
+    # SPARC adds 16?).
+    #
+    # To avoid all this mess, we use the fact that we only care for `l_type`.
+    # Everything else is always set to 0 in all our needed locking calls.
+    # Therefore, we simply use the largest possible `struct flock` for your
+    # libc and set everything to 0. The `l_type` field is guaranteed to be
+    # 16-bit, so it will have the correct offset, alignment, and endianness
+    # without us doing anything. Downside of all this is that all our locks
+    # always affect the entire file. However, we do not need locks for specific
+    # sub-regions of a file, so we should be fine. Eventually, what we end up
+    # with passing to libc is:
+    #
+    #     struct flock {
+    #         uint16_t l_type;
+    #         uint16_t l_whence;
+    #         uint32_t pad0;
+    #         uint64_t pad1;
+    #         uint64_t pad2;
+    #         uint32_t pad3;
+    #         uint32_t pad4;
+    #     }
+    #
+
+    type_flock64 = struct.Struct('=HHIQQII')
+    arg_flock64 = type_flock64.pack(lock_type, 0, 0, 0, 0, 0, 0)
+
+    fcntl.fcntl(fd, lock_cmd, arg_flock64)

--- a/osbuild/util/pathfd.py
+++ b/osbuild/util/pathfd.py
@@ -1,0 +1,716 @@
+"""Path Descriptor
+
+This module implements a path object based on the `O_PATH` file descriptors
+provided by the linux kernel. It does automatic file-descriptor management and
+thus simplifies handling of `O_PATH` quite significantly.
+
+Classic path handling uses strings as internal state. This includes python
+modules like `os.path` or `pathlib`. However, these have major drawbacks,
+including the following:
+
+  * File-system paths have to be resolved on each access. This makes
+    repeated access to the same path (or a sibling path) racy and non-reliable.
+    For instance, accessing `/foo/bar/A` and `/foo/bar/B` consequetively might
+    end up with files from different directories, even though their path
+    suggests that they are siblings. This can happen for many reasons. Simply
+    imagine `/foo/bar` is a symlink and it is changed between the consequetive
+    operations. Another possibility is modifying local mounts.
+    While this behavior is not necessarily wrong, it is more often than not
+    contrary to the intended behavior. By using path-descriptors, you can
+    operate relative to pinned paths, thus picking the point of reference
+    manually, rather than using the root path (or local mount, or working
+    directory).
+
+  * Resolving a file-system path relies on ambient capabilities. The most
+    prominent examples are paths relative to the current working directory. If
+    the current working directory changes between accesses, your relative paths
+    will as well.
+    Again, this is not necessarily bad, but it might not be what you expect. In
+    fact, the path-descriptors provide exactly the same functionality as the
+    current working directory of a process. However, instead of having only one
+    static property as part of a process, path-descriptors are objects that can
+    be created and modified at will by the program.
+
+  * Status queries on file-system objects like `stat()` suffer from TOCTOU
+    races. These can be solved via their fd-based counterparts like `fstat()`,
+    but that requires opening the file either for at least reading or writing.
+    But this is not necessarily what you want, since you might not have read or
+    write access (and unlike `stat()` your operation might not necessarily
+    require either access right).
+    With path-descriptors you can refer to paths in a stable manner without
+    requiring read nor write access to the path.
+
+  * ...
+
+The path-descriptors are functionally superior to normal string-based path
+objects, but not necessarily the better option in all situations. Their
+flexibility and stable behavior is a big strength, but their biggest weakness
+is the overhead involved in all the syscalls to manage them. They are based on
+`O_PATH` file-descriptor, rather than simple strings, and thus require syscalls
+for every single operation. In many situations these additional syscalls
+amortize easily, but that has to be evaluated for every situation separately.
+
+Please be aware that path-descriptors are not suitable for access management!
+Access to a path-descriptor does **NOT** restrict the access you gain via it.
+You can always use relative operations on the path-descriptor to access its
+parents, children, and any other part of the file-system reachable from that
+path.
+You can, however, combine path-descriptors with other technology to achieve
+access restrictions. This implementation allows for this, but considers the
+discussion of this topic beyond the scope of this module.
+"""
+
+
+import errno as _errno
+import os as _os
+import stat as _stat
+
+
+__all__ = [
+    "PathFd",
+]
+
+
+class PathFd:
+    """Path Descriptor
+
+    A path-descriptor object is a representation of a file-system path. Every
+    instance represents exactly one path. Internally, every instance owns its
+    backing `O_PATH` file-descriptor, which pins the capability of referring to
+    the path it represents.
+
+    For a discussion of when to use path-descriptors over simple paths, see the
+    `O_PATH` functionality provided by linux. This path-descriptor simply
+    provides easy access to `O_PATH` file-descriptors.
+
+    Since path-descriptors manage resources, they do provide the standard
+    resource management operations. This means, `close()` releases all internal
+    resources and turns the instance into a no-op stub. Further operations on
+    the stub will trigger assertions. This follows what the python standard
+    library provides, and thus integrates well with context-managers (a default
+    context manager is provided with the implementation, but
+    `contextlib.closing()` would also work.
+    Note that there is no requirement to call `close()`. The only reason to do
+    so is to keep resource management under caller-control if they so wish. If
+    the GC cleanup is enough for you, then you can avoid calling `close()`. But
+    if you want to avoid having stale resources pile up until the next GC
+    round, then you better close your objects when no longer needed.
+    The internal operations of this module always clean up all their temporary
+    resources explicitly to avoid this problem.
+    """
+
+    _fd = None
+
+    def __init__(self, fd = None):
+        """Initialize Path Descriptor
+
+        This creates a new path-descriptor by taking a caller-provided `O_PATH`
+        file-descriptor and consuming it.
+
+        Parameters
+        ----------
+        fd : int, None
+            A raw file descriptor to use for this path descriptor. This must be
+            a file-descriptor opened with `O_PATH`. This function consumes this
+            file-descriptor. That is, regardless whether this function succeeds
+            or fails, it does take full control of the file-descriptor. The
+            caller must not access the original file-descriptor, anymore.
+            Pass `None` to create a path descriptor that is already closed.
+        """
+
+        assert (fd is None) or (fd >= 0)
+
+        self._fd = fd
+
+    @classmethod
+    def from_path(cls, path, *, follow_symlink = False):
+        """Create Path Descriptor from File System Path
+
+        This constructor creates a new path-descriptor from a standard
+        file-system path provided as a string. It simply opens the path as
+        `O_PATH` file-descriptor and creates a wrapping path-descriptor around
+        it. Path resolution happens at the time of this function call. All
+        further operations on the new path-descriptor will happen relative to
+        the desciptor itself. The contents of `path` are not retained and will
+        not be accessible later on.
+
+        Parameters
+        ----------
+        path : String
+            A file-system path in string representation. If it is a relative
+            path, it is interpreted relative to the current working directory
+            at the time of this function call.
+        follow_symlink : Boolean, optional
+            Whether to resolve the final part of the path in case it is a
+            symlink. The default behavior is to not resolve it. That is, if the
+            given path points to a symlink, the path-descriptor will also point
+            to the symlink, rather than pointing to the destination of that
+            symlink.
+            This does not affect symlinks somewhere else in the path, other
+            than the last element.
+
+        Returns
+        -------
+        PathFd
+            A new path-desciptor for the specified path is returned.
+
+        Raises
+        ------
+        OSError
+            Any operating system errors involved in resolving file-system paths
+            can be raised by this function. See `os.open()` in the python
+            standard library for a discussion.
+        """
+        flags = _os.O_CLOEXEC | _os.O_PATH
+        if not follow_symlink:
+            flags |= _os.O_NOFOLLOW
+
+        return PathFd(_os.open(path, flags))
+
+    def close(self):
+        """Close the Path Descriptor
+
+        This closes the path-descriptor and releases all pinned resources. Once
+        this returns, any further operation on the path-descriptor will raise
+        an exception, unless it is explictily supported on closed descriptors.
+
+        This function can be safely called on closed descriptors, in which case
+        it is a no-op.
+        """
+
+        if self._fd is not None:
+            _os.close(self._fd)
+            self._fd = None
+
+    def __del__(self):
+        # Make sure to release internal resources when variables of this type
+        # are cleaned up by the GC. In case they were already explicitly closed
+        # this will be a no-op.
+        self.close()
+
+    def __enter__(self):
+        # Trivial context-manager ala `contextlib.closing()`.
+        return self
+
+    def __exit__(self, *args):
+        # Trivial context-manager ala `contextlib.closing()`.
+        self.close()
+
+    def __int__(self):
+        """Convert to Integer
+
+        Convert the path-descriptor into a file-descriptor. The file-descriptor
+        is only borrowed. It is still owned by the path-descriptor, so you must
+        not close it manually.
+
+        This raises an exception if the path-descriptor is already closed.
+
+        Returns
+        -------
+        int
+            An integer greater than, or equal to, zero is returned.
+        """
+
+        assert self._fd is not None
+
+        return self._fd
+
+    def is_open(self):
+        """Check whether the Path Descriptor is Open
+
+        This simply returns a boolean that tells whether the descriptor is
+        still open. Note that once a descriptor is closed, it cannot be
+        re-opened. You must create a new descriptor to do that.
+
+        This can be safely called on closed descriptors.
+
+        Returns
+        -------
+        Boolean
+            Whether the descriptor is open. This is true for all descriptors
+            until they are closed via `close()`, or if they were created as a
+            closed descriptor.
+        """
+
+        return self._fd is not None
+
+    def clone(self):
+        """Create a Clone
+
+        This clones the given path-descriptor and returns it. The cloned
+        instance will point to the exact same resource as the original, without
+        re-resolving the path.
+
+        The original and the cloned instance do not share any underlying
+        resources. They are fully independent.
+
+        This can be safely called on closed descriptors, in which case the
+        cloned instance will also be closed.
+
+        Returns
+        -------
+        PathFd
+            A new path-desciptor for the same path is returned.
+
+        Raises
+        ------
+        OSError
+            Any operating system errors involved in duplicating
+            file-descriptors can be raised by this function. See `os.dup()` for
+            a discussion of possible errors.
+        """
+
+        if self.is_open():
+            return PathFd(_os.dup(int(self)))
+        else:
+            return PathFd()
+
+    def stat(self):
+        """Query File System Stat-Information
+
+        This performs the `fstat(2)` syscall on the file-system resource this
+        path-descriptor points to.
+
+        This is safe against TOCTOU races. Repeated calls are guaranteed to
+        return the same information, unless the information itself got changed
+        in the meantime.
+
+        This function does not cache any results. Every call results in a new
+        syscall invocation.
+
+        Note that this does not perform any path resolution. It accesses
+        exactly the resource the descriptor points to. If it points to a
+        symlink, it will return information for that symlink, rather than
+        information for the object the symlink points to. You must resolve
+        symlinks when creating a path-descriptor, in case you want symlinks
+        resolved.
+
+        Returns
+        -------
+        stat_result
+            The file-system information is reported as a return value of the
+            `stat_result` type from the python standard library.
+
+        Raises
+        ------
+        OSError
+            See the python standard library for possible errors when querying
+            stat-information (e.g., `os.stat()`).
+        """
+
+        assert self.is_open()
+
+        return _os.fstat(int(self))
+
+    def is_directory(self):
+        """Check whether the Path is a Directory
+
+        This is a convenience wrapper around `stat()` which checks whether the
+        path is a directory. This simply checks for `S_ISDIR()` on the
+        `st_mode` field of the file-system stat-information.
+
+        Returns
+        -------
+        Boolean
+            Whether the file-system object this descriptor points to is a
+            directory.
+
+        Raises
+        ------
+        OSError
+            See the python standard library for possible errors when querying
+            stat-information (e.g., `os.stat()`).
+        """
+
+        assert self.is_open()
+
+        return _stat.S_ISDIR(self.stat().st_mode)
+
+    def is_symlink(self):
+        """Check whether the Path is a Symlink
+
+        This is a convenience wrapper around `stat()` which checks whether the
+        path is a symlink. This simply checks for `S_ISLNK()` on the
+        `st_mode` field of the file-system stat-information.
+
+        Returns
+        -------
+        Boolean
+            Whether the file-system object this descriptor points to is a
+            symlink.
+
+        Raises
+        ------
+        OSError
+            See the python standard library for possible errors when querying
+            stat-information (e.g., `os.stat()`).
+        """
+
+        assert self.is_open()
+
+        return _stat.S_ISLNK(self.stat().st_mode)
+
+    def open_relative(self, path, flags, mode = 0o777):
+        """Open Relative Path
+
+        Open a path relative to this path-descriptor. This simply wraps the
+        `os.open()` call of the python standard-library, but as an
+        object-oriented call on a path-descriptor.
+
+        This behaves like `os.open()` of the python standard library, but uses
+        the path-descriptor as `dif_fd` argument.
+
+        If the given path is absolute, it will be based off the file-system
+        root rather than the path-descriptor this is called on.
+
+        This function always forces `O_CLOEXEC`. You must clear it afterwards,
+        if that is what you want.
+
+        Parameters
+        ----------
+        path : String
+            A file-system path in string representation. If it is a relative
+            path, it is interpreted relative to the path-descriptor this
+            function is called on.
+        flags : int
+            The open-flags to pass to `os.open()`.
+        mode : int, optional
+            The file creation flags to use with `os.open()`. Defaults to
+            `0o777`, but is subject to the current umask.
+
+        Returns
+        -------
+        int
+            The syscall result of `open(2)` is returned. This is usually a
+            file-descriptor.
+
+        Raises
+        ------
+        OSError
+            See the python standard library for possible errors when opening
+            paths (e.g., `os.open()`).
+        """
+
+        assert self.is_open()
+
+        flags |= _os.O_CLOEXEC
+        return _os.open(path, flags, mode, dir_fd = int(self))
+
+    def open_self(self, flags, mode = 0o777):
+        """Open own Path
+
+        Open the file-system object this path-descriptor points to. This wraps
+        the `os.open()` call from the python standard library, but hard-codes
+        the path to the object this path-descriptor points to.
+
+        Unfortunately, for obscure legacy reasons the linux kernel does not
+        provide the `AT_EMPTY_PATH` equivalent for `open(2)`. This means, you
+        cannot directly open a path-descriptor, but have to redirect via
+        `/proc/self/fd/<fd>`. Hence, this is what this implementation does.
+        This is, however, not strictly equivalent to opening the
+        path-descriptor directly. Therefore, some features are blocked to avoid
+        exposing broken behavior:
+
+          * You cannot use `O_NOFOLLOW` with this, as it would open the symlink
+            in `/proc` rather than the object the descriptor points to (and
+            because you cannot open symlinks, it would fail). Hence, passing
+            `O_NOFOLLOW` will raise an exception.
+            If you want this behavior, you must check via `is_symlink()`
+            manually, and then call this without `O_NOFOLLOW`.
+
+          * This relies on `/proc` being a proper `procfs` file-system. This
+            is the case for all known linux systems. If you use non-standard
+            setups, you must be aware that this call will fail, unless `/proc`
+            is properly setup (or worse if you re-use `/proc` for other
+            things).
+
+        This function always forces `O_CLOEXEC`. You must clear it afterwards,
+        if that is what you want.
+
+        Parameters
+        ----------
+        flags : int
+            The open-flags to pass to `os.open()`.
+        mode : int, optional
+            The file creation flags to use with `os.open()`. Defaults to
+            `0o777`, but is subject to the current umask.
+
+        Returns
+        -------
+        int
+            The syscall result of `open(2)` is returned. This is usually a
+            file-descriptor.
+
+        Raises
+        ------
+        OSError
+            See the python standard library for possible errors when opening
+            paths (e.g., `os.open()`).
+        """
+
+        #
+        # Preferably, we would want to use `openat(self, "", ... O_EMPTYPATH)`,
+        # but sadly there is no `AT_EMPTY_PATH` equivalent for `openat(2)`.
+        # Instead, we must go the route via `/proc`.
+        # Note that for questionable security reasons the `O_EMPTYPATH` flag is
+        # unlikely to appear at all (also see `AT_EMPTY_PATH` in `linkat(2)`
+        # for a discussion).
+        #
+        # We simply block the `O_NOFOLLOW` flag to make sure callers will not
+        # accidentally end up opening a file in `/proc`. If you want
+        # `O_NOFOLLOW` with `open_self()`, you are left with checking through
+        # `is_symlink()` before calling `open_self()` without `O_NOFOLLOW`.
+        # Note that this is safe as long as you call it on the same `DirFd`.
+        #
+
+        assert self.is_open()
+        assert not (flags & _os.O_NOFOLLOW)
+
+        flags |= _os.O_CLOEXEC
+        path = _os.path.join("/proc/self/fd/", str(int(self)))
+
+        return _os.open(path, flags, mode)
+
+    def descend(self, path, *, follow_symlink = False):
+        """Create Descendent
+
+        Create a new path-descriptor relative to this path-descriptor. The
+        given path is resolved at the time of this function call, and the new
+        descriptor will point to the file-system object it refers to.
+
+        Note that if your descriptor is an absolute path, it will not use the
+        path-descriptor as relative anchor, but instead be based off the
+        file-system root.
+
+        Also see `from_path()` for the equivalent of this call but relative to
+        the current working directory.
+
+        Parameters
+        ----------
+        path : String
+            A file-system path in string representation. If it is a relative
+            path, it is interpreted relative to the path-descriptor this
+            function is called on.
+        follow_symlink : Boolean, optional
+            Whether to resolve the final part of the path in case it is a
+            symlink. The default behavior is to not resolve it.
+
+        Returns
+        -------
+        PathFd
+            A new path-desciptor for the specified path is returned.
+
+        Raises
+        ------
+        OSError
+            Any operating system errors involved in resolving file-system paths
+            can be raised by this function. See `os.open()` in the python
+            standard library for a discussion.
+        """
+
+        assert self.is_open()
+
+        flags = _os.O_CLOEXEC | _os.O_PATH
+        if not follow_symlink:
+            flags |= _os.O_NOFOLLOW
+
+        return PathFd(self.open_relative(path, flags))
+
+    def enumerate(self, *, follow_symlink = False, fn_open_self = open_self, fn_descend = descend):
+        """Enumerate Directory Entries
+
+        Create a generator that enumerates the directory entries below the
+        directory pointed to by this path-descriptor. Effectively, this calls
+        `os.scandir()` on this path-descriptor and returns all entries. Unlike
+        a normal directory listing, this returns a path-descriptor for each
+        entry, as well as the `os.DirEntry` object as defined by the python
+        standard library.
+
+        This function will raise an exception if the path-descriptor does not
+        point to a directory, or is already closed.
+
+        Listing directory entries is not necessarily atomic. For instance, on
+        linux the `getdents(2)` system call has to be called repeatedly to
+        enumerate an entire directory. There is no guarantee that a single call
+        will suffice. Therefore, no atomicity guarantees are given. At the time
+        an entry is returned by the generator, it might have already been
+        unlinked or moved (regardless of this, the returned path-descriptor is
+        always valid). Furthermore, if new entries are created in the directory
+        while an enumeration is ongoing, there is no guarantee that it will
+        show up in the enumeration. For details on the behavior of parallel
+        file-system modifications, consult your operating system manuals.
+
+        This function diligently avoids race conditions between listing a
+        directory entry and opening a path-descriptor to it. It guarantees
+        coherent behavior and catches common errors. This means, the returned
+        directory entries are guaranteed to be valid entries you can operate
+        on.
+
+        Internally, this function first opens the directory to enumerate, then
+        iterates it and opens a path-descriptor for each entry. It allows the
+        caller to override the functions used to open the directory and to open
+        the path-descriptors. This way, callers can catch specific `OSError`
+        exceptions and modify the behavior. A common scenario is catching
+        access permissions and then modifying the access rights before retrying
+        the operation (this is particularly useful when iterating for deletion).
+        If you override these functions, you must provide the same invariants
+        as the originals do. You usually achieve this by calling into the
+        originals from your functions, and simply extending their
+        functionality, rather than reimplementing it.
+
+        Parameters
+        ----------
+        follow_symlink : Boolean, optional
+            Whether to resolve symlink entries. Default behavior is not to
+            resolve them.
+        fn_open_self : Function, optional
+            Override the function used to open the directory. By default,
+            this uses the `open_self()` method on path-descriptors.
+        fn_descend : Function, optional
+            Override the function used to open directory entries. By default,
+            this uses the `descend()` method on path-descriptors.
+
+        Returns
+        -------
+        Generator
+            A generator that produces tuples of a path-descriptor and an
+            `os.DirEntry` object is returned.
+
+        Raises
+        ------
+        OSError
+            This can raise an `OSError` if the original directory cannot be
+            opened for enumeration. Furthermore, this might raise further
+            errors if the entries cannot be opened via `O_PATH` (e.g., lacking
+            directory execution rights).
+        """
+
+        assert self.is_open()
+
+        # You can open path-descriptors which point to directories even if the
+        # directory was removed. This call should always succeed, except for
+        # wrong setups, access restrictions, or programming errors.
+        flags = _os.O_RDONLY | _os.O_CLOEXEC | _os.O_DIRECTORY
+        dir_fd = fn_open_self(self, flags)
+
+        # Reading from a directory might fail for several reasons. Since
+        # reading is not atomic and might be chunked, each call that fetches
+        # directory entries might fail for these reasons.
+        #
+        #   * ENOENT: If the parent directory is empty and then was dropped via
+        #             `rmdir(2)`, we will get `ENOENT`.
+        #
+        # No other possible error-scenarios are known at this time. This might
+        # need extension in the future, though.
+        readdir_break_on = [ _errno.ENOENT ]
+
+        entries = None
+        try:
+            entries = _os.scandir(dir_fd)
+        except OSError as e:
+            # This operation should be a no-op, but python does not guarantee
+            # it. Technically, this might call `readdir()` (or `getdents(2)`)
+            # so we treat it the same as reading from the `entries` iterator.
+            if not any(e.errno == i for i in readdir_break_on):
+                raise e
+        else:
+            while True:
+                entry = None
+                try:
+                    # This calls `readdir()` (or probably the improved version
+                    # of it: `getdents(2)`). It very linkely is a batched
+                    # operation, so not each call will end up in a syscall.
+                    entry = next(entries)
+                except StopIteration:
+                    break
+                except OSError as e:
+                    # See discussion above on `os.scandir()` for exceptions.
+                    if any(e.errno == i for i in readdir_break_on):
+                        break
+                    else:
+                        raise e
+
+                try:
+                    with fn_descend(self, entry.name, follow_symlink = follow_symlink) as pathfd:
+                        yield (pathfd, entry)
+                except OSError as e:
+                    if e.errno == _errno.ENOENT:
+                        # A file might very well get deleted in between listing
+                        # the directory entries and trying to access it. We can
+                        # safely ignore this and pretend the directory listing
+                        # was chunked differently and never returned this
+                        # unlinked file.
+                        continue
+                    else:
+                        raise e
+        finally:
+            if entries is not None:
+                entries.close()
+            _os.close(dir_fd)
+
+    def traverse(self, *, postorder = False, fn_enumerate = enumerate):
+        """Traverse Directory Tree
+
+        This creates a generator that iteratively traverses a directory tree,
+        yielding an object for every entry in that file-system tree. It
+        operates through `enumerate()` internally, but traveses an entire tree
+        rather than just a single directory level.
+
+        Note that `follow_symlink` is not provided as an option, and this
+        function currently behaves as if it was set to `False`. Traversing a
+        tree and following symlinks easily deadlocks. Furthermore, the
+        semantics are not entirely clear. Therefore, it is left to the caller
+        to resolve symlinks, if they so desire.
+
+        No entry for the object this is called on is yielded. That is, if the
+        directory that `self` points to is empty, this will yield no entries.
+
+        Parameters
+        ----------
+        postorder : Boolean, optional
+            Whether to yield entries in postorder. Default behavior is
+            preorder. That is, in preorder mode a directory is yielded before
+            the entries of the directory are yielded. In postorder mode, this
+            behavior is reversed.
+        fn_enumerate : Function, optional
+            Override the function used to enumerate a directory. By default,
+            this uses the `enumerate()` method on path-descriptors.
+
+        Returns
+        -------
+        Generator
+            A generator that produces tuples of a path-descriptor and an
+            `os.DirEntry` object is returned. Note that the directory entry
+            only contains information for the level it is on. No information
+            about the parent directories is included.
+
+        Raises
+        ------
+        OSError
+            This uses `enumerate()` internally, and thus returns the same set
+            of errors. No additional considerations apply.
+        """
+
+        assert self.is_open()
+
+        # We use a non-recursive implementation that stores every directory we
+        # recurse into on the stack, and pops it once fully enumerated.
+        stack = [ (self, None, fn_enumerate(self)) ]
+
+        while len(stack) > 0:
+            (current_dirfd, current_entry, current_scan) = stack[-1]
+
+            for (sub_dirfd, sub_entry) in current_scan:
+                if sub_dirfd.is_directory():
+                    if not postorder:
+                        yield (sub_dirfd, sub_entry)
+
+                    stack.append((sub_dirfd, sub_entry, fn_enumerate(sub_dirfd)))
+                    break
+                else:
+                    yield (sub_dirfd, sub_entry)
+            else:
+                if postorder and (current_entry is not None):
+                    yield (current_dirfd, current_entry)
+
+                stack.pop()

--- a/test/test_util_linux.py
+++ b/test/test_util_linux.py
@@ -1,0 +1,99 @@
+#
+# Tests for the `osbuild.util.linux` module.
+#
+
+
+import os
+import tempfile
+import unittest
+
+import osbuild.util.linux as linux
+
+
+class TestUtilLinux(unittest.TestCase):
+    def test_fcntl_flock(self):
+        #
+        # This tests the `linux.fcntl_flock()` file-locking helper. Note
+        # that file-locks are on the open-file-description, so they are shared
+        # between dupped file-descriptors. We explicitly create a separate
+        # file-description via `/proc/self/fd/`.
+        #
+        with tempfile.TemporaryFile() as f:
+            fd1 = f.fileno()
+            fd2 = os.open(os.path.join("/proc/self/fd/", str(fd1)), os.O_RDWR | os.O_CLOEXEC)
+
+            # Test: unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: write-lock + unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: read-lock1 + read-lock2 + unlock1 + unlock2
+            linux.fcntl_flock(fd1, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd2, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+            linux.fcntl_flock(fd2, linux.fcntl.F_UNLCK)
+
+            # Test: write-lock1 + write-lock2 + unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            try:
+                linux.fcntl_flock(fd2, linux.fcntl.F_WRLCK)
+                raise SystemError
+            except BlockingIOError:
+                pass
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: write-lock1 + read-lock2 + unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            try:
+                linux.fcntl_flock(fd2, linux.fcntl.F_RDLCK)
+                raise SystemError
+            except BlockingIOError:
+                pass
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: read-lock1 + write-lock2 + unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_RDLCK)
+            try:
+                linux.fcntl_flock(fd2, linux.fcntl.F_WRLCK)
+                raise SystemError
+            except BlockingIOError:
+                pass
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: write-lock1 + read-lock1 + read-lock2 + unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd2, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: read-lock1 + read-lock2 + write-lock1 + unlock1 + unlock2
+            linux.fcntl_flock(fd1, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd2, linux.fcntl.F_RDLCK)
+            try:
+                linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+                raise SystemError
+            except BlockingIOError:
+                pass
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+            linux.fcntl_flock(fd2, linux.fcntl.F_UNLCK)
+
+            # Test: write-lock3 + write-lock1 + close3 + write-lock1 + unlock1
+            fd3 = os.open(os.path.join("/proc/self/fd/", str(fd1)), os.O_RDWR | os.O_CLOEXEC)
+            linux.fcntl_flock(fd3, linux.fcntl.F_WRLCK)
+            try:
+                linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+                raise SystemError
+            except BlockingIOError:
+                pass
+            os.close(fd3)
+            linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Cleanup
+            os.close(fd2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_util_pathfd.py
+++ b/test/test_util_pathfd.py
@@ -1,0 +1,312 @@
+#
+# Tests for the `osbuild.util.pathfd` module.
+#
+
+
+import os
+import tempfile
+import unittest
+
+import osbuild.util.pathfd as pathfd
+
+
+class TestUtilPathFd(unittest.TestCase):
+    def setUp(self):
+        #
+        # Generic Test Setup
+        #
+        # We create a temporary directory tree for all tests. Each entry is
+        # named after its own path (e.g., the file `2_2_0` is located at
+        # `2/2_2/2_2_0`). This allows easy assertions on file-location and
+        # availability.
+        #
+        # The tree we create looks like this:
+        #
+        #     0
+        #     1
+        #     2/
+        #         2_0
+        #         2_1
+        #         2_2/
+        #             2_2_0
+        #             2_2_1
+        #         2_3/
+        #             2_3_0
+        #             2_3_1
+        #     3/
+        #         3_0
+        #         3_1
+        #         3_2
+        #         3_3
+        #     4 -> "2"
+        #     5 -> "2/2_3"
+        #     6 -> "<invalid>"
+        #
+
+        self.dir = tempfile.TemporaryDirectory()
+        self.dirfd = pathfd.PathFd.from_path(self.dir.name)
+
+        flags = os.O_RDWR | os.O_CLOEXEC | os.O_CREAT | os.O_EXCL
+
+        os.close(os.open("0", flags, dir_fd = int(self.dirfd)))
+        os.close(os.open("1", flags, dir_fd = int(self.dirfd)))
+
+        os.mkdir("2", dir_fd = int(self.dirfd))
+        os.close(os.open("2/2_0", flags, dir_fd = int(self.dirfd)))
+        os.close(os.open("2/2_1", flags, dir_fd = int(self.dirfd)))
+        os.mkdir("2/2_2", dir_fd = int(self.dirfd))
+        os.close(os.open("2/2_2/2_2_0", flags, dir_fd = int(self.dirfd)))
+        os.close(os.open("2/2_2/2_2_1", flags, dir_fd = int(self.dirfd)))
+        os.mkdir("2/2_3", dir_fd = int(self.dirfd))
+        os.close(os.open("2/2_3/2_3_0", flags, dir_fd = int(self.dirfd)))
+        os.close(os.open("2/2_3/2_3_1", flags, dir_fd = int(self.dirfd)))
+
+        os.mkdir("3", dir_fd = int(self.dirfd))
+        os.close(os.open("3/3_0", flags, dir_fd = int(self.dirfd)))
+        os.close(os.open("3/3_1", flags, dir_fd = int(self.dirfd)))
+        os.close(os.open("3/3_2", flags, dir_fd = int(self.dirfd)))
+        os.close(os.open("3/3_3", flags, dir_fd = int(self.dirfd)))
+
+        os.symlink("2", "4", dir_fd = int(self.dirfd))
+        os.symlink("2/2_3", "5", dir_fd = int(self.dirfd))
+        os.symlink("<invalid>", "6", dir_fd = int(self.dirfd))
+
+    def tearDown(self):
+        self.dirfd.close()
+        self.dir.cleanup()
+
+    def test_basic(self):
+        #
+        # Basic Tests
+        #
+        # This contains a bunch of hard-coded basic tests for the PathFd
+        # module. Anything non-automated and small enough that it needs no
+        # complex setup is bundled here.
+        #
+
+        # Verify basic constructors calls.
+        _ = pathfd.PathFd()
+        _ = pathfd.PathFd.from_path(self.dir.name)
+        _ = self.dirfd.clone()
+
+        # Verify int-conversion produces an accessible file-descriptor.
+        fd = int(self.dirfd)
+        assert fd >= 0
+        dup = os.dup(fd)
+        assert dup >= 0
+        os.close(dup)
+
+        # Verify context-manager operation.
+        p = self.dirfd.clone()
+        with p as v:
+            assert int(p) == int(v)
+        assert not p.is_open()
+
+        # Verify close() does its job.
+        p = self.dirfd.clone()
+        assert int(p) >= 0
+        p.close()
+        try:
+            assert int(p) >= 0
+            raise SystemError
+        except AssertionError:
+            pass
+
+        # Verify is_open() behavior.
+        assert not pathfd.PathFd().is_open()
+        p = self.dirfd.clone()
+        assert p.is_open()
+        p.close()
+        assert not p.is_open()
+
+        # Verify clones have their own private file-descriptor.
+        p = self.dirfd.clone()
+        assert int(p) != int(self.dirfd)
+
+        # Verify stat() works just like `os.stat()`.
+        assert self.dirfd.stat() == os.stat(self.dir.name)
+
+        # Verify is_directory() works as intended.
+        assert self.dirfd.descend(".").is_directory()
+        assert not self.dirfd.descend("0").is_directory()
+        assert not self.dirfd.descend("1").is_directory()
+        assert self.dirfd.descend("2").is_directory()
+        assert not self.dirfd.descend("2/2_0").is_directory()
+
+        # Verify is_symlink() works as intended.
+        assert not self.dirfd.descend(".").is_symlink()
+        assert not self.dirfd.descend("0").is_symlink()
+        assert not self.dirfd.descend("1").is_symlink()
+        assert self.dirfd.descend("4").is_symlink()
+        assert self.dirfd.descend("5").is_symlink()
+        assert self.dirfd.descend("6").is_symlink()
+
+        # Check for basic `open_relative()` behavior.
+        _ = self.dirfd.open_relative("2/2_0", os.O_RDONLY)
+        try:
+            # '6' is a symlink to a non-existant file, so it cannot resolve
+            _ = self.dirfd.open_relative("6", os.O_RDONLY)
+            raise SystemError
+        except OSError:
+            pass
+        try:
+            # cannot open symlinks (which `O_NOFOLLOW` would try here)
+            _ = self.dirfd.open_relative("4", os.O_RDONLY | os.O_NOFOLLOW)
+            raise SystemError
+        except OSError:
+            pass
+        _ = self.dirfd.open_relative("4", os.O_RDONLY)
+
+        # Check for basic `open_self()` behavior.
+        _ = self.dirfd.open_self(os.O_RDONLY)
+        try:
+            # `open_self()` rejects `O_NOFOLLOW`
+            _ = self.dirfd.descend("4").open_self(os.O_RDONLY | os.O_NOFOLLOW)
+            raise SystemError
+        except AssertionError:
+            pass
+
+        # Check for basic `descend()` behavior.
+        _ = self.dirfd.descend("0")
+        _ = self.dirfd.descend("2")
+        _ = self.dirfd.descend("2/2_0")
+        _ = self.dirfd.descend("2/../2/./2_0")
+        _ = self.dirfd.descend("2").descend("2_0")
+        _ = self.dirfd.descend("4")
+        _ = self.dirfd.descend("5", follow_symlink = True)
+        try:
+            _ = self.dirfd.descend("6", follow_symlink = True)
+            raise SystemError
+        except OSError:
+            pass
+
+    def test_enumerate(self):
+        #
+        # Directory Enumeration
+        #
+        # This contains tests for the `enumerate()` method of pathfd objects.
+        # It defines an array of mappings from pathfd to the directory
+        # listing. It then iterates over the mapping and verifies each
+        # enumeration produces the expected listing.
+        #
+
+        mappings = []
+
+        dirfd = self.dirfd.clone()
+        expected = ["0", "1", "2", "3", "4", "5", "6"]
+        mappings.append((dirfd, expected))
+
+        dirfd = self.dirfd.descend("2/2_2")
+        expected = ["2_2_0", "2_2_1"]
+        mappings.append((dirfd, expected))
+
+        dirfd = self.dirfd.descend("3")
+        expected = ["3_0", "3_1", "3_2", "3_3"]
+        mappings.append((dirfd, expected))
+
+        for (dirfd, expected) in mappings:
+            result = list(map(lambda x: x[1].name, dirfd.enumerate()))
+            result.sort()
+            expected.sort()
+            assert result == expected
+
+    def test_enumerate_unlink_race(self):
+        #
+        # Directory Enumeration vs Unlink
+        #
+        # This runs a directory enumeration, but unlinks an entry during the
+        # enumeration. It verifies that the enumeration will not fall over, but
+        # proceeds gracefully.
+        #
+        # We cannot affect the batch-size the `os.scandir()` call uses
+        # internally. Therefore, we cannot really predict which path is taken.
+        # All we can do is verify no exception is thrown.
+        #
+
+        with tempfile.TemporaryDirectory() as t_dir:
+            t_dirfd = pathfd.PathFd.from_path(t_dir)
+            flags = os.O_RDWR | os.O_CLOEXEC | os.O_CREAT | os.O_EXCL
+            os.close(os.open("0", flags, dir_fd = int(t_dirfd)))
+            os.close(os.open("1", flags, dir_fd = int(t_dirfd)))
+            os.close(os.open("2", flags, dir_fd = int(t_dirfd)))
+            os.close(os.open("3", flags, dir_fd = int(t_dirfd)))
+            os.close(os.open("4", flags, dir_fd = int(t_dirfd)))
+            os.close(os.open("5", flags, dir_fd = int(t_dirfd)))
+            os.close(os.open("6", flags, dir_fd = int(t_dirfd)))
+            os.close(os.open("7", flags, dir_fd = int(t_dirfd)))
+
+            t_entries = []
+            t_enum = t_dirfd.enumerate()
+
+            # Unlink '3' and '4'. This means they must not be returned from the
+            # `next()` calls, but might be internally seen by `os.scandir()`.
+            os.unlink("3", dir_fd = int(t_dirfd))
+            os.unlink("4", dir_fd = int(t_dirfd))
+
+            # Fetch the first entry, triggering a batched `os.scandir()`.
+            t_entries.append(next(t_enum)[1].name)
+
+            # Unlink more entries. Because ordering is random, one of these
+            # might have been returned by the previous call, but we cannot
+            # know. However, this can only apply to one of them. The other must
+            # never be returned.
+            os.unlink("0", dir_fd = int(t_dirfd))
+            os.unlink("7", dir_fd = int(t_dirfd))
+
+            t_entries += list(map(lambda x: x[1].name, t_enum))
+            t_entries.sort()
+
+            expected0 = ["0", "1", "2", "5", "6",    ]
+            expected0.sort()
+            expected1 = [     "1", "2", "5", "6", "7"]
+            expected1.sort()
+            expected2 = [     "1", "2", "5", "6",    ]
+            expected2.sort()
+
+            assert t_entries == expected0 or t_entries == expected1 or t_entries == expected2
+
+    def test_traverse(self):
+        #
+        # Path Traversal
+        #
+        # This tests the recursive enumeration of a directory tree. It defines
+        # a mapping from pathfd to the expected directory listing. It then
+        # iterates the array and verifies each enumeration produces the
+        # expected result.
+        #
+        # Note that the origin of a traversal is not itself yielded by the
+        # traversal.
+        #
+
+        mappings = []
+
+        dirfd = self.dirfd.clone()
+        expected = []
+        expected += ["0", "1"]
+        expected += ["2", "2_0", "2_1"]
+        expected += ["2_2", "2_2_0", "2_2_1"]
+        expected += ["2_3", "2_3_0", "2_3_1"]
+        expected += ["3", "3_0", "3_1", "3_2", "3_3"]
+        expected += ["4", "5", "6"]
+        mappings.append((dirfd, expected))
+
+        dirfd = self.dirfd.descend("2")
+        expected = []
+        expected += ["2_0", "2_1"]
+        expected += ["2_2", "2_2_0", "2_2_1"]
+        expected += ["2_3", "2_3_0", "2_3_1"]
+        mappings.append((dirfd, expected))
+
+        dirfd = self.dirfd.descend("3")
+        expected = ["3_0", "3_1", "3_2", "3_3"]
+        mappings.append((dirfd, expected))
+
+        for (dirfd, expected) in mappings:
+            result = list(map(lambda x: x[1].name, dirfd.traverse()))
+            result.sort()
+            expected.sort()
+            assert result == expected
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is a preview PR with some of the utilities I created for the cache rework. It allows us to discuss the idea of these utilities upfront and probably reducing the amount of review for the cache rework. But I am also fine if this is just an FYI-ish PR and we all ignore it, since it will be included in the final PR, anyway.

This PR introduces two new helper modules in `./osbuild/util/`. The idea here is that these implement independent modules that have no inherent connection to `osbuild`, hence I put them into the `util` subdirectory. Technically, we could move them into their own python projects, but their small size and limited exposure does not really justify the work required to maintain them independently. At the same time, pretending that they are independent modules allows us to structurally (and mentally) separate code from the osbuild core.
The advantages are basically the same as you get with all other kinds of module-separation (be it python modules, C libraries, go packages, you name it...). In short, the knowledge you need to know about individual modules is reduced to the API they expose (at the same time working on the module needs "no knowledge" of its osbuild host).
The disadvantages are probably also well known: We might spend much time designing APIs, where it would be much easier just hard-coding values in the code directly.

This is a trade-off, of course. With `./osbuild/loop.py` we already have something that very much fits the description of such a utility. I did not move it into `./osbuild/util/`, but will gladly do if we all agree.

There is lots of room for discussion and lots of arguments I did not elaborate on for now. If there is interest, I will gladly write up some more. Comments welcome!