### PR TITLE
spec: require matching python3-osbuild version

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -33,7 +33,7 @@ Requires:       systemd
 Requires:       systemd-container
 Requires:       tar
 Requires:       util-linux
-Requires:       python3-%{pypi_name}
+Requires:       python3-%{pypi_name} = %{version}-%{release}
 
 # Turn off dependency generators for assemblers, runners and stages.
 # They run in a container, so there's no reason to generate dependencies


### PR DESCRIPTION
The `osbuild` executable requires that the exact same version of the corresponding python library is installed, but this was not enforced in the RPM package. Thus a old version of osbuild could be installed alongside an older version of python3-osbuild, which results in an osbuild crash (see below).
Therefore, enforce that both installed packages have matching versions by specifying the exact version for the `python3-osbuild` dependency of the `osbuild` package.

With that patch applied updating `osbuild` alone wont be possible anymore:
```
sudo dnf install /home/gicmo/Code/src/osbuild/rpmbuild/RPMS/noarch/osbuild-11-1.20200406gitb08d583.fc32.noarch.rpm

 Problem: conflicting requests
  - nothing provides python3-osbuild = 11-1.20200406gitb08d583.fc32 needed by osbuild-11-1.20200406gitb08d583.fc32.noarch
```

Example osbuild crash if versions are not matching:

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (osbuild 10 (/usr/lib/python3.8/site-packages), Requirement.parse('osbuild==11'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/osbuild", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3252, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3235, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3264, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 585, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 598, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'osbuild==11' distribution was not found and is required by the application
```