### PR TITLE
pipeline: explicitly import importlib.util

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -1,6 +1,7 @@
 
 import hashlib
 import importlib
+import importlib.util
 import json
 import os
 import subprocess


### PR DESCRIPTION
Causes a problem with ostree-osbuild on CI (travis) otherwise:

```
Traceback (most recent call last):
  File "osbuild-ostree", line 345, in <module>
    sys.exit(main())
  File "osbuild-ostree", line 337, in main
    return build(args)
  File "osbuild-ostree", line 257, in build
    output_id, commit_id = build_commit(builddir, args)
  File "osbuild-ostree", line 162, in build_commit
    r = pipeline.run(store.store,
  File "/home/travis/build/gicmo/ostree-osbuild-demo/osbuild/osbuild/pipeline.py", line 358, in run
    r = self.assemble(object_store,
  File "/home/travis/build/gicmo/ostree-osbuild-demo/osbuild/osbuild/pipeline.py", line 314, in assemble
    r = self.assembler.run(input_dir,
  File "/home/travis/build/gicmo/ostree-osbuild-demo/osbuild/osbuild/pipeline.py", line 148, in run
    osbuild_module_path = os.path.dirname(importlib.util.find_
```