### PR TITLE
test: prune cache after each stage-test

### DIFF
--- a/test/osbuildtest.py
+++ b/test/osbuildtest.py
@@ -23,16 +23,14 @@ class TestCase(unittest.TestCase):
     it for actual testing.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.store = os.getenv("OSBUILD_TEST_STORE")
-        if not cls.store:
-            cls.store = tempfile.mkdtemp(prefix="osbuild-test-", dir="/var/tmp")
+    def setUp(self):
+        self.store = os.getenv("OSBUILD_TEST_STORE")
+        if not self.store:
+            self.store = tempfile.mkdtemp(prefix="osbuild-test-", dir="/var/tmp")
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
         if not os.getenv("OSBUILD_TEST_STORE"):
-            shutil.rmtree(cls.store)
+            shutil.rmtree(self.store)
 
     def run_osbuild(self, pipeline, input=None):
         osbuild_cmd = ["python3", "-m", "osbuild", "--json", "--store", self.store, "--libdir", ".", pipeline]


### PR DESCRIPTION
Make sure we prune the caches after each stage-test to keep our disk
footprint small. This does considerably increase build-times since we
no longer share cached entries. However, the current CI builds simply
run out of disk-space.

Once we use separate output-directories we will be able to drop the
automatic checkpointing from the tests, and thus effectively get the
same behavior. Until then, lets prune the caches explicitly.