### PR TITLE
ci: temporarily disable F32 rpm-tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fedora_release: ["31", "32", "33"]
+        fedora_release: ["31", "33"] # XXX: "32" temporarily disabled during freeze
     container:
       image: "quay.io/osbuild/osbuild-fedora${{ matrix.fedora_release }}:latest"
     steps:


### PR DESCRIPTION
The F32 mirrors are currently out-of-sync. This might be related to the
repo freeze that is ongoing. Lets disable F32 until it is released, so
our CI can do its job again.