### PR TITLE
stages/grub2: default to disabling `legacy` support

### DIFF
--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -50,7 +50,8 @@
       "name": "org.osbuild.grub2",
       "options": {
         "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-        "kernel_opts": "ro biosdevname=0 net.ifnames=0"
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+        "legacy": "i386-pc"
       }
     },
     {

--- a/samples/base-rawfs.json
+++ b/samples/base-rawfs.json
@@ -51,7 +51,8 @@
       "name": "org.osbuild.grub2",
       "options": {
         "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-        "kernel_opts": "ro biosdevname=0 net.ifnames=0"
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+        "legacy": "i386-pc"
       }
     },
     {

--- a/samples/base-rpm-qcow2.json
+++ b/samples/base-rpm-qcow2.json
@@ -924,7 +924,8 @@
         "name": "org.osbuild.grub2",
         "options": {
           "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0"
+          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+          "legacy": "i386-pc"
         }
       },
       {

--- a/samples/cloud-base.json
+++ b/samples/cloud-base.json
@@ -53,7 +53,8 @@
       "name": "org.osbuild.grub2",
       "options": {
         "root_fs_uuid": "ea711a29-e460-4879-9d70-9da99ae021f9",
-        "kernel_opts": "ro biosdevname=0 net.ifnames=0"
+        "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+        "legacy": "i386-pc"
       }
     },
     {

--- a/samples/f30-aarch64.json
+++ b/samples/f30-aarch64.json
@@ -74,7 +74,6 @@
       "options": {
         "root_fs_uuid": "7acfe2cc-4134-482a-a9d4-4979a5a87569",
         "kernel_opts": "ro biosdevname=0 net.ifnames=0 console=ttyS0 console=tty1",
-        "legacy": false,
         "uefi": {
           "vendor": "fedora"
         }

--- a/samples/f30-base-uefi.json
+++ b/samples/f30-base-uefi.json
@@ -78,7 +78,8 @@
         "kernel_opts": "ro biosdevname=0 net.ifnames=0 console=ttyS0 console=tty1",
         "uefi": {
           "vendor": "fedora"
-        }
+        },
+        "legacy": "i386-pc"
       }
     },
     {

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -19,9 +19,9 @@ behavior in Fedora 30 and later.
 This stage will overwrite `/etc/default/grub`, `/boot/grub2/grubenv`, and
 `/boot/grub2/grub.cfg`. (Leading directories will be created if not present.)
 
-If Legacy boot support is requested (the default, or explicitly via `legacy`)
-this stage will also overwrite `/boot/grub2/grub.cfg` and will copy the
-GRUB2 files from the buildhost into the target tree:
+If Legacy boot support is requested via `legacy` this stage will also
+overwrite `/boot/grub2/grub.cfg` and will copy the GRUB2 files from the
+buildhost into the target tree:
 * `/usr/share/grub/unicode.pf2`          -> `/boot/grub2/fonts/`
 * `/usr/lib/grub/$platform/*.{mod,lst}` -> `/boot/grub2/$platform/`
   * NOTE: skips `fdt.lst`, which is an empty file
@@ -67,8 +67,8 @@ STAGE_OPTS = """
   "legacy": {
     "description": "Include legacy boot support",
     "oneOf": [
-      {"type": "boolean", "default": true},
-      {"type": "string", "default": "i386-pc"}
+      {"type": "boolean", "default": false},
+      {"type": "string"}
     ]
   },
   "uefi": {
@@ -135,7 +135,7 @@ def main(tree, options):
     root_fs_uuid = options["root_fs_uuid"]
     boot_fs_uuid = options.get("boot_fs_uuid", None)
     kernel_opts = options.get("kernel_opts", "")
-    legacy = options.get("legacy", True)
+    legacy = options.get("legacy", None)
     uefi = options.get("uefi", None)
 
     # legacy boolean means the

--- a/test/pipelines/f30-boot.json
+++ b/test/pipelines/f30-boot.json
@@ -924,7 +924,8 @@
         "name": "org.osbuild.grub2",
         "options": {
           "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0"
+          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
+          "legacy": "i386-pc"
         }
       },
       {


### PR DESCRIPTION
For the sake of backwards compatibility, legacy support was enabled
by default. Flip this around, so that leaving the parameter out
means disabling it.

This is more intuitive, and will pave the way for dropping support
for the value being a bool in the future.

`osbuild-composer` always passes the argumnet explicitly, though
still always as a boolean. We would like to replace that by passing a string. See https://github.com/osbuild/osbuild-composer/pull/501