### PR TITLE
osbuild: add --output-directory=DIR

### DIFF
--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -50,6 +50,7 @@ is not listed here, **osbuild** will deny startup and exit with an error.
 --checkpoint=CHECKPOINT         stage to commit to the object store during
                                 build (can be passed multiple times)
 --json                          output results in JSON format
+--output-directory=DIR          directory where result objects are stored
 
 MANIFEST
 ========

--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -50,6 +50,8 @@ def main():
                         help="stage to commit to the object store during build (can be passed multiple times)")
     parser.add_argument("--json", action="store_true",
                         help="output results in JSON format")
+    parser.add_argument("--output-directory", metavar="DIRECTORY", type=os.path.abspath,
+                        help="directory where result objects are stored")
     args = parser.parse_args()
 
     if args.manifest_path == "-":
@@ -91,7 +93,8 @@ def main():
             args.store,
             interactive=not args.json,
             libdir=args.libdir,
-            secrets=secrets
+            secrets=secrets,
+            output_directory=args.output_directory
         )
     except KeyboardInterrupt:
         print()


### PR DESCRIPTION
Add a new output-directory argument which specifies where to store
result objects. For now, this is purely optional and simply copies from
the old `output_id` into the specified directory. This allows a
backwards compatible transition towards removing any external access to
the osbuild cache.

Note that this has still lots of room for improvements:

  * We only support assembler-output for now, but we could also easily
    support entire trees as output, in case no assembler was selected.
    Alternatively, we could introduce a "copy" assembler, that just
    outputs the input tree.

  * This parameter is optional, but should really be mandatory. There
    is little reason to have the default behavior just dropping any
    generated content. This would be a breaking change, though.

  * We could move data out of a temporary object-store entry, rather
    than copy it. But again, for backwards-compatibility, we leave the
    latest store-object intact and do not move things out of it.

  * We could now transition towards never committing anything to the
    store, not even output IDs, unless explicitly checkpointed.

I tested this locally via:

    sudo python -m osbuild --libdir . samples/base-rpm-qcow2.json --output-directory foobar

It works fine for me, both with cached as well as generated entries.