### PR TITLE
🐎 Allow xz to use all available CPUs

### DIFF
--- a/assemblers/org.osbuild.tar
+++ b/assemblers/org.osbuild.tar
@@ -46,8 +46,28 @@ def main(tree, output_dir, options):
             return 1
         extra_args.append(f"--{compression}")
 
-    subprocess.run(["tar", *extra_args, "-cf", f"{output_dir}/{filename}", "-C", tree, "."],
-                   stdout=subprocess.DEVNULL, check=True)
+    # Set environment variables for the tar operation.
+    tar_env = {
+        # Speed up xz by allowing it to use all CPU cores for compression.
+        "XZ_OPT": "--threads 0"
+    }
+
+    # Set up the tar command.
+    tar_cmd = [
+        "tar",
+        *extra_args,
+        "-cf", f"{output_dir}/{filename}",
+        "-C", tree,
+        "."
+    ]
+
+    # Make a tarball of the tree.
+    subprocess.run(
+        tar_cmd,
+        stdout=subprocess.DEVNULL,
+        check=True,
+        env=tar_env
+    )
 
     return 0
 


### PR DESCRIPTION
By default, xz only uses one CPU core even if multiple cores are
available. If xz compression is chosen, allow xz to use all of the
cores available.

Signed-off-by: Major Hayden <major@redhat.com>