### PR TITLE
samples: fix grub2-legacy in base-qcow2

### DIFF
--- a/samples/base-qcow2.json
+++ b/samples/base-qcow2.json
@@ -925,7 +925,7 @@
         "options": {
           "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
           "kernel_opts": "ro biosdevname=0 net.ifnames=0",
-          "legacy": "386-pc"
+          "legacy": "i386-pc"
         }
       },
       {


### PR DESCRIPTION
This fixes a typo: `386-pc` -> `i386-pc`