### PR TITLE
osbuild: extract remove_tree() into its own module

### DIFF
--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -1,0 +1,93 @@
+"""Linux API Access
+
+This module provides access to linux system-calls and other APIs, in particular
+those not provided by the python standard library. The idea is to provide
+universal wrappers with broad access to linux APIs. Convenience helpers and
+higher-level abstractions are beyond the scope of this module.
+
+In some cases it is overly complex to provide universal access to a specifc
+API. Hence, the API might be restricted to a reduced subset of its
+functionality, just to make sure we can actually implement the wrappers in a
+reasonable manner.
+"""
+
+
+import array
+import fcntl
+
+
+__all__ = [
+    "ioctl_get_immutable",
+    "ioctl_toggle_immutable",
+]
+
+
+# NOTE: These are wrong on at least ALPHA and SPARC. They use different
+#       ioctl number setups. We should fix this, but this is really awkward
+#       in standard python.
+#       Our tests will catch this, so we will not accidentally run into this
+#       on those architectures.
+FS_IOC_GETFLAGS = 0x80086601
+FS_IOC_SETFLAGS = 0x40086602
+
+FS_IMMUTABLE_FL = 0x00000010
+
+
+def ioctl_get_immutable(fd: int):
+    """Query FS_IMMUTABLE_FL
+
+    This queries the `FS_IMMUTABLE_FL` flag on a specified file.
+
+    Arguments
+    ---------
+    fd
+        File-descriptor to operate on.
+
+    Returns
+    -------
+    bool
+        Whether the `FS_IMMUTABLE_FL` flag is set or not.
+
+    Raises
+    ------
+    OSError
+        If the underlying ioctl fails, a matching `OSError` will be raised.
+    """
+
+    if not isinstance(fd, int) or fd < 0:
+        raise ValueError()
+
+    flags = array.array('L', [0])
+    fcntl.ioctl(fd, FS_IOC_GETFLAGS, flags, True)
+    return bool(flags[0] & FS_IMMUTABLE_FL)
+
+
+def ioctl_toggle_immutable(fd: int, set_to: bool):
+    """Toggle FS_IMMUTABLE_FL
+
+    This toggles the `FS_IMMUTABLE_FL` flag on a specified file. It can both set
+    and clear the flag.
+
+    Arguments
+    ---------
+    fd
+        File-descriptor to operate on.
+    set_to
+        Whether to set the `FS_IMMUTABLE_FL` flag or not.
+
+    Raises
+    ------
+    OSError
+        If the underlying ioctl fails, a matching `OSError` will be raised.
+    """
+
+    if not isinstance(fd, int) or fd < 0:
+        raise ValueError()
+
+    flags = array.array('L', [0])
+    fcntl.ioctl(fd, FS_IOC_GETFLAGS, flags, True)
+    if set_to:
+        flags[0] |= FS_IMMUTABLE_FL
+    else:
+        flags[0] &= ~FS_IMMUTABLE_FL
+    fcntl.ioctl(fd, FS_IOC_SETFLAGS, flags, False)

--- a/osbuild/util/rmrf.py
+++ b/osbuild/util/rmrf.py
@@ -1,0 +1,97 @@
+"""Recursive File System Removal
+
+This module implements `rm -rf` as a python function. Its core is the
+`rmtree()` function, which takes a file-system path and then recursively
+deletes everything it finds on that path, until eventually the path entry
+itself is dropped. This is modeled around `shutil.rmtree()`.
+
+This function tries to be as thorough as possible. That is, it tries its best
+to modify permission bits and other flags to make sure directory entries can be
+removed.
+"""
+
+
+import array
+import fcntl
+import os
+import shutil
+
+
+__all__ = [
+    "rmtree",
+]
+
+
+def rmtree(path: str):
+    """Recursively Remove from File System
+
+    This removes the object at the given path from the file-system. It
+    recursively iterates through its content and removes them, before removing
+    the object itself.
+
+    This function is modeled around `shutil.rmtree()`, but extends its
+    functionality with a more aggressive approach. It tries much harder to
+    unlink file system objects. This includes immutable markers and more.
+
+    Note that this function can still fail. In particular, missing permissions
+    can always prevent this function from succeeding. However, a caller should
+    never assume that they can intentionally prevent this function from
+    succeeding. In other words, this function might be extended in any way in
+    the future, to be more powerful and successful in removing file system
+    objects.
+
+    Parameters
+    ---------
+    path
+        A file system path pointing to the object to remove.
+
+    Raises
+    ------
+    Exception
+        This raises the same exceptions as `shutil.rmtree()` (since that
+        function is used internally). Consult its documentation for details.
+    """
+
+    def clear_mutable_flag(path):
+        FS_IOC_GETFLAGS	= 0x80086601
+        FS_IOC_SETFLAGS	= 0x40086602
+        FS_IMMUTABLE_FL	= 0x010
+
+        fd = -1
+        try:
+            fd = os.open(path, os.O_RDONLY)
+            flags = array.array('L', [0])
+            fcntl.ioctl(fd, FS_IOC_GETFLAGS, flags, True)
+            flags[0] &= ~FS_IMMUTABLE_FL
+            fcntl.ioctl(fd, FS_IOC_SETFLAGS, flags, False)
+        except OSError:
+            pass  # clearing flags is best effort
+        finally:
+            if fd > -1:
+                os.close(fd)
+
+    def fixperms(p):
+        clear_mutable_flag(p)
+        os.chmod(p, 0o777)
+
+    def unlink(p):
+        try:
+            os.unlink(p)
+        except IsADirectoryError:
+            rmtree(p)
+        except FileNotFoundError:
+            pass
+
+    def on_error(_fn, p, exc_info):
+        e = exc_info[0]
+        if issubclass(e, FileNotFoundError):
+            pass
+        elif issubclass(e, PermissionError):
+            if p != path:
+                fixperms(os.path.dirname(p))
+            fixperms(p)
+            unlink(p)
+        else:
+            raise e
+
+    shutil.rmtree(path, onerror=on_error)

--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -2,23 +2,9 @@ import os
 import shutil
 import tempfile
 import unittest
-import subprocess
 
 from pathlib import Path
 from osbuild import objectstore
-
-
-def can_set_immutable():
-    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
-        try:
-            os.makedirs(f"{tmp}/f")
-            # fist they give it ...
-            subprocess.run(["chattr", "+i", f"{tmp}/f"], check=True)
-            # ... then they take it away
-            subprocess.run(["chattr", "-i", f"{tmp}/f"], check=True)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            return False
-        return True
 
 
 class TestObjectStore(unittest.TestCase):
@@ -86,18 +72,6 @@ class TestObjectStore(unittest.TestCase):
                     p.touch()
             # there should be no temporary Objects dirs anymore
             self.assertEqual(len(os.listdir(object_store.tmp)), 0)
-
-    # pylint: disable=no-self-use
-    @unittest.skipUnless(can_set_immutable(), "Need root permissions")
-    def test_cleanup_immutable(self):
-        with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
-            with objectstore.ObjectStore(tmp) as object_store:
-                tree = object_store.new()
-                with tree.write() as path:
-                    p = Path(f"{path}/A")
-                    p.touch()
-                    subprocess.run(["chattr", "+i", f"{path}/A"],
-                                   check=True)
 
     # pylint: disable=no-self-use
     def test_duplicate(self):

--- a/test/test_util_linux.py
+++ b/test/test_util_linux.py
@@ -1,0 +1,72 @@
+#
+# Tests for the `osbuild.util.linux` module.
+#
+
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import osbuild.util.linux as linux
+
+
+class TestUtilLinux(unittest.TestCase):
+    def setUp(self):
+        self.vartmpdir = tempfile.TemporaryDirectory(dir="/var/tmp")
+
+    def tearDown(self):
+        self.vartmpdir.cleanup()
+
+    def test_ioctl_get_immutable(self):
+        #
+        # Test the `ioctl_get_immutable()` helper and make sure it works
+        # as intended.
+        #
+
+        with open(f"{self.vartmpdir.name}/immutable", "x") as f:
+            assert not linux.ioctl_get_immutable(f.fileno())
+
+    @unittest.skipUnless(os.geteuid() == 0, "root-only")
+    def test_ioctl_toggle_immutable(self):
+        #
+        # Test the `ioctl_toggle_immutable()` helper and make sure it works
+        # as intended.
+        #
+
+        with open(f"{self.vartmpdir.name}/immutable", "x") as f:
+            # Check the file is mutable by default and if we clear it again.
+            assert not linux.ioctl_get_immutable(f.fileno())
+            linux.ioctl_toggle_immutable(f.fileno(), False)
+            assert not linux.ioctl_get_immutable(f.fileno())
+
+            # Set immutable and check for it. Try again to verify with flag set.
+            linux.ioctl_toggle_immutable(f.fileno(), True)
+            assert linux.ioctl_get_immutable(f.fileno())
+            linux.ioctl_toggle_immutable(f.fileno(), True)
+            assert linux.ioctl_get_immutable(f.fileno())
+
+            # Verify immutable files cannot be unlinked.
+            with self.assertRaises(OSError):
+                os.unlink(f"{self.vartmpdir.name}/immutable")
+
+            # Check again that clearing the flag works.
+            linux.ioctl_toggle_immutable(f.fileno(), False)
+            assert not linux.ioctl_get_immutable(f.fileno())
+
+            # This time, check that we actually set the same flag as `chattr`.
+            subprocess.run(["chattr", "+i",
+                            f"{self.vartmpdir.name}/immutable"], check=True)
+            assert linux.ioctl_get_immutable(f.fileno())
+
+            # Same for clearing it.
+            subprocess.run(["chattr", "-i",
+                            f"{self.vartmpdir.name}/immutable"], check=True)
+            assert not linux.ioctl_get_immutable(f.fileno())
+
+            # Verify we can unlink the file again, once the flag is cleared.
+            os.unlink(f"{self.vartmpdir.name}/immutable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_util_rmrf.py
+++ b/test/test_util_rmrf.py
@@ -1,0 +1,52 @@
+#
+# Tests for the `osbuild.util.rmrf` module.
+#
+
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import osbuild.util.rmrf as rmrf
+
+
+def can_set_immutable():
+    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+        try:
+            os.makedirs(f"{tmp}/f")
+            # fist they give it ...
+            subprocess.run(["chattr", "+i", f"{tmp}/f"], check=True)
+            # ... then they take it away
+            subprocess.run(["chattr", "-i", f"{tmp}/f"], check=True)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
+        return True
+
+
+class TestUtilLinux(unittest.TestCase):
+    @unittest.skipUnless(can_set_immutable(), "Need root permissions")
+    def test_rmtree_immutable(self):
+        #
+        # Test the `rmrf.rmtree()` helper and verify it can correctly unlink
+        # files that are marked immutable.
+        #
+
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as vartmpdir:
+            os.makedirs(f"{vartmpdir}/dir")
+
+            p = pathlib.Path(f"{vartmpdir}/dir/immutable")
+            p.touch()
+            subprocess.run(["chattr", "+i", f"{vartmpdir}/dir/immutable"],
+                           check=True)
+
+            with self.assertRaises(PermissionError):
+                shutil.rmtree(f"{vartmpdir}/dir")
+
+            rmrf.rmtree(f"{vartmpdir}/dir")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This extracts remove_tree() into its own module so we can use it from other places more easily. This series also contains some minor adjustments and documents the ioctl-details. See each commit for details.