### PR TITLE
osbuild: cleanup contextlib usage

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -1,4 +1,5 @@
 
+import contextlib
 import importlib
 import importlib.util
 import os
@@ -13,7 +14,7 @@ __all__ = [
 ]
 
 
-class BuildRoot:
+class BuildRoot(contextlib.AbstractContextManager):
     def __init__(self, root, runner, path="/run/osbuild", libdir=None, var="/var/tmp"):
         self.root = tempfile.mkdtemp(prefix="osbuild-buildroot-", dir=path)
         self.api = tempfile.mkdtemp(prefix="osbuild-api-", dir=path)
@@ -130,9 +131,6 @@ class BuildRoot:
 
     def __del__(self):
         self.unmount()
-
-    def __enter__(self):
-        return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         self.unmount()

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -255,7 +255,6 @@ class Object:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.cleanup()
-        return exc_type is None
 
 
 class HostTree:
@@ -285,7 +284,7 @@ class HostTree:
         pass  # noop for the host
 
 
-class ObjectStore:
+class ObjectStore(contextlib.AbstractContextManager):
     def __init__(self, store):
         self.store = store
         self.objects = f"{store}/objects"
@@ -390,9 +389,5 @@ class ObjectStore:
         for obj in self._objs:
             obj.cleanup()
 
-    def __enter__(self):
-        return self
-
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.cleanup()
-        return exc_type is None

--- a/stages/org.osbuild.ostree
+++ b/stages/org.osbuild.ostree
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import contextlib
 import json
 import os
 import sys
@@ -125,7 +126,7 @@ def ostree(*args, _input=None, **kwargs):
                    check=True)
 
 
-class MountGuard:
+class MountGuard(contextlib.AbstractContextManager):
     def __init__(self):
         self.mounts = []
 
@@ -155,12 +156,8 @@ class MountGuard:
             subprocess.run(["umount", "--lazy", target],
                            check=True)
 
-    def __enter__(self):
-        return self
-
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.unmount()
-        return exc_type is None
 
 
 def make_fs_identifier(desc):


### PR DESCRIPTION
Two cleanups for the context-managers we use:

  * Use `contextlib.AbstractContextManager` if possible. This class
    simply provides a default `__enter__` implementation which just
    returns `self`. So use it where applicable.
    Additionally, it provides an abstract `__exit__` method and thus
    allows static checks for an existance of `__exit__` in the dependent
    class. We might use that everywhere, but this is a separate
    decision, so not included here.

  * Explicitly return `None` from `__exit__`. The python docs state:

        If an exception is supplied, and the method wishes to suppress
        the exception (i.e., prevent it from being propagated), it
        should return a true value. Otherwise, the exception will be
        processed normally upon exit from this method.

    That is, unless we want exceptions to be suppressed, we should
    never return a `truthy` value. The python contextlib suggest using
    `None` as a default return value, so lets just do that.

    In particular, the explicit `return exc_type is None` that we use
    has no effect at all, since it only returns `True` if no exception
    was raised.