### PR TITLE
stages/grub2: ensure grubenv file has size of 1024

### DIFF
--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -254,8 +254,19 @@ def main(tree, options):
 
     with open(grubenv, "w") as env:
         fs_type, fs_id = fs_spec_decode(root_fs)
-        env.write("# GRUB Environment Block\n"
-                  f"kernelopts=root={fs_type}={fs_id} {kernel_opts}\n")
+        data = (
+            "# GRUB Environment Block\n"
+            f"kernelopts=root={fs_type}={fs_id} {kernel_opts}\n"
+        )
+
+        # The 'grubenv' file is, according to the documentation,
+        # a 'preallocated 1024-byte file'. The empty space is
+        # needs to be filled with '#' as padding
+        data += '#' * (1024 - len(data))
+        assert len(data) == 1024
+
+        print(data)
+        env.write(data)
 
     if uefi is not None:
         # UEFI support:


### PR DESCRIPTION
For historical and occult reasons the grubenv file is, according to its [documentation][1] a 'preallocated 1024-byte file'. The unused space in the file needs to be filled with '#' as padding, which tools will count as "free space" and there needs to be a trailing new-line.
Fix our code to do as they say to make grub2-editenv work and in turn greenboot.

[1]: https://www.gnu.org/software/grub/manual/grub/html_node/Environment-block.html
[2] grub-core/lib/envblk.c#L105 (commit 0f102b9844f852d48501d231d32a17e1cc24062d)

Closes #342 