### PR TITLE
util: mark as module by adding __init__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     name="osbuild",
     version="12",
     description="A build system for OS images",
-    packages=["osbuild"],
+    packages=["osbuild", "osbuild.util"],
     license='Apache-2.0',
     entry_points={
         "console_scripts": ["osbuild = osbuild.__main__:main"]


### PR DESCRIPTION
Make sure ./osbuild/util/ is considered a python module. Add
__init__.py to declare it as such.