### PR TITLE
buildroot: reduce nspawn requirements further

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -119,6 +119,7 @@ class BuildRoot(contextlib.AbstractContextManager):
             "systemd-nspawn",
             "--quiet",
             "--register=no",
+            "--keep-unit",
             "--as-pid2",
             "--link-journal=no",
             f"--property=DeviceAllow=block-loop {loopback_allow}",


### PR DESCRIPTION
This adds one more flags to `systemd-nspawn`:

    --keep-unit
        This prevents nspawn from creating its own scope unit and
        instead uses the scope of the caller. Since we want nspawn to
        run with the privileges of the caller, this is fitting for our
        use case.
        Furthermore, this makes nspawn work without a running system
        bus, since it no longer needs to talk to systemd pid1.

        (introduced with systemd-v209)

With this in place, osbuild can be run from within docker containers (or
other containers without systemd as pid1). This still requires some
extra setup, but this can all be done in the container manager.