### PR TITLE
🥊 Resilient testing + log gathering

### DIFF
--- a/jenkins/run_tests.sh
+++ b/jenkins/run_tests.sh
@@ -1,21 +1,42 @@
 #!/bin/bash
 set -euxo pipefail
 
+# Restart systemd to work around some Fedora issues in cloud images.
+systemctl restart systemd-journald
+
+# Get the current journald cursor.
+export JOURNALD_CURSOR=$(journalctl --quiet -n 1 --show-cursor | tail -n 1 | grep -oP 's\=.*$')
+
+# Add a function to preserve the system journal if something goes wrong.
+preserve_journal() {
+  journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log
+  exit 1
+}
+trap "preserve_journal" ERR
+
 # Ensure Ansible is installed.
-sudo dnf -y install ansible
+if ! rpm -q ansible; then
+  sudo dnf -y install ansible
+fi
+
+# Write a simple hosts file for Ansible.
+echo -e "[test_instances]\nlocalhost ansible_connection=local" > hosts.ini
+
+# Set Ansible's config file location.
+export ANSIBLE_CONFIG=ansible-osbuild/ansible.cfg
 
 # Clone the latest version of ansible-osbuild.
-git clone https://github.com/osbuild/ansible-osbuild.git ansible-osbuild
 
 # Get the current SHA of osbuild.
 OSBUILD_VERSION=$(git rev-parse HEAD)
 
 # Run the deployment.
-pushd ansible-osbuild
-  echo -e "[test_instances]\nlocalhost ansible_connection=local" > hosts.ini
-  ansible-playbook \
-    -i hosts.ini \
-    -e osbuild_repo=${WORKSPACE} \
-    -e osbuild_version=${OSBUILD_VERSION} \
-    playbook.yml
-popd
+git clone https://github.com/osbuild/ansible-osbuild.git ansible-osbuild
+ansible-playbook \
+  -i hosts.ini \
+  -e osbuild_repo=${WORKSPACE} \
+  -e osbuild_version=$(git rev-parse HEAD) \
+  ansible-osbuild/playbook.yml
+
+# Collect the systemd journal anyway if we made it all the way to the end.
+journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log


### PR DESCRIPTION
Convert the bash script to an ansible playbook so we can gracefully
handle testing failures and gather logs reliably. Colorful output
is nice, too.

This brings osbuild's testing script in line with the script for
osbuild-composer.

Signed-off-by: Major Hayden <major@redhat.com>