### PR TITLE
Collect tests in logical groups

### DIFF
--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -55,25 +55,6 @@ jobs:
           sudo env "PATH=$PATH" python3 -m osbuild --libdir . samples/noop.json
         done
 
-  source_tests:
-    name: "Source Tests"
-    runs-on: ubuntu-latest
-    steps:
-    - name: "Clone Repository"
-      uses: actions/checkout@v2
-    - name: "Install Dependencies"
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install \
-          rpm \
-          systemd-container
-    - name: "Set up Python"
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: "Run Source Tests"
-      run: sudo env "PATH=$PATH" python3 -m unittest -v test.test_sources
-
   assembler_tests:
     name: "Assembler Tests"
     runs-on: ubuntu-latest

--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -11,6 +11,29 @@ env:
   PYTHONUNBUFFERED: 1
 
 jobs:
+  runtime_tests:
+    name: "Runtime Pipeline Execution Tests"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Clone Repository"
+      uses: actions/checkout@v2
+    - name: "Install Dependencies"
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install \
+          nbd-client \
+          qemu-utils \
+          rpm \
+          systemd-container \
+          tar \
+          yum
+    - name: "Set up Python"
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: "Run Pipeline Tests"
+      run: sudo env "PATH=$PATH" make test-runtime
+
   noop_pipeline_tests:
     name: "Noop-Pipeline Tests"
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,11 +87,6 @@ jobs:
           cd osbuild
           python3 -m unittest -v test.test_util_ostree
 
-      - name: Run test_util_selinux
-        run: |
-          cd osbuild
-          python3 -m unittest -v test.test_util_selinux
-
   rpm_build:
     name: "📦 RPM"
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,11 +82,6 @@ jobs:
           cd osbuild
           python3 -m unittest -v test.test_osrelease
 
-      - name: Run test_util_ostree
-        run: |
-          cd osbuild
-          python3 -m unittest -v test.test_util_ostree
-
   rpm_build:
     name: "📦 RPM"
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,22 +6,24 @@ jobs:
   pylint:
     name: "pylint"
     runs-on: ubuntu-latest
-    container:
-      image: docker.io/library/python:3.7
+    container: docker.io/library/python:3.7
     steps:
       - name: Install pylint
         run: pip install pylint==2.4.1
-
       - name: Clone repository
         uses: actions/checkout@v2
-        with:
-          path: osbuild
-
       - name: Run pylint
-        run: |
-          cd osbuild
-          find . -type f -name "*.py" | xargs pylint
-          pylint runners/* assemblers/* stages/* sources/*
+        run: make test-pylint
+
+  module:
+    name: "Module Unittests"
+    runs-on: ubuntu-latest
+    container: docker.io/library/python:3.7
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+      - name: Run Module Unittests
+        run: make test-module
 
   documentation:
     name: "📚 Documentation"

--- a/test/mod/__init__.py
+++ b/test/mod/__init__.py
@@ -1,0 +1,1 @@
+# The `unittest` module requires `__init__.py` to discover a directory.

--- a/test/mod/test_util_ostree.py
+++ b/test/mod/test_util_ostree.py
@@ -1,3 +1,7 @@
+#
+# Tests for the 'osbuild.util.ostree' module.
+#
+
 import json
 import unittest
 import subprocess
@@ -87,7 +91,3 @@ class TestObjectStore(unittest.TestCase):
 
         for p, v in params.items():
             self.assertEqual(v, js[p])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/mod/test_util_selinux.py
+++ b/test/mod/test_util_selinux.py
@@ -1,3 +1,7 @@
+#
+# Tests for the 'osbuild.util.selinux' module.
+#
+
 import io
 import unittest
 
@@ -36,7 +40,3 @@ class TestObjectStore(unittest.TestCase):
 
         policy = selinux.config_get_policy(cfg)
         self.assertEqual(policy, 'targeted')
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/run/__init__.py
+++ b/test/run/__init__.py
@@ -1,0 +1,1 @@
+# The `unittest` module requires `__init__.py` to discover a directory.

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -1,3 +1,7 @@
+#
+# Runtime Tests for Source Modules
+#
+
 import contextlib
 import ctypes
 import http.server
@@ -10,6 +14,7 @@ import threading
 import unittest
 
 import osbuild.sources
+
 
 def errcheck(ret, _func, _args):
     if ret == -1:


### PR DESCRIPTION
This PR starts grouping tests in logical sets, easily distinguishable by their path: `./test/mod/` for module unit-tests and `./test/run/` for runtime tests. With this in place, we can now use the auto-discovery of `unittest` to run just a selected set of tests. I also added makefile targets to run `unittest` with the correct parameters: `make test-module` and `make test-runtime`.

I discussed this shortly with @gicmo before. We both would like to have an easier way to run unitests locally. With this in place, a short `make test-module` runs all local unittests. A `make test-runtime` runs the more complex runtime tests, and `make test-all` runs all tests in `./test/`.

I did not move all tests to their correct location in this PR. I first wanted to get a discussion going.

Note that this PR does not change the test setup or environment in any way. It merely groups them to allow the auto-discovery of `unittest` to work with it nicely.