### PR TITLE
fscache: preparations for cache rework

### DIFF
--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -14,9 +14,11 @@ reasonable manner.
 
 import array
 import fcntl
+import struct
 
 
 __all__ = [
+    "fcntl_flock",
     "ioctl_get_immutable",
     "ioctl_toggle_immutable",
 ]
@@ -91,3 +93,119 @@ def ioctl_toggle_immutable(fd: int, set_to: bool):
     else:
         flags[0] &= ~FS_IMMUTABLE_FL
     fcntl.ioctl(fd, FS_IOC_SETFLAGS, flags, False)
+
+
+def fcntl_flock(fd: int, lock_type: int):
+    """Perform File-locking Operation
+
+    This function performs a linux file-locking operation on the specified
+    file-descriptor. The specific type of lock must be specified by the caller.
+    This function does not allow to specify the byte-range of the file to lock.
+    Instead, it always applies the lock operations to the entire file.
+
+    For system-level documentation, see the `fcntl(2)` man-page, especially the
+    section about `struct flock` and the locking commands.
+
+    This function always uses the open-file-description locks provided by
+    modern linux kernels. This means, locks are tied to the
+    open-file-description. That is, they are shared between duplicated
+    file-descriptors. Furthermore, acquiring a lock while already holding a
+    lock will update the lock to the new specified lock type, rather than
+    acquiring a new lock.
+
+    So far, this function always performs try-lock operations. The blocking
+    mode is currently not exposed.
+
+    Parameters
+    ----------
+    fd
+        The file-descriptor to use for the locking operation.
+    lock_type
+        The type of lock to use. This can be one of: `fcntl.F_RDLCK`,
+        `fcntl.F_WRLCK`, `fcntl.F_UNLCK`.
+
+    Raises
+    ------
+    OSError
+        If the underlying `fcntl(2)` syscall fails, a matching `OSError` is
+        raised.
+    """
+
+    valid_types = [fcntl.F_RDLCK, fcntl.F_WRLCK, fcntl.F_UNLCK]
+    if not isinstance(fd, int) or fd < 0 or not any(lock_type == v for v in valid_types):
+        raise ValueError()
+
+    #
+    # The `OFD` constants are not available through the `fcntl` module, so we
+    # need to use their integer representations directly. They are the same
+    # across all linux ABIs:
+    #
+    #     F_OFD_GETLK = 36
+    #     F_OFD_SETLK = 37
+    #     F_OFD_SETLKW = 38
+    #
+
+    lock_cmd = 37
+
+    #
+    # We use the linux open-file-descriptor (OFD) version of the POSIX file
+    # locking operations. They attach locks to an open file description, rather
+    # than to a process. They have clear, useful semantics.
+    # This means, we need to use the `fcntl(2)` operation with `struct flock`,
+    # which is rather unfortunate, since it varies depending on compiler
+    # arguments used for the python library, as well as depends on the host
+    # architecture, etc.
+    #
+    # The structure layout of the locking argument is:
+    #
+    #     struct flock {
+    #         short int l_type;
+    #         short int l_whence;
+    #         off_t l_start;
+    #         off_t l_len;
+    #         pid_t int l_pid;
+    #     }
+    #
+    # The possible options for `l_whence` are `SEEK_SET`, `SEEK_CUR`, and
+    # `SEEK_END`. All are provided by the `fcntl` module. Same for the possible
+    # options for `l_type`, which are `L_RDLCK`, `L_WRLCK`, and `L_UNLCK`.
+    #
+    # Depending on which architecture you run on, but also depending on whether
+    # large-file mode was enabled to compile the python library, the values of
+    # the constants as well as the sizes of `off_t` can change. What we know is
+    # that `short int` is always 16-bit on linux, and we know that `fcntl(2)`
+    # does not take a `size` parameter. Therefore, the kernel will just fetch
+    # the structure from user-space with the correct size. The python wrapper
+    # `fcntl.fcntl()` always uses a 1024-bytes buffer and thus we can just pad
+    # our argument with trailing zeros to provide a valid argument to the
+    # kernel. Note that your libc might also do automatic translation to
+    # `fcntl64(2)` and `struct flock64` (if you run on 32bit machines with
+    # large-file support enabled). Also, random architectures change trailing
+    # padding of the structure (MIPS-ABI32 adds 128-byte trailing padding,
+    # SPARC adds 16?).
+    #
+    # To avoid all this mess, we use the fact that we only care for `l_type`.
+    # Everything else is always set to 0 in all our needed locking calls.
+    # Therefore, we simply use the largest possible `struct flock` for your
+    # libc and set everything to 0. The `l_type` field is guaranteed to be
+    # 16-bit, so it will have the correct offset, alignment, and endianness
+    # without us doing anything. Downside of all this is that all our locks
+    # always affect the entire file. However, we do not need locks for specific
+    # sub-regions of a file, so we should be fine. Eventually, what we end up
+    # with passing to libc is:
+    #
+    #     struct flock {
+    #         uint16_t l_type;
+    #         uint16_t l_whence;
+    #         uint32_t pad0;
+    #         uint64_t pad1;
+    #         uint64_t pad2;
+    #         uint32_t pad3;
+    #         uint32_t pad4;
+    #     }
+    #
+
+    type_flock64 = struct.Struct('=HHIQQII')
+    arg_flock64 = type_flock64.pack(lock_type, 0, 0, 0, 0, 0, 0)
+
+    fcntl.fcntl(fd, lock_cmd, arg_flock64)

--- a/osbuild/util/pathfd.py
+++ b/osbuild/util/pathfd.py
@@ -1,0 +1,789 @@
+"""Path Descriptor
+
+This module implements a path object based on the `O_PATH` file descriptors
+provided by the linux kernel. It does automatic file-descriptor management and
+thus simplifies handling of `O_PATH` quite significantly.
+
+Classic path handling uses strings as internal state. This includes python
+modules like `os.path` or `pathlib`. However, these have major drawbacks,
+including the following:
+
+  * File-system paths have to be resolved on each access. This makes
+    repeated access to the same path (or a sibling path) racy and non-reliable.
+    For instance, accessing `/foo/bar/A` and `/foo/bar/B` consequetively might
+    end up with files from different directories, even though their path
+    suggests that they are siblings. This can happen for many reasons. Simply
+    imagine `/foo/bar` is a symlink and it is changed between the consequetive
+    operations. Another possibility is modifying local mounts.
+    While this behavior is not necessarily wrong, it is more often than not
+    contrary to the intended behavior. By using path-descriptors, you can
+    operate relative to pinned paths, thus picking the point of reference
+    manually, rather than using the root path (or local mount, or working
+    directory).
+
+  * Resolving a file-system path relies on ambient capabilities. The most
+    prominent examples are paths relative to the current working directory. If
+    the current working directory changes between accesses, your relative paths
+    will as well.
+    Again, this is not necessarily bad, but it might not be what you expect. In
+    fact, the path-descriptors provide exactly the same functionality as the
+    current working directory of a process. However, instead of having only one
+    static property as part of a process, path-descriptors are objects that can
+    be created and modified at will by the program.
+
+  * Status queries on file-system objects like `stat()` suffer from TOCTOU
+    races. These can be solved via their fd-based counterparts like `fstat()`,
+    but that requires opening the file either for at least reading or writing.
+    But this is not necessarily what you want, since you might not have read or
+    write access (and unlike `stat()` your operation might not necessarily
+    require either access right).
+    With path-descriptors you can refer to paths in a stable manner without
+    requiring read nor write access to the path.
+
+The path-descriptors are functionally superior to normal string-based path
+objects, but not necessarily the better option in all situations. Their
+flexibility and stable behavior is a big strength, but their biggest weakness
+is the overhead involved in all the syscalls to manage them. They are based on
+`O_PATH` file-descriptor, rather than simple strings, and thus require syscalls
+for every single operation. In many situations these additional syscalls
+amortize easily, but that has to be evaluated for every situation separately.
+
+Please be aware that path-descriptors are not suitable for access management!
+Access to a path-descriptor does **NOT** restrict the access you gain via it.
+You can always use relative operations on the path-descriptor to access its
+parents, children, and any other part of the file-system reachable from that
+path.
+You can, however, combine path-descriptors with other technology to achieve
+access restrictions. This implementation allows for this, but considers the
+discussion of this topic beyond the scope of this module.
+"""
+
+
+import contextlib
+import errno
+import os
+import stat
+from typing import Callable, Optional, Tuple
+
+
+__all__ = [
+    "PathFd",
+]
+
+
+#
+# Traversal Selector
+#
+# These flags are used to select which elements are visited by the directory
+# traversal. `PRE` means non-terminals are visited before they are traversed,
+# `POST` means non-terminals are visited after they are traversed, and `IN`
+# means terminals are visited in-order.
+#
+# For details, see `preorder`, `postorder`, and `inorder` traversals of tree
+# data-structures.
+#
+TRAVERSE_PRE = 0x1
+TRAVERSE_IN = 0x2
+TRAVERSE_POST = 0x4
+
+
+class PathFd(contextlib.AbstractContextManager):
+    """Path Descriptor
+
+    A path-descriptor object is a representation of a file-system path. Every
+    instance represents exactly one path. Internally, every instance owns its
+    backing `O_PATH` file-descriptor, which pins the capability of referring to
+    the path it represents.
+
+    For a discussion of when to use path-descriptors over simple paths, see the
+    `O_PATH` functionality provided by linux. This path-descriptor simply
+    provides easy access to `O_PATH` file-descriptors.
+
+    Since path-descriptors manage resources, they do provide the standard
+    resource management operations. This means, `close()` releases all internal
+    resources and turns the instance into a no-op stub. Further operations on
+    the stub will trigger assertions. This follows what the python standard
+    library provides, and thus integrates well with context-managers (a default
+    context manager is provided with the implementation, but
+    `contextlib.closing()` would also work.
+    Note that there is no requirement to call `close()`. The only reason to do
+    so is to keep resource management under caller-control if they so wish. If
+    the GC cleanup is enough for you, then you can avoid calling `close()`. But
+    if you want to avoid having stale resources pile up until the next GC
+    round, then you better close your objects when no longer needed.
+    The internal operations of this module always clean up all their temporary
+    resources explicitly to avoid this problem.
+    """
+
+    _fd = None
+
+    def __init__(self, fd: Optional[int] = None):
+        """Initialize Path Descriptor
+
+        This creates a new path-descriptor by taking a caller-provided `O_PATH`
+        file-descriptor and consuming it.
+
+        Parameters
+        ----------
+        fd
+            A raw file descriptor to use for this path descriptor. This must be
+            a file-descriptor opened with `O_PATH`. This function consumes this
+            file-descriptor. That is, regardless whether this function succeeds
+            or fails, it does take full control of the file-descriptor. The
+            caller must not access the original file-descriptor, anymore.
+            Pass `None` to create a path descriptor that is already closed.
+        """
+
+        if not ((fd is None) or (isinstance(fd, int) and fd >= 0)):
+            raise ValueError()
+
+        self._fd = fd
+
+    @classmethod
+    def from_path(cls,
+                  path: str,
+                  *more_paths,
+                  follow_symlink: bool = False) -> 'PathFd':
+        """Create Path Descriptor from File System Path
+
+        This constructor creates a new path-descriptor from a standard
+        file-system path provided as a string. It simply opens the path as
+        `O_PATH` file-descriptor and creates a wrapping path-descriptor around
+        it. Path resolution happens at the time of this function call. All
+        further operations on the new path-descriptor will happen relative to
+        the desciptor itself. The contents of `path` are not retained and will
+        not be accessible later on.
+
+        The path is created via `os.path.join()` of `path` and `more_paths`.
+
+        Parameters
+        ----------
+        path
+            A file-system path in string representation. If it is a relative
+            path, it is interpreted relative to the current working directory
+            at the time of this function call.
+        more_paths:
+            More paths that are appended one by one via `os.path.join()`.
+        follow_symlink
+            Whether to resolve the final part of the path in case it is a
+            symlink. The default behavior is to not resolve it. That is, if the
+            given path points to a symlink, the path-descriptor will also point
+            to the symlink, rather than pointing to the destination of that
+            symlink.
+            This does not affect symlinks somewhere else in the path, other
+            than the last element.
+
+        Raises
+        ------
+        OSError
+            Any operating system errors involved in resolving file-system paths
+            can be raised by this function. See `os.open()` in the python
+            standard library for a discussion.
+        """
+
+        flags = os.O_CLOEXEC | os.O_PATH
+        if not follow_symlink:
+            flags |= os.O_NOFOLLOW
+
+        return PathFd(os.open(os.path.join(path, *more_paths), flags))
+
+    def close(self):
+        """Close the Path Descriptor
+
+        This closes the path-descriptor and releases all pinned resources. Once
+        this returns, any further operation on the path-descriptor will raise
+        an exception, unless it is explictily supported on closed descriptors.
+
+        This function can be safely called on closed descriptors, in which case
+        it is a no-op.
+        """
+
+        if self._fd is not None:
+            os.close(self._fd)
+            self._fd = None
+
+    def __del__(self):
+        self.close()
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.close()
+
+    def is_open(self) -> bool:
+        """Check whether the Path Descriptor is Open
+
+        This simply returns a boolean that tells whether the descriptor is
+        still open. Note that once a descriptor is closed, it cannot be
+        re-opened. You must create a new descriptor to do that.
+
+        This can be safely called on closed descriptors.
+        """
+
+        return self._fd is not None
+
+    def fileno(self) -> int:
+        """Return File-descriptor
+
+        Return the underlying file-descriptor of the path-descriptor. The
+        file-descriptor is only borrowed. It is still owned by the
+        path-descriptor, so you must not close it manually.
+
+        This raises an exception if the path-descriptor is already closed.
+        """
+
+        if not self.is_open():
+            raise ValueError()
+
+        return self._fd
+
+    def clone(self) -> 'PathFd':
+        """Create a Clone
+
+        This clones the given path-descriptor and returns it. The cloned
+        instance will point to the exact same resource as the original, without
+        re-resolving the path.
+
+        The original and the cloned instance do not share any underlying
+        resources. They are fully independent.
+
+        This can be safely called on closed descriptors, in which case the
+        cloned instance will also be closed.
+
+        Raises
+        ------
+        OSError
+            Any operating system errors involved in duplicating
+            file-descriptors can be raised by this function. See `os.dup()` for
+            a discussion of possible errors.
+        """
+
+        return PathFd(os.dup(self.fileno())) if self.is_open() else PathFd()
+
+    def stat(self) -> os.stat_result:
+        """Query File System Stat-Information
+
+        This performs the `fstat(2)` syscall on the file-system resource this
+        path-descriptor points to.
+
+        This is safe against TOCTOU races. Repeated calls are guaranteed to
+        return the same information, unless the information itself got changed
+        in the meantime.
+
+        This function does not cache any results. Every call results in a new
+        syscall invocation.
+
+        Note that this does not perform any path resolution. It accesses
+        exactly the resource the descriptor points to. If it points to a
+        symlink, it will return information for that symlink, rather than
+        information for the object the symlink points to.
+
+        The file-system information is reported as a return value of the
+        `stat_result` type from the python standard library.
+
+        Raises
+        ------
+        OSError
+            See the python standard library for possible errors when querying
+            stat-information (e.g., `os.stat()`).
+        """
+
+        return os.fstat(self.fileno())
+
+    def is_directory(self) -> bool:
+        """Check whether the Path is a Directory
+
+        This is a convenience wrapper around `stat()` which checks whether the
+        path is a directory. This simply checks for `S_ISDIR()` on the
+        `st_mode` field of the file-system stat-information.
+
+        Raises
+        ------
+        OSError
+            See the python standard library for possible errors when querying
+            stat-information (e.g., `os.stat()`).
+        """
+
+        return stat.S_ISDIR(self.stat().st_mode)
+
+    def is_symlink(self) -> bool:
+        """Check whether the Path is a Symlink
+
+        This is a convenience wrapper around `stat()` which checks whether the
+        path is a symlink. This simply checks for `S_ISLNK()` on the
+        `st_mode` field of the file-system stat-information.
+
+        Raises
+        ------
+        OSError
+            See the python standard library for possible errors when querying
+            stat-information (e.g., `os.stat()`).
+        """
+
+        return stat.S_ISLNK(self.stat().st_mode)
+
+    def open_relative(self, path: str, flags: int, mode: int = 0o777) -> int:
+        """Open Relative Path
+
+        Open a path relative to this path-descriptor. This simply wraps the
+        `os.open()` call of the python standard-library, but as an
+        object-oriented call on a path-descriptor.
+
+        This behaves like `os.open()` of the python standard library, but uses
+        the path-descriptor as `dir_fd` argument.
+
+        If the given path is absolute, it will be based off the file-system
+        root rather than the path-descriptor this is called on.
+
+        This function always forces `O_CLOEXEC`. You must clear it afterwards,
+        if that is what you want.
+
+        The result of `os.open(2)` is returned. This is usually a
+        file-descriptor.
+
+        Parameters
+        ----------
+        path
+            A file-system path in string representation. If it is a relative
+            path, it is interpreted relative to the path-descriptor this
+            function is called on.
+        flags
+            The open-flags to pass to `os.open()`.
+        mode
+            The file creation flags to use with `os.open()`. Defaults to
+            `0o777`, but is subject to the current umask.
+
+        Raises
+        ------
+        OSError
+            See the python standard library for possible errors when opening
+            paths (e.g., `os.open()`).
+        """
+
+        flags |= os.O_CLOEXEC
+        return os.open(path, flags, mode, dir_fd=self.fileno())
+
+    def open_self(self, flags: int, mode: int = 0o777) -> int:
+        """Open own Path
+
+        Open the file-system object this path-descriptor points to. This wraps
+        the `os.open()` call from the python standard library, but hard-codes
+        the path to the object this path-descriptor points to.
+
+        Unfortunately, for obscure legacy reasons the linux kernel does not
+        provide the `AT_EMPTY_PATH` equivalent for `open(2)`. This means, you
+        cannot directly open a path-descriptor, but have to redirect via
+        `/proc/self/fd/<fd>`. Hence, this is what this implementation does.
+        This is, however, not strictly equivalent to opening the
+        path-descriptor directly. Therefore, some features are blocked to avoid
+        exposing broken behavior:
+
+          * You cannot use `O_NOFOLLOW` with this, as it would open the symlink
+            in `/proc` rather than the object the descriptor points to (and
+            because you cannot open symlinks, it would fail). Hence, passing
+            `O_NOFOLLOW` will raise an exception.
+            If you want this behavior, you must check via `is_symlink()`
+            manually, and then call this without `O_NOFOLLOW`.
+
+          * This relies on `/proc` being a proper `procfs` file-system. This
+            is the case for all known linux systems. If you use non-standard
+            setups, you must be aware that this call will fail, unless `/proc`
+            is properly setup (or worse if you re-use `/proc` for other
+            things).
+
+        This function always forces `O_CLOEXEC`. You must clear it afterwards,
+        if that is what you want.
+
+        The result of `os.open(2)` is returned. This is usually a
+        file-descriptor.
+
+        Parameters
+        ----------
+        flags
+            The open-flags to pass to `os.open()`.
+        mode
+            The file creation flags to use with `os.open()`. Defaults to
+            `0o777`, but is subject to the current umask.
+
+        Raises
+        ------
+        OSError
+            See the python standard library for possible errors when opening
+            paths (e.g., `os.open()`).
+        """
+
+        #
+        # Preferably, we would want to use `openat(self, "", ... O_EMPTYPATH)`,
+        # but sadly there is no `AT_EMPTY_PATH` equivalent for `openat(2)`.
+        # Instead, we must go the route via `/proc`.
+        # Note that for questionable security reasons the `O_EMPTYPATH` flag is
+        # unlikely to appear at all (also see `AT_EMPTY_PATH` in `linkat(2)`
+        # for a discussion).
+        #
+        # We simply block the `O_NOFOLLOW` flag to make sure callers will not
+        # accidentally end up opening a file in `/proc`. If you want
+        # `O_NOFOLLOW` with `open_self()`, you are left with checking through
+        # `is_symlink()` before calling `open_self()` without `O_NOFOLLOW`.
+        # Note that this is safe as long as you call it on the same `DirFd`.
+        #
+
+        flags |= os.O_CLOEXEC
+        path = os.path.join("/proc/self/fd/", str(self.fileno()))
+
+        assert not (flags & os.O_NOFOLLOW)
+
+        return os.open(path, flags, mode)
+
+    def descend(self,
+                path: str,
+                *more_paths,
+                follow_symlink: bool = False) -> 'PathFd':
+        """Create Descendent
+
+        Create a new path-descriptor relative to this path-descriptor. The
+        given path is resolved at the time of this function call, and the new
+        descriptor will point to the file-system object it refers to.
+
+        Note that if your descriptor is an absolute path, it will not use the
+        path-descriptor as relative anchor, but instead be based off the
+        current file-system root.
+
+        Also see `from_path()` for the equivalent of this call but relative to
+        the current working directory.
+
+        The path is created via `os.path.join()` of `path` and `more_paths`.
+
+        Parameters
+        ----------
+        path
+            A file-system path in string representation.
+        more_paths:
+            More paths that are appended one by one via `os.path.join()`.
+        follow_symlink
+            Whether to resolve the final part of the path in case it is a
+            symlink. The default behavior is to not resolve it.
+
+        Raises
+        ------
+        OSError
+            Any operating system errors involved in resolving file-system paths
+            can be raised by this function. See `os.open()` in the python
+            standard library for a discussion.
+        """
+
+        flags = os.O_CLOEXEC | os.O_PATH
+        if not follow_symlink:
+            flags |= os.O_NOFOLLOW
+
+        return PathFd(self.open_relative(os.path.join(path, *more_paths), flags))
+
+    def unlink_relative(self, path: str, *more_paths):
+        """Unlink Entry
+
+        Unlink a file-system entry given as a relative path to the
+        path-descriptor.
+
+        Parameters
+        ----------
+        path
+            A file-system path in string representation.
+        more_paths:
+            More paths that are appended one by one via `os.path.join()`.
+
+        Raises
+        ------
+        OSError
+            A possible OS error of the underlying operation will be re-raised.
+        """
+
+        os.unlink(os.path.join(path, *more_paths), dir_fd=self.fileno())
+
+    def mkdir_relative(self, path: str, *more_paths) -> 'PathFd':
+        """Create and Open Subdirectory
+
+        Create a subdirectory and descend into it. This will make sure not to
+        leak an empty subdirectory if the descent fails.
+
+        Parameters
+        ----------
+        path
+            A file-system path in string representation.
+        more_paths:
+            More paths that are appended one by one via `os.path.join()`.
+
+        Raises
+        ------
+        OSError
+            A possible OS error of the underlying operation will be re-raised.
+        """
+
+        # We want to create a subdirectory and know whether we successfully
+        # created it, or whether it was already created. Unfortunately, with
+        # asynchronous python exceptions, we do not know whether `mkdir(2)`
+        # returned or not. Hence, we have to guess what happened. If we can
+        # sufficiently assume that we did not create the directory, then there
+        # is no reason to try removing it on error. However, in case of doubt,
+        # we just throw an `rmdir(2)` at it, but ignore any possible OS error.
+        p = os.path.join(path, *more_paths)
+        try:
+            # An OSError during `mkdir(2)` definitely means we did not create
+            # the directory. Hence, OSError can be forwarded directly and
+            # other exceptions can be handled by the parent exception handler.
+            os.mkdir(p, dir_fd=self.fileno())
+
+            try:
+                return self.descend(p)
+            except OSError:
+                # At this point, we certainly created the directory but then
+                # were unable to open a path-descriptor. Try removing the
+                # directory, but always re-raise the original error, since
+                # that is what triggered the error condition.
+                try:
+                    os.rmdir(p, dir_fd=self.fileno())
+                except OSError:
+                    pass
+                raise
+        except OSError:
+            # Already handled by the other handlers.
+            raise
+        except:
+            # This can only be programming errors or asynchronous exceptions.
+            # Python does not allow us to deduce where these happened, so we
+            # just always assume it happended after the call to `mkdir(2)`.
+            # We cannot move the `mkdir(2)` out of the try-block, since then
+            # there is a race directly after it returned and entering the
+            # try-block. Meh.
+            # Always reraise the original error.
+            try:
+                os.rmdir(p, dir_fd=self.fileno())
+            except OSError:
+                pass
+            raise
+
+    def rmdir_relative(self, path: str, *more_paths):
+        """Remove Subdirectory
+
+        Unlink a directory given as a relative path to the path-descriptor. Note
+        that you cannot unlink ".", so `rmdir_self()` is not allowed on linux.
+        It may be added in the future, though.
+
+        Parameters
+        ----------
+        path
+            A file-system path in string representation.
+        more_paths:
+            More paths that are appended one by one via `os.path.join()`.
+
+        Raises
+        ------
+        OSError
+            A possible OS error of the underlying operation will be re-raised.
+        """
+
+        os.rmdir(os.path.join(path, *more_paths), dir_fd=self.fileno())
+
+    # pylint: disable=too-many-branches
+    def enumerate(self,
+                  *,
+                  follow_symlink: bool = False,
+                  fn_open_self: Callable = open_self,
+                  fn_descend: Callable = descend) -> Tuple[int, os.DirEntry]:
+        """Enumerate Directory Entries
+
+        Create a generator that enumerates the directory entries below the
+        directory pointed to by this path-descriptor. Effectively, this calls
+        `os.scandir()` on this path-descriptor and returns all entries. Unlike
+        a normal directory listing, this returns a path-descriptor for each
+        entry, as well as the `os.DirEntry` object as defined by the python
+        standard library.
+
+        This function will raise an exception if the path-descriptor does not
+        point to a directory, or is already closed.
+
+        Listing directory entries is not necessarily atomic. For instance, on
+        linux the `getdents(2)` system call has to be called repeatedly to
+        enumerate an entire directory. There is no guarantee that a single call
+        will suffice. Therefore, no atomicity guarantees are given. At the time
+        an entry is returned by the generator, it might have already been
+        unlinked or moved (regardless of this, the returned path-descriptor is
+        always valid). Furthermore, if new entries are created in the directory
+        while an enumeration is ongoing, there is no guarantee that it will
+        show up in the enumeration. For details on the behavior of parallel
+        file-system modifications, consult your operating system manuals.
+
+        This function diligently avoids race conditions between listing a
+        directory entry and opening a path-descriptor to it. It guarantees
+        coherent behavior and catches common errors. This means, the returned
+        directory entries are guaranteed to be valid entries you can operate
+        on.
+
+        Internally, this function first opens the directory to enumerate, then
+        iterates it and opens a path-descriptor for each entry. It allows the
+        caller to override the functions used to open the directory and to open
+        the path-descriptors. This way, callers can catch specific `OSError`
+        exceptions and modify the behavior. A common scenario is catching
+        access permissions and then modifying the access rights before retrying
+        the operation (this is particularly useful when iterating for deletion).
+        If you override these functions, you must provide the same invariants
+        as the originals do. You usually achieve this by calling into the
+        originals from your functions, and simply extending their
+        functionality, rather than reimplementing it.
+
+        Parameters
+        ----------
+        follow_symlink
+            Whether to resolve symlink entries. Default behavior is not to
+            resolve them.
+        fn_open_self
+            Override the function used to open the directory. By default,
+            this uses the `open_self()` method on path-descriptors.
+        fn_descend
+            Override the function used to open directory entries. By default,
+            this uses the `descend()` method on path-descriptors.
+
+        Raises
+        ------
+        OSError
+            This can raise an `OSError` if the original directory cannot be
+            opened for enumeration. Furthermore, this might raise further
+            errors if the entries cannot be opened via `O_PATH` (e.g., lacking
+            directory execution rights).
+        """
+
+        if not self.is_open():
+            raise ValueError()
+
+        # You can open path-descriptors which point to directories even if the
+        # directory was removed. This call should always succeed, except for
+        # wrong setups, access restrictions, or programming errors.
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY
+        dir_fd = fn_open_self(self, flags)
+
+        # Reading from a directory might fail for several reasons. Since
+        # reading is not atomic and might be chunked, each call that fetches
+        # directory entries might fail for these reasons.
+        #
+        #   * ENOENT: If the parent directory is empty and then was dropped via
+        #             `rmdir(2)`, we will get `ENOENT`. Since initially the
+        #             directory could be opened, it must have been deleted while
+        #             we iterated. Hence, we simply consider the iteration done
+        #             as if we iterated directly before the removal (note that
+        #             a directory must be empty before it can be unlinked).
+        #
+        # No other possible error-scenarios are known at this time. This might
+        # need extension in the future, though.
+        readdir_break_on = [errno.ENOENT]
+
+        entries = None
+        try:
+            entries = os.scandir(dir_fd)
+        except OSError as e:
+            # This operation should be a no-op, but python does not guarantee
+            # it. Technically, this might call `readdir()` (or `getdents(2)`)
+            # so we treat it the same as reading from the `entries` iterator.
+            if e.errno not in readdir_break_on:
+                raise e
+        else:
+            while True:
+                entry = None
+                try:
+                    # This calls `readdir()` (or probably the improved version
+                    # of it: `getdents(2)`). It very linkely is a batched
+                    # operation, so not each call will end up in a syscall.
+                    entry = next(entries)
+                except StopIteration:
+                    break
+                except OSError as e:
+                    # See discussion above on `os.scandir()` for exceptions.
+                    if e.errno in readdir_break_on:
+                        break
+                    raise
+
+                try:
+                    with fn_descend(self,
+                                    entry.name,
+                                    follow_symlink=follow_symlink) as pathfd:
+                        yield (pathfd, entry)
+                except OSError as e:
+                    if e.errno == errno.ENOENT:
+                        # A file might very well get deleted in between listing
+                        # the directory entries and trying to access it. We can
+                        # safely ignore this and pretend the directory listing
+                        # was chunked differently and never returned this
+                        # unlinked file.
+                        continue
+                    raise
+        finally:
+            if entries is not None:
+                entries.close()
+            os.close(dir_fd)
+
+    def traverse(self,
+                 *,
+                 order: int = 0,
+                 fn_enumerate: Callable = enumerate) -> Tuple[int, int, os.DirEntry]:
+        """Traverse Directory Tree
+
+        This creates a generator that iteratively traverses a directory tree,
+        yielding an object for every entry in that file-system tree. It
+        operates through `enumerate()` internally, but traveses an entire tree
+        rather than just a single directory level.
+
+        Note that `follow_symlink` is not provided as an option, and this
+        function currently behaves as if it was set to `False`. Traversing a
+        tree and following symlinks easily deadlocks. Furthermore, the
+        semantics are not entirely clear. Therefore, it is left to the caller
+        to resolve symlinks, if they so desire.
+
+        No entry for the object this is called on is yielded. That is, if the
+        directory that `self` points to is empty, this will yield no entries.
+
+        A generator that produces tuples of a path-descriptor, the traversal
+        indicator, and an `os.DirEntry` object is returned. Note that the
+        directory entry only contains information for the level it is on. No
+        information about the parent directories is included.
+
+        Parameters
+        ----------
+        order
+            A selector of which elements to yield. It must be a combination
+            of `TRAVERSE_PRE` (yield non-terminals before traversing them),
+            `TRAVERSE_POST` (yield non-termianls after traversing them), and
+            `TRAVERSE_IN` (yield terminals).
+            The yielded tuples contain one of these flags to indicate where
+            they are yielded.
+        fn_enumerate
+            Override the function used to enumerate a directory. By default,
+            this uses the `enumerate()` method on path-descriptors.
+
+        Raises
+        ------
+        OSError
+            This uses `enumerate()` internally, and thus returns the same set
+            of errors. No additional considerations apply.
+        """
+
+        if not self.is_open():
+            raise ValueError()
+
+        # We use a non-recursive implementation that stores every directory we
+        # recurse into on the stack, and pops it once fully enumerated.
+        stack = [(self, None, fn_enumerate(self))]
+
+        while len(stack) > 0:
+            (current_dirfd, current_entry, current_scan) = stack[-1]
+
+            for (sub_dirfd, sub_entry) in current_scan:
+                if not sub_dirfd.is_directory():
+                    if order & TRAVERSE_IN:
+                        yield (sub_dirfd, TRAVERSE_IN, sub_entry)
+                else:
+                    if order & TRAVERSE_PRE:
+                        yield (sub_dirfd, TRAVERSE_PRE, sub_entry)
+
+                    stack.append((sub_dirfd, sub_entry, fn_enumerate(sub_dirfd)))
+                    break
+            else:
+                if order & TRAVERSE_POST:
+                    if current_entry is not None:
+                        yield (current_dirfd, TRAVERSE_POST, current_entry)
+
+                stack.pop()

--- a/osbuild/util/scratchdir.py
+++ b/osbuild/util/scratchdir.py
@@ -1,0 +1,122 @@
+"""Scratch Directory
+
+This module implements a scratch-directory. It allows creating temporary
+directories with lock-files. It ensures the temporary directories are correctly
+removed again, once they are no longer needed.
+"""
+
+
+import contextlib
+import errno
+import os
+import uuid
+
+from osbuild.util import linux, pathfd, rmrf
+
+
+__all__ = [
+    "ScratchDir",
+]
+
+
+class ScratchDir(contextlib.AbstractContextManager):
+    """Scratch Directory
+
+    Every `ScratchDir` instance represents a temporary directory. The
+    constructor takes a path to the parent directory where to create the
+    temporary directory, as well as the name of the lockfile to place in the
+    directory.
+
+    By default, a scratch-dir does not perform any operations. Only once you
+    enter its context-manager, it will create the directory. Once you exit it,
+    all contents of the directory are removed. Re-entering the context-manager
+    will create a new directory with a different name. Recursively entering the
+    context-manager is supported and will retain the directory. That is, a
+    scratch-dir is only cleaned up once all active context managers exited.
+
+    The scratch-dir implementation makes sure to clean everything up in case of
+    any exceptions raised during runtime. However, there are cases with
+    asynchronous exceptions that python cannot handle. Hence, sometimes there
+    might be remnants after a process crashed. However, the lockfiles created
+    by all scratch-dirs allow parallel cleanup routines to check whether a
+    directory is still used, and if not, it can be cleaned up.
+    """
+
+    _parent_dfd = None
+    _lock_name = None
+    _n = 0
+
+    _name = None
+    _pinned_dfd = None
+    _scratch_dfd = None
+    _lock_fd = None
+
+    def __init__(self, parent_dfd: pathfd.PathFd, lock_name: str = "directory.lock"):
+        self._parent_dfd = parent_dfd
+        self._lock_name = lock_name
+        self._n = 0
+
+    def _first(self):
+        while self._scratch_dfd is None:
+            # We generate a unique name for the directory. We rely on the UUID
+            # generator for sufficient uniqueness.
+            self._name = uuid.uuid4().hex
+
+            # Create our scratch directory. We pin the parent directory so it
+            # cannot be closed while our context-manager is active.
+            self._pinned_dfd = self._parent_dfd.clone()
+            self._scratch_dfd = self._pinned_dfd.mkdir_relative(self._name)
+
+            # Create our temporary lockfile and acquire it.
+            flags = os.O_RDWR | os.O_CLOEXEC | os.O_TMPFILE
+            self._lock_fd = self._pinned_dfd.open_relative(".", flags)
+            linux.fcntl_flock(self._lock_fd, linux.fcntl.F_WRLCK)
+
+            # Attempt linking the lock-file into our temporary directory. There
+            # might be a parallel tempdir-cleanup running, so in case of
+            # `ENOENT` we simply try again. Note that this loop will terminate,
+            # if you program your cleanup correctly. Directory traversals use
+            # generation counters (or similar techniques) to make sure they
+            # terminate even if there are parallel additions to a directory.
+            fdpath = os.path.join("/proc/self/fd/", str(self._lock_fd))
+            try:
+                os.link(fdpath, self._lock_name, dst_dir_fd=self._scratch_dfd.fileno())
+            except OSError as e:
+                if e != errno.ENOENT:
+                    raise
+                self._last()
+
+    def _last(self):
+        if self._lock_fd is not None:
+            linux.fcntl_flock(self._lock_fd, linux.fcntl.F_UNLCK)
+            self._lock_fd = os.close(self._lock_fd)
+
+        if self._scratch_dfd is not None:
+            # Call `rmrf.rmtree()` on the directory. Since it does not support
+            # path-descriptors, we use the indirection via /proc.
+            rmrf.rmtree(os.path.join("/proc/self/fd/",
+                                     str(self._pinned_dfd.fileno()),
+                                     self._name))
+            self._scratch_dfd = self._scratch_dfd.close()
+
+        if self._pinned_dfd is not None:
+            self._pinned_dfd = self._pinned_dfd.close()
+
+        self._name = None
+
+    def __enter__(self):
+        self._n += 1
+        try:
+            if self._n == 1:
+                self._first()
+        except:
+            self._n -= 1
+            if self._n == 0:
+                self._last()
+            raise
+        return self._scratch_dfd
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self._n -= 1
+        if self._n == 0:
+            self._last()

--- a/test/test_util_linux.py
+++ b/test/test_util_linux.py
@@ -136,6 +136,24 @@ class TestUtilLinux(unittest.TestCase):
             # Cleanup
             os.close(fd2)
 
+    # pylint: disable=no-self-use
+    def test_proc_boot_id(self):
+        #
+        # Test the `proc_boot_id()` function which reads the current boot-id
+        # from the kernel. Make sure it is a valid UUID and also consistent on
+        # repeated queries.
+        #
+
+        bootid = linux.proc_boot_id("test")
+        assert len(bootid.hex) == 32
+        assert bootid.version == 4
+
+        bootid2 = linux.proc_boot_id("test")
+        assert bootid.int == bootid2.int
+
+        bootid3 = linux.proc_boot_id("foobar")
+        assert bootid.int != bootid3.int
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_util_linux.py
+++ b/test/test_util_linux.py
@@ -67,6 +67,75 @@ class TestUtilLinux(unittest.TestCase):
             # Verify we can unlink the file again, once the flag is cleared.
             os.unlink(f"{self.vartmpdir.name}/immutable")
 
+    def test_fcntl_flock(self):
+        #
+        # This tests the `linux.fcntl_flock()` file-locking helper. Note
+        # that file-locks are on the open-file-description, so they are shared
+        # between dupped file-descriptors. We explicitly create a separate
+        # file-description via `/proc/self/fd/`.
+        #
+
+        with tempfile.TemporaryFile() as f:
+            fd1 = f.fileno()
+            fd2 = os.open(os.path.join("/proc/self/fd/", str(fd1)), os.O_RDWR | os.O_CLOEXEC)
+
+            # Test: unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: write-lock + unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: read-lock1 + read-lock2 + unlock1 + unlock2
+            linux.fcntl_flock(fd1, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd2, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+            linux.fcntl_flock(fd2, linux.fcntl.F_UNLCK)
+
+            # Test: write-lock1 + write-lock2 + unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            with self.assertRaises(BlockingIOError):
+                linux.fcntl_flock(fd2, linux.fcntl.F_WRLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: write-lock1 + read-lock2 + unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            with self.assertRaises(BlockingIOError):
+                linux.fcntl_flock(fd2, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: read-lock1 + write-lock2 + unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_RDLCK)
+            with self.assertRaises(BlockingIOError):
+                linux.fcntl_flock(fd2, linux.fcntl.F_WRLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: write-lock1 + read-lock1 + read-lock2 + unlock
+            linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd2, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Test: read-lock1 + read-lock2 + write-lock1 + unlock1 + unlock2
+            linux.fcntl_flock(fd1, linux.fcntl.F_RDLCK)
+            linux.fcntl_flock(fd2, linux.fcntl.F_RDLCK)
+            with self.assertRaises(BlockingIOError):
+                linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+            linux.fcntl_flock(fd2, linux.fcntl.F_UNLCK)
+
+            # Test: write-lock3 + write-lock1 + close3 + write-lock1 + unlock1
+            fd3 = os.open(os.path.join("/proc/self/fd/", str(fd1)), os.O_RDWR | os.O_CLOEXEC)
+            linux.fcntl_flock(fd3, linux.fcntl.F_WRLCK)
+            with self.assertRaises(BlockingIOError):
+                linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            os.close(fd3)
+            linux.fcntl_flock(fd1, linux.fcntl.F_WRLCK)
+            linux.fcntl_flock(fd1, linux.fcntl.F_UNLCK)
+
+            # Cleanup
+            os.close(fd2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_util_pathfd.py
+++ b/test/test_util_pathfd.py
@@ -1,0 +1,364 @@
+#
+# Tests for the `osbuild.util.pathfd` module.
+#
+
+
+import os
+import tempfile
+import unittest
+
+from osbuild.util import pathfd
+
+
+class TestUtilPathFd(unittest.TestCase):
+    def setUp(self):
+        #
+        # Generic Test Setup
+        #
+        # We create a temporary directory tree for all tests. Each entry is
+        # named after its own path (e.g., the file `2_2_0` is located at
+        # `2/2_2/2_2_0`). This allows easy assertions on file-location and
+        # availability.
+        #
+        # The tree we create looks like this:
+        #
+        #     0
+        #     1
+        #     2/
+        #         2_0
+        #         2_1
+        #         2_2/
+        #             2_2_0
+        #             2_2_1
+        #         2_3/
+        #             2_3_0
+        #             2_3_1
+        #     3/
+        #         3_0
+        #         3_1
+        #         3_2
+        #         3_3
+        #     4 -> "2"
+        #     5 -> "2/2_3"
+        #     6 -> "<invalid>"
+        #
+
+        self.dir = tempfile.TemporaryDirectory()
+        self.dirfd = pathfd.PathFd.from_path(self.dir.name)
+
+        flags = os.O_RDWR | os.O_CLOEXEC | os.O_CREAT | os.O_EXCL
+
+        os.close(os.open("0", flags, dir_fd=self.dirfd.fileno()))
+        os.close(os.open("1", flags, dir_fd=self.dirfd.fileno()))
+
+        os.mkdir("2", dir_fd=self.dirfd.fileno())
+        os.close(os.open("2/2_0", flags, dir_fd=self.dirfd.fileno()))
+        os.close(os.open("2/2_1", flags, dir_fd=self.dirfd.fileno()))
+        os.mkdir("2/2_2", dir_fd=self.dirfd.fileno())
+        os.close(os.open("2/2_2/2_2_0", flags, dir_fd=self.dirfd.fileno()))
+        os.close(os.open("2/2_2/2_2_1", flags, dir_fd=self.dirfd.fileno()))
+        os.mkdir("2/2_3", dir_fd=self.dirfd.fileno())
+        os.close(os.open("2/2_3/2_3_0", flags, dir_fd=self.dirfd.fileno()))
+        os.close(os.open("2/2_3/2_3_1", flags, dir_fd=self.dirfd.fileno()))
+
+        os.mkdir("3", dir_fd=self.dirfd.fileno())
+        os.close(os.open("3/3_0", flags, dir_fd=self.dirfd.fileno()))
+        os.close(os.open("3/3_1", flags, dir_fd=self.dirfd.fileno()))
+        os.close(os.open("3/3_2", flags, dir_fd=self.dirfd.fileno()))
+        os.close(os.open("3/3_3", flags, dir_fd=self.dirfd.fileno()))
+
+        os.symlink("2", "4", dir_fd=self.dirfd.fileno())
+        os.symlink("2/2_3", "5", dir_fd=self.dirfd.fileno())
+        os.symlink("<invalid>", "6", dir_fd=self.dirfd.fileno())
+
+    def tearDown(self):
+        self.dirfd.close()
+        self.dir.cleanup()
+
+    # pylint: disable=too-many-statements
+    def test_basic(self):
+        #
+        # Basic Tests
+        #
+        # This contains a bunch of hard-coded basic tests for the PathFd
+        # module. Anything non-automated and small enough that it needs no
+        # complex setup is bundled here.
+        #
+
+        # Verify basic constructors calls.
+        _ = pathfd.PathFd()
+        _ = pathfd.PathFd.from_path(self.dir.name)
+        _ = pathfd.PathFd.from_path('.', self.dir.name, '.')
+        _ = pathfd.PathFd.from_path(self.dir.name, "2")
+        _ = self.dirfd.clone()
+
+        # Verify int-conversion produces an accessible file-descriptor.
+        fd = self.dirfd.fileno()
+        assert fd >= 0
+        dup = os.dup(fd)
+        assert dup >= 0
+        os.close(dup)
+
+        # Verify context-manager operation.
+        p = self.dirfd.clone()
+        with p as v:
+            assert p.fileno() == v.fileno()
+        assert not p.is_open()
+
+        # Verify close() does its job.
+        p = self.dirfd.clone()
+        assert p.fileno() >= 0
+        p.close()
+        with self.assertRaises(ValueError):
+            assert p.fileno() >= 0
+
+        # Verify is_open() behavior.
+        assert not pathfd.PathFd().is_open()
+        p = self.dirfd.clone()
+        assert p.is_open()
+        p.close()
+        assert not p.is_open()
+
+        # Verify clones have their own private file-descriptor.
+        p = self.dirfd.clone()
+        assert p.fileno() != self.dirfd.fileno()
+
+        # Verify stat() works just like `os.stat()`.
+        assert self.dirfd.stat() == os.stat(self.dir.name)
+
+        # Verify is_directory() works as intended.
+        assert self.dirfd.descend(".").is_directory()
+        assert not self.dirfd.descend("0").is_directory()
+        assert not self.dirfd.descend("1").is_directory()
+        assert self.dirfd.descend("2").is_directory()
+        assert not self.dirfd.descend("2/2_0").is_directory()
+
+        # Verify is_symlink() works as intended.
+        assert not self.dirfd.descend(".").is_symlink()
+        assert not self.dirfd.descend("0").is_symlink()
+        assert not self.dirfd.descend("1").is_symlink()
+        assert self.dirfd.descend("4").is_symlink()
+        assert self.dirfd.descend("5").is_symlink()
+        assert self.dirfd.descend("6").is_symlink()
+
+        # Check for basic `open_relative()` behavior.
+        _ = self.dirfd.open_relative("2/2_0", os.O_RDONLY)
+        with self.assertRaises(OSError):
+            # '6' is a symlink to a non-existant file, so it cannot resolve
+            _ = self.dirfd.open_relative("6", os.O_RDONLY)
+        with self.assertRaises(OSError):
+            # cannot open symlinks (which `O_NOFOLLOW` would try here)
+            _ = self.dirfd.open_relative("4", os.O_RDONLY | os.O_NOFOLLOW)
+        _ = self.dirfd.open_relative("4", os.O_RDONLY)
+
+        # Check for basic `open_self()` behavior.
+        _ = self.dirfd.open_self(os.O_RDONLY)
+        with self.assertRaises(AssertionError):
+            # `open_self()` rejects `O_NOFOLLOW`
+            _ = self.dirfd.descend("4").open_self(os.O_RDONLY | os.O_NOFOLLOW)
+
+        # Check for basic `descend()` behavior.
+        _ = self.dirfd.descend("0")
+        _ = self.dirfd.descend("2")
+        _ = self.dirfd.descend("2/2_0")
+        _ = self.dirfd.descend("2", "..", "2", "2_0")
+        _ = self.dirfd.descend("2/../2/./2_0")
+        _ = self.dirfd.descend("2").descend("2_0")
+        _ = self.dirfd.descend("4")
+        _ = self.dirfd.descend("5", follow_symlink=True)
+        with self.assertRaises(OSError):
+            _ = self.dirfd.descend("6", follow_symlink=True)
+
+    def test_unlink(self):
+        #
+        # Unlink Operation
+        #
+
+        flags = os.O_RDWR | os.O_CLOEXEC | os.O_CREAT | os.O_EXCL
+
+        os.close(os.open("foobar", flags, dir_fd=self.dirfd.fileno()))
+        self.dirfd.unlink_relative("foobar")
+
+        os.close(os.open("foobar", flags, dir_fd=self.dirfd.fileno()))
+        self.dirfd.unlink_relative(".", "foobar")
+
+    def test_mkrmdir(self):
+        #
+        # Directory Creation/Removal
+        #
+
+        self.dirfd.mkdir_relative("foobar").close()
+        self.dirfd.rmdir_relative("foobar")
+
+    def test_enumerate(self):
+        #
+        # Directory Enumeration
+        #
+        # This contains tests for the `enumerate()` method of pathfd objects.
+        # It defines an array of mappings from pathfd to the directory
+        # listing. It then iterates over the mapping and verifies each
+        # enumeration produces the expected listing.
+        #
+
+        mappings = []
+
+        dirfd = self.dirfd.clone()
+        expected = ["0", "1", "2", "3", "4", "5", "6"]
+        mappings.append((dirfd, expected))
+
+        dirfd = self.dirfd.descend("2/2_2")
+        expected = ["2_2_0", "2_2_1"]
+        mappings.append((dirfd, expected))
+
+        dirfd = self.dirfd.descend("3")
+        expected = ["3_0", "3_1", "3_2", "3_3"]
+        mappings.append((dirfd, expected))
+
+        for (dirfd, expected) in mappings:
+            result = list(map(lambda x: x[1].name, dirfd.enumerate()))
+            result.sort()
+            expected.sort()
+            assert result == expected
+
+    # pylint: disable=no-self-use
+    def test_enumerate_unlink_race(self):
+        #
+        # Directory Enumeration vs Unlink
+        #
+        # This runs a directory enumeration, but unlinks an entry during the
+        # enumeration. It verifies that the enumeration will not fall over, but
+        # proceeds gracefully.
+        #
+        # We cannot affect the batch-size the `os.scandir()` call uses
+        # internally. Therefore, we cannot really predict which path is taken.
+        # All we can do is verify no exception is thrown.
+        #
+
+        with tempfile.TemporaryDirectory() as t_dir:
+            t_dirfd = pathfd.PathFd.from_path(t_dir)
+            flags = os.O_RDWR | os.O_CLOEXEC | os.O_CREAT | os.O_EXCL
+            os.close(os.open("0", flags, dir_fd=t_dirfd.fileno()))
+            os.close(os.open("1", flags, dir_fd=t_dirfd.fileno()))
+            os.close(os.open("2", flags, dir_fd=t_dirfd.fileno()))
+            os.close(os.open("3", flags, dir_fd=t_dirfd.fileno()))
+            os.close(os.open("4", flags, dir_fd=t_dirfd.fileno()))
+            os.close(os.open("5", flags, dir_fd=t_dirfd.fileno()))
+            os.close(os.open("6", flags, dir_fd=t_dirfd.fileno()))
+            os.close(os.open("7", flags, dir_fd=t_dirfd.fileno()))
+
+            t_entries = []
+            t_enum = t_dirfd.enumerate()
+
+            # Unlink '3' and '4'. This means they must not be returned from the
+            # `next()` calls, but might be internally seen by `os.scandir()`.
+            os.unlink("3", dir_fd=t_dirfd.fileno())
+            os.unlink("4", dir_fd=t_dirfd.fileno())
+
+            # Fetch the first entry, triggering a batched `os.scandir()`.
+            t_entries.append(next(t_enum)[1].name)
+
+            # Unlink more entries. Because ordering is random, one of these
+            # might have been returned by the previous call, but we cannot
+            # know. However, this can only apply to one of them. The other must
+            # never be returned.
+            os.unlink("0", dir_fd=t_dirfd.fileno())
+            os.unlink("7", dir_fd=t_dirfd.fileno())
+
+            t_entries += list(map(lambda x: x[1].name, t_enum))
+            t_entries.sort()
+
+            expected0 = ["0", "1", "2", "5", "6"]
+            expected0.sort()
+            expected1 = ["1", "2", "5", "6", "7"]
+            expected1.sort()
+            expected2 = ["1", "2", "5", "6"]
+            expected2.sort()
+
+            assert t_entries in [expected0, expected1, expected2]
+
+    def test_traverse(self):
+        #
+        # Path Traversal
+        #
+        # This tests the recursive enumeration of a directory tree. It defines
+        # a mapping from pathfd to the expected directory listing. It then
+        # iterates the array and verifies each enumeration produces the
+        # expected result.
+        #
+        # Note that the origin of a traversal is not itself yielded by the
+        # traversal.
+        #
+
+        mappings = []
+
+        dirfd = self.dirfd.clone()
+        expected = []
+        expected += ["0", "1"]
+        expected += ["2", "2_0", "2_1"]
+        expected += ["2_2", "2_2_0", "2_2_1"]
+        expected += ["2_3", "2_3_0", "2_3_1"]
+        expected += ["3", "3_0", "3_1", "3_2", "3_3"]
+        expected += ["4", "5", "6"]
+        mappings.append((dirfd, expected))
+
+        dirfd = self.dirfd.descend("2")
+        expected = []
+        expected += ["2_0", "2_1"]
+        expected += ["2_2", "2_2_0", "2_2_1"]
+        expected += ["2_3", "2_3_0", "2_3_1"]
+        mappings.append((dirfd, expected))
+
+        dirfd = self.dirfd.descend("3")
+        expected = ["3_0", "3_1", "3_2", "3_3"]
+        mappings.append((dirfd, expected))
+
+        for (dirfd, expected) in mappings:
+            order = pathfd.TRAVERSE_PRE | pathfd.TRAVERSE_IN
+            result = list(map(lambda x: x[2].name, dirfd.traverse(order=order)))
+            result.sort()
+            expected.sort()
+            assert result == expected
+
+    def test_nondir(self):
+        #
+        # Test FS Operations on Unlinked Directories
+        #
+        # This runs a bunch of tests to verify how operations behave if they
+        # operate on directory path-descriptors that have been unlinked.
+        #
+
+        # verify simple directory creation works
+        d = self.dirfd.mkdir_relative("foo")
+        d.mkdir_relative("bar")
+        d.rmdir_relative("bar")
+        d.close()
+        self.dirfd.rmdir_relative("foo")
+
+        # `mkdir(2)` on an unlinked dir does not work
+        d = self.dirfd.mkdir_relative("foo")
+        self.dirfd.rmdir_relative("foo")
+        with self.assertRaises(OSError):
+            d.mkdir_relative("bar")
+        d.close()
+
+        # verify basic `O_TMPFILE` linking works
+        d = self.dirfd.mkdir_relative("foo")
+        flags = os.O_RDWR | os.O_CLOEXEC | os.O_TMPFILE
+        f = d.open_relative(".", flags)
+        p = os.path.join("/proc/self/fd/", str(f))
+        os.link(p, "bar", dst_dir_fd=d.fileno())
+        os.close(f)
+        d.unlink_relative("bar")
+        self.dirfd.rmdir_relative("foo")
+        d.close()
+
+        # verify `O_TMPFILE` cannot pin a directory, nor can it link afterwards
+        d = self.dirfd.mkdir_relative("foo")
+        flags = os.O_RDWR | os.O_CLOEXEC | os.O_TMPFILE
+        f = d.open_relative(".", flags)
+        self.dirfd.rmdir_relative("foo")
+        p = os.path.join("/proc/self/fd/", str(f))
+        with self.assertRaises(OSError):
+            os.link(p, "bar", dst_dir_fd=d.fileno())
+        os.close(f)
+        d.close()

--- a/test/test_util_scratchdir.py
+++ b/test/test_util_scratchdir.py
@@ -1,0 +1,42 @@
+#
+# Tests for the `osbuild.util.scratchdir` module.
+#
+
+
+import os
+import tempfile
+import unittest
+
+from osbuild.util import pathfd, scratchdir
+
+
+class TestUtilScratchDir(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.TemporaryDirectory()
+        self.dirfd = pathfd.PathFd.from_path(self.dir.name)
+
+    def tearDown(self):
+        self.dirfd.close()
+        self.dir.cleanup()
+
+    def test_basic(self):
+        #
+        # Basic Functionality Tests
+        #
+
+        # make sure the constructor does not actually do anything
+        s = scratchdir.ScratchDir(self.dirfd, "lockname")
+        assert len(list(self.dirfd.enumerate())) == 0
+
+        # acquire the scratch-dir and check the lockfile exists
+        with s as fd:
+            assert os.access("lockname", os.R_OK, dir_fd=fd.fileno())
+        assert len(list(self.dirfd.enumerate())) == 0
+
+        # try again, and this time try recursion
+        with s as fd:
+            assert os.access("lockname", os.R_OK, dir_fd=fd.fileno())
+            with s as fd2:
+                assert os.access("lockname", os.R_OK, dir_fd=fd2.fileno())
+            assert os.access("lockname", os.R_OK, dir_fd=fd.fileno())
+        assert len(list(self.dirfd.enumerate())) == 0


### PR DESCRIPTION
This is my cleanup of the previous fscache-utils and now extended with the first use-case: The scratch-directories.

I hope I incorporated all the previous feedback! The commit-messages contain details on each utility. This does not hook up the code with the current osbuild pipelines. I will do that in the final step when introducing the new cache-directory as well.

I am fine with leaving this unmerged, or merging it unused. I just thought for review it might be better to post this early.