### PR TITLE
sources/ostree: enable locked-access explicitly

### DIFF
--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -27,6 +27,11 @@ def main(options, checksums, cache, output):
     repo_cache = os.path.join(cache, "repo")
     ostree("init", mode="archive", repo=repo_cache)
 
+    # Make sure the cache repository uses locks to protect the metadata during
+    # shared access. This is the default since `2018.5`, but lets document this
+    # explicitly here.
+    ostree("config", "set", "repo.locking", "true", repo=repo_cache)
+
     repo_out = os.path.join(output, "repo")
     ostree("init", mode="archive", repo=repo_out)
 


### PR DESCRIPTION
Make sure access to the shared ostree metadata is locked properly. This
is the default since 2018.5, but lets be explicit here. This also makes
sure that the option exists and the local version supports locked and
protected access.

It is unclear whether the `ostree init` honors that as well. It really
should, and if it doesn't we can always report it upstream.

(This is untested. I just prototyped this. Lets see what the CI says :eyes:)