### PR TITLE
Move more tests into `make test-module`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,11 +77,6 @@ jobs:
           cd osbuild
           python3 -m unittest -v test.test_objectstore
 
-      - name: Run test_osrelease
-        run: |
-          cd osbuild
-          python3 -m unittest -v test.test_osrelease
-
   rpm_build:
     name: "📦 RPM"
     runs-on: ubuntu-latest

--- a/osbuild/util/osrelease.py
+++ b/osbuild/util/osrelease.py
@@ -1,0 +1,51 @@
+"""OS-Release Information
+
+This module implements handlers for the `/etc/os-release` type of files. The
+related documentation can be found in `os-release(5)`.
+"""
+
+import os
+
+
+def parse_files(*paths):
+    """Read Operating System Information from `os-release`
+
+    This creates a dictionary with information describing the running operating
+    system. It reads the information from the path array provided as `paths`.
+    The first available file takes precedence. It must be formatted according
+    to the rules in `os-release(5)`.
+    """
+    osrelease = {}
+
+    path = next((p for p in paths if os.path.exists(p)), None)
+    if path:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                if line[0] == "#":
+                    continue
+                key, value = line.split("=", 1)
+                osrelease[key] = value.strip('"')
+
+    return osrelease
+
+
+def describe_os(*paths):
+    """Read the Operating System Description from `os-release`
+
+    This creates a string describing the running operating-system name and
+    version. It uses `parse_files()` underneath to acquire the requested
+    information.
+
+    The returned string uses the format `${ID}${VERSION_ID}` with all dots
+    stripped.
+    """
+    osrelease = parse_files(*paths)
+
+    # Fetch `ID` and `VERSION_ID`. Defaults are defined in `os-release(5)`.
+    osrelease_id = osrelease.get("ID", "linux")
+    osrelease_version_id = osrelease.get("VERSION_ID", "")
+
+    return osrelease_id + osrelease_version_id.replace(".", "")

--- a/test/mod/test_util_jsoncomm.py
+++ b/test/mod/test_util_jsoncomm.py
@@ -2,11 +2,11 @@
 # Tests for the 'osbuild.util.jsoncomm' module.
 #
 
-
 import asyncio
 import os
 import tempfile
 import unittest
+
 from osbuild.util import jsoncomm
 
 
@@ -153,7 +153,3 @@ class TestUtilJsonComm(unittest.TestCase):
 
         msg = self.client.recv()
         assert msg[0] == {}
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/mod/test_util_osrelease.py
+++ b/test/mod/test_util_osrelease.py
@@ -1,9 +1,14 @@
+#
+# Tests for the `osbuild.util.osrelease` module.
+#
+
 import os
 import unittest
 
 from osbuild.util import osrelease
 
-class TestOSRelease(unittest.TestCase):
+
+class TestUtilOSRelease(unittest.TestCase):
     def test_non_existant(self):
         """Verify default os-release value, if no files are given."""
         self.assertEqual(osrelease.describe_os(), "linux")

--- a/test/mod/test_util_rmrf.py
+++ b/test/mod/test_util_rmrf.py
@@ -2,7 +2,6 @@
 # Tests for the `osbuild.util.rmrf` module.
 #
 
-
 import os
 import pathlib
 import shutil
@@ -10,7 +9,7 @@ import subprocess
 import tempfile
 import unittest
 
-import osbuild.util.rmrf as rmrf
+from osbuild.util import rmrf
 
 
 def can_set_immutable():
@@ -46,7 +45,3 @@ class TestUtilLinux(unittest.TestCase):
                 shutil.rmtree(f"{vartmpdir}/dir")
 
             rmrf.rmtree(f"{vartmpdir}/dir")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_osrelease.py
+++ b/test/test_osrelease.py
@@ -1,12 +1,12 @@
 import os
 import unittest
 
-import osbuild
+from osbuild.util import osrelease
 
 class TestOSRelease(unittest.TestCase):
     def test_non_existant(self):
         """Verify default os-release value, if no files are given."""
-        self.assertEqual(osbuild.pipeline.describe_os(), "linux")
+        self.assertEqual(osrelease.describe_os(), "linux")
 
     def test_describe_os(self):
         """Test host os detection. test/os-release contains the os-release files
@@ -14,4 +14,4 @@ class TestOSRelease(unittest.TestCase):
         """
         for entry in os.scandir("test/os-release"):
             with self.subTest(entry.name):
-                self.assertEqual(osbuild.pipeline.describe_os(entry.path), entry.name)
+                self.assertEqual(osrelease.describe_os(entry.path), entry.name)


### PR DESCRIPTION
This moves some more utility tests into `test-module`, as well as moves the os-release parser into `./util/` to keep it with the other helpers.