### PR TITLE
build: fill in preliminary NEWS entry for v13

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,38 @@
 # OSBuild - Build-Pipelines for Operating System Artifacts
 
+## CHANGES WITH 13:
+
+        * Stage `org.osbuild.yum` has been dropped. It has been deprecated for
+          some time and `org.osbuild.rpm` provides a better alternative.
+
+        * XZ compression now utilizes all available CPU cores. This affects all
+          stages and assemblers that support XZ compression. It should decrease
+          compression times considerably.
+
+        * `org.osbuild.grub2` now supports referring to file-systems via a label
+          additionally to a UUID. This affects all places where an existing
+          file-system is referred to. Disk creation still requires a UUID to be
+          provided. `org.osbuild.fstab` gained similar support.
+
+        * RHEL-8.3 is now supported as host system.
+
+        * The 'libdir' layout in `/usr/lib/osbuild/` has been simplified.
+          Distributions are no longer required to create mount anchors during
+          installation. Instead, all modules (stages, assemblers, sources, and
+          runners) can be copied verbatim from the source tree.
+
+        * `org.osbuild.grub2` now correctly pads `grubenv` files to 1024 bytes.
+          This was not done correctly, previously, and caused other parsers to
+          fail.
+
+        * The containerization via systemd-nspawn was adjusted to support
+          running in a container. With sufficient privileges, you can now run
+          osbuild pipelines from within a container.
+
+        Contributions from: Christian Kellner, David Rheinsberg, Major Hayden
+
+        - Berlin, 2020-04-29
+
 ## CHANGES WITH 12:
 
         * The `qemu` assembler now supports the `VHDX` image format. This is the


### PR DESCRIPTION
Create a preliminary NEWS entry for the upcoming v13 release. Lots of
fixes all over the place, but most of them not worth mentioning for the
release. However, we do have some feature improvements as well.

@gicmo As usual, feel free to adjust, extend, delete.