### PR TITLE
spec: pretrans script to remove osbuild dirs

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -103,6 +103,20 @@ exit 0
 # We have some integration tests, but those require running a VM, so that would
 # be an overkill for RPM check script.
 
+%pretrans -p <lua>
+-- usr/lib/osbuild/.../osbuild used to be a directory but is now a symlink;
+-- rpm cannot replace a directory with a link[1]; as a work-around remove it
+-- in case that the target is a directory
+-- [1] https://docs.fedoraproject.org/en-US/packaging-guidelines/Directory_Replacement/
+folder = {"assemblers", "stages"}
+for i, target in ipairs(folder) do
+  path = "/usr/lib/osbuild/" .. target .. "/osbuild"
+  st = posix.stat(path)
+  if st and st.type == "directory" then
+    os.remove(path)
+  end
+end
+
 %files
 %license LICENSE
 %{_bindir}/osbuild


### PR DESCRIPTION
Commit 58d368df0db8043926eb9856d6f9d14a669190e0 introduced having symlinks from `<libdir>/{assemblers, ..., stages}/osbuild` to a single mountpoint in `/usr/lib/osbuild/osbuild`. Since rpm does not support replacing directories ([packaging guidelines][1]), a `%pretrans` lua script is required to remove the directory before creating the symlink.

I held of doing the RPMs because I am not sure we want to actually do that and carry that script around. An alternative would be to keep the the `osbuild` directory in the various subdirs (and add `osbuild` for `runners`, `sources`) and then do bind-mounts to all of those. I personally have a slight preference for that. Happy to do it and then throw the patch in the respective RPMs.

[1]: https://docs.fedoraproject.org/en-US/packaging-guidelines/Directory_Replacement/