### PR TITLE
jenkins: remove composer directories before the tests

### DIFF
--- a/jenkins/run_tests.sh
+++ b/jenkins/run_tests.sh
@@ -39,6 +39,7 @@ ansible-playbook \
   -i hosts.ini \
   -e osbuild_repo=${WORKSPACE} \
   -e osbuild_version=$(git rev-parse HEAD) \
+  -e cleanup_composer_directories=yes \
   ansible-osbuild/playbook.yml
 
 # Run the tests only on Fedora 31 for now.


### PR DESCRIPTION
This commit turns on the `cleanup_composer_directories` option to clean up
the osbuild-composer directories during the time the services are stopped
(when ansible-osbuild is about to deploy the new versions of the
services).

Taken from osbuild/osbuild-composer#575, thanks to @major!