### PR TITLE
Revert "buildroot: explicitly invoke runners via python3"

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -120,8 +120,6 @@ class BuildRoot(contextlib.AbstractContextManager):
             *[f"--bind-ro={b}" for b in nspawn_ro_binds],
             *[f"--bind={b}" for b in (binds or [])],
             *[f"--bind-ro={b}" for b in (readonly_binds or [])],
-            "--",
-            "python3",
             f"/run/osbuild/lib/runners/{self.runner}"
             ] + argv, check=check, **kwargs)
 


### PR DESCRIPTION
This reverts commit 33844711cd20f29d067047aaeb8682ac188428ba.

There are systems were our runners have no standard python3 location
available. They will fix the environment before invoking any further
utilities. Therefore, we cannot rely on `python3 foo.py` to work in our
ad-hoc containers.

This simply reverts the behavior back to using the shebang.