### PR TITLE
🚽 Use Jenkins pipeline for better flow

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,51 @@
+pipeline {
+    agent none
+
+    options {
+        timestamps()
+        ansiColor('xterm')
+    }
+
+    stages {
+        stage("Functional Testing") {
+            parallel {
+                stage('Fedora 31 image') {
+                    agent {
+                        label "fedora31"
+                    }
+                    environment {
+                        TEST_TYPE = "image"
+                    }
+                    steps {
+                        sh "jenkins/run_tests.sh"
+                    }
+                }
+                stage('Fedora 32 image') {
+                    agent {
+                        label "fedora32"
+                    }
+                    environment {
+                        TEST_TYPE = "image"
+                    }
+                    steps {
+                        sh "jenkins/run_tests.sh"
+                    }
+                }
+                // Disable RHEL 8.3 image testing for now until we work out the
+                // QEMU issues there.
+                //
+                // stage('RHEL 8.2 image') {
+                //     agent {
+                //         label "rhel82"
+                //     }
+                //     environment {
+                //         TEST_TYPE = "image"
+                //     }
+                //     steps {
+                //         sh "jenkins/run_tests.sh"
+                //     }
+                // }
+            }
+        }
+    }
+}

--- a/jenkins/run_tests.sh
+++ b/jenkins/run_tests.sh
@@ -4,6 +4,10 @@ set -euxo pipefail
 # Read variables about the OS.
 source /etc/os-release
 
+# Create temporary directories for Ansible.
+sudo mkdir -vp /opt/ansible_{local,remote}
+sudo chmod -R 777 /opt/ansible_{local,remote}
+
 # Restart systemd to work around some Fedora issues in cloud images.
 sudo systemctl restart systemd-journald
 
@@ -49,7 +53,7 @@ if [[ $NAME == "Fedora" ]] && [[ $VERSION_ID == "31" ]]; then
     -e journald_cursor="${JOURNALD_CURSOR}" \
     -e test_type=${TEST_TYPE:-image} \
     -i hosts.ini \
-    /opt/osbuild-composer/jenkins/test.yml
+    ansible-osbuild/repos/osbuild-composer/jenkins/test.yml
 fi
 
 # Collect the systemd journal anyway if we made it all the way to the end.


### PR DESCRIPTION
By using a small Jenkins pipeline in the repository, we can define
almost all of our testing parameters in the repo itself and not inside
Jenkins.

This also allows us to use the GitHub Branch Source plugin and
auto-discover new repositories without `ok to test` bombs in
pull requests.