### PR TITLE
cli: drop --build-env argument

### DIFF
--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -37,8 +37,6 @@ The following command-line options are supported. If an option is passed, which
 is not listed here, **osbuild** will deny startup and exit with an error.
 
 -h, --help                      print usage information and exit immediately
---build-env=PATH                json file containing a description of the build
-                                environment
 --store=DIR                     directory where intermediary file system trees
                                 are stored
 --sources=PATH                  json file containing a dictionary of source

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -73,8 +73,6 @@ def parse_arguments(sys_argv):
 
     parser.add_argument("manifest_path", metavar="MANIFEST",
                         help="json file containing the manifest that should be built, or a '-' to read from stdin")
-    parser.add_argument("--build-env", metavar="FILE", type=os.path.abspath,
-                        help="json file containing a description of the build environment")
     parser.add_argument("--store", metavar="DIRECTORY", type=os.path.abspath,
                         default=".osbuild",
                         help="directory where intermediary os trees are stored")
@@ -120,11 +118,6 @@ def osbuild_cli(*, sys_argv=[]):
             sources_options = json.load(f)
 
     pipeline = osbuild.load(pipeline, sources_options)
-
-    if args.build_env:
-        with open(args.build_env) as f:
-            build_pipeline, runner = osbuild.load_build(json.load(f), sources_options)
-        pipeline.prepend_build_env(build_pipeline, runner)
 
     secrets = {}
     if args.secrets:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -185,13 +185,6 @@ class Pipeline:
         build = self.build.tree_id if self.build else None
         self.assembler = Assembler(name, build, self.tree_id, options or {})
 
-    def prepend_build_env(self, build_pipeline, runner):
-        pipeline = self
-        while pipeline.build:
-            pipeline = pipeline.build
-        pipeline.build = build_pipeline
-        pipeline.runner = runner
-
     def description(self, *, with_id=False):
         description = {}
         if self.build:


### PR DESCRIPTION
Drop the --build-env command-line argument. It is not used by anything.
Furthermore, our manifests now allow embedding build-environments, so
there is little reason to continue supporting this.