### PR TITLE
Release osbuild version 14

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,32 @@
 # OSBuild - Build-Pipelines for Operating System Artifacts
 
+## CHANGES WITH 14:
+
+        * Schema validation: The osbuild python library gained support for
+          retrieving the metadata of modules and schema validation. This is
+          being used on each invocation of osbuild in order to validate the
+          manifest. Should the validation fail the build is aborted and
+          validation errors are returned, either in human readable form or
+          in JSON, if `--json` was specified.
+
+        * A `--inspect` command line option was added for osbuild. Instead
+          of attempting to build the pipeline, the manifest will be printed
+          to stdout in JSON form, including all the calulcated identifiers
+          of stages, the assembler and the `tree_id` and `output_id` of the
+          pipeline (and build pipelines). Schema validation will be done and
+          errors will be reported.
+
+        * Internally, the buildroot class now uses `PYTHONPATH` to point to
+          the `osbuild` module instead of the symlinks or bind-mounts in the
+          individual modules.
+
+        * Fixes to the CI and many cleanups to the schemata, sample and test
+          pipelines as a result of the schema validation work.
+
+        Contributions from: Christian Kellner, David Rheinsberg, Ondřej Budai
+
+        - Berlin, 2020-05-06
+
 ## CHANGES WITH 13:
 
         * Stage `org.osbuild.yum` has been dropped. It has been deprecated for

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -1,6 +1,6 @@
 %global         forgeurl https://github.com/osbuild/osbuild
 
-Version:        13
+Version:        14
 
 %forgemeta
 

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -74,16 +74,16 @@ make man
 %py3_install
 
 mkdir -p %{buildroot}%{pkgdir}/stages
-install -p -m 0755 $(find stages/* -not -path "*/osbuild") %{buildroot}%{pkgdir}/stages/
+install -p -m 0755 $(find stages -type f) %{buildroot}%{pkgdir}/stages/
 
 mkdir -p %{buildroot}%{pkgdir}/assemblers
-install -p -m 0755 $(find assemblers/* -not -path "*/osbuild") %{buildroot}%{pkgdir}/assemblers/
+install -p -m 0755 $(find assemblers -type f) %{buildroot}%{pkgdir}/assemblers/
 
 mkdir -p %{buildroot}%{pkgdir}/runners
-install -p -m 0755 $(find runners/* -not -path "*/osbuild") %{buildroot}%{pkgdir}/runners
+install -p -m 0755 $(find runners -type f -or -type l) %{buildroot}%{pkgdir}/runners
 
 mkdir -p %{buildroot}%{pkgdir}/sources
-install -p -m 0755 $(find sources/* -not -path "*/osbuild") %{buildroot}%{pkgdir}/sources
+install -p -m 0755 $(find sources -type f) %{buildroot}%{pkgdir}/sources
 
 # mount point for bind mounting the osbuild library
 mkdir -p %{buildroot}%{pkgdir}/osbuild

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -102,7 +102,7 @@ def osbuild_cli(*, sys_argv=[]):
     manifest = parse_manifest(args.manifest_path)
 
     # first thing after parsing is validation of the input
-    index = osbuild.meta.Index(args.libdir)
+    index = osbuild.meta.Index(args.libdir or "/usr/lib/osbuild")
     res = osbuild.meta.validate(manifest, index)
     if not res:
         if args.json or args.inspect:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="osbuild",
-    version="13",
+    version="14",
     description="A build system for OS images",
     packages=["osbuild", "osbuild.util"],
     license='Apache-2.0',


### PR DESCRIPTION
Small fix for `main_cli` to always set the `libdir`, small spec file changes and the `NEWS.md` entries.

Did an update test and a quick build of `samples/base-qcow2.json` to ensure that this release is good to put into RPMs. (-:

```
→ rpmlint osbuild.spec rpmbuild/RPMS/noarch/*
osbuild.spec:8: E: hardcoded-library-path in %{_prefix}/lib/%{pypi_name}
osbuild.spec: W: invalid-url Source0: https://github.com/osbuild/osbuild/archive/v14/osbuild-14.tar.gz HTTP Error 404: Not Found
osbuild.noarch: W: incoherent-version-in-changelog 1-3 ['14-1.20200506git0a07bcb.fc32', '14-1.20200506git0a07bcb']
osbuild.noarch: W: only-non-binary-in-usr-lib
osbuild-ostree.noarch: W: only-non-binary-in-usr-lib
osbuild-ostree.noarch: W: no-documentation
3 packages and 1 specfiles checked; 1 errors, 5 warnings.
```

```
→ rpm -qil rpmbuild/RPMS/noarch/osbuild-14-1.20200506git0a07bcb.fc32.noarch.rpm 
Name        : osbuild
Version     : 14
Release     : 1.20200506git0a07bcb.fc32
Architecture: noarch
Install Date: (not installed)
Group       : Unspecified
Size        : 115730
License     : ASL 2.0
Signature   : (none)
Source RPM  : osbuild-14-1.20200506git0a07bcb.fc32.src.rpm
Build Date  : Wed 06 May 2020 18:19:55 CEST
Build Host  : cobalt
URL         : https://github.com/osbuild/osbuild
Summary     : A build system for OS images
Description :
A build system for OS images
/usr/bin/osbuild
/usr/lib/osbuild
/usr/lib/osbuild/assemblers
/usr/lib/osbuild/assemblers/org.osbuild.noop
/usr/lib/osbuild/assemblers/org.osbuild.qemu
/usr/lib/osbuild/assemblers/org.osbuild.rawfs
/usr/lib/osbuild/assemblers/org.osbuild.tar
/usr/lib/osbuild/osbuild
/usr/lib/osbuild/runners
/usr/lib/osbuild/runners/org.osbuild.arch
/usr/lib/osbuild/runners/org.osbuild.fedora30
/usr/lib/osbuild/runners/org.osbuild.fedora31
/usr/lib/osbuild/runners/org.osbuild.fedora32
/usr/lib/osbuild/runners/org.osbuild.fedora33
/usr/lib/osbuild/runners/org.osbuild.linux
/usr/lib/osbuild/runners/org.osbuild.rhel81
/usr/lib/osbuild/runners/org.osbuild.rhel82
/usr/lib/osbuild/runners/org.osbuild.rhel83
/usr/lib/osbuild/runners/org.osbuild.ubuntu1804
/usr/lib/osbuild/schemas
/usr/lib/osbuild/sources
/usr/lib/osbuild/sources/org.osbuild.dnf
/usr/lib/osbuild/sources/org.osbuild.files
/usr/lib/osbuild/stages
/usr/lib/osbuild/stages/org.osbuild.chrony
/usr/lib/osbuild/stages/org.osbuild.debug-shell
/usr/lib/osbuild/stages/org.osbuild.error
/usr/lib/osbuild/stages/org.osbuild.firewall
/usr/lib/osbuild/stages/org.osbuild.first-boot
/usr/lib/osbuild/stages/org.osbuild.fix-bls
/usr/lib/osbuild/stages/org.osbuild.fstab
/usr/lib/osbuild/stages/org.osbuild.groups
/usr/lib/osbuild/stages/org.osbuild.grub2
/usr/lib/osbuild/stages/org.osbuild.hostname
/usr/lib/osbuild/stages/org.osbuild.kernel-cmdline
/usr/lib/osbuild/stages/org.osbuild.keymap
/usr/lib/osbuild/stages/org.osbuild.locale
/usr/lib/osbuild/stages/org.osbuild.noop
/usr/lib/osbuild/stages/org.osbuild.rpm
/usr/lib/osbuild/stages/org.osbuild.script
/usr/lib/osbuild/stages/org.osbuild.selinux
/usr/lib/osbuild/stages/org.osbuild.systemd
/usr/lib/osbuild/stages/org.osbuild.test
/usr/lib/osbuild/stages/org.osbuild.timezone
/usr/lib/osbuild/stages/org.osbuild.users
/usr/lib/osbuild/stages/org.osbuild.zipl
/usr/share/licenses/osbuild
/usr/share/licenses/osbuild/LICENSE
/usr/share/man/man1/osbuild.1.gz
/usr/share/man/man5/osbuild-manifest.5.gz
/usr/share/osbuild/schemas
/usr/share/osbuild/schemas/osbuild1.json
```