### PR TITLE
objectstore: drop bind-mounts

### DIFF
--- a/test/test_objectstore.py
+++ b/test/test_objectstore.py
@@ -274,12 +274,6 @@ class TestObjectStore(unittest.TestCase):
             with host.write() as _:
                 pass
 
-        # check we actually cannot write to the path
-        with host.read() as path:
-            p = Path(f"{path}/osbuild-test-file")
-            with self.assertRaises(OSError):
-                p.touch()
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We currently create bind-mounts for all objectstore entries before using
them. However, we only use them to pass them into systemd-nspawn, which
then mounts them again.

This commit drops these mounts.