### PR TITLE
pipeline: use stage output if no assembler is set

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -367,9 +367,15 @@ class Pipeline:
                 results.update(r)  # This will also update 'success'
 
             if results["success"] and output_directory is not None:
-                output_source = object_store.resolve_ref(results["output_id"])
-                if output_source is not None:
-                    subprocess.run(["cp", "--reflink=auto", "-a", f"{output_source}/.", output_directory], check=True)
+                copy_from = None
+
+                if "output_id" in results:
+                    copy_from = object_store.resolve_ref(results["output_id"])
+                elif "tree_id" in results:
+                    copy_from = object_store.resolve_ref(results["tree_id"])
+
+                if copy_from is not None:
+                    subprocess.run(["cp", "--reflink=auto", "-a", f"{copy_from}/.", output_directory], check=True)
 
         return results
 


### PR DESCRIPTION
If no assembler is set in a pipeline, use the output from the last stage as output from osbuild.

This change allows us to verify stages from our tests without poking into the cache. Furthermore, it moves stages and assemblers closer together in their behavior, maybe even allowing us to expand our assembler support into multi-stage assemblers in the future.