### PR TITLE
docs: add osbuild-api man-page

### DIFF
--- a/docs/osbuild-api.1.rst
+++ b/docs/osbuild-api.1.rst
@@ -1,0 +1,176 @@
+===========
+osbuild-api
+===========
+
+----------------------------------------------
+Build-Pipelines for Operating System Artifacts
+----------------------------------------------
+
+:Manual section: 1
+:Manual group: User Commands
+
+SYNOPSIS
+========
+
+| ``osbuild-api`` [ OPTIONS ]
+
+DESCRIPTION
+===========
+
+**osbuild-api** is a machine interface to ``osbuild``\(1). It is a build engine
+to produce operation system artifacts, including file-system trees, images, and
+packages.
+
+OPTIONS
+=======
+
+**osbuild-api** reads the pipeline description from standard-input and returns
+a result on standard-output. Its behavior can be customized via command line
+options. These command-line options control how **osbuild-api** integrates into
+the system. They are meant for system-administration. Any option that controls
+properties of individual pipeline runs must be passed via standard-input.
+
+--cache-directory=DIRECTORY
+        Directory where intermediary artifacts are cached. If not specified,
+        intermediary artifacts are discarded immediately. This directory can be
+        safely shared between multiple parallel runs.
+
+        This entry is optional. If not given, no entries are cached.
+
+--library-directory=DIRECTORY
+        Directory where to take **osbuild** modules from.
+
+        By default, they are taken from `/usr/lib/osbuild`.
+
+--scratch-directory=DIRECTORY
+        Directory used to assemble artifacts. This is exclusively used for
+        temporary data and will be cleared after each run. You can safely share
+        this directory between multiple parallel runs.
+
+        This option is mandatory, unless ``--cache-directory`` is given, in
+        which case temporary artifacts are stored in the cache.
+
+EXITCODES
+=========
+
+The exit-codes of **osbuild-api** signal the following conditions:
+
+Exitcode: **0**
+        Operation finished without any setup errors. This means all command-line
+        arguments were parsed correctly, and the environment behaved as
+        expected. This does **not** mean that the given pipeline description was
+        valid, or that it was produced successfully. This information is
+        provided on standard-output (see section **OUTPUT**). A non-zero
+        exitcode always signals an abnormal program exit triggered by invalid
+        setups, which needs administrator intervention.
+
+Exitcode: **100**
+        The **osbuild-api** program was interrupted by the user. This is usually
+        triggered by *CTRL+c* on a terminal.
+
+Exitcodes: **101**, **102**, **103**
+        The **standard-input**, **standard-output**, or **standard-error** (in
+        that order) streams were not provided upon execution of **osbuild-api**.
+        The caller must provide valid file-descriptors for all 3 standard
+        streams when executing **osbuild-api**.
+
+Exitcode: **104**
+        There were invalid arguments passed on the command-line, or mandatory
+        arguments were missing.
+
+INPUT
+=====
+
+The input to **osbuild-api** is a description of the operation to perform. It
+must be passed on standard-input. It is a *JSON* formatted document with the
+following structure:
+
+|
+| {
+|   "**checkpoints**": [
+|     "<id-0>",
+|     "<id-1>",
+|     ...
+|     "<id-n>"
+|   ],
+|
+|   "**manifest**": {
+|     ...
+|   },
+|
+|   "**output-directory**": "path/to/output/directory"
+| }
+|
+
+No other entries than the specified entries are allowed. If an entry is not
+specified, its default value is assumed.
+
+**checkpoints**
+        The **checkpoints** array specifies a list of module IDs that should be
+        stored in the shared cache. Whenever the pipeline engine produces a
+        stage with the specified ID, it will store it in the cache. All other
+        intermediary artifacts are immediately discarded.
+
+        The default value is an empty array.
+
+**manifest**
+        The manifest describes a pipeline as well as as the required resources
+        to build it. Its format is described in ``osbuild-manifest``\(5).
+
+        The default value is an empty dictionary.
+
+**output-directory**
+        The output directory specifies a path to an existing directory where to
+        place the produced output artifact.
+
+        This entry is mandatory.
+
+OUTPUT
+======
+
+After completion, **osbuild-api** writes its result description to
+standard-output. This description is a *JSON* formatted document with the
+following structure:
+
+|
+| {
+|   "**success**": true,
+|   "**debug**": {
+|     "**stdout**": [ ... ]
+|     "**stderr**": [ ... ]
+|   }
+| }
+|
+
+No other entries than the specified entries are produced.
+
+**success**
+        This is a boolean that represents whether the pipeline execution
+        succeeded.
+
+**debug**
+        This is a dictionary of debug information. It may or may not be present.
+        Its content is solely meant for debugging by a human.
+
+**debug.stderr**:
+        The concatenated standard-error of all stages of the pipeline execution.
+        It is split into lines and provided as an array.
+
+**debug.stdout**:
+        Similar to **debug.stderr** but for content on standard-output. Note
+        that this is intentionally *not* interleaved with standard-error, since
+        applications will buffer differently for both streams.
+
+Artifacts are not marshalled as part of the output. Instead, they are stored in
+the output-directory specified by the caller in the input description. It is the
+caller's responsibility to cleanup the specified output-directory. Note that
+under normal operation no data is written to the output-directory on error.
+However, during abnormal program exit there might be leftovers. This condition
+can be detected by a non-zero exit code (see section **EXITCODES**), or
+alternatively if standard-output is closed without a valid *JSON* output
+description written to it.
+
+SEE ALSO
+========
+
+``osbuild``\(1), ``osbuild-manifest``\(5), ``osbuild-composer``\(1)

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -108,6 +108,7 @@ exit 0
 %license LICENSE
 %{_bindir}/osbuild
 %{_mandir}/man1/%{name}.1*
+%{_mandir}/man1/%{name}-api.1*
 %{_mandir}/man5/%{name}-manifest.5*
 %{_datadir}/osbuild/schemas
 %{pkgdir}


### PR DESCRIPTION
This only adds the man-page for `osbuild-api`. It is meant as starting point for us to discuss whether we want to go this route or not. Comments welcome!

*Text from commit-message:*

This adds osbuild-api(1). It describes the exposed interfaces as well
as the behavior of the `osbuild-api` program.

The `osbuild-api` program differs from `osbuild` in several ways:

  * It is meant solely for machine-interaction. This means, all its
    input and output is well-defined, structured, and does not contain
    any enhancements for readability.

  * Its behavior on errors is defined and documented. This includes
    exit-codes on invalid setup, as well as predictable behavior when
    pipeline-execution fails.

  * It supports integration with socket-activation or `inetd`-style
    daemons. This means any runtime properties must be controllable via
    standard-input, and any accompanying output was be produced on
    standard-output.
    At the same time, any properties that are part of the system
    administration must be passed via command-line arguments (or
    environment, for what it is worth). Similarly, non-zero exit-codes
    are only valid as reaction to invalid setup. A failed pipeline
    execution (or other properties of the runtime engine) must not
    cause non-zero exit-codes, as these would otherwise cause needless
    syslog-entries and service-failure. Instead, all these must runtime
    errors must be signalled as result values back to the sender.

  * No insight knowledge about the behavior is required to interact with
    it. In particular, no insight knowledge into the cache structure is
    required (nor allowed). Instead, all file-system paths are either
    specified by the sender/command-line, or they are returned by
    `osbuild-api` in its output. Nothing is left implicit.

  * No abbreviations, no convenience features, no aliasing, no
    de-duplication, ... Anything that is purely meant to ease human
    interaction is left out. This reduces ambiguity, improves future
    compatibility, and avoids unintentional breakage of the API.

    This does not exclude convenience features from being introduced in
    the future. However, these must be justified other than enhancing
    human interaction. This tool is not meant for direct invocation on
    the command-line, and thus does not try to appeal to it.

With this in place, we can turn `osbuild` into a more CLI focussed tool.
I imagine sub-commands that allow us to control osbuild better from the
command line, including:

  * `osbuild cache [...]`
    A way to query, populate, and purge the cache. We might even add
    commands to configure parameters of the cache, like maximum size.

  * `osbuild run [...]`
    A more human-friendly way to run the pipeline engine. It could print
    information in a human-readable way on standard-output and provide
    better convenience features.

  * `osbuild inspect [...]`
    A similar tool like the current `--inspect` command-line to print
    and debug manifests.