### PR TITLE
Test with internal Jenkins in parallel

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -1,0 +1,29 @@
+pipeline {
+    agent none
+
+    options {
+        timestamps()
+        ansiColor('xterm')
+    }
+
+    stages {
+        stage("Functional Testing") {
+            parallel {
+                stage('Fedora 31 image') {
+                    agent { label "fedora31" }
+                    environment { TEST_TYPE = "image" }
+                    steps {
+                        sh "schutzbot/run_tests.sh"
+                    }
+                }
+                stage('Fedora 32 image') {
+                    agent { label "fedora32" }
+                    environment { TEST_TYPE = "image" }
+                    steps {
+                        sh "schutzbot/run_tests.sh"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schutzbot/run_tests.sh
+++ b/schutzbot/run_tests.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Read variables about the OS.
+source /etc/os-release
+
+# Create temporary directories for Ansible.
+sudo mkdir -vp /opt/ansible_{local,remote}
+sudo chmod -R 777 /opt/ansible_{local,remote}
+
+# Remove Fedora modular repositories to speed up dnf-json.
+sudo rm -rfv /etc/yum.repos.d/fedora*modular*
+
+# Ensure /tmp is mounted on tmpfs.
+sudo systemctl enable tmp.mount || \
+  sudo systemctl unmask tmp.mount && sudo systemctl start tmp.mount
+
+# Restart systemd to work around some Fedora issues in cloud images.
+sudo systemctl restart systemd-journald
+
+# Get the current journald cursor.
+export JOURNALD_CURSOR=$(sudo journalctl --quiet -n 1 --show-cursor | tail -n 1 | grep -oP 's\=.*$')
+
+# Add a function to preserve the system journal if something goes wrong.
+preserve_journal() {
+  sudo journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log
+  exit 1
+}
+trap "preserve_journal" ERR
+
+# Ensure Ansible is installed.
+if ! rpm -q ansible; then
+  sudo dnf -y install ansible
+fi
+
+# Write a simple hosts file for Ansible.
+echo -e "[test_instances]\nlocalhost ansible_connection=local" > hosts.ini
+
+# Set Ansible's config file location.
+export ANSIBLE_CONFIG=ansible-osbuild/ansible.cfg
+
+# Clone the latest version of ansible-osbuild.
+
+# Get the current SHA of osbuild.
+OSBUILD_VERSION=$(git rev-parse HEAD)
+
+# Deploy the software.
+git clone https://github.com/osbuild/ansible-osbuild.git ansible-osbuild
+ansible-playbook \
+  -i hosts.ini \
+  -e osbuild_repo=${WORKSPACE} \
+  -e osbuild_version=$(git rev-parse HEAD) \
+  -e cleanup_composer_directories=yes \
+  ansible-osbuild/playbook.yml
+
+# Run the tests only on Fedora 31 for now.
+if [[ $NAME == "Fedora" ]] && [[ $VERSION_ID == "31" ]]; then
+  ansible-playbook \
+    -e workspace=${WORKSPACE} \
+    -e journald_cursor="${JOURNALD_CURSOR}" \
+    -e test_type=${TEST_TYPE:-image} \
+    -i hosts.ini \
+    ansible-osbuild/repos/osbuild-composer/jenkins/test.yml
+fi
+
+# Collect the systemd journal anyway if we made it all the way to the end.
+sudo journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log


### PR DESCRIPTION
Attempt osbuild testing on the internal Jenkins deployment with
nodes that are destroyed after each use. The internal Jenkins looks for
a Jenkinsfile inside the `schutzbot` directory.

Let's not remove the `jenkins` directory (used by jenkins.osbuild.org)
yet until we know the internal Jenkins is stable and performs well.

Signed-off-by: Major Hayden <major@redhat.com>