### PR TITLE
buildroot: drop kwargs from buildroot.run()

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -73,16 +73,13 @@ class BuildRoot(contextlib.AbstractContextManager):
             shutil.rmtree(self.var)
             self.var = None
 
-    def run(self, argv, binds=None, readonly_binds=None, **kwargs):
+    def run(self, argv, binds=None, readonly_binds=None):
         """Runs a command in the buildroot.
 
         Its arguments mean the same as those for subprocess.run().
         """
 
         nspawn_ro_binds = []
-
-        # pylint suggests to epxlicitly pass `check` to subprocess.run()
-        check = kwargs.pop("check", False)
 
         # make osbuild API-calls accessible to the container
         nspawn_ro_binds.append(f"{self.api}:/run/osbuild/api")
@@ -121,7 +118,7 @@ class BuildRoot(contextlib.AbstractContextManager):
             *[f"--bind={b}" for b in (binds or [])],
             *[f"--bind-ro={b}" for b in (readonly_binds or [])],
             f"/run/osbuild/lib/runners/{self.runner}"
-            ] + argv, check=check, **kwargs)
+            ] + argv, check=False, stdin=subprocess.DEVNULL)
 
     def __del__(self):
         self.unmount()

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -101,7 +101,6 @@ class Stage:
                     [f"/run/osbuild/lib/stages/{self.name}"],
                     binds=[f"{tree}:/run/osbuild/tree"],
                     readonly_binds=ro_binds,
-                    stdin=subprocess.DEVNULL,
                 )
                 return BuildResult(self, r.returncode, api.output)
 
@@ -154,7 +153,6 @@ class Assembler:
                     [f"/run/osbuild/lib/assemblers/{self.name}"],
                     binds=binds,
                     readonly_binds=ro_binds,
-                    stdin=subprocess.DEVNULL,
                 )
                 return BuildResult(self, r.returncode, api.output)
 


### PR DESCRIPTION
Drop the `kwargs` forwarding from buildroot.run() to subprocess.run().
We do not use it other than for `stdin=subprocess.DEVNULL`. Set that
option directly instead.

Doing the kwargs forwarding mixes the argument namespaces and is very
hard to read. It is not clear from the call-site which argument goes to
buildroot.run() and which to subprocess.run().

Lastly, it requires us to manually fetch `check` just to make pylint
happy. Lets just drop this dance and make the API explicit.