### PR TITLE
buildroot: use `bwrap` to contain stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ of the pipeline description, and more.
 
 The requirements for this project are:
 
+ * `bubblewrap >= 0.4.0`
  * `python >= 3.7`
- * `systemd-nspawn >= 244`
 
 Additionally, the built-in stages require:
 

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -23,6 +23,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-docutils
 
 Requires:       bash
+Requires:       bubblewrap
 Requires:       coreutils
 Requires:       curl
 Requires:       dnf
@@ -31,7 +32,6 @@ Requires:       glibc
 Requires:       policycoreutils
 Requires:       qemu-img
 Requires:       systemd
-Requires:       systemd-container
 Requires:       tar
 Requires:       util-linux
 Requires:       python3-%{pypi_name} = %{version}-%{release}


### PR DESCRIPTION
This needs a rebase and minor tweaks to the CI. It works on my machine to build all the fedora images, so if we want to go that route, we can easily pick it up.


*Commit Message:*


This swaps the `systemd-nspawn` implementation for `bubblewrap` to
contain sub-processes. It also adjusts the `BuildRoot` implementation
to reduce the number of mounts required to keep locally.

This has the following advantages:

  * We know exactly how the build-root looks like. Only the bits and
    pieces we select will end up in the build-root. We can let RPM
    authors know what environment their post-install scripts need to
    run in, and we can reliably test this.

  * We no longer need any D-Bus access or access to other PID1
    facilities. Bubblewrap allows us to execute from any environment,
    including containers and sandboxes.

  * Bubblewrap setup is significantly faster than nspawn. This is a
    minor point though, since nspawn is still fast enough compared to
    the operations we perform in the container.

  * Bubblewrap does not require root.

At the same time, we have a bunch of downsides which might increase the
workload in the future:

  * We now control the build-root, which also means we have to make sure
    it works on all our supported architectures, all quirks are
    included, and all required resources are accessible from within the
    build-root.
    The good thing here is that we have lots of previous-art we can
    follow, and all the other ones just play whack-a-mole, so we can
    join that fun.

The `bubblewrap` project is used by podman and flatpak, it is packaged
for all major distributions, and looks like a stable dependency.