### PR TITLE
Use JSON schema draft 4

### DIFF
--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -232,7 +232,7 @@ class Schema:
             return res
 
         try:
-            Validator = jsonschema.Draft7Validator
+            Validator = jsonschema.Draft4Validator
             Validator.check_schema(self.data)
             self._validator = Validator(self.data)
         except jsonschema.exceptions.SchemaError as err:

--- a/schemas/osbuild1.json
+++ b/schemas/osbuild1.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "$id": "https://osbuild.org/schemas/osbuild1.json",
 
   "title": "OSBuild Manifest",
@@ -10,7 +10,6 @@
     "pipeline": { "$ref": "#/definitions/pipeline" },
     "sources": { "$ref": "#/definitions/sources" }
   },
-  "required": [],
 
   "definitions": {
     "assembler": {
@@ -49,8 +48,7 @@
         "assembler": { "$ref": "#/definitions/assembler" },
         "build": { "$ref": "#/definitions/build" },
         "stages": { "$ref": "#/definitions/stages" }
-      },
-      "required": []
+      }
     },
 
     "source": {


### PR DESCRIPTION
@jkozol discovered that RHEL 8.2 only has jsonschema 2.6.0. Except for `"required": []` in `osbuild1.json` we don't seem to require anything > `draft 4`, so downgrade to that.