### PR TITLE
ci: improve reliability and consolidate environment

### DIFF
--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -22,6 +22,17 @@ jobs:
       with:
         run: make test-runtime
 
+  boot_tests:
+    name: "Boot Tests"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Clone Repository"
+      uses: actions/checkout@v2
+    - name: "Run Boot Tests"
+      uses: osbuild/containers/ghci/actions/ghci-osbuild@ghci/v1
+      with:
+        run: python3 -m unittest -v test.test_boot
+
   noop_pipeline_tests:
     name: "Noop-Pipeline Tests"
     runs-on: ubuntu-latest

--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -17,24 +17,10 @@ jobs:
     steps:
     - name: "Clone Repository"
       uses: actions/checkout@v2
-    - name: "Install Dependencies"
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install \
-          nbd-client \
-          qemu-utils \
-          rpm \
-          systemd-container \
-          tar \
-          yum
-    - name: "Set up Python"
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install Python Packages
-      run: pip install jsonschema
     - name: "Run Pipeline Tests"
-      run: sudo env "PATH=$PATH" make test-runtime
+      uses: osbuild/containers/ghci/actions/ghci-osbuild@ghci/v1
+      with:
+        run: make test-runtime
 
   noop_pipeline_tests:
     name: "Noop-Pipeline Tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ env:
 jobs:
   include:
     - name: f30-boot
-      before_install: sudo apt-get install -y systemd-container yum qemu-kvm
-      script: sudo env "PATH=$PATH" python3 -m unittest -v test.test_boot
+      script: echo Nothing to do.

--- a/test/test_assemblers.py
+++ b/test/test_assemblers.py
@@ -14,7 +14,7 @@ class TestAssemblers(osbuildtest.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        subprocess.run(["modprobe", "nbd"], check=True)
+        subprocess.run(["modprobe", "nbd"], check=False)
 
     def run_assembler(self, name, options):
         with open("test/pipelines/f30-base.json") as f:

--- a/test/testing-rpms/README.md
+++ b/test/testing-rpms/README.md
@@ -1,3 +1,0 @@
-# Warning
-
-Don't use this folder. RPM files stored here are automatically managed from the Makefile.


### PR DESCRIPTION
This PR contains a set of 4 improvements for the current Github-Actions based CI:

1) The (to-my-knowledge-)unused `./test/testing-rpms` directory is dropped.

2) The `modprobe nbd` invocation is now made non-fatal to allow running on systems with `nbd` pre-loaded, or with `/lib/modules/` not mapped.

3) Use the images provided by `osbuild/containers` for our first set of CI runs. If this works out, we can switch over the other test-cases as well.

4) Move the last travis-based test over to the Github-Actions based CI.