### PR TITLE
CI: Use Jenkins' merged repo for testing

### DIFF
--- a/schutzbot/run_tests.sh
+++ b/schutzbot/run_tests.sh
@@ -43,9 +43,14 @@ export ANSIBLE_CONFIG=ansible-osbuild/ansible.cfg
 OSBUILD_VERSION=$(git rev-parse HEAD)
 
 # Deploy osbuild-composer and osbuild using RPMs built in a mock chroot.
+# NOTE(mhayden): Jenkins clones the repository and then merges the code from
+# the pull request into the repo. This creates a new SHA that exists only in
+# Jenkins. We use ${WORKSPACE} below to tell ansible-osbuild to use the clone
+# that Jenkins made for testing osbuild.
 git clone https://github.com/osbuild/ansible-osbuild.git ansible-osbuild
 ansible-playbook \
   -i hosts.ini \
+  -e osbuild_repo_url=${WORKSPACE} \
   -e osbuild_version=$(git rev-parse HEAD) \
   -e install_source=mock \
   ansible-osbuild/playbook.yml


### PR DESCRIPTION
When Jenkins clones a repository for testing, it does the base clone
first and then merges the code from the PR afterwards. This ensures that
the code merges properly and is tested properly, but it also makes a SHA
that only exists inside Jenkins. 😢

Tell ansible-osbuild to use the repository that Jenkins made so that the
SHA is valid.

Signed-off-by: Major Hayden <major@redhat.com>