### PR TITLE
assemblers/ostree.commit: support archiving

### DIFF
--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -15,9 +15,14 @@ Takes a file system tree that is already conforming to the ostree
 system layout[1] and commits it to an archive repository.
 
 The repository is located at the `/repo` directory and additional
-metadata is stored in `/commit.id` and `/compose.json` which contain
-the commit id and the compose information respectively.
+metadata is stored in `/compose.json` which contains the commit
+compose information.
 
+Alternatively, if the `tar` option is supplied, the repository and
+the `compose.json` will be archived in a file named via the
+`tar.filename` option. This supports auto-compression via the file
+extension (see the tar man page). Requires the `tar` command to be
+in the build root.
 
 [1] https://ostree.readthedocs.io/en/stable/manual/adapting-existing/
 """
@@ -38,6 +43,18 @@ STAGE_OPTS = """
   "parent": {
     "description": "commit id of the parent commit",
     "type": "string"
+  },
+  "tar": {
+    "description": "Emit a tarball as the result",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["filename"],
+    "properties": {
+      "filename": {
+        "description": "File-name of the tarball to create. Compression is determined by the extension.",
+        "type": "string"
+      }
+    }
   }
 }
 """
@@ -87,6 +104,7 @@ def main(tree, output_dir, options):
     ref = options["ref"]
     tmp_is_dir = options.get("tmp-is-dir", True)
     parent = options.get("parent", None)
+    tar = options.get("tar", None)
 
     with tempfile.TemporaryDirectory(dir=output_dir) as root:
         print("Initializing root filesystem", file=sys.stderr)
@@ -127,6 +145,21 @@ def main(tree, output_dir, options):
             subprocess.run(argv,
                            stdout=sys.stderr,
                            check=True)
+
+    if tar:
+        filename = tar["filename"]
+        command = [
+            "tar",
+            "--remove-files",
+            "--auto-compress",
+            "-cf", os.path.join(output_dir, filename),
+            "-C", output_dir,
+            "repo", "compose.json"
+        ]
+        subprocess.run(command,
+                       stdout=sys.stderr,
+                       check=True)
+
 
 
 if __name__ == '__main__':

--- a/samples/f31-ostree-commit.json
+++ b/samples/f31-ostree-commit.json
@@ -245,6 +245,7 @@
         "sha256:6dc68869e3f76b3893e67334e44e2df076c6a695c34801bda17ee74bdbcd56c1": "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/s/systemd-pam-243-4.gitef67743.fc31.x86_64.rpm",
         "sha256:2cb4bf18b759143cf2aeb6041e8b2edcaa1444d5f1eff8a6681ba8ca9da2a91c": "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/s/systemd-rpm-macros-243-4.gitef67743.fc31.noarch.rpm",
         "sha256:5d83d0aa80fb9a9ad9cb3f4f34878a8934e25530989c21e377c61107dd22475c": "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/s/systemd-udev-243-4.gitef67743.fc31.x86_64.rpm",
+        "sha256:9975496f29601a1c2cdb89e63aac698fdd8283ba3a52a9d91ead9473a0e064c8": "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/t/tar-1.32-2.fc31.x86_64.rpm",
         "sha256:9c118bf51ab45f3da02c226872dbdd2dca0c1ca3f6a23532255ee0f495adf15a": "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/t/tree-1.8.0-3.fc31.x86_64.rpm",
         "sha256:b737fde58005843aa4b0fd0ae0da7c7da7d8d7733c161db717ee684ddacffd18": "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/t/trousers-0.3.13-13.fc31.x86_64.rpm",
         "sha256:a81b0e79a6ec19343c97c50f02abda957288adadf1f59b09104126dc8e9246df": "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/t/trousers-lib-0.3.13-13.fc31.x86_64.rpm",
@@ -713,6 +714,7 @@
                 "sha256:6dc68869e3f76b3893e67334e44e2df076c6a695c34801bda17ee74bdbcd56c1",
                 "sha256:2cb4bf18b759143cf2aeb6041e8b2edcaa1444d5f1eff8a6681ba8ca9da2a91c",
                 "sha256:5d83d0aa80fb9a9ad9cb3f4f34878a8934e25530989c21e377c61107dd22475c",
+                "sha256:9975496f29601a1c2cdb89e63aac698fdd8283ba3a52a9d91ead9473a0e064c8",
                 "sha256:9c118bf51ab45f3da02c226872dbdd2dca0c1ca3f6a23532255ee0f495adf15a",
                 "sha256:b737fde58005843aa4b0fd0ae0da7c7da7d8d7733c161db717ee684ddacffd18",
                 "sha256:a81b0e79a6ec19343c97c50f02abda957288adadf1f59b09104126dc8e9246df",
@@ -1251,7 +1253,10 @@
     "assembler": {
       "name": "org.osbuild.ostree.commit",
       "options": {
-        "ref": "fedora/x86_64/osbuild-demo"
+        "ref": "fedora/x86_64/osbuild-demo",
+        "tar": {
+          "filename": "commit.tar"
+        }
       }
     }
   }


### PR DESCRIPTION
Introduce a new `tar` option, which when given together with the required `tar.filename` option, will result in the output of the assembler being a tarball that contains the repo and the compose information (`compose.json`).
Requires the `tar` command to be present in the build root. Modify the sample to use that option and include the tar for the build pipeline.