### PR TITLE
test: convert to new pipeline executor

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -364,7 +364,7 @@ class Pipeline:
 
                 results.update(r)  # This will also update 'success'
 
-            if results["success"] and output_directory is not None:
+            if results["success"] and output_directory and "output_id" in results:
                 output_source = object_store.resolve_ref(results["output_id"])
                 if output_source is not None:
                     subprocess.run(["cp", "--reflink=auto", "-a", f"{output_source}/.", output_directory], check=True)

--- a/test/test.py
+++ b/test/test.py
@@ -136,6 +136,29 @@ class TestBase():
 
         return r.returncode == 0 and "compose" in r.stdout
 
+    @staticmethod
+    def have_tree_diff() -> bool:
+        """Check for tree-diff Tool
+
+        Check whether the current test-run has access to the `tree-diff` tool.
+        We currently use the one from a checkout, so it is available whenever
+        a checkout is available.
+        """
+
+        return TestBase.have_test_checkout()
+
+    @staticmethod
+    def tree_diff(path1, path2):
+        """Compare File-System Trees
+
+        Run the `tree-diff` tool from the osbuild checkout. It produces a JSON
+        output that describes the difference between 2 file-system trees.
+        """
+
+        checkout = TestBase.locate_test_checkout()
+        output = subprocess.check_output([os.path.join(checkout, "tree-diff"), path1, path2])
+        return json.loads(output)
+
 
 class OSBuild(contextlib.AbstractContextManager):
     """OSBuild Executor

--- a/test/test_boot.py
+++ b/test/test_boot.py
@@ -2,35 +2,43 @@
 import os
 import subprocess
 import tempfile
+import unittest
 
-from . import osbuildtest
+from . import test
 
 
-class TestBoot(osbuildtest.TestCase):
+class TestBoot(unittest.TestCase):
+    def setUp(self):
+        self.osbuild = test.OSBuild(self)
+
     def test_boot(self):
-        _, output_id = self.run_osbuild("test/pipelines/f30-boot.json")
+        #
+        # Build an image and test-boot it.
+        #
 
-        with tempfile.TemporaryDirectory() as d:
-            output_file = os.path.join(d, "output")
+        with self.osbuild as osb:
+            osb.compile_file("test/pipelines/f30-boot.json")
+            with osb.map_output("f30-boot.qcow2") as qcow2, \
+                 tempfile.TemporaryDirectory() as d:
 
-            subprocess.run(["qemu-system-x86_64",
-                            "-snapshot",
-                            "-m", "1024",
-                            "-M", "accel=kvm:hvf:tcg",
+                output_file = os.path.join(d, "output")
+                subprocess.run(["qemu-system-x86_64",
+                                "-snapshot",
+                                "-m", "1024",
+                                "-M", "accel=kvm:hvf:tcg",
 
-                            # be silent
-                            "-nographic",
-                            "-monitor", "none",
-                            "-serial", "none",
+                                # be silent
+                                "-nographic",
+                                "-monitor", "none",
+                                "-serial", "none",
 
-                            # create /dev/vport0p1
-                            "-chardev", f"file,path={output_file},id=stdio",
-                            "-device", "virtio-serial",
-                            "-device", "virtserialport,chardev=stdio",
+                                # create /dev/vport0p1
+                                "-chardev", f"file,path={output_file},id=stdio",
+                                "-device", "virtio-serial",
+                                "-device", "virtserialport,chardev=stdio",
 
-                            f"{self.get_path_to_store(output_id)}/f30-boot.qcow2"],
-                           encoding="utf-8",
-                           check=True)
-
-            with open(output_file, "r") as f:
-                self.assertEqual(f.read().strip(), "running")
+                                qcow2],
+                               encoding="utf-8",
+                               check=True)
+                with open(output_file, "r") as f:
+                    self.assertEqual(f.read().strip(), "running")

--- a/test/test_stages.py
+++ b/test/test_stages.py
@@ -1,48 +1,131 @@
+import difflib
 import json
 import os
+import pprint
 import tempfile
+import unittest
 
-from test import osbuildtest
+from . import test
 
 
-class TestDescriptions(osbuildtest.TestCase):
+class TestDescriptions(unittest.TestCase, test.TestBase):
+
+    def assertTreeDiffsEqual(self, tree_diff1, tree_diff2):
+        """
+        Asserts two tree diffs for equality.
+
+        Before assertion, the two trees are sorted, therefore order of files
+        doesn't matter.
+
+        There's a special rule for asserting differences where we don't
+        know the exact before/after value. This is useful for example if
+        the content of file is dependant on current datetime. You can use this
+        feature by putting null value in difference you don't care about.
+
+        Example:
+            "/etc/shadow": {content: ["sha256:xxx", null]}
+
+            In this case the after content of /etc/shadow doesn't matter.
+            The only thing that matters is the before content and that
+            the content modification happened.
+        """
+
+        def _sorted_tree(tree):
+            sorted_tree = json.loads(json.dumps(tree, sort_keys=True))
+            sorted_tree["added_files"] = sorted(sorted_tree["added_files"])
+            sorted_tree["deleted_files"] = sorted(sorted_tree["deleted_files"])
+
+            return sorted_tree
+
+        tree_diff1 = _sorted_tree(tree_diff1)
+        tree_diff2 = _sorted_tree(tree_diff2)
+
+        def raise_assertion(msg):
+            diff = '\n'.join(
+                difflib.ndiff(
+                    pprint.pformat(tree_diff1).splitlines(),
+                    pprint.pformat(tree_diff2).splitlines(),
+                )
+            )
+            raise AssertionError(f"{msg}\n\n{diff}")
+
+        self.assertEqual(tree_diff1['added_files'], tree_diff2['added_files'])
+        self.assertEqual(tree_diff1['deleted_files'], tree_diff2['deleted_files'])
+
+        if len(tree_diff1['differences']) != len(tree_diff2['differences']):
+            raise_assertion('length of differences different')
+
+        for (file1, differences1), (file2, differences2) in \
+                zip(tree_diff1['differences'].items(), tree_diff2['differences'].items()):
+
+            if file1 != file2:
+                raise_assertion(f"filename different: {file1}, {file2}")
+
+            if len(differences1) != len(differences2):
+                raise_assertion("length of file differences different")
+
+            for (difference1_kind, difference1_values), (difference2_kind, difference2_values) in \
+                    zip(differences1.items(), differences2.items()):
+                if difference1_kind != difference2_kind:
+                    raise_assertion(f"different difference kinds: {difference1_kind}, {difference2_kind}")
+
+                if difference1_values[0] is not None \
+                        and difference2_values[0] is not None \
+                        and difference1_values[0] != difference2_values[0]:
+                    raise_assertion(f"before values are different: {difference1_values[0]}, {difference2_values[0]}")
+
+                if difference1_values[1] is not None \
+                        and difference2_values[1] is not None \
+                        and difference1_values[1] != difference2_values[1]:
+                    raise_assertion(f"after values are different: {difference1_values[1]}, {difference2_values[1]}")
+
+    def setUp(self):
+        self.osbuild = test.OSBuild(self)
 
     def run_stage_test(self, test_dir: str):
-        pipeline1 = f"{test_dir}/a.json"
-        pipeline2 = f"{test_dir}/b.json"
-        tree_id1, _ = self.run_osbuild(pipeline1)
-        tree_id2, _ = self.run_osbuild(pipeline2)
+        with self.osbuild as osb:
 
-        with tempfile.TemporaryDirectory() as empty:
-            if tree_id1:
-                tree1 = self.get_path_to_store(tree_id1)
-            else:
-                tree1 = empty
+            def run(path):
+                checkpoints = []
+                context = None
 
-            if tree_id2:
-                tree2 = self.get_path_to_store(tree_id2)
-            else:
-                tree2 = empty
+                with open(path, "r") as f:
+                    data = f.read()
 
-            actual_diff = self.run_tree_diff(tree1, tree2)
+                tree = osb.treeid_from_manifest(data)
+                if tree:
+                    checkpoints += [tree]
+                    context = osb.map_object(tree)
 
-        with open(f"{test_dir}/diff.json") as f:
-            expected_diff = json.load(f)
+                osb.compile(data, checkpoints=checkpoints)
+                return context
 
-        self.assertTreeDiffsEqual(expected_diff, actual_diff)
+            ctx_a = run(f"{test_dir}/a.json")
+            ctx_b = run(f"{test_dir}/b.json")
+            ctx_a = ctx_a or tempfile.TemporaryDirectory()
+            ctx_b = ctx_b or tempfile.TemporaryDirectory()
+
+            with ctx_a as tree1, ctx_b as tree2:
+                actual_diff = self.tree_diff(tree1, tree2)
+
+            with open(f"{test_dir}/diff.json") as f:
+                expected_diff = json.load(f)
+
+            self.assertTreeDiffsEqual(expected_diff, actual_diff)
 
 
-def generate_test_case(test):
+def generate_test_case(path):
+    @unittest.skipUnless(test.TestBase.have_tree_diff(), "tree-diff missing")
     def test_case(self):
-        self.run_stage_test(test)
+        self.run_stage_test(path)
 
     return test_case
 
 
 def init_tests():
     test_dir = 'test/stages_tests'
-    for test in os.listdir(test_dir):
-        setattr(TestDescriptions, f"test_{test}", generate_test_case(f"{test_dir}/{test}"))
+    for name in os.listdir(test_dir):
+        setattr(TestDescriptions, f"test_{name}", generate_test_case(f"{test_dir}/{name}"))
 
 
 init_tests()


### PR DESCRIPTION
This series adds a new pipeline executor which no longer relies on "output_id" and "tree_id", and then converts the tests over.