### PR TITLE
sources: pass the library dir to the sources

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -86,13 +86,11 @@ class Stage:
                 "options": self.options,
             }
 
-            sources_dir = f"{libdir}/sources" if libdir else "/usr/lib/osbuild/sources"
-
             ro_binds = [f"{sources_output}:/run/osbuild/sources"]
 
             with API(f"{build_root.api}/osbuild", args, interactive) as api, \
                 sources.SourcesServer(f"{build_root.api}/sources",
-                                      sources_dir,
+                                      libdir or "/usr/lib/osbuild",
                                       self.sources,
                                       f"{cache}/sources",
                                       sources_output,

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -7,9 +7,9 @@ from .util import jsoncomm
 
 class SourcesServer:
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, socket_address, sources_libdir, options, cache, output, secrets=None):
+    def __init__(self, socket_address, libdir, options, cache, output, secrets=None):
         self.socket_address = socket_address
-        self.sources_libdir = sources_libdir
+        self.libdir = libdir
         self.cache = cache
         self.output = output
         self.options = options or {}
@@ -24,11 +24,12 @@ class SourcesServer:
             "secrets": self.secrets.get(source, {}),
             "cache": f"{self.cache}/{source}",
             "output": f"{self.output}/{source}",
-            "checksums": checksums
+            "checksums": checksums,
+            "libdir": self.libdir
         }
 
         r = subprocess.run(
-            [f"{self.sources_libdir}/{source}"],
+            [f"{self.libdir}/sources/{source}"],
             input=json.dumps(msg),
             stdout=subprocess.PIPE,
             encoding="utf-8",

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -92,7 +92,7 @@ class TestSources(unittest.TestCase):
                     fileServer(), \
                     osbuild.sources.SourcesServer(
                             f"{tmpdir}/sources-api",
-                            "./sources", source_options,
+                            "./", source_options,
                             f"{tmpdir}/cache", f"{tmpdir}/dst"):
                     self.check_case(source, case_options, f"{tmpdir}/sources-api")
                     self.check_case(source, case_options, f"{tmpdir}/sources-api")


### PR DESCRIPTION
The idea is that source can themselves spawn other modules, esp. new secrets modules. For this they need to know the library dir, aka 'libdir' throughout the osbuild source. Therefore change the SourceServer to directly get the library directory instead of just the sub-directory to the sources. Then pass the library directory to via the JSON API to the source.
Adjust all usage of the SourceServer, including the tests.

If it goes in before #405, it can be changed to use that instead of the `__file__` hack.