### PR TITLE
pipeline: drop {tree, output}_id from --inspect js

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -195,14 +195,6 @@ class Pipeline:
             assembler = self.assembler.description(with_id=with_id)
             description["assembler"] = assembler
 
-        if with_id:
-            tree_id = self.tree_id
-            if tree_id:
-                description["tree_id"] = tree_id
-            output_id = self.output_id
-            if output_id:
-                description["output_id"] = tree_id
-
         return description
 
     def build_stages(self, object_store, interactive, libdir, secrets):


### PR DESCRIPTION
We want to get rid of `tree_id` and `output_id` because the they are now considered internals of the store and clients should not use them directly. NB: they are still there indirectly as the `id` of the last stage and the assembler.

Also, the `output_id` was never correct here, because it was the `tree_id` as well. Ups.