### PR TITLE
GH Actions: Use upstream Fedora containers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,19 +109,21 @@ jobs:
       matrix:
         fedora_release: ["31", "32", "33"]
     container:
-      image: "quay.io/osbuild/osbuild-fedora${{ matrix.fedora_release }}:latest"
+      image: "docker.io/library/fedora:${{ matrix.fedora_release }}"
     steps:
       - name: "📥 Prepare container"
         run: |
           echo "fastestmirror=1" >> /etc/dnf/dnf.conf
           echo "install_weak_deps=0" >> /etc/dnf/dnf.conf
           rm -fv /etc/yum.repos.d/fedora*modular*
+          dnf -y upgrade
+          dnf -y install dnf-plugins-core findutils git make rpm-build rpmdevtools
 
       - name: "🗄️ Clone the repository"
         uses: actions/checkout@v2
 
       - name: "🛒 Install RPM build dependencies"
-        run: dnf -y builddep osbuild.spec
+        run: dnf -qy builddep osbuild.spec
 
       - name: "🛠️ Build RPMs"
         run: |


### PR DESCRIPTION
Work around the quay.io issues by using the standard Fedora containers.
Also, make most of the dnf operations a little quieter to make it easier
to find problems.

Signed-off-by: Major Hayden <major@redhat.com>