### PR TITLE
Build in a mock chroot first

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -1,13 +1,59 @@
 pipeline {
     agent none
 
+    environment {
+        // We upload build RPMs and repository files here.
+        OPENSHIFT_CONTAINER = "osbuildci-artifacts"
+        // The files we upload are available under this URL.
+        // This is auto-generated from OpenStack.
+        MOCK_REPO_BASE_URL = "https://rhos-d.infra.prod.upshift.rdu2.redhat.com:13808/v1/AUTH_95e858620fb34bcc9162d9f52367a560/osbuildci-artifacts"
+    }
+
     options {
-        timestamps()
         ansiColor('xterm')
+        timestamps()
     }
 
     stages {
+        stage("Mock") {
+            // Halt the entire pipeline if a single RPM build fails. That
+            // could indicate a code problem that needs to be investigated.
+            failFast true
+
+            parallel {
+                stage('Fedora 31') {
+                    agent { label "fedora31" }
+                    environment {
+                        OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
+                    }
+                    steps {
+                        sh "schutzbot/mockbuild.sh"
+                    }
+                }
+                stage('Fedora 32') {
+                    agent { label "fedora32" }
+                    environment {
+                        OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
+                    }
+                    steps {
+                        sh "schutzbot/mockbuild.sh"
+                    }
+                }
+                stage('RHEL 8.2') {
+                    agent { label "rhel82" }
+                    environment {
+                        OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
+                    }
+                    steps {
+                        sh "schutzbot/mockbuild.sh"
+                    }
+                }
+            }
+        }
         stage("Functional Testing") {
+            // Allow the other stages to finish if a single stage fails.
+            failFast false
+
             parallel {
                 stage('Fedora 31 image') {
                     agent { label "fedora31" }

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Get OS details.
+source /etc/os-release
+
+# Install packages.
+sudo dnf -qy install createrepo_c mock
+if [[ $ID == 'fedora' ]]; then
+    sudo dnf -qy install python3-openstackclient
+else
+    sudo pip3 -qq install python-openstackclient
+fi
+
+# Set variables.
+CONTAINER=osbuildci-artifacts
+WORKSPACE=${WORKSPACE:-$(pwd)}
+MOCK_CONFIG="${ID}-${VERSION_ID%.*}-$(uname -m)"
+REPO_DIR=repo/${BUILD_TAG}/${ID}${VERSION_ID//./}
+
+# Clone osbuild-composer.
+# TODO(mhayden): After the next osbuild-composer release, use the latest tag
+# in the osbuild-composer repository. We can't do that right now because
+# osbuild-composer v12 is missing c0ad652db58059e0e99eb7253b6ba85f25bead3f
+# which maks RHEL 8's qemu happy with the image tests.
+git clone https://github.com/osbuild/osbuild-composer
+
+# Build source RPMs.
+make srpm
+make -C osbuild-composer srpm
+
+# Fix RHEL 8 mock template.
+sudo curl --retry 5 -Lsko /etc/mock/templates/rhel-8.tpl \
+    https://gitlab.cee.redhat.com/snippets/2208/raw
+
+# Add fastestmirror to the Fedora template.
+sudo sed -i '/^install_weak_deps.*/a fastestmirror=1' \
+    /etc/mock/templates/fedora-branched.tpl
+
+# Compile RPMs in a mock chroot
+sudo mock -r $MOCK_CONFIG --no-bootstrap-chroot \
+    --resultdir $REPO_DIR --with=tests \
+    rpmbuild/SRPMS/*.src.rpm osbuild-composer/rpmbuild/SRPMS/*.src.rpm
+sudo chown -R $USER ${REPO_DIR}
+
+# Move the logs out of the way.
+mv ${REPO_DIR}/*.log $WORKSPACE
+
+# Create a repo of the built RPMs.
+createrepo_c ${REPO_DIR}
+
+# Prepare to upload to swift.
+mkdir -p ~/.config/openstack
+cp $OPENSTACK_CREDS ~/.config/openstack/clouds.yml
+export OS_CLOUD=psi
+
+# Upload repository to swift.
+pushd repo
+    find * -type f -print | xargs openstack object create -f value $CONTAINER
+popd


### PR DESCRIPTION
Build the RPMs in a mock using a simple script so that ansible-osbuild
can focus fully on deployment rather than compiling RPMs.

Signed-off-by: Major Hayden <major@redhat.com>