### PR TITLE
pipeline: drop tree/output ID from results

### DIFF
--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -195,6 +195,20 @@ class Object:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.cleanup()
 
+    def export(self, to_directory):
+        """Copy object into an external directory"""
+        with self.read() as from_directory:
+            subprocess.run(
+                [
+                    "cp",
+                    "--reflink=auto",
+                    "-a",
+                    f"{from_directory}/.",
+                    to_directory,
+                ],
+                check=True,
+            )
+
 
 class HostTree:
     """Read-only access to the host file system

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -241,7 +241,6 @@ class Pipeline:
         tree = object_store.new(base_id=self.tree_id)
 
         if object_store.contains(self.tree_id):
-            results["tree_id"] = self.tree_id
             return results, build_tree, tree
 
         # Not in the store yet, need to actually build it, but maybe
@@ -282,7 +281,6 @@ class Pipeline:
             if stage.checkpoint:
                 object_store.commit(tree, stage.id)
 
-        results["tree_id"] = self.tree_id
         return results, build_tree, tree
 
     def assemble(self, object_store, build_tree, tree, interactive, libdir, output_directory=None):

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -291,11 +291,6 @@ class Pipeline:
         if not self.assembler:
             return results
 
-        # if the output is already in the store, short-circuit
-        if object_store.contains(self.output_id):
-            results["output_id"] = self.output_id
-            return results
-
         output = object_store.new()
 
         with build_tree.read() as build_dir, \


### PR DESCRIPTION
Now with the release out, with the German holiday over, and all callers adjusted, we can proceed and drop the `output_id` and `tree_id` from the osbuild results.

The osbuild CI passes with this. Lets see what Schutzbot has to say!

Resolves #390.