### PR TITLE
sources: fix break when secrets is None

### DIFF
--- a/sources/org.osbuild.files
+++ b/sources/org.osbuild.files
@@ -110,7 +110,7 @@ def main(options, checksums, cache, output):
             try:
                 if isinstance(urls[checksum], dict):
                     # check if url needs rhsm secrets
-                    if urls[checksum].get("secrets").get("name") == "org.osbuild.rhsm":
+                    if urls[checksum].get("secrets", {}).get("name") == "org.osbuild.rhsm":
                         # rhsm secrets only need to be retrieved once and can then be reused
                         if rhsm_secrets is None:
                             try:


### PR DESCRIPTION
When the urls' secrets field is not set, an error is thrown when trying to get the name of the secrets. The secrets now have a default value of {} when they are checked for the name.