### PR TITLE
pipeline: checkpoint assemblers just like stages

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -30,9 +30,17 @@ def mark_checkpoints(pipeline, checkpoints):
             stage.checkpoint = True
             points.remove(c)
 
+    def mark_assembler(assembler):
+        c = assembler.id
+        if c in points:
+            assembler.checkpoint = True
+            points.remove(c)
+
     def mark_pipeline(pl):
         for stage in pl.stages:
             mark_stage(stage)
+        if pl.assembler:
+            mark_assembler(pl.assembler)
         if pl.build:
             mark_pipeline(pl.build)
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -108,6 +108,7 @@ class Assembler:
         self.build = build
         self.base = base
         self.options = options
+        self.checkpoint = False
 
     @property
     def id(self):
@@ -308,7 +309,8 @@ class Pipeline:
             results["success"] = False
             return results
 
-        object_store.commit(output, self.output_id)
+        if self.assembler.checkpoint:
+            object_store.commit(output, self.assembler.id)
         if output_directory:
             output.export(output_directory)
         output.cleanup()


### PR DESCRIPTION
Change the assembler-commit to be conditional on checkpoints, just like we already do for stages. This means, assembler output is not automatically committed, but only if you requested so via a checkpoint.

With this in place we can start sharing caches in osbuild-composer. The only thing in the cache will be sources as well as checkpointed stages. We can start checkpointing known pipelines and thus make use of the cache. Furthermore, we can cache sources, as long as we do not fetch an unbound set of RPMs. However, our RPM set is currently static, so this should not be an issue. Nevertheless, it is up to Composer to decide when to enable the cache.

(This is based on #414 and should go in only if that one is merged.)