### PR TITLE
CI: Use RHEL 8 CDN image

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -39,8 +39,8 @@ pipeline {
                         sh "schutzbot/mockbuild.sh"
                     }
                 }
-                stage('RHEL 8.2') {
-                    agent { label "rhel82" }
+                stage('RHEL 8 CDN') {
+                    agent { label "rhel8" }
                     environment {
                         OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
                     }
@@ -55,7 +55,7 @@ pipeline {
             failFast false
 
             parallel {
-                stage('Fedora 31 image') {
+                stage('Fedora 31') {
                     agent { label "fedora31" }
                     environment { TEST_TYPE = "image" }
                     steps {
@@ -67,7 +67,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Fedora 32 image') {
+                stage('Fedora 32') {
                     agent { label "fedora32" }
                     environment { TEST_TYPE = "image" }
                     steps {
@@ -79,15 +79,15 @@ pipeline {
                         }
                     }
                 }
-                stage('RHEL 8.2 image') {
-                    agent { label "rhel82" }
+                stage('RHEL 8 CDN') {
+                    agent { label "rhel8" }
                     environment { TEST_TYPE = "image" }
                     steps {
                         run_tests()
                     }
                     post {
                         always {
-                            preserve_logs('rhel82-image')
+                            preserve_logs('rhel8-image')
                         }
                     }
                 }

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -29,14 +29,6 @@ git clone https://github.com/osbuild/osbuild-composer
 make srpm
 make -C osbuild-composer srpm
 
-# Fix RHEL 8 mock template.
-sudo curl --retry 5 -Lsko /etc/mock/templates/rhel-8.tpl \
-    https://gitlab.cee.redhat.com/snippets/2208/raw
-
-# Add fastestmirror to the Fedora template.
-sudo sed -i '/^install_weak_deps.*/a fastestmirror=1' \
-    /etc/mock/templates/fedora-branched.tpl
-
 # Compile RPMs in a mock chroot
 sudo mock -r $MOCK_CONFIG --no-bootstrap-chroot \
     --resultdir $REPO_DIR --with=tests \


### PR DESCRIPTION
Now that we have a fully subscribed RHEL 8 image, let's use that instead
of RHEL 8.2 nightlies.

Signed-off-by: Major Hayden <major@redhat.com>