### PR TITLE
pipeline: fix pylint-warning triggered by rebase

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -2,7 +2,6 @@
 import hashlib
 import json
 import os
-import subprocess
 import tempfile
 
 from .api import API


### PR DESCRIPTION
Fix osbuild/pipeline.py unused import. We now trigger pylint warnings alongside pylint errors, and a PR rebase did not consider this.