### PR TITLE
org.osbuild.grub: convert to use templates

### DIFF
--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -176,23 +176,43 @@ def copy_efi_data(tree, vendor):
                         symlinks=False)
 
 
-def write_grub_cfg(tree, path, grub_fs):
-    """Write the grub config to `tree` at `path`"""
-    fs_type, fs_id = fs_spec_decode(grub_fs)
-    type2opt = {
-        "UUID": "--fs-uuid",
-        "LABEL": "--label"
-    }
-    search = type2opt[fs_type] + " " + fs_id
-    with open(os.path.join(tree, path), "w") as cfg:
-        cfg.write("set timeout=0\n"
-                  "load_env\n"
-                  f"search --no-floppy --set=root {search}\n"
-                  "set boot=${root}\n"
-                  "function load_video {\n"
-                  "  insmod all_video\n"
-                  "}\n"
-                  "blscfg\n")
+class GrubConfig:
+    def __init__(self, rootfs, bootfs):
+        self.rootfs = rootfs
+        self.bootfs = bootfs
+        self.path = "boot/grub2/grub.cfg"
+
+    @property
+    def grubfs(self):
+        """The filesystem containing the grub files,
+
+        This is  either a separate partition (self.bootfs if set) or
+        the root file system (self.rootfs)
+        """
+        return self.bootfs or self.rootfs
+
+    def write(self, tree):
+        """Write the grub config to `tree` at `self.path`"""
+        path = os.path.join(tree, self.path)
+
+        fs_type, fs_id = fs_spec_decode(self.grubfs)
+        type2opt = {
+            "UUID": "--fs-uuid",
+            "LABEL": "--label"
+        }
+
+        # options for the configuration strings
+        search = type2opt[fs_type] + " " + fs_id
+
+        with open(path) as cfg:
+            cfg.write("set timeout=0\n"
+                      "load_env\n"
+                      f"search --no-floppy --set=root {search}\n"
+                      "set boot=${root}\n"
+                      "function load_video {\n"
+                      "  insmod all_video\n"
+                      "}\n"
+                      "blscfg\n")
 
 
 def write_grub_cfg_redirect(tree, path, separate_boot):
@@ -230,6 +250,9 @@ def main(tree, options):
     # will only contain a small config file redirecting to the one in
     # /boot/grub2 and will not have a grubenv itself.
     hybrid = uefi and legacy
+
+    # Prepare the actual grub configuration file, will be written further down
+    config = GrubConfig(root_fs, boot_fs)
 
     # grub_fs points to the filesystem containing the grub files, which is
     # either a separate partition (boot_fs) or the root file system (root_fs)
@@ -292,10 +315,11 @@ def main(tree, options):
         if hybrid:
             write_grub_cfg_redirect(tree, grubcfg, separate_boot)
         else:
-            write_grub_cfg(tree, grubcfg, grub_fs)
+            config.path = grubcfg
+            config.write(tree)
 
     if legacy:
-        write_grub_cfg(tree, "boot/grub2/grub.cfg", grub_fs)
+        config.write(tree)
         copy_modules(tree, legacy)
         copy_font(tree)
 

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -156,6 +156,20 @@ blscfg
 """
 
 
+# The grub2 redirect configuration template. This is used in case of
+# hybrid (uefi + legacy) boot. In this case this configuration, which
+# is located in the EFI directory, will redirect to the main grub.cfg
+# (GRUB_CFG_TEMPLATE).
+# The parameters are:
+#   - $root: specifies the path to the grub2 directory relative to
+#     to the file-system where the directory is located on
+GRUB_REDIRECT_TEMPLATE = """
+search --no-floppy --set prefix --file ${root}grub2/grub.cfg
+set prefix=($$prefix)${root}grub2
+configfile $$prefix/grub.cfg
+"""
+
+
 def fs_spec_decode(spec):
     for key in ["uuid", "label"]:
         val = spec.get(key)
@@ -237,12 +251,16 @@ class GrubConfig:
         """Write a grub config pointing to the other cfg"""
         print("hybrid boot support enabled. Writing alias grub config")
 
-        # options for the configuration string
-        root = "/" if self.separate_boot else "/boot/"
+        # configuration options for the template
+        config = {
+            "root": "/" if self.separate_boot else "/boot/"
+        }
+
+        tplt = string.Template(GRUB_REDIRECT_TEMPLATE)
+        data = tplt.safe_substitute(config)
+
         with open(os.path.join(tree, path), "w") as cfg:
-            cfg.write(f"search --no-floppy --set prefix --file {root}grub2/grub.cfg\n"
-                      f"set prefix=($prefix){root}grub2\n"
-                      "configfile $prefix/grub.cfg\n")
+            cfg.write(data)
 
 
 def main(tree, options):

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -191,6 +191,10 @@ class GrubConfig:
         """
         return self.bootfs or self.rootfs
 
+    @property
+    def separate_boot(self):
+        return self.bootfs is not None
+
     def write(self, tree):
         """Write the grub config to `tree` at `self.path`"""
         path = os.path.join(tree, self.path)
@@ -214,15 +218,16 @@ class GrubConfig:
                       "}\n"
                       "blscfg\n")
 
+    def write_redirect(self, tree, path):
+        """Write a grub config pointing to the other cfg"""
+        print("hybrid boot support enabled. Writing alias grub config")
 
-def write_grub_cfg_redirect(tree, path, separate_boot):
-    """Write a grub config pointing to the other cfg"""
-    print("hybrid boot support enabled. Writing alias grub config")
-    root = "/" if separate_boot else "/boot/"
-    with open(os.path.join(tree, path), "w") as cfg:
-        cfg.write(f"search --no-floppy --set prefix --file {root}grub2/grub.cfg\n"
-                  f"set prefix=($prefix){root}grub2\n"
-                  "configfile $prefix/grub.cfg\n")
+        # options for the configuration string
+        root = "/" if self.separate_boot else "/boot/"
+        with open(os.path.join(tree, path), "w") as cfg:
+            cfg.write(f"search --no-floppy --set prefix --file {root}grub2/grub.cfg\n"
+                      f"set prefix=($prefix){root}grub2\n"
+                      "configfile $prefix/grub.cfg\n")
 
 
 def main(tree, options):
@@ -253,11 +258,6 @@ def main(tree, options):
 
     # Prepare the actual grub configuration file, will be written further down
     config = GrubConfig(root_fs, boot_fs)
-
-    # grub_fs points to the filesystem containing the grub files, which is
-    # either a separate partition (boot_fs) or the root file system (root_fs)
-    grub_fs = boot_fs or root_fs
-    separate_boot = boot_fs is not None
 
     # Create the configuration file that determines how grub.cfg is generated.
     if write_defaults:
@@ -313,7 +313,7 @@ def main(tree, options):
 
         grubcfg = f"boot/efi/EFI/{vendor}/grub.cfg"
         if hybrid:
-            write_grub_cfg_redirect(tree, grubcfg, separate_boot)
+            config.write_redirect(tree, grubcfg)
         else:
             config.path = grubcfg
             config.write(tree)

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -41,6 +41,7 @@ Both UEFI and Legacy can be specified at the same time.
 import json
 import os
 import shutil
+import string
 import sys
 
 SCHEMA = """
@@ -139,6 +140,22 @@ SCHEMA = """
 """
 
 
+# The main grub2 configuration file template. Used for UEFI and legacy
+# boot. The parameters are currently:
+#   - $search: to specify the search criteria of how to locate grub's
+#     "root device", i.e. the device where the "OS images" are stored.
+GRUB_CFG_TEMPLATE = """
+set timeout=0
+load_env
+search --no-floppy --set=root $search
+set boot=$${root}
+function load_video {
+  insmod all_video
+}
+blscfg
+"""
+
+
 def fs_spec_decode(spec):
     for key in ["uuid", "label"]:
         val = spec.get(key)
@@ -205,18 +222,16 @@ class GrubConfig:
             "LABEL": "--label"
         }
 
-        # options for the configuration strings
-        search = type2opt[fs_type] + " " + fs_id
+        # configuration options for the main template
+        config = {
+            "search": type2opt[fs_type] + " " + fs_id
+        }
 
-        with open(path) as cfg:
-            cfg.write("set timeout=0\n"
-                      "load_env\n"
-                      f"search --no-floppy --set=root {search}\n"
-                      "set boot=${root}\n"
-                      "function load_video {\n"
-                      "  insmod all_video\n"
-                      "}\n"
-                      "blscfg\n")
+        tplt = string.Template(GRUB_CFG_TEMPLATE)
+        data = tplt.safe_substitute(config)
+
+        with open(path, "w") as cfg:
+            cfg.write(data)
 
     def write_redirect(self, tree, path):
         """Write a grub config pointing to the other cfg"""

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -316,10 +316,11 @@ def main(tree, options):
             config.write_redirect(tree, grubcfg)
         else:
             config.path = grubcfg
-            config.write(tree)
+
+    # Now actually write the main grub.cfg file
+    config.write(tree)
 
     if legacy:
-        config.write(tree)
         copy_modules(tree, legacy)
         copy_font(tree)
 


### PR DESCRIPTION
Convert the `org.osbuild.grub` stage to use templates instead of inline strings. Puts the actually used grub config front and center.

Split out from #371 