### PR TITLE
Take care not to put large content on /tmp

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -632,7 +632,7 @@ def main(tree, output_dir, options, loop_client):
 
     # Now assemble the filesystem hierarchy and copy the tree into the image
     with contextlib.ExitStack() as cm:
-        root = cm.enter_context(tempfile.TemporaryDirectory(prefix="osbuild-mnt"))
+        root = cm.enter_context(tempfile.TemporaryDirectory(dir=output_dir, prefix="osbuild-mnt-"))
         disk = cm.enter_context(loop_client.device(image, 0, size))
         # iterate the partition according to their position in the filesystem tree
         for partition in pt.partitions_with_filesystems():

--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -131,7 +131,7 @@ def main(tree, srcdir, options, workdir):
 if __name__ == '__main__':
     stage_args = json.load(sys.stdin)
 
-    with tempfile.TemporaryDirectory() as _workdir:
+    with tempfile.TemporaryDirectory(dir="/var/tmp") as _workdir:
         r = main(stage_args["tree"],
                  stage_args["sources"],
                  stage_args["options"],


### PR DESCRIPTION
Most stages and assemblers already use `/var/tmp` to store large
files or trees. Do this in the qemu assembler and copy stage as well.