### PR TITLE
Add custom selinux policy to allow using labels unknown to the host

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -112,6 +112,7 @@ class BuildRoot(contextlib.AbstractContextManager):
             "--keep-unit",
             "--as-pid2",
             "--link-journal=no",
+            "--capability=CAP_MAC_ADMIN",  # for SELinux labeling
             f"--directory={self.root}",
             "--setenv=PYTHONPATH=/run/osbuild/lib",
             *[f"--bind-ro={b}" for b in nspawn_ro_binds],

--- a/selinux/osbuild.fc
+++ b/selinux/osbuild.fc
@@ -1,0 +1,4 @@
+/usr/bin/osbuild		--	gen_context(system_u:object_r:osbuild_exec_t,s0)
+/usr/lib/osbuild/assemblers/.*	--	gen_context(system_u:object_r:osbuild_exec_t,s0)
+/usr/lib/osbuild/stages/.*	--	gen_context(system_u:object_r:osbuild_exec_t,s0)
+/usr/lib/osbuild/sources/.*	--	gen_context(system_u:object_r:osbuild_exec_t,s0)

--- a/selinux/osbuild.if
+++ b/selinux/osbuild.if
@@ -1,0 +1,95 @@
+
+## <summary>policy for osbuild</summary>
+
+########################################
+## <summary>
+##	Execute osbuild_exec_t in the osbuild domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`osbuild_domtrans',`
+	gen_require(`
+		type osbuild_t, osbuild_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, osbuild_exec_t, osbuild_t)
+')
+
+######################################
+## <summary>
+##	Execute osbuild in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`osbuild_exec',`
+	gen_require(`
+		type osbuild_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, osbuild_exec_t)
+')
+
+########################################
+## <summary>
+##	Execute osbuild in the osbuild domain, and
+##	allow the specified role the osbuild domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	The role to be allowed the osbuild domain.
+##	</summary>
+## </param>
+#
+interface(`osbuild_run',`
+	gen_require(`
+		type osbuild_t;
+		attribute_role osbuild_roles;
+	')
+
+	osbuild_domtrans($1)
+	roleattribute $2 osbuild_roles;
+')
+
+########################################
+## <summary>
+##	Role access for osbuild
+## </summary>
+## <param name="role">
+##	<summary>
+##	Role allowed access
+##	</summary>
+## </param>
+## <param name="domain">
+##	<summary>
+##	User domain for the role
+##	</summary>
+## </param>
+#
+interface(`osbuild_role',`
+	gen_require(`
+		type osbuild_t;
+		attribute_role osbuild_roles;
+	')
+
+	roleattribute $1 osbuild_roles;
+
+	osbuild_domtrans($2)
+
+	ps_process_pattern($2, osbuild_t)
+	allow $2 osbuild_t:process { signull signal sigkill };
+')

--- a/selinux/osbuild.te
+++ b/selinux/osbuild.te
@@ -1,0 +1,57 @@
+policy_module(osbuild, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+attribute_role osbuild_roles;
+roleattribute system_r osbuild_roles;
+
+type osbuild_t;
+type osbuild_exec_t;
+application_domain(osbuild_t, osbuild_exec_t)
+role osbuild_roles types osbuild_t;
+
+########################################
+#
+# osbuild local policy
+#
+
+allow osbuild_t self:fifo_file manage_fifo_file_perms;
+allow osbuild_t self:unix_stream_socket create_stream_socket_perms;
+
+# #####################################
+# Customization
+#
+
+# make an osbuild_t unconfined domain
+unconfined_domain(osbuild_t)
+
+# execute setfiles in the setfiles_mac domain
+# when in the osbuild_t domain
+seutil_domtrans_setfiles_mac(osbuild_t)
+
+# Allow sysadm and unconfined to run osbuild
+optional_policy(`
+        gen_require(`
+                type sysadm_t;
+                role sysadm_r;
+        ')
+
+        osbuild_run(sysadm_t, sysadm_r)
+')
+
+optional_policy(`
+        gen_require(`
+                type unconfined_t;
+                role unconfined_r;
+        ')
+
+        osbuild_run(unconfined_t, unconfined_r)
+')
+
+# allow transitioning to install_t (for ostree)
+optional_policy(`
+	anaconda_domtrans_install(osbuild_t)
+')

--- a/selinux/osbuild.te
+++ b/selinux/osbuild.te
@@ -51,6 +51,15 @@ optional_policy(`
         osbuild_run(unconfined_t, unconfined_r)
 ')
 
+optional_policy(`
+        gen_require(`
+                type unconfined_service_t;
+                role system_r;
+        ')
+
+        osbuild_run(unconfined_service_t, system_r)
+')
+
 # allow transitioning to install_t (for ostree)
 optional_policy(`
 	anaconda_domtrans_install(osbuild_t)

--- a/selinux/osbuild_selinux.8
+++ b/selinux/osbuild_selinux.8
@@ -1,0 +1,147 @@
+.TH  "osbuild_selinux"  "8"  "20-06-09" "osbuild" "SELinux Policy osbuild"
+.SH "NAME"
+osbuild_selinux \- Security Enhanced Linux Policy for the osbuild processes
+.SH "DESCRIPTION"
+
+Security-Enhanced Linux secures the osbuild processes via flexible mandatory access control.
+
+The osbuild processes execute with the osbuild_t SELinux type. You can check if you have these processes running by executing the \fBps\fP command with the \fB\-Z\fP qualifier.
+
+For example:
+
+.B ps -eZ | grep osbuild_t
+
+
+.SH "ENTRYPOINTS"
+
+The osbuild_t SELinux type can be entered via the \fBosbuild_exec_t\fP file type.
+
+The default entrypoint paths for the osbuild_t domain are the following:
+
+/usr/lib/osbuild/stages/*, /usr/lib/osbuild/sources/*, /usr/lib/osbuild/assemblers/*, /usr/bin/osbuild
+.SH PROCESS TYPES
+SELinux defines process types (domains) for each process running on the system
+.PP
+You can see the context of a process using the \fB\-Z\fP option to \fBps\bP
+.PP
+Policy governs the access confined processes have to files.
+SELinux osbuild policy is very flexible allowing users to setup their osbuild processes in as secure a method as possible.
+.PP
+The following process types are defined for osbuild:
+
+.EX
+.B osbuild_t
+.EE
+.PP
+Note:
+.B semanage permissive -a osbuild_t
+can be used to make the process type osbuild_t permissive. SELinux does not deny access to permissive process types, but the AVC (SELinux denials) messages are still generated.
+
+.SH BOOLEANS
+SELinux policy is customizable based on least access required.  osbuild policy is extremely flexible and has several booleans that allow you to manipulate the policy and run osbuild with the tightest access possible.
+
+
+.PP
+If you want to deny user domains applications to map a memory region as both executable and writable, this is dangerous and the executable should be reported in bugzilla, you must turn on the deny_execmem boolean. Disabled by default.
+
+.EX
+.B setsebool -P deny_execmem 1
+
+.EE
+
+.PP
+If you want to control the ability to mmap a low area of the address space, as configured by /proc/sys/vm/mmap_min_addr, you must turn on the mmap_low_allowed boolean. Disabled by default.
+
+.EX
+.B setsebool -P mmap_low_allowed 1
+
+.EE
+
+.PP
+If you want to disable kernel module loading, you must turn on the secure_mode_insmod boolean. Disabled by default.
+
+.EX
+.B setsebool -P secure_mode_insmod 1
+
+.EE
+
+.PP
+If you want to allow unconfined executables to make their heap memory executable.  Doing this is a really bad idea. Probably indicates a badly coded executable, but could indicate an attack. This executable should be reported in bugzilla, you must turn on the selinuxuser_execheap boolean. Disabled by default.
+
+.EX
+.B setsebool -P selinuxuser_execheap 1
+
+.EE
+
+.PP
+If you want to allow unconfined executables to make their stack executable.  This should never, ever be necessary. Probably indicates a badly coded executable, but could indicate an attack. This executable should be reported in bugzilla, you must turn on the selinuxuser_execstack boolean. Enabled by default.
+
+.EX
+.B setsebool -P selinuxuser_execstack 1
+
+.EE
+
+.SH "MANAGED FILES"
+
+The SELinux process type osbuild_t can manage files labeled with the following file types.  The paths listed are the default paths for these file types.  Note the processes UID still need to have DAC permissions.
+
+.br
+.B file_type
+
+	all files on the system
+.br
+
+.SH FILE CONTEXTS
+SELinux requires files to have an extended attribute to define the file type.
+.PP
+You can see the context of a file using the \fB\-Z\fP option to \fBls\bP
+.PP
+Policy governs the access confined processes have to these files.
+SELinux osbuild policy is very flexible allowing users to setup their osbuild processes in as secure a method as possible.
+.PP
+
+.I The following file types are defined for osbuild:
+
+
+.EX
+.PP
+.B osbuild_exec_t
+.EE
+
+- Set files with the osbuild_exec_t type, if you want to transition an executable to the osbuild_t domain.
+
+.br
+.TP 5
+Paths:
+/usr/lib/osbuild/stages/*, /usr/lib/osbuild/sources/*, /usr/lib/osbuild/assemblers/*, /usr/bin/osbuild
+
+.PP
+Note: File context can be temporarily modified with the chcon command.  If you want to permanently change the file context you need to use the
+.B semanage fcontext
+command.  This will modify the SELinux labeling database.  You will need to use
+.B restorecon
+to apply the labels.
+
+.SH "COMMANDS"
+.B semanage fcontext
+can also be used to manipulate default file context mappings.
+.PP
+.B semanage permissive
+can also be used to manipulate whether or not a process type is permissive.
+.PP
+.B semanage module
+can also be used to enable/disable/install/remove policy modules.
+
+.B semanage boolean
+can also be used to manipulate the booleans
+
+.PP
+.B system-config-selinux
+is a GUI tool available to customize SELinux policy settings.
+
+.SH AUTHOR
+This manual page was auto-generated using
+.B "sepolicy manpage".
+
+.SH "SEE ALSO"
+selinux(8), osbuild(8), semanage(8), restorecon(8), chcon(1), sepolicy(8), setsebool(8)


### PR DESCRIPTION
A usual step in creating OS file system trees is to apply the correct SELinux labels for all files and directories. This is done by the `org.osbuild.selinux` stage, which internally uses the `setfiles` command in order to do so. The SELiunx policy to be used the for this operation one of the newly created system, not the host one. It therefore can contain labels that are not known on the host. The kernel will prevent setting invalid, i.e. unknown, labels unless the caller has the `CAP_MAC_ADMIN` capability. By default, setfiles is executed in the `setfiles_t` domain, where it lacks that capability. Therefore a custom osbuild SELinux policy was created, with a special transition rule that will execute `setfiles` in the `setfiles_mac_t` domain. All stages, sources and assemblers as well as the main binary are label with the new `osbuild_exec_t` label.
Additionally a the transition from `osbuild_t` to `install_t` is allowed via `anaconda_domtrans_install`, so that `ostree` and `rpm-ostree`, which are labeled as `install_exec_t`, can transition to the `install_t` domain when called form osbuild.
Update the spec file to build the policy and include it in a new osbuild-selinux sub-package.

In order for processes to have the `CAP_MAC_ADMIN` capability, the container needs to have it to begin with, so add that capability when starting the container via `systemd-nspawn`.

It would be great if @wrabcak could have a look if I got the policy correct (thanks @bachradsusi for giving me a starting point on that).

Closes #400 