### PR TITLE
sources/files: reduce the concurrent curl processes

### DIFF
--- a/sources/org.osbuild.files
+++ b/sources/org.osbuild.files
@@ -163,7 +163,7 @@ def main(options, checksums, cache, output):
     os.makedirs(cache, exist_ok=True)
     os.makedirs(output, exist_ok=True)
 
-    with concurrent.futures.ProcessPoolExecutor(max_workers=15) as executor:
+    with concurrent.futures.ProcessPoolExecutor(max_workers=4) as executor:
         requested_urls = []
         rhsm_secrets = None
 


### PR DESCRIPTION
We appear to be throttled by some mirrors if we are too eager. Back off.

Signed-off-by: Tom Gundersen <teg@jklm.no>