### PR TITLE
stages/selinux: support label overrides 

### DIFF
--- a/osbuild/util/selinux.py
+++ b/osbuild/util/selinux.py
@@ -1,5 +1,6 @@
 """SELinux utility functions"""
 
+import os
 import subprocess
 
 from typing import Dict, TextIO
@@ -46,3 +47,10 @@ def setfiles(spec_file: str, root: str, *paths):
                         spec_file,
                         f"{root}{path}"],
                        check=True)
+
+
+def getfilecon(path: str) -> str:
+    """Get the security context associated with `path`"""
+    label = os.getxattr(path, b"security.selinux",
+                        follow_symlinks=False)
+    return label.decode().strip('\n\0')

--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -25,6 +25,7 @@ import os
 import subprocess
 import sys
 
+
 SCHEMA = """
 "additionalProperties": false,
 "required": ["file_contexts"],
@@ -36,10 +37,12 @@ SCHEMA = """
 }
 """
 
+
 def main(tree, options):
     file_contexts = os.path.join(f"{tree}", options["file_contexts"])
 
     subprocess.run(["setfiles", "-F", "-r", f"{tree}", f"{file_contexts}", f"{tree}"], check=True)
+
 
 if __name__ == '__main__':
     args = json.load(sys.stdin)

--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -33,6 +33,13 @@ SCHEMA = """
   "file_contexts": {
     "type": "string",
     "description": "Path to the active SELinux policy's `file_contexts`"
+  },
+  "labels": {
+    "type": "object",
+    "description": "Labels to set of the specified files or folders",
+    "items": {
+      "type": "object"
+    }
   }
 }
 """
@@ -40,8 +47,13 @@ SCHEMA = """
 
 def main(tree, options):
     file_contexts = os.path.join(f"{tree}", options["file_contexts"])
+    labels = options.get("labels", {})
 
     subprocess.run(["setfiles", "-F", "-r", f"{tree}", f"{file_contexts}", f"{tree}"], check=True)
+
+    for path, label in labels.items():
+        fullpath = os.path.join(tree, path.lstrip("/"))
+        subprocess.run(["chcon", "-v", label, fullpath], check=True)
 
 
 if __name__ == '__main__':

--- a/test/data/stages/selinux/test_basic.json
+++ b/test/data/stages/selinux/test_basic.json
@@ -1,6 +1,9 @@
 {
   "options": {
-    "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+    "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+    "labels": {
+      "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+    }
   },
   "labels": {
     "/bin": "system_u:object_r:bin_t:s0",
@@ -10,6 +13,7 @@
     "/home": "system_u:object_r:home_root_t:s0",
     "/lib": "system_u:object_r:lib_t:s0",
     "/usr": "system_u:object_r:usr_t:s0",
-    "/usr/bin/cp": "system_u:object_r:bin_t:s0"
+    "/usr/bin/ls": "system_u:object_r:bin_t:s0",
+    "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
   }
 }

--- a/test/data/stages/selinux/test_basic.json
+++ b/test/data/stages/selinux/test_basic.json
@@ -1,0 +1,15 @@
+{
+  "options": {
+    "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+  },
+  "labels": {
+    "/bin": "system_u:object_r:bin_t:s0",
+    "/boot": "system_u:object_r:boot_t:s0",
+    "/dev": "system_u:object_r:device_t:s0",
+    "/etc": "system_u:object_r:etc_t:s0",
+    "/home": "system_u:object_r:home_root_t:s0",
+    "/lib": "system_u:object_r:lib_t:s0",
+    "/usr": "system_u:object_r:usr_t:s0",
+    "/usr/bin/cp": "system_u:object_r:bin_t:s0"
+  }
+}

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -3,6 +3,7 @@
 #
 
 import difflib
+import glob
 import json
 import os
 import pprint
@@ -88,7 +89,7 @@ class TestStages(test.TestBase):
     def setUp(self):
         self.osbuild = test.OSBuild(self)
 
-    def run_stage_test(self, test_dir: str):
+    def run_stage_diff_test(self, test_dir: str):
         with self.osbuild as osb:
 
             def run(path):
@@ -121,6 +122,8 @@ class TestStages(test.TestBase):
 
     def test_stages(self):
         path = os.path.join(self.locate_test_data(), "stages")
-        for name in os.listdir(path):
-            with self.subTest(stage=name):
-                self.run_stage_test(os.path.join(path, name))
+        for t in glob.glob(f"{path}/*/diff.json"):
+            test_path = os.path.dirname(t)
+            test_name = os.path.basename(test_path)
+            with self.subTest(stage=test_name):
+                self.run_stage_diff_test(test_path)


### PR DESCRIPTION
Add new option `labels` that can contain `path`: `label` pairs to overwrite the default labels for `path`.

NB: These manually set labels will not survive a relabeling and are most useful to adjust policy in the buildroot, e.g. for `cp` to be able to copy labels unknown to the host, by labeling it as `system_u:object_r:install_exec_t:s0`.