### PR TITLE
Deploy and test using scripts from osbuild-composer

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -7,6 +7,10 @@ pipeline {
 
     options {
         ansiColor('xterm')
+        timeout(
+            time: 3,
+            unit: "HOURS"
+        )
         timestamps()
     }
 
@@ -59,21 +63,20 @@ pipeline {
                         )
                     }
                 }
-                // NOTE(mhayden): Disabling this for now since we don't have
-                // access to these repositories in AWS.
-                // stage('RHEL 8.3 Nightly') {
-                //     agent { label "rhel83" }
-                //     environment {
-                //         OPENSTACK_CREDS = credentials('psi-openstack-clouds-yaml')
-                //     }
-                //     steps {
-                //         sh "schutzbot/mockbuild.sh"
-                //         stash (
-                //             includes: 'osbuild-mock.repo',
-                //             name: 'rhel83'
-                //         )
-                //     }
-                // }
+                // NOTE(mhayden): RHEL 8.3 is only available in PSI for now.
+                stage('RHEL 8.3 Nightly') {
+                    agent { label "rhel83 && psi" }
+                    environment {
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                    }
+                    steps {
+                        sh "schutzbot/mockbuild.sh"
+                        stash (
+                            includes: 'osbuild-mock.repo',
+                            name: 'rhel83'
+                        )
+                    }
+                }
             }
         }
         stage("Functional Testing") {
@@ -120,6 +123,22 @@ pipeline {
                         }
                     }
                 }
+                stage('RHEL 8.3 Image') {
+                    agent { label "rhel83 && psi" }
+                    environment {
+                        TEST_TYPE = "image"
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                    }
+                    steps {
+                        unstash 'rhel83'
+                        run_tests()
+                    }
+                    post {
+                        always {
+                            preserve_logs('rhel83-image')
+                        }
+                    }
+                }
             }
         }
     }
@@ -140,6 +159,9 @@ void run_tests() {
 // Move logs to a unique location and tell Jenkins to capture them on success
 // or failure.
 void preserve_logs(test_slug) {
+
+    // Save the systemd journal.
+    sh "journalctl --boot > systemd-journald.log"
 
     // Make a directory for the log files and move the logs there.
     sh "mkdir ${test_slug} && mv *.log ${test_slug}/"

--- a/schutzbot/run_tests.sh
+++ b/schutzbot/run_tests.sh
@@ -1,56 +1,19 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Get OS details.
-source /etc/os-release
+# Clone osbuild-composer.
+git clone --depth 1 https://github.com/osbuild/osbuild-composer
 
-# Set up a dnf repository for the RPMs we built via mock.
-sudo cp osbuild-mock.repo /etc/yum.repos.d/osbuild-mock.repo
-dnf repository-packages osbuild-mock list
+# Move the repository file into place so the osbuild-composer CI scripts can
+# copy it into place.
+mv ${WORKSPACE}/osbuild-mock.repo osbuild-composer/
 
-# Create temporary directories for Ansible.
-sudo mkdir -vp /opt/ansible_{local,remote}
-sudo chmod -R 777 /opt/ansible_{local,remote}
+# Change the workspace directory to point to where osbuild-composer is cloned.
+WORKSPACE=${WORKSPACE}/osbuild-composer
+export WORKSPACE
 
-# Restart systemd to work around some Fedora issues in cloud images.
-sudo systemctl restart systemd-journald
-
-# Get the current journald cursor.
-export JOURNALD_CURSOR=$(sudo journalctl --quiet -n 1 --show-cursor | tail -n 1 | grep -oP 's\=.*$')
-
-# Add a function to preserve the system journal if something goes wrong.
-preserve_journal() {
-  sudo journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log
-  exit 1
-}
-trap "preserve_journal" ERR
-
-# Write a simple hosts file for Ansible.
-echo -e "[test_instances]\nlocalhost ansible_connection=local" > hosts.ini
-
-# Deploy osbuild-composer and osbuild using RPMs built in a mock chroot.
-# NOTE(mhayden): Jenkins clones the repository and then merges the code from
-# the pull request into the repo. This creates a new SHA that exists only in
-# Jenkins. We use ${WORKSPACE} below to tell ansible-osbuild to use the clone
-# that Jenkins made for testing osbuild.
-export ANSIBLE_CONFIG=ansible-osbuild/ansible.cfg
-git clone https://github.com/osbuild/ansible-osbuild.git ansible-osbuild
-ansible-playbook \
-  -i hosts.ini \
-  -e install_source=os \
-  ansible-osbuild/playbook.yml
-
-# Ensure the testing package is installed.
-sudo dnf -y install osbuild-composer-tests
-
-# Run the image tests from osbuild-composer to stress-test osbuild.
-git clone https://github.com/osbuild/osbuild-composer
-ansible-playbook \
-  -e workspace=${WORKSPACE} \
-  -e journald_cursor="${JOURNALD_CURSOR}" \
-  -e test_type=${TEST_TYPE:-image} \
-  -i hosts.ini \
-  osbuild-composer/schutzbot/test.yml
-
-# Collect the systemd journal anyway if we made it all the way to the end.
-sudo journalctl --after-cursor=${JOURNALD_CURSOR} > systemd-journald.log
+# Deploy osbuild-composer/osbuild and run the image tests.
+pushd osbuild-composer
+    schutzbot/deploy.sh
+    schutzbot/run_image_tests.sh
+popd


### PR DESCRIPTION
Now that osbuild-composer is using bash scripts to deploy and run tests,
use those scripts with osbuild. Also bring the Jenkins pipeline file in
line with osbuild-composer's too.

Signed-off-by: Major Hayden <major@redhat.com>