### PR TITLE
runners: use platform-python on RHEL

### DIFF
--- a/runners/org.osbuild.rhel81
+++ b/runners/org.osbuild.rhel81
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.6
+#!/usr/libexec/platform-python
 
 import os
 import subprocess

--- a/runners/org.osbuild.rhel82
+++ b/runners/org.osbuild.rhel82
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.6
+#!/usr/libexec/platform-python
 
 import os
 import subprocess


### PR DESCRIPTION
Runner are invoked to prepare the execution of stages and assemblers inside the container. The setup tasks are specific to the distribution and maybe the version of it, therefore specific runners are used for each distribution+version combination.
The build the first (most nested) build root, `/usr` is taken from the host to bootstrap the container. On RHEL, the python interpreter to be used for software that belongs to the platform is platform-python, as it provides a stable API. Therefore the RHEL runners should use that instead of relying on the presence of `/usr/bin/python3.6`, which might not be installed and is indeed not installed by default.