### PR TITLE
CI: Add coverity scan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,39 @@
+name: Coverity
+on:
+  schedule:
+    - cron: '0 5 * * *' # Daily at 05:00 UTC
+
+jobs:
+  coverity:
+    name: "Test Suite"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: osbuild
+    steps:
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          path: osbuild
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install python3-setuptools
+
+      - name: Download Coverity Tool
+        run: |
+          make coverity-download
+        env:
+         COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
+
+      - name: Coverity check
+        run: |
+          make coverity-check
+
+      - name: Upload analysis results
+        run: |
+          make coverity-submit
+        env:
+         COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
+         COVERITY_EMAIL: ${{ secrets.COVERITY_EMAIL }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ __pycache__
 /.vscode
 /.idea
 /.gdb_history
+
+cov-analysis-linux64/
+cov-analysis-osbuild.xz
+cov-int/


### PR DESCRIPTION
Add  coverity related targets to the `Makefile`, including downloading the tool, running the "build", archiving the results and submitting it to coverity for analysis.
The downloading and submitting need `COVERITY_{EMAIL, TOKEN}` to be defined in the environment.

Add a github workflow that will trigger the run of coverity every night at 05:00 UTC. Uses the new Makefile coverity targets.