### PR TITLE
Makefile: rename 'test-mod' target to match help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ $(SRCDIR)/test/data/manifests/fedora-boot.json: $(SRCDIR)/test/data/manifests/f3
 test-data: $(TEST_MANIFESTS_GEN)
 
 .PHONY: test-units
-test-mod:
+test-module:
 	@$(PYTHON3) -m unittest \
 		discover \
 			--start=$(SRCDIR)/test/mod \


### PR DESCRIPTION
Rename the 'test-mod' target to 'test-module' to match the help string.

Decided to rename the target not the help string because I think `make test-module` is more informative, bit a teensy-weensy bit.