### PR TITLE
osbuild: use osbuild_cli directly as main entry

### DIFF
--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -4,10 +4,9 @@ This specifies the entrypoint of the osbuild module when run as executable. For
 compatibility we will continue to run the CLI.
 """
 
-import sys
 
-from osbuild.main_cli import main_cli as main
+from osbuild.main_cli import osbuild_cli as main
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -101,8 +101,8 @@ def parse_arguments(sys_argv):
 
 
 # pylint: disable=too-many-branches
-def osbuild_cli(*, sys_argv):
-    args = parse_arguments(sys_argv)
+def osbuild_cli():
+    args = parse_arguments(sys.argv)
     manifest = parse_manifest(args.manifest_path)
 
     # first thing after parsing is validation of the input
@@ -164,14 +164,4 @@ def osbuild_cli(*, sys_argv):
             print()
             print(f"{RESET}{BOLD}{RED}Failed{RESET}")
 
-    return 0 if r["success"] else 1
-
-
-def main_cli():
-    """osbuild-cli entrypoint
-
-    This is the entrypoint used by the `osbuild` executable. We simply fetch the
-    global configuration and parameters necessary and invoke the API entrypoint.
-    """
-
-    sys.exit(osbuild_cli(sys_argv=sys.argv))
+    sys.exit(0 if r["success"] else 1)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     ],
     entry_points={
         "console_scripts": [
-            "osbuild = osbuild.main_cli:main_cli"
+            "osbuild = osbuild.main_cli:osbuild_cli"
         ]
     },
 )


### PR DESCRIPTION
Instead of having a another indirection via `main_cli`, directly use `osbuild_cli` in as main function in `__main__.py`. Compared to `main_cli` `osbuild_cli` also does indeed return a value that can be given to `sys.exit` in `__main__`.