### PR TITLE
sources/files: do not pass floats to --max-time

### DIFF
--- a/sources/org.osbuild.files
+++ b/sources/org.osbuild.files
@@ -17,6 +17,7 @@ import concurrent.futures
 import glob
 import itertools
 import json
+import math
 import os
 import subprocess
 import sys
@@ -102,7 +103,7 @@ def fetch(url, checksum, directory):
             curl_command = [
                 "curl",
                 "--silent",
-                "--max-time", f"{300 - elapsed_time}",
+                "--max-time", f"{int(math.ceil(300 - elapsed_time))}",
                 "--connect-timeout", "60",
                 "--fail",
                 "--location",


### PR DESCRIPTION
curl uses strtod from the C standard library to convert the --max-time's value
from string to double. However, this is what strtod expects:

nonempty sequence of decimal digits optionally containing decimal-point
character (as determined by the current C locale)

Yeah, unfortunately, the decimal-point character is determined by the current
C locale. For example, Czech and German locale uses command as the
decimal-point character.

For reasons I don't fully understand, Python thinks it's running on en_US
locale, even though LC_NUMERIC is set to cs_CZ, so it uses a full stop as the
decimal-point character when converting float to string. However, as written
before, curl fails to parse this because it expects comma.

The fix I chose is simple: Use math.ceil, so only an integer can be passed to
curl. Why ceil? Because --max-time == 0 sounds fishy.