### PR TITLE
ci: schedule coverity only for osbuild/osbuild

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   coverity:
     name: "Test Suite"
+    if: github.repository == 'osbuild/osbuild'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Don't schedule the run of coverity on forks of osbuild, but only on the main repository.