### PR TITLE
org.osbuild.qemu: use subformat=fixed for vhdx

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -673,7 +673,7 @@ def main(tree, output_dir, options, loop_client):
             "vdi": [],
             "vmdk": ["-c"],
             "vpc": ["-o", "subformat=fixed,force_size"],
-            "vhdx": []
+            "vhdx": ["-o", "subformat=fixed"],
         }
         subprocess.run([
             "qemu-img",


### PR DESCRIPTION
AWS snapshot import reliability is relatively low for imported VHDX
images from time to time. The raw image format works very reliably and
osbuild-composer has temporarily switched to the raw format for AWS
images.

Try using `subformat=fixed` when creating the VHDX as this is the
required setting for Azure. It's possible that AWS needs the image
formatted the same way.

Signed-off-by: Major Hayden <major@redhat.com>