### PR TITLE
Remove ability to pass in secrets via the command line

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -86,8 +86,6 @@ def parse_arguments(sys_argv):
                         help="directory where intermediary os trees are stored")
     parser.add_argument("--sources", metavar="FILE", type=os.path.abspath,
                         help="json file containing a dictionary of source configuration")
-    parser.add_argument("--secrets", metavar="FILE", type=os.path.abspath,
-                        help="json file containing a dictionary of secrets that are passed to sources")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath,
                         help="the directory containing stages, assemblers, and the osbuild library")
     parser.add_argument("--checkpoint", metavar="ID", action="append", type=str, default=None,
@@ -127,11 +125,6 @@ def osbuild_cli(*, sys_argv):
 
     pipeline = osbuild.load(pipeline, sources_options)
 
-    secrets = {}
-    if args.secrets:
-        with open(args.secrets) as f:
-            secrets = json.load(f)
-
     if args.checkpoint:
         missed = mark_checkpoints(pipeline, args.checkpoint)
         if missed:
@@ -153,7 +146,6 @@ def osbuild_cli(*, sys_argv):
             args.store,
             interactive=not args.json,
             libdir=args.libdir,
-            secrets=secrets,
             output_directory=args.output_directory
         )
     except KeyboardInterrupt:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -240,7 +240,6 @@ class Pipeline:
             tree = object_store.new()
             return results, build_tree, tree
 
-
         # Create a new tree. The base is our tree_id because if that
         # is already in the store, we can short-circuit directly and
         # exit directly; `tree` is then used to read the tree behind

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -73,8 +73,7 @@ class Stage:
             cache,
             interactive=False,
             libdir=None,
-            var="/var/tmp",
-            secrets=None):
+            var="/var/tmp"):
         with buildroot.BuildRoot(build_tree, runner, libdir=libdir, var=var) as build_root, \
             tempfile.TemporaryDirectory(prefix="osbuild-sources-output-", dir=var) as sources_output:
             if interactive:
@@ -96,8 +95,7 @@ class Stage:
                                       libdir or "/usr/lib/osbuild",
                                       self.sources,
                                       f"{cache}/sources",
-                                      sources_output,
-                                      secrets):
+                                      sources_output):
                 r = build_root.run(
                     [f"/run/osbuild/lib/stages/{self.name}"],
                     binds=[f"{tree}:/run/osbuild/tree"],
@@ -204,7 +202,7 @@ class Pipeline:
 
         return description
 
-    def build_stages(self, object_store, interactive, libdir, secrets):
+    def build_stages(self, object_store, interactive, libdir):
         results = {"success": True}
 
         # We need a build tree for the stages below, which is either
@@ -220,8 +218,7 @@ class Pipeline:
 
             r, t, tree = build.build_stages(object_store,
                                             interactive,
-                                            libdir,
-                                            secrets)
+                                            libdir)
 
             results["build"] = r
             if not r["success"]:
@@ -275,8 +272,7 @@ class Pipeline:
                               object_store.store,
                               interactive=interactive,
                               libdir=libdir,
-                              var=object_store.store,
-                              secrets=secrets)
+                              var=object_store.store)
 
             results["stages"].append(r.as_dict())
             if not r.success:
@@ -323,7 +319,7 @@ class Pipeline:
 
         return results
 
-    def run(self, store, interactive=False, libdir=None, secrets=None, output_directory=None):
+    def run(self, store, interactive=False, libdir=None, output_directory=None):
         os.makedirs("/run/osbuild", exist_ok=True)
         results = {}
 
@@ -341,8 +337,7 @@ class Pipeline:
             else:
                 results, build_tree, tree = self.build_stages(object_store,
                                                               interactive,
-                                                              libdir,
-                                                              secrets)
+                                                              libdir)
 
                 if not results["success"]:
                     return results

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -7,13 +7,12 @@ from .util import jsoncomm
 
 class SourcesServer:
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, socket_address, libdir, options, cache, output, secrets=None):
+    def __init__(self, socket_address, libdir, options, cache, output):
         self.socket_address = socket_address
         self.libdir = libdir
         self.cache = cache
         self.output = output
         self.options = options or {}
-        self.secrets = secrets or {}
         self.barrier = threading.Barrier(2)
         self.event_loop = None
         self.thread = None
@@ -21,7 +20,6 @@ class SourcesServer:
     def _run_source(self, source, checksums):
         msg = {
             "options": self.options.get(source, {}),
-            "secrets": self.secrets.get(source, {}),
             "cache": f"{self.cache}/{source}",
             "output": f"{self.output}/{source}",
             "checksums": checksums,


### PR DESCRIPTION
The way secrets work has been changed via commit 372b117: instead of passing them in via the command line, the information how to obtain secrets are encoded along the sources themselves. The only stage that still has support for the old style way is the deprecated `org.osbuild.dnf stage`, which might be removed in the near future.