### PR TITLE
Add support for format options and compression to qemu assembler

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -52,9 +52,33 @@ SCHEMA = """
     }
   },
   "format": {
-    "description": "Image file format to use",
-    "type": "string",
-    "enum": ["raw", "raw.xz", "qcow2", "vdi", "vmdk", "vpc", "vhdx"]
+    "oneOf": [
+      {
+        "description": "Image file format to use (legacy; options and compression are hardcoded for each format, use the object form)",
+        "type": "string",
+        "enum": ["raw", "raw.xz", "qcow2", "vdi", "vmdk", "vpc", "vhdx"]
+      },
+      {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "description": "Image file format to pass to qemu-img convert -O",
+            "type": "string",
+            "enum": ["raw", "raw.xz", "qcow2", "vdi", "vmdk", "vpc", "vhdx"]
+          },
+          "options": {
+            "description": "Format options to pass to qemu-img convert -o (ignored for raw and raw.xz)",
+            "type": "string"
+          },
+          "compressed": {
+            "description": "Compress the image using qemu-img convert -c (ignored for raw and raw.xz)",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    ]
   },
   "filename": {
     "description": "Image filename",
@@ -600,9 +624,20 @@ def install_zipl(root: str, device: str, pt: PartitionTable):
 
 
 def convert_image(image, output_filename, fmt):
-    if fmt == "raw":
+    # convert format to the new object form
+    if isinstance(fmt, str):
+        if fmt in ["raw", "raw.xz", "vdi", "vhdx"]:
+            fmt = {"type": fmt}
+        elif fmt in ["qcow2", "vmdk"]:
+            fmt = {"type": fmt, "compressed": True}
+        elif fmt == "vpc":
+            fmt = {"type": fmt, "options": "subformat=fixed,force_size"}
+        else:
+            raise ValueError("`format` must be one of raw, raw.xz, qcow2, vdi, vmdk, vpc, vhdx")
+
+    if fmt["type"] == "raw":
         subprocess.run(["cp", image, output_filename], check=True)
-    elif fmt == "raw.xz":
+    elif fmt["type"] == "raw.xz":
         with open(output_filename, "w") as f:
             subprocess.run(
                 ["xz", "--keep", "--stdout", "-0", image],
@@ -613,18 +648,16 @@ def convert_image(image, output_filename, fmt):
                 }
             )
     else:
-        extra_args = {
-            "qcow2": ["-c"],
-            "vdi": [],
-            "vmdk": ["-c"],
-            "vpc": ["-o", "subformat=fixed,force_size"],
-            "vhdx": []
-        }
+        extra_args = []
+        if fmt.get("compressed", False):
+            extra_args += ["-c"]
+        if fmt.get("options", ""):
+            extra_args += ["-o", fmt["options"]]
         subprocess.run([
             "qemu-img",
             "convert",
-            "-O", fmt,
-            *extra_args[fmt],
+            "-O", fmt["type"],
+            *extra_args,
             image,
             output_filename
         ], check=True)

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -640,9 +640,6 @@ def main(tree, output_dir, options, loop_client):
     if size % 512 != 0:
         raise ValueError("`size` must be a multiple of sector size (512)")
 
-    if fmt not in ["raw", "raw.xz", "qcow2", "vdi", "vmdk", "vpc", "vhdx"]:
-        raise ValueError("`format` must be one of raw, qcow, vdi, vmdk, vpc, vhdx")
-
     image = "/var/tmp/osbuild-image.raw"
 
     # Create an empty image file

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -599,6 +599,37 @@ def install_zipl(root: str, device: str, pt: PartitionTable):
                    check=True)
 
 
+def convert_image(image, output_filename, fmt):
+    if fmt == "raw":
+        subprocess.run(["cp", image, output_filename], check=True)
+    elif fmt == "raw.xz":
+        with open(output_filename, "w") as f:
+            subprocess.run(
+                ["xz", "--keep", "--stdout", "-0", image],
+                stdout=f,
+                check=True,
+                env={
+                    "XZ_OPT": "--threads 0"
+                }
+            )
+    else:
+        extra_args = {
+            "qcow2": ["-c"],
+            "vdi": [],
+            "vmdk": ["-c"],
+            "vpc": ["-o", "subformat=fixed,force_size"],
+            "vhdx": []
+        }
+        subprocess.run([
+            "qemu-img",
+            "convert",
+            "-O", fmt,
+            *extra_args[fmt],
+            image,
+            output_filename
+        ], check=True)
+
+
 def main(tree, output_dir, options, loop_client):
     fmt = options["format"]
     filename = options["filename"]
@@ -655,34 +686,8 @@ def main(tree, output_dir, options, loop_client):
         if bootloader["type"] == "zipl":
             install_zipl(root, disk, pt)
 
-    if fmt == "raw":
-        subprocess.run(["cp", image, f"{output_dir}/{filename}"], check=True)
-    elif fmt == "raw.xz":
-        with open(f"{output_dir}/{filename}", "w") as f:
-            subprocess.run(
-                ["xz", "--keep", "--stdout", "-0", image],
-                stdout=f,
-                check=True,
-                env={
-                    "XZ_OPT": "--threads 0"
-                }
-            )
-    else:
-        extra_args = {
-            "qcow2": ["-c"],
-            "vdi": [],
-            "vmdk": ["-c"],
-            "vpc": ["-o", "subformat=fixed,force_size"],
-            "vhdx": []
-        }
-        subprocess.run([
-            "qemu-img",
-            "convert",
-            "-O", fmt,
-            *extra_args[fmt],
-            image,
-            f"{output_dir}/{filename}"
-        ], check=True)
+    output_filename = f"{output_dir}/{filename}"
+    convert_image(image, output_filename, fmt)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In the near future, we would like to build `vmdk` images in `streamOptimized` subformat. This is currently not possible. This PRs add support for specifying format options and compression to qemu assembler.

I will add tests later, I just want to get feedback on the implementation, therefore marking this as a draft.