### PR TITLE
Introduce pipeline monitoring

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,3 +4,6 @@ max-line-length=120
 
 [TYPECHECK]
 ignored-classes=osbuild.loop.LoopInfo
+
+[DESIGN]
+max-attributes=10

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -201,7 +201,6 @@ class Filesystem:
         maker(device, self.uuid, self.label)
 
 
-# pylint: disable=too-many-instance-attributes
 class Partition:
     def __init__(self,
                  pttype: str = None,

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -70,3 +70,4 @@ class API:
     def __exit__(self, *args):
         self.event_loop.call_soon_threadsafe(self.event_loop.stop)
         self.thread.join()
+        self.event_loop.close()

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -2,19 +2,18 @@ import asyncio
 import io
 import json
 import os
-import sys
 import tempfile
 import threading
 from .util import jsoncomm
 
 
 class API:
-    def __init__(self, socket_address, args, interactive):
+    def __init__(self, socket_address, args, monitor):
         self.socket_address = socket_address
         self.input = args
-        self.interactive = interactive
         self._output_data = io.StringIO()
         self._output_pipe = None
+        self.monitor = monitor
         self.event_loop = asyncio.new_event_loop()
         self.thread = threading.Thread(target=self._run_event_loop)
         self.barrier = threading.Barrier(2)
@@ -41,9 +40,7 @@ class API:
         raw = os.read(self._output_pipe, 4096)
         data = raw.decode("utf-8")
         self._output_data.write(data)
-
-        if self.interactive:
-            sys.stdout.write(data)
+        self.monitor.log(data)
 
     def _setup_stdio(self, server, addr):
         with self._prepare_input() as stdin, \

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -13,6 +13,7 @@ import sys
 
 import osbuild
 import osbuild.meta
+import osbuild.monitor
 
 
 RESET = "\033[0m"
@@ -145,10 +146,13 @@ def osbuild_cli():
         print("No output directory or checkpoints specified, exited without building.")
         return 0
 
+    monitor_name = "NullMonitor" if args.json else "LogMonitor"
+    monitor = osbuild.monitor.make(monitor_name, sys.stdout.fileno())
+
     try:
         r = pipeline.run(
             args.store,
-            interactive=not args.json,
+            monitor,
             libdir=args.libdir,
             output_directory=args.output_directory
         )

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -1,0 +1,126 @@
+"""
+Monitor pipeline activity
+
+The osbuild `Pipeline` class supports monitoring of its activities
+by providing a monitor object that implements the `BaseMonitor`
+interface. During the execution of the pipeline various functions
+are called on the monitor object at certain events. Consult the
+`BaseMonitor` class for the description of all available events.
+"""
+
+import abc
+import json
+import os
+import sys
+
+from typing import Dict
+
+import osbuild
+
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+class TextWriter:
+    """Helper class for writing text to file descriptors"""
+    def __init__(self, fd: int):
+        self.fd = fd
+        self.isatty = os.isatty(fd)
+
+    def term(self, text, *, clear=False):
+        """Write text if attached to a terminal."""
+        if not self.isatty:
+            return
+
+        if clear:
+            self.write(RESET)
+
+        self.write(text)
+
+    def write(self, text: str):
+        """Write all of text to the log file descriptor"""
+        data = text.encode("utf-8")
+        n = len(data)
+        while n:
+            k = os.write(self.fd, data)
+            n -= k
+            if n:
+                data = data[n:]
+
+
+class BaseMonitor(abc.ABC):
+    """Base class for all pipeline monitors"""
+
+    def __init__(self, fd: int):
+        """Logging will be done to file descriptor `fd`"""
+        self.out = TextWriter(fd)
+
+    def begin(self, pipeline: osbuild.Pipeline):
+        """Called once at the beginning of a build"""
+
+    def finish(self, result: Dict):
+        """Called at the very end of the build"""
+
+    def stage(self, stage: osbuild.Stage):
+        """Called when a stage is being built"""
+
+    def assembler(self, assembler: osbuild.Assembler):
+        """Called when an assembler is being built"""
+
+    def result(self, result: osbuild.pipeline.BuildResult):
+        """Called when a module is done with its result"""
+
+    def log(self, message: str):
+        """Called for all module log outputs"""
+
+
+class NullMonitor(BaseMonitor):
+    """Monitor class that does not report anything"""
+
+
+class LogMonitor(BaseMonitor):
+    """Monitor that follows show the log output of modules
+
+    This monitor will print a header with `name: id` followed
+    by the options for each module as it is being built. The
+    full log messages of the modules will be print as soon as
+    they become available.
+    The constructor argument `fd` is a file descriptor, where
+    the log will get written to. If `fd`  is a `TTY`, escape
+    sequences will be used to highlight sections of the log.
+    """
+    def stage(self, stage):
+        self.module(stage)
+
+    def assembler(self, assembler):
+        self.out.term(BOLD, clear=True)
+        self.out.write("Assembler ")
+        self.out.term(RESET)
+
+        self.module(assembler)
+
+    def module(self, module):
+        options = module.options or {}
+        title = f"{module.name}: {module.id}"
+
+        self.out.term(BOLD, clear=True)
+        self.out.write(title)
+        self.out.term(RESET)
+        self.out.write(" ")
+
+        json.dump(options, self.out, indent=2)
+        self.out.write("\n")
+
+    def log(self, message):
+        self.out.write(message)
+
+
+def make(name, fd):
+    module = sys.modules[__name__]
+    monitor = getattr(module, name, None)
+    if not monitor:
+        raise ValueError(f"Unknown monitor: {name}")
+    if not issubclass(monitor, BaseMonitor):
+        raise ValueError(f"Invalid monitor: {name}")
+    return monitor(fd)

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -40,7 +40,6 @@ def umount(target, lazy=True):
     subprocess.run(["umount"] + args + [target], check=True)
 
 
-# pylint: disable=too-many-instance-attributes
 class Object:
     def __init__(self, store: "ObjectStore"):
         self._init = True

--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -101,6 +101,7 @@ class LoopServer:
     def __exit__(self, *args):
         self.event_loop.call_soon_threadsafe(self.event_loop.stop)
         self.thread.join()
+        self.event_loop.close()
         for lo in self.devs:
             lo.close()
 

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -6,7 +6,6 @@ from .util import jsoncomm
 
 
 class SourcesServer:
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, socket_address, libdir, options, cache, output):
         self.socket_address = socket_address
         self.libdir = libdir

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -1,0 +1,96 @@
+#
+# Test for monitoring classes and integration
+#
+
+import json
+import os
+import multiprocessing as mp
+import sys
+import tempfile
+import unittest
+
+import osbuild
+import osbuild.meta
+from osbuild.api import API
+from osbuild.monitor import LogMonitor
+from osbuild.util import jsoncomm
+from .. import test
+
+
+def setup_stdio(path):
+    """Copy of what the osbuild runners do to setup stdio"""
+    with jsoncomm.Socket.new_client(path) as client:
+        req = {'method': 'setup-stdio'}
+        client.send(req)
+        msg, fds, _ = client.recv()
+        for sio in ['stdin', 'stdout', 'stderr']:
+            target = getattr(sys, sio)
+            source = fds[msg[sio]]
+            os.dup2(source, target.fileno())
+        fds.close()
+
+
+def echo(path):
+    """echo stdin to stdout after setting stdio up via API
+
+    Meant to be called as the main function in a process
+    simulating an osbuild runner and a stage run which does
+    nothing but returns the supplied options to stdout again.
+    """
+    setup_stdio(path)
+    data = json.load(sys.stdin)
+    json.dump(data, sys.stdout)
+    sys.exit(0)
+
+
+class TestMonitor(unittest.TestCase):
+    def test_log_monitor_api(self):
+        # Basic log and API integration check
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args = {"foo": "bar"}
+            path = os.path.join(tmpdir, "osbuild-api")
+            logfile = os.path.join(tmpdir, "log.txt")
+
+            with open(logfile, "w") as log, \
+                 API(path, args, LogMonitor(log.fileno())) as api:
+                p = mp.Process(target=echo, args=(path, ))
+                p.start()
+                p.join()
+                self.assertEqual(p.exitcode, 0)
+                output = api.output
+                assert output
+
+            self.assertEqual(json.dumps(args), output)
+            with open(logfile) as f:
+                log = f.read()
+            self.assertEqual(log, output)
+
+    @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
+    def test_log_monitor_vfuncs(self):
+        # Checks the basic functioning of the LogMonitor
+        pipeline = osbuild.Pipeline("org.osbuild.linux")
+        pipeline.add_stage("org.osbuild.noop", {}, {
+            "isthisthereallife": False
+        })
+        pipeline.set_assembler("org.osbuild.noop")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storedir = os.path.join(tmpdir, "store")
+            outputdir = os.path.join(tmpdir, "output")
+
+            logfile = os.path.join(tmpdir, "log.txt")
+
+            with open(logfile, "w") as log:
+                monitor = LogMonitor(log.fileno())
+                res = pipeline.run(storedir,
+                                   monitor,
+                                   libdir=os.path.abspath(os.curdir),
+                                   output_directory=outputdir)
+
+                with open(logfile) as f:
+                    log = f.read()
+
+            assert res
+            self.assertIn(pipeline.stages[0].id, log)
+            self.assertIn(pipeline.assembler.id, log)
+            self.assertIn("isthisthereallife", log)

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -2,12 +2,14 @@
 # Test for monitoring classes and integration
 #
 
+import io
 import json
 import os
 import multiprocessing as mp
 import sys
 import tempfile
 import unittest
+from collections import defaultdict
 
 import osbuild
 import osbuild.meta
@@ -41,6 +43,40 @@ def echo(path):
     data = json.load(sys.stdin)
     json.dump(data, sys.stdout)
     sys.exit(0)
+
+
+class TapeMonitor(osbuild.monitor.BaseMonitor):
+    """Record the usage of all called functions"""
+    def __init__(self):
+        super().__init__(sys.stderr.fileno())
+        self.counter = defaultdict(int)
+        self.stages = set()
+        self.asm = None
+        self.results = set()
+        self.logger = io.StringIO()
+
+    def begin(self, pipeline: osbuild.Pipeline):
+        self.counter["begin"] += 1
+
+    def finish(self, result):
+        self.counter["finish"] += 1
+        self.output = self.logger.getvalue()
+
+    def stage(self, stage: osbuild.Stage):
+        self.counter["stages"] += 1
+        self.stages.add(stage.id)
+
+    def assembler(self, assembler: osbuild.Assembler):
+        self.counter["assembler"] += 1
+        self.asm = assembler.id
+
+    def result(self, result: osbuild.pipeline.BuildResult):
+        self.counter["result"] += 1
+        self.results.add(result.id)
+
+    def log(self, message: str):
+        self.counter["log"] += 1
+        self.logger.write(message)
 
 
 class TestMonitor(unittest.TestCase):
@@ -94,3 +130,37 @@ class TestMonitor(unittest.TestCase):
             self.assertIn(pipeline.stages[0].id, log)
             self.assertIn(pipeline.assembler.id, log)
             self.assertIn("isthisthereallife", log)
+
+    @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
+    def test_monitor_integration(self):
+        # Checks the monitoring API is called properly from the pipeline
+        pipeline = osbuild.Pipeline("org.osbuild.linux")
+        pipeline.add_stage("org.osbuild.noop", {}, {
+            "isthisthereallife": False
+        })
+        pipeline.add_stage("org.osbuild.noop", {}, {
+            "isthisjustfantasy": True
+        })
+        pipeline.set_assembler("org.osbuild.noop")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storedir = os.path.join(tmpdir, "store")
+            outputdir = os.path.join(tmpdir, "output")
+
+            tape = TapeMonitor()
+            res = pipeline.run(storedir,
+                               tape,
+                               libdir=os.path.abspath(os.curdir),
+                               output_directory=outputdir)
+
+        assert res
+        self.assertEqual(tape.counter["begin"], 1)
+        self.assertEqual(tape.counter["finish"], 1)
+        self.assertEqual(tape.counter["stages"], 2)
+        self.assertEqual(tape.counter["assembler"], 1)
+        self.assertEqual(tape.counter["stages"], 2)
+        self.assertEqual(tape.counter["result"], 3)
+        self.assertIn(pipeline.stages[0].id, tape.stages)
+        self.assertIn(pipeline.assembler.id, tape.asm)
+        self.assertIn("isthisthereallife", tape.output)
+        self.assertIn("isthisjustfantasy", tape.output)


### PR DESCRIPTION
Introduce the concept of pipeline monitoring: A new monitor class is passed to the `pipeline.run()` function. The main idea is to separate the monitoring from the code that builds pipeline. Through the build process various methods will be called on that object, representing the different steps and their targets during the build process. This can be used to fully stream the output of the various stages or just indicate the start and finish of the individual stages.

This replaces the 'interactive' argument throughout the pipeline code. The old interactive behavior is replicated via the new `LogMonitor` class that logs the beginning of stages/assembler, but also streams all the output of them to `stdout`. The non-interactive of not reporting anything behavior is done by using the `NullMonitor` class, which in turn does nothing.

A new JSON monitor is added in PR #473 which can be used in clients to follow the progress.

TODO:
 - [x] Tests
 - [x] Integrate `JsonMonitor` via a new command line option

Solves issue #319