### PR TITLE
monitoring: add JSON lines streaming 

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,3 +4,6 @@ max-line-length=120
 
 [TYPECHECK]
 ignored-classes=osbuild.loop.LoopInfo
+
+[DESIGN]
+max-attributes=10

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -201,7 +201,6 @@ class Filesystem:
         maker(device, self.uuid, self.label)
 
 
-# pylint: disable=too-many-instance-attributes
 class Partition:
     def __init__(self,
                  pttype: str = None,

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -70,3 +70,4 @@ class API:
     def __exit__(self, *args):
         self.event_loop.call_soon_threadsafe(self.event_loop.stop)
         self.thread.join()
+        self.event_loop.close()

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -2,19 +2,18 @@ import asyncio
 import io
 import json
 import os
-import sys
 import tempfile
 import threading
 from .util import jsoncomm
 
 
 class API:
-    def __init__(self, socket_address, args, interactive):
+    def __init__(self, socket_address, args, monitor):
         self.socket_address = socket_address
         self.input = args
-        self.interactive = interactive
         self._output_data = io.StringIO()
         self._output_pipe = None
+        self.monitor = monitor
         self.event_loop = asyncio.new_event_loop()
         self.thread = threading.Thread(target=self._run_event_loop)
         self.barrier = threading.Barrier(2)
@@ -41,9 +40,7 @@ class API:
         raw = os.read(self._output_pipe, 4096)
         data = raw.decode("utf-8")
         self._output_data.write(data)
-
-        if self.interactive:
-            sys.stdout.write(data)
+        self.monitor.log(data)
 
     def _setup_stdio(self, server, addr):
         with self._prepare_input() as stdin, \

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -13,6 +13,7 @@ import sys
 
 import osbuild
 import osbuild.meta
+import osbuild.monitor
 
 
 RESET = "\033[0m"
@@ -141,10 +142,14 @@ def osbuild_cli(*, sys_argv):
         sys.stdout.write("\n")
         return 0
 
+
+    monitor_name = "NullMonitor" if args.json else "LogMonitor"
+    monitor = osbuild.monitor.make(monitor_name, sys.stdout.fileno())
+
     try:
         r = pipeline.run(
             args.store,
-            interactive=not args.json,
+            monitor,
             libdir=args.libdir,
             output_directory=args.output_directory
         )

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -97,6 +97,10 @@ def parse_arguments(sys_argv):
                         help="directory where result objects are stored")
     parser.add_argument("--inspect", action="store_true",
                         help="return the manifest in JSON format including all the ids")
+    parser.add_argument("--monitor", metavar="NAME", default=None,
+                        help="Name of the monitor to be used")
+    parser.add_argument("--monitor-fd", metavar="FD", type=int, default=sys.stdout.fileno(),
+                        help="File descriptor to be used for the monitor")
 
     return parser.parse_args(sys_argv[1:])
 
@@ -142,9 +146,11 @@ def osbuild_cli(*, sys_argv):
         sys.stdout.write("\n")
         return 0
 
+    if not args.monitor:
+        monitor_name = "NullMonitor" if args.json else "LogMonitor"
+        setattr(args, "monitor", monitor_name)
 
-    monitor_name = "NullMonitor" if args.json else "LogMonitor"
-    monitor = osbuild.monitor.make(monitor_name, sys.stdout.fileno())
+    monitor = osbuild.monitor.make(args.monitor, args.monitor_fd)
 
     try:
         r = pipeline.run(

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -1,0 +1,126 @@
+"""
+Monitor pipeline activity
+
+The osbuild `Pipeline` class supports monitoring of its activities
+by providing a monitor object that implements the `BaseMonitor`
+interface. During the execution of the pipeline various functions
+are called on the monitor object at certain events. Consult the
+`BaseMonitor` class for the description of all available events.
+"""
+
+import abc
+import json
+import os
+import sys
+
+from typing import Dict
+
+import osbuild
+
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+
+
+class TextWriter:
+    """Helper class for writing text to file descriptors"""
+    def __init__(self, fd: int):
+        self.fd = fd
+        self.isatty = os.isatty(fd)
+
+    def term(self, text, *, clear=False):
+        """Write text if attached to a terminal."""
+        if not self.isatty:
+            return
+
+        if clear:
+            self.write(RESET)
+
+        self.write(text)
+
+    def write(self, text: str):
+        """Write all of text to the log file descriptor"""
+        data = text.encode("utf-8")
+        n = len(data)
+        while n:
+            k = os.write(self.fd, data)
+            n -= k
+            if n:
+                text = data[n:]
+
+
+class BaseMonitor(abc.ABC):
+    """Base class for all pipeline monitors"""
+
+    def __init__(self, fd: int):
+        """Logging will be done to file descriptor `fd`"""
+        self.out = TextWriter(fd)
+
+    def begin(self, pipeline: osbuild.Pipeline):
+        """Called once at the beginning of a build"""
+
+    def finish(self, result: Dict):
+        """Called at the very end of the build"""
+
+    def stage(self, stage: osbuild.Stage):
+        """Called when a stage is being built"""
+
+    def assembler(self, assembler: osbuild.Assembler):
+        """Called when an assembler is being built"""
+
+    def result(self, result: osbuild.pipeline.BuildResult):
+        """Called when a module is done with its result"""
+
+    def log(self, message: str):
+        """Called for all module log outputs"""
+
+
+class NullMonitor(BaseMonitor):
+    """Monitor class that does not report anything"""
+
+
+class LogMonitor(BaseMonitor):
+    """Monitor that follows show the log output of modules
+
+    This monitor will print a header with `name: id` followed
+    by the options for each module as it is being built. The
+    full log messages of the modules will be print as soon as
+    they become available.
+    The constructor argument `fd` is a file descriptor, where
+    the log will get written to. If `fd`  is a `TTY`, escape
+    sequences will be used to highlight sections of the log.
+    """
+    def stage(self, stage):
+        self.module(stage)
+
+    def assembler(self, assembler):
+        self.out.term(BOLD, clear=True)
+        self.out.write("Assembler ")
+        self.out.term(RESET)
+
+        self.module(assembler)
+
+    def module(self, module):
+        options = module.options or {}
+        title = f"{module.name}: {module.id}"
+
+        self.out.term(BOLD, clear=True)
+        self.out.write(title)
+        self.out.term(RESET)
+        self.out.write(" ")
+
+        json.dump(options, self.out, indent=2)
+        self.out.write("\n")
+
+    def log(self, message):
+        self.out.write(message)
+
+
+def make(name, fd):
+    module = sys.modules[__name__]
+    monitor = getattr(module, name, None)
+    if not monitor:
+        raise ValueError(f"Unknown monitor: {name}")
+    if not issubclass(monitor, BaseMonitor):
+        raise ValueError(f"Invalid monitor: {name}")
+    return monitor(fd)

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -40,7 +40,6 @@ def umount(target, lazy=True):
     subprocess.run(["umount"] + args + [target], check=True)
 
 
-# pylint: disable=too-many-instance-attributes
 class Object:
     def __init__(self, store: "ObjectStore"):
         self._init = True

--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -101,6 +101,7 @@ class LoopServer:
     def __exit__(self, *args):
         self.event_loop.call_soon_threadsafe(self.event_loop.stop)
         self.thread.join()
+        self.event_loop.close()
         for lo in self.devs:
             lo.close()
 

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -6,7 +6,6 @@ from .util import jsoncomm
 
 
 class SourcesServer:
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, socket_address, libdir, options, cache, output):
         self.socket_address = socket_address
         self.libdir = libdir


### PR DESCRIPTION
NB: depends on #470 

This new monitor class will stream JSON records according to JSON Lines (http://jsonlines.org/), i.e. exactly one JSON object per line, like `{"type": "update", "data": ...}`.
For ever stage, assembler a message before it is being built a message is sent with the following information:
```js
  {
    "type": "build",
    "data": {
      "module": {
        "type": "assembler",
        "name": "org.osbuild.rawfs",
        "id": "8cb7287d9ac5c561c9aa6ef712..."
      },
      "progress": {
        "current": 7,
        "total": 7
      }
    }
  }<LF>
```

NB: No actual new lines in the output, just here to make the data more readable. The only new line is at the end (<LF>). This should allow clients to follow the progress of the build process.

Example golang program to demonstrate the usage:
```go
package main

import (
	"bufio"
	"bytes"
	"encoding/json"
	"fmt"
	"log"
	"os"
	"os/exec"
	"strconv"
)

type MonitorLog struct {
	Type string
	Data *json.RawMessage
}

type ProgressLog struct {
	Module struct {
		Type string
		Name string
		Id   string
	}
	Progress struct {
		Current int
		Total   int
	}
}

func main() {
	r, w, err := os.Pipe()

	if err != nil {
		log.Fatal(err)
	}

	target := "samples/error.json"
	if len(os.Args) > 1 {
		target = os.Args[1]
	}

	cmd := exec.Command(
		"python3",
		"-m", "osbuild",
		"--libdir", ".",
		"--store", "osbuild-store",
		"--output-directory", "osbuild-output",
		"--json",
		"--monitor", "JsonLinesMonitor",
		"--monitor-fd", strconv.FormatUint(3, 10),
		target,
	)
	var out bytes.Buffer
	cmd.Stdout = &out
	cmd.Stderr = os.Stderr

	go func() {
		scanner := bufio.NewScanner(r)
		for scanner.Scan() {
			var data json.RawMessage
			msg := MonitorLog{
				Data: &data,
			}

			line := scanner.Text()
			if err := json.Unmarshal([]byte(line), &msg); err != nil {
				log.Fatal(err)
			}

			switch msg.Type {
			case "progress":
				var p ProgressLog
				if err := json.Unmarshal(data, &p); err != nil {
					log.Fatal(err)
				}

				fmt.Printf("\r %d of %d: %s",
					p.Progress.Current,
					p.Progress.Total,
					p.Module.Id)

			default:
				log.Fatalf("unknown log: %q", msg.Type)
			}
		}
	}()

	cmd.ExtraFiles = append(cmd.ExtraFiles, w)

	err = cmd.Start()
	if err != nil {
		log.Fatal(err)
	}

	err = w.Close()
	if err != nil {
		log.Fatal(err)
	}

	err = cmd.Wait()

	fmt.Printf("\nResult: %q\n", out.String())

	if err != nil {
		log.Fatal(err)
	}
}
```

Example usage (in an osbuild checkout of this PR):
```
→ sudo go run monitor.go samples/base-qcow2.json
 1 of 8: 5f765969c08c5dd5c8c70be51aea247f0e6e751385d10469d87787d3315806d7
```
