### PR TITLE
schutzbot: remove enabling of rcm socket unit

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -69,7 +69,6 @@ if [[ "${ID}${VERSION_ID//./}" == rhel82 ]]; then
 fi
 
 # Start services.
-sudo systemctl enable --now osbuild-rcm.socket
 sudo systemctl enable --now osbuild-composer.socket
 
 # Verify that the API is running.


### PR DESCRIPTION
The whole rcm subpackage was removed in osbuild-composer's commit fbfa191.
Unfortunately, this broke osbuild's schutzbot because it tries to start
the rcm socket.

This commit removes enabling of the not-anymore-existing socket unit.