### PR TITLE
Use script for telegram notification

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -158,12 +158,22 @@ pipeline {
 
     post {
         success {
-            when { branch 'master' }
-            telegramSend "💚 CI passed for osbuild-composer master branch!. ${env.BUILD_URL}"
+            node('schutzbot') {
+                script {
+                    if (env.BRANCH_NAME == 'master') {
+                        telegramSend "💚 CI passed for osbuild master branch ${env.BUILD_URL}"
+                    }
+                }
+            }
         }
         unsuccessful {
-            when { branch 'master' }
-            telegramSend "💣 CI failed for osbuild-composer master branch! ${env.BUILD_URL}"
+            node('schutzbot') {
+                script {
+                    if (env.BRANCH_NAME == 'master') {
+                        telegramSend "💣 CI failed for osbuild master branch ${env.BUILD_URL}"
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Jenkins' declarative pipelines have interesting requirements around when
you can use traditional groovy scripting in the pipeline and some items
in `post` require special handling.

Signed-off-by: Major Hayden <major@redhat.com>