### PR TITLE
osbuild: return if output-directory not specified

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -148,6 +148,10 @@ def osbuild_cli(*, sys_argv):
         sys.stdout.write("\n")
         return 0
 
+    if not args.output_directory and not args.checkpoint:
+        print("No output directory or checkpoints specified, exited without building.")
+        return 0
+
     try:
         r = pipeline.run(
             args.store,


### PR DESCRIPTION
If the user does not specify an output directory or checkpoints to osbuild, exit 
successfully without building.

Previously, if a user did not include an output directory or checkpoints, it would 
build the manifest and throw out the result. Returning early will be clearer to the 
user and avoid wasting work.