### PR TITLE
objectstore: support for PathLike and cleaner path handling

### DIFF
--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -239,11 +239,11 @@ class HostTree:
 
 
 class ObjectStore(contextlib.AbstractContextManager):
-    def __init__(self, store):
+    def __init__(self, store: PathLike):
         self.store = store
-        self.objects = f"{store}/objects"
-        self.refs = f"{store}/refs"
-        self.tmp = f"{store}/tmp"
+        self.objects = os.path.join(store, "objects")
+        self.refs = os.path.join(store, "refs")
+        self.tmp = os.path.join(store, "tmp")
         os.makedirs(self.store, exist_ok=True)
         os.makedirs(self.objects, exist_ok=True)
         os.makedirs(self.refs, exist_ok=True)
@@ -259,7 +259,7 @@ class ObjectStore(contextlib.AbstractContextManager):
         """Returns the path to the given object_id"""
         if not object_id:
             return None
-        return f"{self.refs}/{object_id}"
+        return os.path.join(self.refs, object_id)
 
     def tempdir(self, prefix=None, suffix=None):
         """Return a tempfile.TemporaryDirectory within the store"""
@@ -316,7 +316,7 @@ class ObjectStore(contextlib.AbstractContextManager):
         # will always produce the same content hash, but that is not
         # guaranteed. If an object with the same treesum already exist, us
         # the existing one instead
-        obj.store_tree(f"{self.objects}/{treesum_hash}")
+        obj.store_tree(os.path.join(self.objects, treesum_hash))
 
         # symlink the object_id (config hash) in the refs directory to the
         # treesum (content hash) in the objects directory. If a symlink by

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -59,10 +59,8 @@ class Object:
         if self._init:
             return
 
-        source = self.store.resolve_ref(self._base)
-        subprocess.run(["cp", "--reflink=auto", "-a",
-                        f"{source}/.", self._tree],
-                       check=True)
+        with self.store.new(self._base) as obj:
+            obj.export(self._tree)
         self._init = True
 
     @property

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import tempfile
 import weakref
-from typing import Optional
+from typing import Optional, Union
 
 from osbuild.util import ctx, rmrf
 from . import treesum
@@ -14,6 +14,10 @@ from . import treesum
 __all__ = [
     "ObjectStore",
 ]
+
+
+# Type for valid inputs to `os.fspath`
+PathLike = Union[str, bytes, os.PathLike]
 
 
 def mount(source, target, bind=True, ro=True, private=True, mode="0755"):
@@ -192,7 +196,7 @@ class Object:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.cleanup()
 
-    def export(self, to_directory):
+    def export(self, to_directory: PathLike):
         """Copy object into an external directory"""
         with self.read() as from_directory:
             subprocess.run(
@@ -200,8 +204,8 @@ class Object:
                     "cp",
                     "--reflink=auto",
                     "-a",
-                    f"{from_directory}/.",
-                    to_directory,
+                    os.fspath(from_directory) + "/.",
+                    os.fspath(to_directory),
                 ],
                 check=True,
             )

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -86,7 +86,7 @@ class Stage:
                                       sources_output):
                 r = build_root.run(
                     [f"/run/osbuild/lib/stages/{self.name}"],
-                    binds=[f"{tree}:/run/osbuild/tree"],
+                    binds=[os.fspath(tree) + ":/run/osbuild/tree"],
                     readonly_binds=ro_binds,
                 )
                 return BuildResult(self, r.returncode, api.output)
@@ -130,11 +130,12 @@ class Assembler:
 
             binds = []
             if output_dir:
+                output_dir = os.fspath(output_dir)
                 os.makedirs(output_dir, exist_ok=True)
                 binds.append(f"{output_dir}:/run/osbuild/output")
                 args["output_dir"] = "/run/osbuild/output"
 
-            ro_binds = [f"{tree}:/run/osbuild/tree"]
+            ro_binds = [os.fspath(tree) + ":/run/osbuild/tree"]
 
             with remoteloop.LoopServer(f"{build_root.api}/remoteloop"), \
                 API(f"{build_root.api}/osbuild", args, monitor) as api:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -82,7 +82,7 @@ class Stage:
                 sources.SourcesServer(f"{build_root.api}/sources",
                                       libdir or "/usr/lib/osbuild",
                                       self.sources,
-                                      f"{cache}/sources",
+                                      os.path.join(cache, "sources"),
                                       sources_output):
                 r = build_root.run(
                     [f"/run/osbuild/lib/stages/{self.name}"],

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -36,7 +36,7 @@ class TestObjectStore(unittest.TestCase):
 
             with object_store.new() as tree:
                 with tree.write() as path:
-                    p = Path(f"{path}/A")
+                    p = Path(path, "A")
                     p.touch()
                 object_store.commit(tree, "a")
 
@@ -49,9 +49,9 @@ class TestObjectStore(unittest.TestCase):
 
             with object_store.new() as tree:
                 with tree.write() as path:
-                    p = Path(f"{path}/A")
+                    p = Path(path, "A")
                     p.touch()
-                    p = Path(f"{path}/B")
+                    p = Path(path, "B")
                     p.touch()
                 object_store.commit(tree, "b")
 
@@ -74,7 +74,7 @@ class TestObjectStore(unittest.TestCase):
                 tree = object_store.new()
                 self.assertEqual(len(os.listdir(object_store.tmp)), 1)
                 with tree.write() as path:
-                    p = Path(f"{path}/A")
+                    p = Path(path, "A")
                     p.touch()
             # there should be no temporary Objects dirs anymore
             self.assertEqual(len(os.listdir(object_store.tmp)), 0)
@@ -85,14 +85,14 @@ class TestObjectStore(unittest.TestCase):
             object_store = objectstore.ObjectStore(tmp)
             with object_store.new() as tree:
                 with tree.write() as path:
-                    p = Path(f"{path}/A")
+                    p = Path(path, "A")
                     p.touch()
                 object_store.commit(tree, "a")
 
             with object_store.new() as tree:
                 with tree.write() as path:
                     shutil.copy2(f"{object_store.refs}/a/A",
-                                 f"{path}/A")
+                                 os.path.join(path, "A"))
                 object_store.commit(tree, "b")
 
             assert os.path.exists(f"{object_store.refs}/a")
@@ -111,7 +111,7 @@ class TestObjectStore(unittest.TestCase):
             object_store = objectstore.ObjectStore(tmp)
             with object_store.new() as tree:
                 with tree.write() as path:
-                    p = Path(f"{path}/A")
+                    p = Path(path, "A")
                     p.touch()
                 object_store.commit(tree, "a")
 
@@ -122,7 +122,7 @@ class TestObjectStore(unittest.TestCase):
             with object_store.new() as tree:
                 tree.base = "b"
                 with tree.write() as path:
-                    p = Path(f"{path}/C")
+                    p = Path(path, "C")
                     p.touch()
                 object_store.commit(tree, "c")
 
@@ -146,7 +146,7 @@ class TestObjectStore(unittest.TestCase):
             with object_store.new() as tree:
                 path = tree.write()
                 with tree.write() as path, \
-                     open(f"{path}/data", "w") as f:
+                     open(os.path.join(path, "data"), "w") as f:
                     f.write(data)
                     st = os.fstat(f.fileno())
                     data_inode = st.st_ino
@@ -158,7 +158,7 @@ class TestObjectStore(unittest.TestCase):
                 # check that "data" is still the very
                 # same file after committing
                 with tree.read() as path:
-                    with open(f"{path}/data", "r") as f:
+                    with open(os.path.join(path, "data"), "r") as f:
                         st = os.fstat(f.fileno())
                         self.assertEqual(st.st_ino, data_inode)
                         data_read = f.read()
@@ -172,7 +172,7 @@ class TestObjectStore(unittest.TestCase):
                 self.assertEqual(tree.base, "x")
                 self.assertEqual(tree.treesum, x_hash)
                 with tree.read() as path:
-                    with open(f"{path}/data", "r") as f:
+                    with open(os.path.join(path, "data"), "r") as f:
                         # copy-on-write: since we have not written
                         # to the tree yet, "data" should be the
                         # very same file as that one of object "x"
@@ -182,11 +182,11 @@ class TestObjectStore(unittest.TestCase):
                         self.assertEqual(data, data_read)
                 with tree.write() as path:
                     # "data" must of course still be present
-                    assert os.path.exists(f"{path}/data")
+                    assert os.path.exists(os.path.join(path, "data"))
                     # but since it is a copy, have a different inode
-                    st = os.stat(f"{path}/data")
+                    st = os.stat(os.path.join(path, "data"))
                     self.assertNotEqual(st.st_ino, data_inode)
-                    p = Path(f"{path}/other_data")
+                    p = Path(path, "other_data")
                     p.touch()
                 # now that we have written, the treesum
                 # should have changed
@@ -250,13 +250,13 @@ class TestObjectStore(unittest.TestCase):
         object_store = objectstore.ObjectStore(self.store)
         with object_store.new() as tree:
             with tree.write() as path:
-                p = Path(f"{path}/A")
+                p = Path(path, "A")
                 p.touch()
             assert not object_store.contains("a")
             object_store.commit(tree, "a")
             assert object_store.contains("a")
             with tree.write() as path:
-                p = Path(f"{path}/B")
+                p = Path(path, "B")
                 p.touch()
             object_store.commit(tree, "b")
 
@@ -282,6 +282,6 @@ class TestObjectStore(unittest.TestCase):
 
         # check we actually cannot write to the path
         with host.read() as path:
-            p = Path(f"{path}/osbuild-test-file")
+            p = Path(path, "osbuild-test-file")
             with self.assertRaises(OSError):
                 p.touch()

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -79,7 +79,7 @@ class TestDescriptions(unittest.TestCase):
             "assembler": {
                 "name": "org.osbuild.test"
             }
-            })
+        })
 
     def test_moduleinfo(self):
         index = osbuild.meta.Index(os.curdir)


### PR DESCRIPTION
Support for [`os.PathLike`](https://docs.python.org/3/library/os.html#os.PathLike), i.e. has a `__fspath__` method, throughout `objectstore` (and its test) and overall cleaner path handling. This also prepares that in future `Object.{read, write}` can return such `os.PathLike` object instead of plain paths, which can then in turn support setting additional metadata on tree data.