### PR TITLE
use cache in assembler tests

### DIFF
--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -132,17 +132,17 @@ class TestAssemblers(test.TestBase):
     @unittest.skipUnless(test.TestBase.have_tree_diff(), "tree-diff missing")
     def test_qemu(self):
         loctl = loop.LoopControl()
-        for fmt in ["raw", "raw.xz", "qcow2", "vmdk", "vdi"]:
-            with self.subTest(fmt=fmt):
-                print(f"  {fmt}", flush=True)
-                options = {
-                    "format": fmt,
-                    "filename": f"image.{fmt}",
-                    "ptuuid": "b2c09a39-db93-44c5-846a-81e06b1dc162",
-                    "root_fs_uuid": "aff010e9-df95-4f81-be6b-e22317251033",
-                    "size": 2 * 1024 * 1024 * 1024
-                }
-                with self.osbuild as osb:
+        with self.osbuild as osb:
+            for fmt in ["raw", "raw.xz", "qcow2", "vmdk", "vdi"]:
+                with self.subTest(fmt=fmt):
+                    print(f"  {fmt}", flush=True)
+                    options = {
+                        "format": fmt,
+                        "filename": f"image.{fmt}",
+                        "ptuuid": "b2c09a39-db93-44c5-846a-81e06b1dc162",
+                        "root_fs_uuid": "aff010e9-df95-4f81-be6b-e22317251033",
+                        "size": 2 * 1024 * 1024 * 1024
+                    }
                     with self.run_assembler(osb,
                                             "org.osbuild.qemu",
                                             options,
@@ -175,11 +175,11 @@ class TestAssemblers(test.TestBase):
             ("tree.tar.gz", None, ["application/x-tar"]),
             ("tree.tar.gz", "gzip", ["application/x-gzip", "application/gzip"])
         ]
-        for filename, compression, expected_mimetypes in cases:
-            options = {"filename": filename}
-            if compression:
-                options["compression"] = compression
-            with self.osbuild as osb:
+        with self.osbuild as osb:
+            for filename, compression, expected_mimetypes in cases:
+                options = {"filename": filename}
+                if compression:
+                    options["compression"] = compression
                 with self.run_assembler(osb,
                                         "org.osbuild.tar",
                                         options,


### PR DESCRIPTION
use one osbuild executor for all qemu tests

This way the test can benefit from osbuild's internal cache:

The first subtest builds all the stages and  runs the assembler
The next subtests can reuse the built stages and just run the assembler

Some data from my machine:

Building the manifest takes about 120 seconds
Running just the assembler on the cache's content takes 30 seconds.

Before this change, the whole manifest was built 3 times:
3 * 120 = 360 seconds

After this change, the whole manifest is built once and the cache
is reused 2 times:
1 * 120 + 2 * 30 = 180 seconds