### PR TITLE
Isolate the build root's network

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -188,6 +188,7 @@ class BuildRoot(contextlib.AbstractContextManager):
             "--setenv", "PYTHONPATH", "/run/osbuild/lib",
             "--unshare-ipc",
             "--unshare-pid",
+            "--unshare-net"
         ]
 
         cmd += mounts

--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -70,14 +70,14 @@ class LoopServer(api.BaseAPI):
         self.devs.append(lo)
         return lo.devname
 
-    def _message(self, msg, fds, sock, addr):
+    def _message(self, msg, fds, sock):
         fd = fds[msg["fd"]]
         dir_fd = fds[msg["dir_fd"]]
         offset = msg.get("offset")
         sizelimit = msg.get("sizelimit")
 
         devname = self._create_device(fd, dir_fd, offset, sizelimit)
-        sock.send({"devname": devname}, destination=addr)
+        sock.send({"devname": devname})
 
     def _cleanup(self):
         for lo in self.devs:

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -36,9 +36,9 @@ class SourcesServer(api.BaseAPI):
         except ValueError:
             return {"error": f"source returned malformed json: {r.stdout}"}
 
-    def _message(self, msg, fds, sock, addr):
+    def _message(self, msg, fds, sock):
         reply = self._run_source(msg["source"], msg["checksums"])
-        sock.send(reply, destination=addr)
+        sock.send(reply)
 
 
 def get(source, checksums, api_path="/run/osbuild/api/sources"):

--- a/osbuild/util/jsoncomm.py
+++ b/osbuild/util/jsoncomm.py
@@ -321,7 +321,7 @@ class Socket(contextlib.AbstractContextManager):
 
         return (payload, fdset, msg[3])
 
-    def send(self, payload: object, *, destination: Optional[str] = None, fds: Optional[list] = None):
+    def send(self, payload: object, *, fds: Optional[list] = None):
         """Send Message
 
         Send a new message via this socket. This operation is synchronous. The
@@ -352,5 +352,5 @@ class Socket(contextlib.AbstractContextManager):
         if fds:
             cmsg.append((socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds)))
 
-        n = self._socket.sendmsg([serialized], cmsg, 0, destination)
+        n = self._socket.sendmsg([serialized], cmsg, 0)
         assert n == len(serialized)

--- a/osbuild/util/jsoncomm.py
+++ b/osbuild/util/jsoncomm.py
@@ -114,6 +114,21 @@ class Socket(contextlib.AbstractContextManager):
         self.close()
         return False
 
+    @property
+    def blocking(self):
+        """Get the current blocking mode of the socket.
+
+        This is related to the socket's timeout, i.e. if no time out is set
+        the socket is in blocking mode; otherwise it is non-blocking.
+        """
+        timeout = self._socket.gettimeout()
+        return timeout is not None
+
+    @blocking.setter
+    def blocking(self, value: bool):
+        """Set the blocking mode of the socket."""
+        self._socket.setblocking(value)
+
     def close(self):
         """Close Socket
 

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -23,12 +23,12 @@ class APITester(osbuild.api.BaseAPI):
 
     endpoint = "test-api"
 
-    def _message(self, msg, _fds, sock, addr):
+    def _message(self, msg, _fds, sock):
         self.messages += 1
 
         if msg["method"] == "echo":
             msg["method"] = "reply"
-            sock.send(msg, destination=addr)
+            sock.send(msg)
 
     def _cleanup(self):
         self.clean = True

--- a/test/mod/test_util_jsoncomm.py
+++ b/test/mod/test_util_jsoncomm.py
@@ -165,3 +165,14 @@ class TestUtilJsonComm(unittest.TestCase):
 
         msg = self.client.recv()
         assert msg[0] == {}
+
+    def test_accept_timeout(self):
+        #
+        # Test calling `accept` without any connection being ready to be
+        # established will not throw any exceptions but return `None`
+        address = pathlib.Path(self.dir.name, "noblock")
+        listener = jsoncomm.Socket.new_server(address)
+        listener.listen()
+
+        conn = listener.accept()
+        self.assertIsNone(conn)

--- a/test/mod/test_util_jsoncomm.py
+++ b/test/mod/test_util_jsoncomm.py
@@ -84,7 +84,7 @@ class TestUtilJsonComm(unittest.TestCase):
         assert msg[0] == data
         assert len(msg[1]) == 0
 
-        self.server.send(data, destination=msg[2])
+        self.server.send(data)
         msg = self.client.recv()
         assert msg[0] == data
         assert len(msg[1]) == 0
@@ -154,7 +154,7 @@ class TestUtilJsonComm(unittest.TestCase):
 
         def echo(socket):
             msg = socket.recv()
-            socket.send(msg[0], destination=msg[2])
+            socket.send(msg[0])
             loop.stop()
 
         self.client.send({})


### PR DESCRIPTION
Unshare, i.e. create a new network namespace, for the build root. This will make sure that neither stages, assemblers nor the tools they are using are relying on the host's network.
For this to work, the `jsoncomm.Socket` is switch to use a connection orient protocol `SOCK_SEQPACKET`, which avoids the issue that the host could not send packets to the container, because the address of the client in the container was not visible to the host when the network was "unshared".