### PR TITLE
Finish assembler tests clean-up

### DIFF
--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -14,6 +14,8 @@ import unittest
 from osbuild import loop
 from .. import test
 
+MEBIBYTE = 1024 * 1024
+
 
 @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
 class TestAssemblers(test.TestBase):
@@ -92,7 +94,7 @@ class TestAssemblers(test.TestBase):
         options = {
             "filename": "image.raw",
             "root_fs_uuid": "016a1cda-5182-4ab3-bf97-426b00b74eb0",
-            "size": 2 * 1024 * 1024 * 1024
+            "size": 512 * MEBIBYTE
         }
         with self.osbuild as osb:
             with self.run_assembler(osb, "org.osbuild.rawfs", options, "image.raw") as (tree, image):
@@ -143,7 +145,7 @@ class TestAssemblers(test.TestBase):
                         "filename": f"image.{fmt}",
                         "ptuuid": "b2c09a39-db93-44c5-846a-81e06b1dc162",
                         "root_fs_uuid": "aff010e9-df95-4f81-be6b-e22317251033",
-                        "size": 2 * 1024 * 1024 * 1024
+                        "size": 512 * MEBIBYTE
                     }
                     with self.run_assembler(osb,
                                             "org.osbuild.qemu",

--- a/test/run/test_boot.py
+++ b/test/run/test_boot.py
@@ -24,11 +24,11 @@ class TestBoot(test.TestBase):
                                 "manifests/fedora-boot.json")
 
         with self.osbuild as osb:
-            osb.compile_file(manifest)
-            with osb.map_output("fedora-boot.qcow2") as qcow2, \
-                 tempfile.TemporaryDirectory() as d:
+            with tempfile.TemporaryDirectory(dir="/var/tmp") as temp_dir:
+                osb.compile_file(manifest, output_dir=temp_dir)
+                qcow2 = os.path.join(temp_dir, "fedora-boot.qcow2")
+                output_file = os.path.join(temp_dir, "output")
 
-                output_file = os.path.join(d, "output")
                 subprocess.run(["qemu-system-x86_64",
                                 "-snapshot",
                                 "-m", "1024",


### PR DESCRIPTION
Currently, the assembler tests store more built images that needed. This PR deletes them as soon as possible so we don't run out of disk space. Also, the size of the built images was lowered from 2GiB to 512 MiB.

See individual commits for more details.