### PR TITLE
osbuild: unified libdir handling

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -87,7 +87,7 @@ def parse_arguments(sys_argv):
                         help="directory where intermediary os trees are stored")
     parser.add_argument("--sources", metavar="FILE", type=os.path.abspath,
                         help="json file containing a dictionary of source configuration")
-    parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath,
+    parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath, default="/usr/lib/osbuild",
                         help="the directory containing stages, assemblers, and the osbuild library")
     parser.add_argument("--checkpoint", metavar="ID", action="append", type=str, default=None,
                         help="stage to commit to the object store during build (can be passed multiple times)")
@@ -107,7 +107,7 @@ def osbuild_cli():
     manifest = parse_manifest(args.manifest_path)
 
     # first thing after parsing is validation of the input
-    index = osbuild.meta.Index(args.libdir or "/usr/lib/osbuild")
+    index = osbuild.meta.Index(args.libdir)
     res = osbuild.meta.validate(manifest, index)
     if not res:
         if args.json or args.inspect:
@@ -153,7 +153,7 @@ def osbuild_cli():
         r = pipeline.run(
             args.store,
             monitor,
-            libdir=args.libdir,
+            args.libdir,
             output_directory=args.output_directory
         )
     except KeyboardInterrupt:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -62,9 +62,9 @@ class Stage:
             build_tree,
             cache,
             monitor,
-            libdir=None,
+            libdir,
             var="/var/tmp"):
-        with buildroot.BuildRoot(build_tree, runner, libdir=libdir, var=var) as build_root, \
+        with buildroot.BuildRoot(build_tree, runner, libdir, var=var) as build_root, \
             tempfile.TemporaryDirectory(prefix="osbuild-sources-output-", dir=var) as sources_output:
 
             args = {
@@ -81,7 +81,7 @@ class Stage:
             api = API(args, monitor)
             build_root.register_api(api)
 
-            src = sources.SourcesServer(libdir or "/usr/lib/osbuild",
+            src = sources.SourcesServer(libdir,
                                         self.sources,
                                         os.path.join(cache, "sources"),
                                         sources_output)
@@ -119,8 +119,8 @@ class Assembler:
             description["id"] = self.id
         return description
 
-    def run(self, tree, runner, build_tree, monitor, output_dir=None, libdir=None, var="/var/tmp"):
-        with buildroot.BuildRoot(build_tree, runner, libdir=libdir, var=var) as build_root:
+    def run(self, tree, runner, build_tree, monitor, libdir, output_dir=None, var="/var/tmp"):
+        with buildroot.BuildRoot(build_tree, runner, libdir, var=var) as build_root:
 
             args = {
                 "tree": "/run/osbuild/tree",
@@ -266,7 +266,7 @@ class Pipeline:
                               build_path,
                               object_store.store,
                               monitor,
-                              libdir=libdir,
+                              libdir,
                               var=object_store.store)
 
                 monitor.result(r)
@@ -300,8 +300,8 @@ class Pipeline:
                                    self.runner,
                                    build_dir,
                                    monitor,
+                                   libdir,
                                    output_dir=output_dir,
-                                   libdir=libdir,
                                    var=object_store.store)
 
             monitor.result(r)
@@ -320,7 +320,7 @@ class Pipeline:
 
         return results
 
-    def run(self, store, monitor, libdir=None, output_directory=None):
+    def run(self, store, monitor, libdir, output_directory=None):
         os.makedirs("/run/osbuild", exist_ok=True)
         results = {}
 

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -93,7 +93,7 @@ class TestDescriptions(unittest.TestCase):
             for p in [data, cache, output]:
                 p.mkdir()
 
-            res = asm.run(data, runner, root, monitor, output, libdir)
+            res = asm.run(data, runner, root, monitor, libdir, output)
 
         self.assertEqual(res.success, True)
         self.assertEqual(res.id, asm.id)


### PR DESCRIPTION
Change the default of libdir to /usr/lib/osbuild and remove redundant logic. 
Additionally, change how the python package is detected.

Instead of checking if libdir is None, check if /usr/lib/osbuild is empty - i.e. 
if the user has specified a different directory than the default.