### PR TITLE
selinux: allow nnp and nosuid domain transitions

### DIFF
--- a/selinux/osbuild.if
+++ b/selinux/osbuild.if
@@ -93,3 +93,22 @@ interface(`osbuild_role',`
 	ps_process_pattern($2, osbuild_t)
 	allow $2 osbuild_t:process { signull signal sigkill };
 ')
+
+########################################
+## <summary>
+##	osbuild nnp / nosuid transitions to domain
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain to be allowed to transition into.
+## </summary>
+## </param>
+#
+interface(`osbuild_nnp_nosuid_trans',`
+	gen_require(`
+		type osbuild_t;
+		class process2 { nnp_transition nosuid_transition };
+	')
+
+	allow osbuild_t $1:process2 {nnp_transition nosuid_transition};
+')

--- a/selinux/osbuild.te
+++ b/selinux/osbuild.te
@@ -31,6 +31,7 @@ unconfined_domain(osbuild_t)
 # execute setfiles in the setfiles_mac domain
 # when in the osbuild_t domain
 seutil_domtrans_setfiles_mac(osbuild_t)
+osbuild_nnp_nosuid_trans(setfiles_mac_t)
 
 # Allow sysadm and unconfined to run osbuild
 optional_policy(`
@@ -63,4 +64,5 @@ optional_policy(`
 # allow transitioning to install_t (for ostree)
 optional_policy(`
 	anaconda_domtrans_install(osbuild_t)
+	osbuild_nnp_nosuid_trans(install_t)
 ')


### PR DESCRIPTION
Allow `osbuild_t` to `nnp` and `nosuid` domain transition to `install_t` (for `ostree` and `cp`) and `setfiles_mac_t` (`setfiles`) domains. This is needed because bubblewrap (`bwrap`), which replaced `systemd-nspawn` to contain processes, always bind-mounts with (`nosuid`/`MS_NOSUID`) and always sets the No-New-Privs [flags](https://man7.org/linux/man-pages/man2/prctl.2.html) via `PR_SET_NO_NEW_PRIVS`.

Fixes #494 