### PR TITLE
Add support for passing metadata from modules to osbuild

### DIFF
--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -145,16 +145,15 @@ def main(tree, output_dir, options, meta):
         if parent:
             argv += [f"--parent={parent}"]
 
-        argv += [
-            f"--add-metadata-string=rpmostree.inputhash={meta['id']}",
-            f"--write-composejson-to={output_dir}/compose.json"
-
-        ]
-
         if os_version:
             argv += [
                 f"--add-metadata-string=version={os_version}",
             ]
+
+        argv += [
+            f"--add-metadata-string=rpmostree.inputhash={meta['id']}",
+            f"--write-composejson-to={output_dir}/compose.json"
+        ]
 
         with treefile.as_tmp_file() as path:
             argv += [path, root]

--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import tempfile
 
+from osbuild import api
 from osbuild.util import ostree
 
 
@@ -161,6 +162,11 @@ def main(tree, output_dir, options, meta):
             subprocess.run(argv,
                            stdout=sys.stderr,
                            check=True)
+
+        with open(os.path.join(output_dir, "compose.json"), "r") as f:
+            compose = json.load(f)
+
+        api.metadata({"compose": compose})
 
     if tar:
         filename = tar["filename"]

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -18,12 +18,13 @@ def cleanup(*objs):
 
 
 class BuildResult:
-    def __init__(self, origin, returncode, output):
+    def __init__(self, origin, returncode, output, metadata):
         self.name = origin.name
         self.id = origin.id
         self.options = origin.options
         self.success = returncode == 0
         self.output = output
+        self.metadata = metadata
 
     def as_dict(self):
         return vars(self)
@@ -90,7 +91,7 @@ class Stage:
                                binds=[os.fspath(tree) + ":/run/osbuild/tree"],
                                readonly_binds=ro_binds)
 
-            return BuildResult(self, r.returncode, api.output)
+            return BuildResult(self, r.returncode, api.output, api.metadata)
 
 
 class Assembler:
@@ -148,7 +149,7 @@ class Assembler:
                                binds=binds,
                                readonly_binds=ro_binds)
 
-            return BuildResult(self, r.returncode, api.output)
+            return BuildResult(self, r.returncode, api.output, api.metadata)
 
 
 class Pipeline:

--- a/stages/org.osbuild.noop
+++ b/stages/org.osbuild.noop
@@ -10,12 +10,15 @@ leaves the tree untouched. Useful for testing, debugging, and wasting time.
 import json
 import sys
 
+
 SCHEMA = """
 "additionalProperties": true
 """
 
+
 def main(_tree, options):
     print("Not doing anything with these options:", json.dumps(options))
+
 
 if __name__ == '__main__':
     args = json.load(sys.stdin)

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -33,6 +33,7 @@ import tempfile
 
 import osbuild.sources
 
+
 SCHEMA = """
 "additionalProperties": false,
 "properties": {

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -32,6 +32,7 @@ import sys
 import tempfile
 
 import osbuild.sources
+from osbuild import api
 
 
 SCHEMA = """
@@ -82,6 +83,32 @@ def packages_from_legacy(legacy):
         else:
             packages.append({"checksum": package, "check_gpg": False})
     return packages
+
+
+def generate_package_metadata(tree):
+    query = r"""\{
+    "name": "%{NAME}",
+    "version": "%{VERSION}",
+    "release": "%{RELEASE}",
+    "epoch": %|EPOCH?{"%{EPOCH}"}:{null}|,
+    "arch": %|ARCH?{"%{ARCH}"}:{null}|,
+    "sigmd5": %|SIGMD5?{"%{SIGMD5}"}:{null}|
+    \},
+    """
+
+    cmd = [
+        "rpm",
+        "-qa",
+        "--root", tree,
+        "--qf=" + query
+    ]
+
+    res = subprocess.run(cmd, stdout=subprocess.PIPE,
+                         check=True, encoding="utf-8")
+
+    raw = res.stdout.strip()
+    jsdata = '{"packages": [' + raw[:-1] + "]}"
+    return json.loads(jsdata)
 
 
 def main(tree, sources, options):
@@ -153,6 +180,10 @@ def main(tree, sources, options):
     # remove random seed from the tree if exists
     with contextlib.suppress(FileNotFoundError):
         os.unlink(f"{tree}/var/lib/systemd/random-seed")
+
+    # generate the metadata
+    md = generate_package_metadata(tree)
+    api.metadata(md)
 
     return 0
 

--- a/test/data/stages/rpm/metadata.json
+++ b/test/data/stages/rpm/metadata.json
@@ -1,0 +1,1602 @@
+{
+  "ecc30889f76280f2ff42989450e63c23ba12220747de83da286206c02e0b4e75": {
+    "packages": [
+      {
+        "name": "libgcc",
+        "version": "9.0.1",
+        "release": "0.10.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "52c6ee669d58d82b70fa8a76f004a1d4"
+      },
+      {
+        "name": "whois-nls",
+        "version": "5.4.2",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "20a5c0f1b5b1dddf644425b8c26b2923"
+      },
+      {
+        "name": "systemd-rpm-macros",
+        "version": "241",
+        "release": "7.gita2eaa1c.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "62b10480af8e773faf9f06f359f304e5"
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "version": "20190128",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "bf272520850adb1f8eed36e44d28d167"
+      },
+      {
+        "name": "libreport-filesystem",
+        "version": "2.10.0",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "a9fe3af9ebadaa37a357fb54a5788d55"
+      },
+      {
+        "name": "kbd-misc",
+        "version": "2.0.4",
+        "release": "13.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "ee684c3a77d61f68f379d529497e309c"
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "version": "30",
+        "release": "1",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "087f285cb1ebcaaa331eb7a2a06911ad"
+      },
+      {
+        "name": "fedora-repos",
+        "version": "30",
+        "release": "1",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "75e955e5279e5718456c992fd2b6b89a"
+      },
+      {
+        "name": "setup",
+        "version": "2.13.3",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "af78eb1db33fedafa3b9d6e112dbcf7c"
+      },
+      {
+        "name": "basesystem",
+        "version": "11",
+        "release": "7.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "16b9266485a71b7dd230d14a3986f170"
+      },
+      {
+        "name": "libselinux",
+        "version": "2.9",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "f58e483f076b520565f330c62bb8b199"
+      },
+      {
+        "name": "glibc-all-langpacks",
+        "version": "2.29",
+        "release": "9.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "009c9b8779e047e57b5ddaa4f4d21e4b"
+      },
+      {
+        "name": "glibc",
+        "version": "2.29",
+        "release": "9.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "b32d256ba608b4989b75db682d7ebf3d"
+      },
+      {
+        "name": "libsepol",
+        "version": "2.9",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "33f41734056ee96b596211b3b1253d10"
+      },
+      {
+        "name": "xz-libs",
+        "version": "5.2.4",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "2d7d12ced369bfa993a2d43db22c0442"
+      },
+      {
+        "name": "libgpg-error",
+        "version": "1.33",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "f7fc8fce80c5f1887b3f36c52e83ac8c"
+      },
+      {
+        "name": "libdb",
+        "version": "5.3.28",
+        "release": "37.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "286c03b8cb0954f48067d3207341149a"
+      },
+      {
+        "name": "mkpasswd",
+        "version": "5.4.2",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "234b65a3cd2a27e489296f1294c3b5d7"
+      },
+      {
+        "name": "elfutils-libelf",
+        "version": "0.176",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "072942419104a354b65607b4f1710b68"
+      },
+      {
+        "name": "libuuid",
+        "version": "2.33.2",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "dd4a35e07c40962a4b59ea8bf3d140eb"
+      },
+      {
+        "name": "expat",
+        "version": "2.2.6",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "154562eac3e536224065971ea8e101ab"
+      },
+      {
+        "name": "libunistring",
+        "version": "0.9.10",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "950494f4b989656f4996c9c0dce9008f"
+      },
+      {
+        "name": "libidn2",
+        "version": "2.1.1a",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "2ea22d5d4eed35e72a3ee1489ca1ba08"
+      },
+      {
+        "name": "libcom_err",
+        "version": "1.44.6",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "4806eb4beaf05c93768ec3d3f8b41b8f"
+      },
+      {
+        "name": "lua-libs",
+        "version": "5.3.5",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "ecd8807c3baa41145daf521dcf54d378"
+      },
+      {
+        "name": "kmod",
+        "version": "25",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "847b41fd7bfe4baeef8b7a25cf24ab29"
+      },
+      {
+        "name": "sqlite-libs",
+        "version": "3.26.0",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "9a7f651054a224a019661caae0045d21"
+      },
+      {
+        "name": "libacl",
+        "version": "2.2.53",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "977414305d9a3ccc7802805e8492da05"
+      },
+      {
+        "name": "libcap-ng",
+        "version": "0.7.9",
+        "release": "7.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "5d6166dc8d9143344c4465392e76ee90"
+      },
+      {
+        "name": "libffi",
+        "version": "3.1",
+        "release": "19.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "837cab1bc8c0cb823a972d793d1de864"
+      },
+      {
+        "name": "libsmartcols",
+        "version": "2.33.2",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "3d8facbc2734917514a3000fcec697f1"
+      },
+      {
+        "name": "libksba",
+        "version": "1.3.5",
+        "release": "9.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "9a770df18626b7f8e0fc8ef0e0fa4741"
+      },
+      {
+        "name": "grub2-common",
+        "version": "2.02",
+        "release": "75.fc30",
+        "epoch": "1",
+        "arch": "noarch",
+        "sigmd5": "a67e8c45c724671bbd373e9cf6bf4b0c"
+      },
+      {
+        "name": "findutils",
+        "version": "4.6.0",
+        "release": "22.fc30",
+        "epoch": "1",
+        "arch": "x86_64",
+        "sigmd5": "2a0dc15b01f536ec0edb560cfd26b5d1"
+      },
+      {
+        "name": "keyutils-libs",
+        "version": "1.6",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "2e74336d96c8d3045aaab7cd7389eb0b"
+      },
+      {
+        "name": "p11-kit-trust",
+        "version": "0.23.15",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "ddc38a8cc0011a0888ca052d46d6fdfa"
+      },
+      {
+        "name": "grep",
+        "version": "3.1",
+        "release": "9.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "1e9a4190a606b6bfd9d2cb011987c62c"
+      },
+      {
+        "name": "file",
+        "version": "5.36",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "83eebd8390820ac4fd5d1c70a88f0731"
+      },
+      {
+        "name": "acl",
+        "version": "2.2.53",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "310836751e5ffcee963fd955120c25ca"
+      },
+      {
+        "name": "mpfr",
+        "version": "3.1.6",
+        "release": "4.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "6bf12acc182be6f4d87ca91192c65870"
+      },
+      {
+        "name": "libcomps",
+        "version": "0.1.11",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "c4929c8ba58e0029a5b5dcbbe2d2da43"
+      },
+      {
+        "name": "libdb-utils",
+        "version": "5.3.28",
+        "release": "37.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "c8ed42205e9ed2bcc875533b96e645f2"
+      },
+      {
+        "name": "brotli",
+        "version": "1.0.7",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "b4323bacab5b55af2051575b0d536670"
+      },
+      {
+        "name": "diffutils",
+        "version": "3.7",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "8d816d1d0c75105683c191ec0cd5623c"
+      },
+      {
+        "name": "hardlink",
+        "version": "1.3",
+        "release": "8.fc30",
+        "epoch": "1",
+        "arch": "x86_64",
+        "sigmd5": "3260a438edf0f2931c934f8c86246e45"
+      },
+      {
+        "name": "libgomp",
+        "version": "9.0.1",
+        "release": "0.10.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "e42cf9aca3c574bbf032c627fd538f8b"
+      },
+      {
+        "name": "libpcap",
+        "version": "1.9.0",
+        "release": "3.fc30",
+        "epoch": "14",
+        "arch": "x86_64",
+        "sigmd5": "953fecbfb6f381cb2335fed40f02e7a2"
+      },
+      {
+        "name": "libseccomp",
+        "version": "2.4.0",
+        "release": "0.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "4d9fc4b736881eb1dfaa1c744fb903b6"
+      },
+      {
+        "name": "gawk",
+        "version": "4.2.1",
+        "release": "6.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "09e5d4d1ccf9e99c32b72e703e50d913"
+      },
+      {
+        "name": "libxkbcommon",
+        "version": "0.8.3",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "e9f3a8045f4e89723d5cf9d7216d4083"
+      },
+      {
+        "name": "ncurses",
+        "version": "6.1",
+        "release": "10.20180923.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "ad5806f7d1d0a4096c8896db9c9af8ce"
+      },
+      {
+        "name": "qrencode-libs",
+        "version": "3.4.4",
+        "release": "8.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "c7fcb5a7db530445f3118af3184c1f21"
+      },
+      {
+        "name": "coreutils-common",
+        "version": "8.31",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "6d5c53db44938167956fe27279ad0eb2"
+      },
+      {
+        "name": "libssh",
+        "version": "0.8.7",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "a139025741ba60be9c4e08ed525fa5bb"
+      },
+      {
+        "name": "shared-mime-info",
+        "version": "1.12",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "9eef8c626c3a05a462e2bc9bba34fb70"
+      },
+      {
+        "name": "libkcapi",
+        "version": "1.1.4",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "b838c12920fd79a1fd6bcf62e2876bb5"
+      },
+      {
+        "name": "libcroco",
+        "version": "0.6.13",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "02f991b7690d50c2e8169d1fb5c7d160"
+      },
+      {
+        "name": "gettext-libs",
+        "version": "0.19.8.1",
+        "release": "18.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "75bcce3ffb1e4823aa5a15ddfc1d6aca"
+      },
+      {
+        "name": "krb5-libs",
+        "version": "1.17",
+        "release": "4.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "254f4d27b6251c3043a51a940b543600"
+      },
+      {
+        "name": "libnsl2",
+        "version": "1.2.0",
+        "release": "4.20180605git4a062cf.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "af07adaf5494e9aac5d463e639be5b20"
+      },
+      {
+        "name": "curl",
+        "version": "7.64.0",
+        "release": "6.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "033c36e7da049c89a3eca3b40ffd64b7"
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "version": "0.176",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "d96cac444b513dc35a724be8051d58c4"
+      },
+      {
+        "name": "cracklib-dicts",
+        "version": "2.9.6",
+        "release": "19.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "b57ddb428d0c16efbd95bbf67d4d584d"
+      },
+      {
+        "name": "gzip",
+        "version": "1.9",
+        "release": "9.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "4408cac3439b2ddb76278d8c54efedd3"
+      },
+      {
+        "name": "libpwquality",
+        "version": "1.4.0",
+        "release": "12.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "ca3f9449939aaf86bc9e278a6ecf2a89"
+      },
+      {
+        "name": "kbd",
+        "version": "2.0.4",
+        "release": "13.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "6229d1d20a352d388454be8a322b5f76"
+      },
+      {
+        "name": "kpartx",
+        "version": "0.7.9",
+        "release": "6.git2df6110.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "c513af23e6b67180eb7f14befd3bf341"
+      },
+      {
+        "name": "openssl-pkcs11",
+        "version": "0.4.10",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "e6fb8f884048dfb05b36f53f3d891558"
+      },
+      {
+        "name": "libfdisk",
+        "version": "2.33.2",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "700610fb7214694f992f91903f466963"
+      },
+      {
+        "name": "dbus",
+        "version": "1.12.12",
+        "release": "7.fc30",
+        "epoch": "1",
+        "arch": "x86_64",
+        "sigmd5": "70b2e9d295a9da63e6373f2f8c00be93"
+      },
+      {
+        "name": "systemd-libs",
+        "version": "241",
+        "release": "7.gita2eaa1c.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "5154179a41ca7657076797bbbb24963b"
+      },
+      {
+        "name": "device-mapper-libs",
+        "version": "1.02.154",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "4414bb6c40a27d663673363b29abe016"
+      },
+      {
+        "name": "ca-certificates",
+        "version": "2018.2.26",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "1c621d41b92bb05bd11bf7afc423bb23"
+      },
+      {
+        "name": "util-linux",
+        "version": "2.33.2",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "9a0f8b6eebcb7a467a6493b0897d0496"
+      },
+      {
+        "name": "cryptsetup-libs",
+        "version": "2.1.0",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "7b1c77d32414e905abfe40a2a97edf72"
+      },
+      {
+        "name": "rpm-libs",
+        "version": "4.14.2.1",
+        "release": "4.fc30.1",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "1674b85cb6216681592bf359f16d2199"
+      },
+      {
+        "name": "openssl-libs",
+        "version": "1.1.1b",
+        "release": "3.fc30",
+        "epoch": "1",
+        "arch": "x86_64",
+        "sigmd5": "2165eda87e7f6b97e1ceac0c91f8e7fd"
+      },
+      {
+        "name": "crypto-policies",
+        "version": "20190211",
+        "release": "2.gite3eacfc.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "02ea2cddf4fa790c6fce5bc2f630f93c"
+      },
+      {
+        "name": "grub2-tools",
+        "version": "2.02",
+        "release": "75.fc30",
+        "epoch": "1",
+        "arch": "x86_64",
+        "sigmd5": "c1f78d97cb0bbf6cd466842255a084a8"
+      },
+      {
+        "name": "systemd",
+        "version": "241",
+        "release": "7.gita2eaa1c.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "56f14905257f077d512d794bf448f97f"
+      },
+      {
+        "name": "dbus-broker",
+        "version": "20",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "1e6c3a6368a756b541334213255755f9"
+      },
+      {
+        "name": "systemd-udev",
+        "version": "241",
+        "release": "7.gita2eaa1c.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "9e26c5318db7a0780fe50e48b41c815d"
+      },
+      {
+        "name": "libevent",
+        "version": "2.1.8",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "db9513990d58c6811ab7af0c24da50c4"
+      },
+      {
+        "name": "libsolv",
+        "version": "0.7.4",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "456b75e26827dec93751c9ebc28ed517"
+      },
+      {
+        "name": "ima-evm-utils",
+        "version": "1.1",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "6c98846ac55252d45144462fe9015e20"
+      },
+      {
+        "name": "deltarpm",
+        "version": "3.6",
+        "release": "29.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "a1f538ecd714934852b774aa7ac18846"
+      },
+      {
+        "name": "python3-pip",
+        "version": "19.0.3",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "14e600b119d0ef5a12bb249e0bb6fe7a"
+      },
+      {
+        "name": "python3",
+        "version": "3.7.3",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "0573776f32cae06226e8e9463616bdb0"
+      },
+      {
+        "name": "python3-libcomps",
+        "version": "0.1.11",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "4c8f5d99fa785896acffa6d77d613dc8"
+      },
+      {
+        "name": "python3-unbound",
+        "version": "1.8.3",
+        "release": "4.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "5e889c41d2aa892e55ee104ec1d0c920"
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "version": "4.14.2.1",
+        "release": "4.fc30.1",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "9bd1a347f9a0e0fedf43c1af09ff3278"
+      },
+      {
+        "name": "libsecret",
+        "version": "0.18.8",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "45dfa7f236e6b0cf76be7e03018f8b46"
+      },
+      {
+        "name": "gnupg2-smime",
+        "version": "2.2.13",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "438d46826aa95ce202b0796440faca14"
+      },
+      {
+        "name": "gpgme",
+        "version": "1.12.0",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "f313d6c69f340aa598b533e501e9753f"
+      },
+      {
+        "name": "libdnf",
+        "version": "0.28.1",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "39f972610f99c7d3610722c8972ee979"
+      },
+      {
+        "name": "python3-hawkey",
+        "version": "0.28.1",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "2caa6bbecd44ea1ca106e0ead7d73b0d"
+      },
+      {
+        "name": "rpm-sign-libs",
+        "version": "4.14.2.1",
+        "release": "4.fc30.1",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "83552e4d2d4d313b5f234e7f1d3af627"
+      },
+      {
+        "name": "python3-dnf",
+        "version": "4.2.2",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "12dea1bd9c72d8d65ec38fd191e99936"
+      },
+      {
+        "name": "gpg-pubkey",
+        "version": "cfc659b9",
+        "release": "5b6eac67",
+        "epoch": null,
+        "arch": null,
+        "sigmd5": null
+      },
+      {
+        "name": "xkeyboard-config",
+        "version": "2.24",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "6333653616e42d509e7b1f5b97fe5683"
+      },
+      {
+        "name": "tzdata",
+        "version": "2019a",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "9acfd2721598a8269a4ea39be492be53"
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "version": "40.8.0",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "27caf2e62a8758be111a75a632ec523e"
+      },
+      {
+        "name": "ncurses-base",
+        "version": "6.1",
+        "release": "10.20180923.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "6dcf28a49d39fb633860d00dda8245da"
+      },
+      {
+        "name": "dnf-data",
+        "version": "4.2.2",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "643b460fda84b5932b71ea98ea664c76"
+      },
+      {
+        "name": "kbd-legacy",
+        "version": "2.0.4",
+        "release": "13.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "cce8b4caa8aa4df98b6d683a434d34f4"
+      },
+      {
+        "name": "fedora-release",
+        "version": "30",
+        "release": "1",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "0b43e4b63adefd5eb12ff4ddbdd140c9"
+      },
+      {
+        "name": "fedora-release-common",
+        "version": "30",
+        "release": "1",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "be222759bec5d4f143f226a67bd6e715"
+      },
+      {
+        "name": "filesystem",
+        "version": "3.10",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "c63518c1714504f7e9cabce15dfcffe3"
+      },
+      {
+        "name": "pcre2",
+        "version": "10.32",
+        "release": "9.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "600bb3ffb28dfb90de4a3bf1f6d2424b"
+      },
+      {
+        "name": "ncurses-libs",
+        "version": "6.1",
+        "release": "10.20180923.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "2811582890d1111ff69efe44eb08386a"
+      },
+      {
+        "name": "glibc-common",
+        "version": "2.29",
+        "release": "9.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "a0e2c65e81025f04834a99b4d0a0c431"
+      },
+      {
+        "name": "bash",
+        "version": "5.0.2",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "dcb7c9d7b851752c5ae1283f2124644a"
+      },
+      {
+        "name": "zlib",
+        "version": "1.2.11",
+        "release": "15.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "dff0e3c6d3d6685d3732bcf55a435dae"
+      },
+      {
+        "name": "bzip2-libs",
+        "version": "1.0.6",
+        "release": "29.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "50a52c7c5c2aaffe5cc7d2b58c368561"
+      },
+      {
+        "name": "libxml2",
+        "version": "2.9.9",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "e77cfaf54048239c2e0ee54227568cae"
+      },
+      {
+        "name": "libxcrypt",
+        "version": "4.4.4",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "7f3155eda4330416e3c82bdac3a3c9b6"
+      },
+      {
+        "name": "libzstd",
+        "version": "1.3.8",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "5912802d03fdab00ec61f0848fcd8365"
+      },
+      {
+        "name": "libcap",
+        "version": "2.26",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "082fc3dafcf6c10460863d9d005ad36e"
+      },
+      {
+        "name": "libgcrypt",
+        "version": "1.8.4",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "3333b598b922c6a7090456603bd5dee6"
+      },
+      {
+        "name": "gmp",
+        "version": "6.1.2",
+        "release": "10.fc30",
+        "epoch": "1",
+        "arch": "x86_64",
+        "sigmd5": "a3a565bfc47f1e16709ed094d3a2cf57"
+      },
+      {
+        "name": "popt",
+        "version": "1.16",
+        "release": "17.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "555a13d2bda34c9da344a8211a14a10d"
+      },
+      {
+        "name": "libassuan",
+        "version": "2.5.2",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "609cb220453f80fd14c3ab4634e4a336"
+      },
+      {
+        "name": "libstdc++",
+        "version": "9.0.1",
+        "release": "0.10.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "7fecfa6eae7f5529f49cd9b6678798da"
+      },
+      {
+        "name": "readline",
+        "version": "8.0",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "da2ba923aa76ee6a43ce869b1b5c6a49"
+      },
+      {
+        "name": "kmod-libs",
+        "version": "25",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "bc422386f02947026035d0a942827f76"
+      },
+      {
+        "name": "libattr",
+        "version": "2.4.48",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "fc77eb57f5fe4a3d4d00c5788fcafed2"
+      },
+      {
+        "name": "sed",
+        "version": "4.5",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "21207e26f151df274ad8ba5e09a30e54"
+      },
+      {
+        "name": "audit-libs",
+        "version": "3.0",
+        "release": "0.7.20190326git03e7489.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "11ee0ea54f7943c79dd4c290e2ca200b"
+      },
+      {
+        "name": "p11-kit",
+        "version": "0.23.15",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "9509f521e79e46cd29ef8c700d42d10d"
+      },
+      {
+        "name": "lz4-libs",
+        "version": "1.8.3",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "f835563e6125ca28f7ec802be41fc8bd"
+      },
+      {
+        "name": "file-libs",
+        "version": "5.36",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "33bea38851955f83d35fb13258cf0bf5"
+      },
+      {
+        "name": "alternatives",
+        "version": "1.11",
+        "release": "4.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "95ca40e1ec4346908b7d5d0c0fb294c4"
+      },
+      {
+        "name": "json-c",
+        "version": "0.13.1",
+        "release": "4.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "11b0fe7c10d83e2219ac5381c6245e2f"
+      },
+      {
+        "name": "libtasn1",
+        "version": "4.13",
+        "release": "7.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "3ee272105c9b8fdd04d2162d8b416112"
+      },
+      {
+        "name": "pcre",
+        "version": "8.43",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "d2476908922ee5437035bca6d189ba2d"
+      },
+      {
+        "name": "xz",
+        "version": "5.2.4",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "12b9c90889c66496e1b824e769a6bf39"
+      },
+      {
+        "name": "libsemanage",
+        "version": "2.9",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "9c39b9890de6d0eece02837f6a6790a8"
+      },
+      {
+        "name": "libpsl",
+        "version": "0.20.2",
+        "release": "6.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "58f5b8233c9ace4287c7bb1165f4550f"
+      },
+      {
+        "name": "nettle",
+        "version": "3.4.1rc1",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "db8d9e6f1ed4f66849791c37bbecc4c8"
+      },
+      {
+        "name": "libmetalink",
+        "version": "0.1.3",
+        "release": "8.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "3973ce817229820d828559174480bd26"
+      },
+      {
+        "name": "pigz",
+        "version": "2.4",
+        "release": "4.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "be871354aee649a86727d527164ea133"
+      },
+      {
+        "name": "cpio",
+        "version": "2.12",
+        "release": "10.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "dd7c0c5a6f6e7aae5d47d84dd9c2c530"
+      },
+      {
+        "name": "gdbm-libs",
+        "version": "1.18",
+        "release": "4.fc30",
+        "epoch": "1",
+        "arch": "x86_64",
+        "sigmd5": "d6d818466f5af43dc8b257515150aebc"
+      },
+      {
+        "name": "libargon2",
+        "version": "20161029",
+        "release": "8.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "b7260cce3d4ec32258542b4ea3581bf2"
+      },
+      {
+        "name": "libnghttp2",
+        "version": "1.37.0",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "15fc41aad3e4d628ed1adb2508e3a78c"
+      },
+      {
+        "name": "iptables-libs",
+        "version": "1.8.0",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "9227d0c77f1a2d4e37ae5fb3b86136de"
+      },
+      {
+        "name": "libsigsegv",
+        "version": "2.11",
+        "release": "7.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "1c6899f738f09f16fa21315534c0afbf"
+      },
+      {
+        "name": "libverto",
+        "version": "0.3.0",
+        "release": "7.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "451262c3d1288440f817da72acfc7fbe"
+      },
+      {
+        "name": "libyaml",
+        "version": "0.2.1",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "2012de44898fd094c1ccc27c297f298c"
+      },
+      {
+        "name": "npth",
+        "version": "1.6",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "cd412d35d60ee2a97053863ae601f5db"
+      },
+      {
+        "name": "which",
+        "version": "2.21",
+        "release": "14.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "95675070b4f04d0c2c807e5d63d61df4"
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "version": "2.1.27",
+        "release": "0.6rc7.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "e1fe30dee8d5b3e9f1942cca082e67ac"
+      },
+      {
+        "name": "openldap",
+        "version": "2.4.47",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "38ba4968a49472346324c5d6a484d4ef"
+      },
+      {
+        "name": "libcurl",
+        "version": "7.64.0",
+        "release": "6.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "c1db9adbfb50aaceb9c82fcba738b8f5"
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "version": "1.1.4",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "b39d450d0e3d67f2ecda31d8b7eb0fc5"
+      },
+      {
+        "name": "glib2",
+        "version": "2.60.1",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "bd382b6d9f33e394f29a8a5a818a22fd"
+      },
+      {
+        "name": "gettext",
+        "version": "0.19.8.1",
+        "release": "18.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "062543c1f56c2780d5d568b3bf75a214"
+      },
+      {
+        "name": "libtirpc",
+        "version": "1.1.4",
+        "release": "2.rc2.fc30.1",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "3681bc42a28e5c24fa9d4ae24820eec8"
+      },
+      {
+        "name": "libarchive",
+        "version": "3.3.3",
+        "release": "6.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "e7785d9c80eb282bea0ab086dec04623"
+      },
+      {
+        "name": "openssl",
+        "version": "1.1.1b",
+        "release": "3.fc30",
+        "epoch": "1",
+        "arch": "x86_64",
+        "sigmd5": "7615c40ecea7231e6a29118af16b3d42"
+      },
+      {
+        "name": "elfutils-libs",
+        "version": "0.176",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "f5808fbe17c2d8724a9a2b3912adb03e"
+      },
+      {
+        "name": "cracklib",
+        "version": "2.9.6",
+        "release": "19.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "7952690f78ae558b3cb8481a5fada30e"
+      },
+      {
+        "name": "procps-ng",
+        "version": "3.3.15",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "351336aea5ecd19a749d2d192f66e4a0"
+      },
+      {
+        "name": "pam",
+        "version": "1.3.1",
+        "release": "17.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "f4004fe272a54f4581c309143e6cc0d3"
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "version": "2.02",
+        "release": "75.fc30",
+        "epoch": "1",
+        "arch": "x86_64",
+        "sigmd5": "90b66de4e5ba78a94a649f2fc40d1da4"
+      },
+      {
+        "name": "device-mapper",
+        "version": "1.02.154",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "3c4a03264c278c9a4dff83f654445512"
+      },
+      {
+        "name": "rpm",
+        "version": "4.14.2.1",
+        "release": "4.fc30.1",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "df678a7bc578d058bfed9bb4513d342c"
+      },
+      {
+        "name": "libmount",
+        "version": "2.33.2",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "e5490dc92d162fbe919f1562ba0896a6"
+      },
+      {
+        "name": "coreutils",
+        "version": "8.31",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "12b1a1c233a3d33f4ebe0642d985dfe1"
+      },
+      {
+        "name": "libblkid",
+        "version": "2.33.2",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "dfd73d3251bd732ecc42fef0f2fe7c6f"
+      },
+      {
+        "name": "shadow-utils",
+        "version": "4.6",
+        "release": "8.fc30",
+        "epoch": "2",
+        "arch": "x86_64",
+        "sigmd5": "57e452d182742849faea7e4253b59ded"
+      },
+      {
+        "name": "libutempter",
+        "version": "1.1.6",
+        "release": "16.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "5dd0cb594e59253a0682d95a5c2b3fc6"
+      },
+      {
+        "name": "systemd-pam",
+        "version": "241",
+        "release": "7.gita2eaa1c.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "2f9807eef0a9df7b8cb93a36d3235726"
+      },
+      {
+        "name": "dracut",
+        "version": "049",
+        "release": "26.git20181204.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "23d54d236461ef9272c371ac00a94af7"
+      },
+      {
+        "name": "trousers-lib",
+        "version": "0.3.13",
+        "release": "12.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "a58e404fad70b1996017867c1d28ede3"
+      },
+      {
+        "name": "grubby",
+        "version": "8.40",
+        "release": "30.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "565afe2e2aba236f7e3e7678aa54c3ce"
+      },
+      {
+        "name": "os-prober",
+        "version": "1.74",
+        "release": "8.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "98af4d3fdeabb91671afb75fdc3c9a08"
+      },
+      {
+        "name": "gnutls",
+        "version": "3.6.7",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "1b28f047dff8e9b6886d2ecaf9068f9e"
+      },
+      {
+        "name": "dbus-common",
+        "version": "1.12.12",
+        "release": "7.fc30",
+        "epoch": "1",
+        "arch": "noarch",
+        "sigmd5": "4bd5b0101d71efd4868e67a28e4252d7"
+      },
+      {
+        "name": "systemd-bootchart",
+        "version": "233",
+        "release": "4.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "b7879faf448062a3282de38b2a131692"
+      },
+      {
+        "name": "trousers",
+        "version": "0.3.13",
+        "release": "12.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "5ec034c0b4a099c087797d4d5ef57f82"
+      },
+      {
+        "name": "zchunk-libs",
+        "version": "1.1.1",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "40dadf8858e76e708f0637471eb3a14c"
+      },
+      {
+        "name": "libmodulemd1",
+        "version": "1.8.6",
+        "release": "3.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "a2318d33927f562bc969da2a1a82da54"
+      },
+      {
+        "name": "rpm-build-libs",
+        "version": "4.14.2.1",
+        "release": "4.fc30.1",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "34b123d7c75c1aa31b976dd1a7d10740"
+      },
+      {
+        "name": "python-pip-wheel",
+        "version": "19.0.3",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "d4d849dd499eb76f9e0c953e352046cf"
+      },
+      {
+        "name": "python3-setuptools",
+        "version": "40.8.0",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "7d634972f6b29e54f9212ea01ae08841"
+      },
+      {
+        "name": "python3-libs",
+        "version": "3.7.3",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "bfe6f4d7cb204af0c6c5c44dd6c479a6"
+      },
+      {
+        "name": "unbound-libs",
+        "version": "1.8.3",
+        "release": "4.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "9eb2f9525b6a39bd0e768a30da48c29e"
+      },
+      {
+        "name": "dbus-libs",
+        "version": "1.12.12",
+        "release": "7.fc30",
+        "epoch": "1",
+        "arch": "x86_64",
+        "sigmd5": "cb4c18b76ef0a0206b6d045a0a02a772"
+      },
+      {
+        "name": "libusbx",
+        "version": "1.0.22",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "738e8a7fa5d3711f9257dcebb407f362"
+      },
+      {
+        "name": "pinentry",
+        "version": "1.1.0",
+        "release": "5.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "898a0d2943c7d767319e3cb332232f7a"
+      },
+      {
+        "name": "gnupg2",
+        "version": "2.2.13",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "74c0fe355e80c47150b07c0502340b3a"
+      },
+      {
+        "name": "librepo",
+        "version": "1.9.6",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "4e24dcd802efe0815d941a9b942493b3"
+      },
+      {
+        "name": "python3-libdnf",
+        "version": "0.28.1",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "b34153f3a3dec3c71fcba6f513480e6f"
+      },
+      {
+        "name": "python3-gpg",
+        "version": "1.12.0",
+        "release": "1.fc30",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "5c16ff772f433d05c290e0e6f01ba520"
+      },
+      {
+        "name": "python3-rpm",
+        "version": "4.14.2.1",
+        "release": "4.fc30.1",
+        "epoch": null,
+        "arch": "x86_64",
+        "sigmd5": "4fbd62083cebb27aeefb540ba138badb"
+      },
+      {
+        "name": "dnf",
+        "version": "4.2.2",
+        "release": "2.fc30",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "6dccfa0abef0b49ef03d72224e64a530"
+      }
+    ]
+  },
+  "c0aafd26057080f873c2ef0629065eea039704815cec14e7dd8811dd4e98374e": {
+    "packages": [
+      {
+        "name": "fedora-gpg-keys",
+        "version": "30",
+        "release": "1",
+        "epoch": null,
+        "arch": "noarch",
+        "sigmd5": "087f285cb1ebcaaa331eb7a2a06911ad"
+      },
+      {
+        "name": "gpg-pubkey",
+        "version": "cfc659b9",
+        "release": "5b6eac67",
+        "epoch": null,
+        "arch": null,
+        "sigmd5": null
+      }
+    ]
+  }
+}

--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -118,7 +118,7 @@ class TestAssemblers(test.TestBase):
 
             data = json.dumps(manifest)
             with tempfile.TemporaryDirectory(dir="/var/tmp") as output_dir:
-                osb.compile(data, output_dir=output_dir)
+                result = osb.compile(data, output_dir=output_dir)
                 compose_file = os.path.join(output_dir, "compose.json")
                 repo = os.path.join(output_dir, "repo")
 
@@ -132,6 +132,10 @@ class TestAssemblers(test.TestBase):
                 assert ref
                 assert rpmostree_inputhash
                 assert os_version
+                self.assertIn("metadata", result["assembler"])
+                metadata = result["assembler"]["metadata"]
+                self.assertIn("compose", metadata)
+                self.assertEqual(compose, metadata["compose"])
 
                 md = subprocess.check_output(
                     [

--- a/test/test.py
+++ b/test/test.py
@@ -279,6 +279,8 @@ class OSBuild(contextlib.AbstractContextManager):
         The produced artifact (if any) is stored in the directory passed via
         the output_dir parameter. If it's set to None, a temporary directory
         is used and thus the caller cannot access the built artifact.
+
+        Returns the build result as dictionary.
         """
 
         if output_dir is None:
@@ -318,6 +320,8 @@ class OSBuild(contextlib.AbstractContextManager):
         if p.returncode != 0:
             self._print_result(p.returncode, data_stdout, data_stderr)
             self._unittest.assertEqual(p.returncode, 0)
+
+        return json.loads(data_stdout)
 
     def compile_file(self, file_stdin, output_dir=None, checkpoints=None):
         """Compile an Artifact


### PR DESCRIPTION
Add functionality to `osbuild.api.API` so that metadata can be passed from modules (stages, assemblers) back to osbuild. There add the metadata to the `BuildResult` so it gets passed on further to the caller.
Use the new functionality to return compose information from the `ostree.commit` assembler.