### PR TITLE
ostree: add support for setting version metadata

### DIFF
--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -37,6 +37,10 @@ SCHEMA = """
     "type": "string",
     "default": ""
   },
+  "os_version": {
+    "description": "Set the version of the OS as commit metadata",
+    "type": "string"
+  },
   "tmp-is-dir": {
     "description": "Create a regular directory for /tmp",
     "type": "boolean",
@@ -104,6 +108,7 @@ def init_rootfs(root, tmp_is_dir):
 
 def main(tree, output_dir, options, meta):
     ref = options["ref"]
+    os_version = options.get("os_version", None)
     tmp_is_dir = options.get("tmp-is-dir", True)
     parent = options.get("parent", None)
     tar = options.get("tar", None)
@@ -142,7 +147,13 @@ def main(tree, output_dir, options, meta):
         argv += [
             f"--add-metadata-string=rpmostree.inputhash={meta['id']}",
             f"--write-composejson-to={output_dir}/compose.json"
+
         ]
+
+        if os_version:
+            argv += [
+                f"--add-metadata-string=version={os_version}",
+            ]
 
         with treefile.as_tmp_file() as path:
             argv += [path, root]

--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -65,6 +65,7 @@ SCHEMA = """
 }
 """
 
+
 TOPLEVEL_DIRS = ["dev", "proc", "run", "sys", "sysroot", "var"]
 TOPLEVEL_LINKS = {
     "home": "var/home",
@@ -175,7 +176,6 @@ def main(tree, output_dir, options, meta):
         subprocess.run(command,
                        stdout=sys.stderr,
                        check=True)
-
 
 
 if __name__ == '__main__':

--- a/test/data/manifests/fedora-ostree-commit.json
+++ b/test/data/manifests/fedora-ostree-commit.json
@@ -682,7 +682,8 @@
     "assembler": {
       "name": "org.osbuild.ostree.commit",
       "options": {
-        "ref": "fedora/x86_64/osbuild"
+        "ref": "fedora/x86_64/osbuild",
+        "os_version": "32"
       }
     }
   },

--- a/test/data/manifests/mpp-fedora-ostree-commit.json
+++ b/test/data/manifests/mpp-fedora-ostree-commit.json
@@ -97,7 +97,8 @@
     "assembler": {
       "name": "org.osbuild.ostree.commit",
       "options": {
-        "ref": "fedora/x86_64/osbuild"
+        "ref": "fedora/x86_64/osbuild",
+        "os_version": "32"
       }
     }
   }

--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -127,9 +127,11 @@ class TestAssemblers(test.TestBase):
                 commit_id = compose["ostree-commit"]
                 ref = compose["ref"]
                 rpmostree_inputhash = compose["rpm-ostree-inputhash"]
+                os_version = compose["ostree-version"]
                 assert commit_id
                 assert ref
                 assert rpmostree_inputhash
+                assert os_version
 
                 md = subprocess.check_output(
                     [
@@ -140,6 +142,16 @@ class TestAssemblers(test.TestBase):
                         commit_id
                     ], encoding="utf-8").strip()
                 self.assertEqual(md, f"'{rpmostree_inputhash}'")
+
+                md = subprocess.check_output(
+                    [
+                        "ostree",
+                        "show",
+                        "--repo", repo,
+                        "--print-metadata-key=version",
+                        commit_id
+                    ], encoding="utf-8").strip()
+                self.assertEqual(md, f"'{os_version}'")
 
     @unittest.skipUnless(test.TestBase.have_tree_diff(), "tree-diff missing")
     def test_qemu(self):


### PR DESCRIPTION
Add a new `os_version` option that will result in the `version` metadata being set as commit metadata. This will then be shown in the `rpm-ostree status` output. (That this was missing was pointed out by @mrguitar)