### PR TITLE
buildroot: ensure /sys/fs/selinux is read-only

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -150,6 +150,7 @@ class BuildRoot(contextlib.AbstractContextManager):
         # Setup API file-systems.
         mounts += ["--proc", "/proc"]
         mounts += ["--bind", "/sys", "/sys"]
+        mounts += ["--ro-bind-try", "/sys/fs/selinux", "/sys/fs/selinux"]
 
         # We execute our own modules by bind-mounting them from the host into
         # the build-root. We have minimal requirements on the build-root, so

--- a/test/data/README.md
+++ b/test/data/README.md
@@ -41,3 +41,7 @@ do not allow comments, this file shortly describes their purpose.
    This directory contains test-data for runtime tests of the source-engines. It
    contains a directory that is served via HTTP in the tests, and a directory of
    test-cases what to expect when using the attached `sources.json`.
+
+ * `scripts`:
+   This directory contains scripts used from other tests, i.e. although they are
+   executables they are at the same time test-data to the actual (unit) tests.

--- a/test/data/scripts/mount_flags.py
+++ b/test/data/scripts/mount_flags.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+#
+# Small script that returns 0 if all the requested mount flags
+# are present for a given mount and returns 1 otherwise
+
+import argparse
+import os
+import sys
+
+
+# from /usr/include/sys/mount.h
+# these are file-system independent
+MS_RDONLY = 1
+MS_NOSUID = 2
+MS_NODEV = 4
+MS_NOEXEC = 8
+
+KNOWN_FLAGS = {
+    "ro": MS_RDONLY,
+    "nosuid": MS_NOSUID,
+    "nodev": MS_NODEV,
+    "noexec": MS_NOEXEC
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check for mount flags")
+    parser.add_argument("path", metavar="PATH",
+                        help="path for the file-system to check for read-only status")
+    parser.add_argument("flags", metavar="FLAGS",
+                        help="comma separated list of flags to check for")
+    args = parser.parse_args(sys.argv[1:])
+
+    want = 0
+    strflags = [x.strip() for x in args.flags.split(",")]
+    for flag in strflags:
+        num = KNOWN_FLAGS.get(flag, None)
+        if flag is None:
+            print(f"Unknown flag: '{flag}'")
+            sys.exit(2)
+        want |= num
+
+    sb = os.statvfs(args.path)
+    have = sb.f_flag
+    ok = (have & want) == want
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -2,15 +2,11 @@
 # Test for API infrastructure
 #
 
-import pathlib
 import os
-import sys
 import tempfile
 import unittest
 
 import osbuild
-from osbuild.buildroot import BuildRoot
-from osbuild.monitor import NullMonitor
 from osbuild.util import jsoncomm
 
 
@@ -69,27 +65,3 @@ class TestAPI(unittest.TestCase):
             with self.assertRaises(AssertionError):
                 with api:
                     pass
-
-    def test_buildroot(self):
-        # Check API and BuildRoot integration: the runner will call
-        # api.setup_stdio and thus check that connecting to the api
-        # works correctly
-        runner = "org.osbuild.linux"
-        libdir = os.path.abspath(os.curdir)
-        var = pathlib.Path(self.tmp.name, "var")
-        var.mkdir()
-
-        monitor = NullMonitor(sys.stderr.fileno())
-        with BuildRoot("/", runner, libdir=libdir, var=var) as root:
-            api = osbuild.api.API({}, monitor)
-            root.register_api(api)
-
-            r = root.run(["/usr/bin/true"])
-            self.assertEqual(r.returncode, 0)
-
-            # Test we can use `.run` multiple times
-            r = root.run(["/usr/bin/true"])
-            self.assertEqual(r.returncode, 0)
-
-            r = root.run(["/usr/bin/false"])
-            self.assertNotEqual(r.returncode, 0)

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -1,0 +1,48 @@
+#
+# Test for the build root
+#
+
+import pathlib
+import os
+import sys
+import tempfile
+import unittest
+
+import osbuild
+from osbuild.buildroot import BuildRoot
+from osbuild.monitor import NullMonitor
+from .. import test
+
+
+@unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
+class TestBuildRoot(test.TestBase):
+    """Check BuildRoot"""
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_basic(self):
+        # This also checks the API and BuildRoot integration:
+        # the runner will call api.setup_stdio and thus check
+        # that connecting to the api works correctly
+        runner = "org.osbuild.linux"
+        libdir = os.path.abspath(os.curdir)
+        var = pathlib.Path(self.tmp.name, "var")
+        var.mkdir()
+
+        monitor = NullMonitor(sys.stderr.fileno())
+        with BuildRoot("/", runner, libdir=libdir, var=var) as root:
+            api = osbuild.api.API({}, monitor)
+            root.register_api(api)
+
+            r = root.run(["/usr/bin/true"])
+            self.assertEqual(r.returncode, 0)
+
+            # Test we can use `.run` multiple times
+            r = root.run(["/usr/bin/true"])
+            self.assertEqual(r.returncode, 0)
+
+            r = root.run(["/usr/bin/false"])
+            self.assertNotEqual(r.returncode, 0)


### PR DESCRIPTION
Make sure "/sys/fs/selinux" is read-only, otherwise libselinux and tools will assume that SELinux is available and active and in turn use /sys/fs/selinux to e.g. verify the file systems labels; this will then prevent setting unknown labels via `setfiles`.

Fixes #499 

Missing:
- [x] Test
