### PR TITLE
api: prevent early output retrieval

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -91,7 +91,7 @@ class Stage:
                                binds=[os.fspath(tree) + ":/run/osbuild/tree"],
                                readonly_binds=ro_binds)
 
-            return BuildResult(self, r.returncode, api.output, api.metadata)
+        return BuildResult(self, r.returncode, api.output, api.metadata)
 
 
 class Assembler:
@@ -149,7 +149,7 @@ class Assembler:
                                binds=binds,
                                readonly_binds=ro_binds)
 
-            return BuildResult(self, r.returncode, api.output, api.metadata)
+        return BuildResult(self, r.returncode, api.output, api.metadata)
 
 
 class Pipeline:

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -73,12 +73,13 @@ class TestMonitor(unittest.TestCase):
             path = os.path.join(tmpdir, "osbuild-api")
             logfile = os.path.join(tmpdir, "log.txt")
 
-            with open(logfile, "w") as log, \
-                 API(args, LogMonitor(log.fileno()), socket_address=path) as api:
-                p = mp.Process(target=echo, args=(path, ))
-                p.start()
-                p.join()
-                self.assertEqual(p.exitcode, 0)
+            with open(logfile, "w") as log:
+                api = API(args, LogMonitor(log.fileno()), socket_address=path)
+                with api as api:
+                    p = mp.Process(target=echo, args=(path, ))
+                    p.start()
+                    p.join()
+                    self.assertEqual(p.exitcode, 0)
                 output = api.output  # pylint: disable=no-member
                 assert output
 


### PR DESCRIPTION
Change the API endpoint to prevent retrieving monitor-output from a
running instance. Instead, we require the caller to exit the API context
before querying the monitor-output. This guarantees that the api-thread
was synchronously taken down and scheduled any outstanding events.

This fixes an issue where a side-channel notifies us of a buildroot
exit, but the api-thread has not yet returned from epoll, and thus might
not have dispatched pending I/O events, yet. If we instead wait for the
thread to exit, we have a synchronous shutdown and know that all
*ordered* kernel events must have been handled.

In particular, imagine a build-root program running (like `echo` in the
test_monitor unittest) which writes data to the stdout-pipe and then
immediately exits. The syscall-order guarantees that the data is written
to the pipe before the SIGCHLD is sent (or wait(2) returns). However, we
retrieve the SIGCHLD from our main-thread usually (p.join() in our test,
and BuildRoot() in our main code), while the pipe-reading is done from
an API thread. Therefore, we might end up handling the SIGCHLD first
(just imagine a single-threaded CPU that schedules the main task before
the thread). To avoid this race, we can simply synchronize with the
api-thread. Since we already have this synchronization as part of the
api-thread takedown, it is as simple as stopping the api-thread before
continuing with operations.

Lastly, if a write operation to a pipe was issued, we are guaranteed
that a SIGCHLD synchronization across processes is ordered correctly.
Furthermore, the python event-loop also guarantees that stopping an
event-loop will necessarily dispatch all outstanding events. A read is
guaranteed to be outstanding in our race-scenario, so the read will be
dispatched. The only possible problem is `_output_ready()` only
dispatching a maximum of 4096 bytes. This might need to be fixed
separately. A comment is left in place.