### PR TITLE
Retrieve module arguments via explicit API call

### DIFF
--- a/assemblers/org.osbuild.noop
+++ b/assemblers/org.osbuild.noop
@@ -10,13 +10,19 @@ and then exits.
 import json
 import sys
 
+import osbuild.api
+
+
 SCHEMA = """
 "additionalProperties": false
 """
+
+
 def main(_tree, _output_dir, options):
     print("Not doing anything with these options:", json.dumps(options))
 
+
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["output_dir"], args.get("options", {}))
     sys.exit(r)

--- a/assemblers/org.osbuild.oci-archive
+++ b/assemblers/org.osbuild.oci-archive
@@ -28,6 +28,8 @@ import subprocess
 import sys
 import tempfile
 
+import osbuild.api
+
 
 DEFAULT_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -269,6 +271,6 @@ def main(tree, output_dir, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["output_dir"], args["options"])
     sys.exit(r)

--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -184,6 +184,6 @@ def main(tree, output_dir, options, meta):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = api.arguments()
     r = main(args["tree"], args["output_dir"], args["options"], args["meta"])
     sys.exit(r)

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -29,7 +29,10 @@ import subprocess
 import sys
 import tempfile
 from typing import List, BinaryIO
+
+import osbuild.api
 import osbuild.remoteloop as remoteloop
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -143,6 +146,7 @@ SCHEMA = """
   }
 }
 """
+
 
 @contextlib.contextmanager
 def mount(source, dest):
@@ -697,6 +701,6 @@ def main(tree, output_dir, options, loop_client):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     ret = main(args["tree"], args["output_dir"], args["options"], remoteloop.LoopClient("/run/osbuild/api/remoteloop"))
     sys.exit(ret)

--- a/assemblers/org.osbuild.rawfs
+++ b/assemblers/org.osbuild.rawfs
@@ -21,11 +21,13 @@ read from `/proc/sys/kernel/random/uuid` if your kernel provides it.
 
 
 import contextlib
-import json
 import os
 import subprocess
 import sys
+
+import osbuild.api
 import osbuild.remoteloop as remoteloop
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -104,6 +106,6 @@ def main(tree, output_dir, options, loop_client):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["output_dir"], args["options"], remoteloop.LoopClient("/run/osbuild/api/remoteloop"))
     sys.exit(r)

--- a/stages/org.osbuild.chrony
+++ b/stages/org.osbuild.chrony
@@ -8,9 +8,12 @@ Modifies /etc/chrony.conf, removing all "server" or "pool" lines and adding
 a "server" line for each server listed in `timeservers`.
 """
 
-import json
+
 import sys
 import re
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -49,6 +52,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -18,12 +18,12 @@ Supported sources are currently:
 """
 
 
-import json
 import os
 import sys
 import subprocess
 import tempfile
 
+import osbuild.api
 import osbuild.sources
 
 
@@ -129,7 +129,7 @@ def main(tree, srcdir, options, workdir):
 
 
 if __name__ == '__main__':
-    stage_args = json.load(sys.stdin)
+    stage_args = osbuild.api.arguments()
 
     with tempfile.TemporaryDirectory(dir="/var/tmp") as _workdir:
         r = main(stage_args["tree"],

--- a/stages/org.osbuild.debug-shell
+++ b/stages/org.osbuild.debug-shell
@@ -9,9 +9,11 @@ Also symlinks the service file into /etc/systemd/system/sysinit.target.wants/.
 """
 
 
-import json
 import os
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -64,6 +66,6 @@ UnsetEnvironment=LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETAR
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.error
+++ b/stages/org.osbuild.error
@@ -7,8 +7,10 @@ wasting time.
 """
 
 
-import json
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -29,6 +31,6 @@ def main(_tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args.get("options", {}))
     sys.exit(r)

--- a/stages/org.osbuild.firewall
+++ b/stages/org.osbuild.firewall
@@ -26,9 +26,11 @@ are different arches or OSes.
 """
 
 
-import json
 import subprocess
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -61,6 +63,7 @@ SCHEMA = """
 }
 """
 
+
 def main(tree, options):
     # Takes a list of <port|application protocol>:<transport protocol> pairs
     ports = options.get("ports", [])
@@ -82,6 +85,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.first-boot
+++ b/stages/org.osbuild.first-boot
@@ -16,9 +16,11 @@ any further first-boot commands.
 """
 
 
-import json
 import os
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -38,6 +40,7 @@ SCHEMA = """
   }
 }
 """
+
 
 def add_first_boot(tree, commands, wait_for_network):
     if wait_for_network:
@@ -68,6 +71,7 @@ Type=oneshot
     os.makedirs(f"{tree}/etc", exist_ok=True)
     open(f"{tree}/etc/osbuild-first-boot", 'a').close()
 
+
 def main(tree, options):
     commands = options["commands"]
     wait_for_network = options.get("wait_for_network", False)
@@ -80,6 +84,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.fix-bls
+++ b/stages/org.osbuild.fix-bls
@@ -19,9 +19,11 @@ This stage reads and (re)writes all .conf files in /boot/loader/entries.
 
 
 import glob
-import json
 import re
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -58,6 +60,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.fstab
+++ b/stages/org.osbuild.fstab
@@ -11,8 +11,10 @@ This stage replaces /etc/fstab, removing any existing entries.
 """
 
 
-import json
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -67,6 +69,7 @@ SCHEMA = """
 }
 """
 
+
 def main(tree, options):
     filesystems = options["filesystems"]
 
@@ -91,6 +94,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.groups
+++ b/stages/org.osbuild.groups
@@ -10,9 +10,12 @@ If no `gid` is given, `groupadd` will choose one.
 If the specified group name or GID is already in use, this stage will fail.
 """
 
-import json
+
 import subprocess
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -36,6 +39,7 @@ SCHEMA = """
 }
 """
 
+
 def groupadd(root, name, gid=None):
     arguments = []
     if gid:
@@ -56,6 +60,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -46,11 +46,13 @@ information on that file.
 """
 
 
-import json
 import os
 import shutil
 import string
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -419,6 +421,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.hostname
+++ b/stages/org.osbuild.hostname
@@ -10,10 +10,12 @@ hostname and writes it to /etc/hostname.
 """
 
 
-import json
 import os
 import subprocess
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -25,6 +27,7 @@ SCHEMA = """
   }
 }
 """
+
 
 def main(tree, options):
     hostname = options["hostname"]
@@ -40,6 +43,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.ignition
+++ b/stages/org.osbuild.ignition
@@ -17,8 +17,9 @@ configuration, in case that ignition is run.
 """
 
 
-import json
 import sys
+
+import osbuild.api
 
 
 STAGE_OPTS = """
@@ -52,6 +53,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args.get("options", {}))
     sys.exit(r)

--- a/stages/org.osbuild.kernel-cmdline
+++ b/stages/org.osbuild.kernel-cmdline
@@ -8,9 +8,12 @@ command line.
 https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html
 """
 
-import json
+
 import os
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -56,6 +59,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.keymap
+++ b/stages/org.osbuild.keymap
@@ -11,10 +11,12 @@ Valid keymaps are generally found in /lib/kbd/keymaps.
 """
 
 
-import json
 import subprocess
 import sys
 import os
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -45,6 +47,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.locale
+++ b/stages/org.osbuild.locale
@@ -11,10 +11,12 @@ target system with `LANG={language}`.
 """
 
 
-import json
 import subprocess
 import sys
 import os
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -43,6 +45,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.noop
+++ b/stages/org.osbuild.noop
@@ -10,6 +10,8 @@ leaves the tree untouched. Useful for testing, debugging, and wasting time.
 import json
 import sys
 
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": true
@@ -21,6 +23,6 @@ def main(_tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args.get("options", {}))
     sys.exit(r)

--- a/stages/org.osbuild.ostree
+++ b/stages/org.osbuild.ostree
@@ -22,11 +22,11 @@ the sysroot and the deployments. Additional kernel options can be passed via
 
 
 import contextlib
-import json
 import os
 import sys
 import subprocess
 
+import osbuild.api
 import osbuild.sources
 from osbuild.util import selinux
 
@@ -333,7 +333,7 @@ def main(tree, sources, options):
 
 
 if __name__ == '__main__':
-    stage_args = json.load(sys.stdin)
+    stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["sources"],
              stage_args["options"])

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -189,6 +189,6 @@ def main(tree, sources, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = api.arguments()
     r = main(args["tree"], args["sources"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.rpm-ostree
+++ b/stages/org.osbuild.rpm-ostree
@@ -31,11 +31,11 @@ human users need to be part of.
 """
 
 
-import json
 import os
 import subprocess
 import sys
 
+import osbuild.api
 from osbuild.util import ostree
 
 
@@ -80,6 +80,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -20,10 +20,11 @@ may not match the tree's policy.
 """
 
 
-import json
 import os
 import subprocess
 import sys
+
+import osbuild.api
 
 
 SCHEMA = """
@@ -57,6 +58,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.systemd
+++ b/stages/org.osbuild.systemd
@@ -13,9 +13,10 @@ Uses `systemctl` from the buildhost.
 """
 
 
-import json
 import subprocess
 import sys
+
+import osbuild.api
 
 
 SCHEMA = """
@@ -66,6 +67,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.test
+++ b/stages/org.osbuild.test
@@ -10,9 +10,11 @@ Creates `/etc/systemd/system/osbuild-test.service`, and a symlink to it in
 """
 
 
-import json
 import os
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -24,6 +26,7 @@ SCHEMA = """
   }
 }
 """
+
 
 def main(tree, options):
     script = options["script"]
@@ -49,6 +52,6 @@ ExecStopPost=/usr/bin/systemctl poweroff
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.timezone
+++ b/stages/org.osbuild.timezone
@@ -10,10 +10,12 @@ the `--timezone` option, which will re-create `/etc/localtime`.
 """
 
 
-import json
 import subprocess
 import sys
 import os
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -25,6 +27,7 @@ SCHEMA = """
   }
 }
 """
+
 
 def main(tree, options):
     zone = options["zone"]
@@ -46,6 +49,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -11,10 +11,12 @@ assumptions about its host system.
 """
 
 
-import json
 import subprocess
 import sys
 import os
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -164,6 +166,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.zipl
+++ b/stages/org.osbuild.zipl
@@ -6,9 +6,10 @@ Configures `zipl` with a minimal config so it can be used in
 the assembler to write the bootmap and bootloader code.
 """
 
-import json
 import os
 import sys
+
+import osbuild.api
 
 
 SCHEMA = """
@@ -40,6 +41,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -68,6 +68,17 @@ class TestAPI(unittest.TestCase):
                 with api:
                     pass
 
+    def test_get_arguments(self):
+        tmpdir = self.tmp.name
+        path = os.path.join(tmpdir, "osbuild-api")
+        args = {"options": {"answer": 42}}
+        monitor = osbuild.monitor.BaseMonitor(sys.stderr.fileno())
+
+        with osbuild.api.API(args, monitor, socket_address=path) as _:
+            data = osbuild.api.arguments(path=path)
+            self.assertEqual(data, args)
+
+
     def test_metadata(self):
         # Check that `api.metadata` leads to `API.metadata` being
         # set correctly


### PR DESCRIPTION
Add a new `get-arguments` `api.API` call to fetch the input/arguments.  Additionally, new `arguments` method is provided as a client counterpart for the new API call.
This prepares the deprecation of `setup_stdio`: use that in stages and assemblers instead of reading JSON from `stdin`, which requires the runner using `API.setup_stdio` to provide the arguments. 