### PR TITLE
osbuild: remove objectstore logic in pipeline

### DIFF
--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -264,12 +264,12 @@ class ObjectStore(contextlib.AbstractContextManager):
                                            prefix=prefix,
                                            suffix=suffix)
 
-    @contextlib.contextmanager
     def get(self, object_id):
-        with Object(self) as obj:
-            obj.base = object_id
-            with obj.read() as path:
-                yield path
+        if not self.contains(object_id):
+            return None
+
+        obj = self.new(base_id=object_id)
+        return obj
 
     def new(self, base_id=None):
         """Creates a new temporary `Object`.

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -332,11 +332,12 @@ class Pipeline:
             # tree exists, we return it as well, but we do not care if it is
             # missing, since it is not a mandatory part of the result and would
             # usually be needless overhead.
-            if object_store.contains(self.output_id):
+            obj = object_store.get(self.output_id)
+
+            if obj:
                 results = {"success": True}
-                if output_directory:
-                    with object_store.new(base_id=self.output_id) as output:
-                        output.export(output_directory)
+                obj.export(output_directory)
+
             else:
                 results, build_tree, tree = self.build_stages(object_store,
                                                               monitor,


### PR DESCRIPTION
Change objectstore.get to return an object instead of a path, and remove logic 
with the same functionality in pipeline.run by replacing it with a call to objectstore.get.