### PR TITLE
Record bubblewrap errors to the log

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -88,6 +88,7 @@ class Stage:
             build_root.register_api(src)
 
             r = build_root.run([f"/run/osbuild/lib/stages/{self.name}"],
+                               monitor,
                                binds=[os.fspath(tree) + ":/run/osbuild/tree"],
                                readonly_binds=ro_binds)
 
@@ -146,6 +147,7 @@ class Assembler:
             build_root.register_api(rls)
 
             r = build_root.run([f"/run/osbuild/lib/assemblers/{self.name}"],
+                               monitor,
                                binds=binds,
                                readonly_binds=ro_binds)
 

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -37,14 +37,14 @@ class TestBuildRoot(test.TestBase):
             api = osbuild.api.API({}, monitor)
             root.register_api(api)
 
-            r = root.run(["/usr/bin/true"])
+            r = root.run(["/usr/bin/true"], monitor)
             self.assertEqual(r.returncode, 0)
 
             # Test we can use `.run` multiple times
-            r = root.run(["/usr/bin/true"])
+            r = root.run(["/usr/bin/true"], monitor)
             self.assertEqual(r.returncode, 0)
 
-            r = root.run(["/usr/bin/false"])
+            r = root.run(["/usr/bin/false"], monitor)
             self.assertNotEqual(r.returncode, 0)
 
     @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
@@ -70,7 +70,7 @@ class TestBuildRoot(test.TestBase):
                    "/scripts",
                    "ro"]
 
-            r = root.run(cmd, readonly_binds=ro_binds)
+            r = root.run(cmd, monitor, readonly_binds=ro_binds)
             self.assertEqual(r.returncode, 0)
 
             cmd = ["/scripts/mount_flags.py",
@@ -78,7 +78,7 @@ class TestBuildRoot(test.TestBase):
                    "ro"]
 
             binds = [f"{rw_data}:/rw-data"]
-            r = root.run(cmd, binds=binds, readonly_binds=ro_binds)
+            r = root.run(cmd, monitor, binds=binds, readonly_binds=ro_binds)
             self.assertEqual(r.returncode, 1)
 
     @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
@@ -106,5 +106,5 @@ class TestBuildRoot(test.TestBase):
                    "/sys/fs/selinux",
                    "ro"]
 
-            r = root.run(cmd, readonly_binds=ro_binds)
+            r = root.run(cmd, monitor, readonly_binds=ro_binds)
             self.assertEqual(r.returncode, 0)


### PR DESCRIPTION
In case that `bubblewrap` fails to, e.g. because it fails to execute the runner, it will print an error message to `stderr`. Currently, this output is not capture and thus not logged. To fix that, the `BuildRoot.run` method now takes a monitor object and will stream `stdout`/`stderr` to the log via the monitor.

Closes #458 