### PR TITLE
Use BuildRoot.output instead of api.setup_stdio

### DIFF
--- a/assemblers/org.osbuild.tar
+++ b/assemblers/org.osbuild.tar
@@ -19,9 +19,11 @@ Buildhost commands used: `tar` and any named `compression` program.
 """
 
 
-import json
 import subprocess
 import sys
+
+import osbuild.api
+
 
 SCHEMA = """
 "additionalProperties": false,
@@ -38,6 +40,7 @@ SCHEMA = """
   }
 }
 """
+
 
 def main(tree, output_dir, options):
     filename = options["filename"]
@@ -76,6 +79,6 @@ def main(tree, output_dir, options):
 
 
 if __name__ == '__main__':
-    args = json.load(sys.stdin)
+    args = osbuild.api.arguments()
     r = main(args["tree"], args["output_dir"], args["options"])
     sys.exit(r)

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -92,7 +92,7 @@ class Stage:
                                binds=[os.fspath(tree) + ":/run/osbuild/tree"],
                                readonly_binds=ro_binds)
 
-        return BuildResult(self, r.returncode, api.output, api.metadata)
+        return BuildResult(self, r.returncode, r.output, api.metadata)
 
 
 class Assembler:
@@ -151,7 +151,7 @@ class Assembler:
                                binds=binds,
                                readonly_binds=ro_binds)
 
-        return BuildResult(self, r.returncode, api.output, api.metadata)
+        return BuildResult(self, r.returncode, r.output, api.metadata)
 
 
 class Pipeline:

--- a/runners/org.osbuild.fedora30
+++ b/runners/org.osbuild.fedora30
@@ -3,7 +3,6 @@
 import os
 import subprocess
 import sys
-import osbuild.api
 
 
 def ldconfig():
@@ -37,7 +36,6 @@ def nsswitch():
 
 
 if __name__ == "__main__":
-    osbuild.api.setup_stdio()
     ldconfig()
     sysusers()
     tmpfiles()

--- a/runners/org.osbuild.linux
+++ b/runners/org.osbuild.linux
@@ -2,11 +2,8 @@
 
 import subprocess
 import sys
-import osbuild.api
 
 
 if __name__ == "__main__":
-    osbuild.api.setup_stdio()
-
     r = subprocess.run(sys.argv[1:], check=False)
     sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel81
+++ b/runners/org.osbuild.rhel81
@@ -3,7 +3,6 @@
 import os
 import subprocess
 import sys
-import osbuild.api
 
 
 def ldconfig():
@@ -71,7 +70,6 @@ def python_alternatives():
         pass
 
 if __name__ == "__main__":
-    osbuild.api.setup_stdio()
     ldconfig()
     sysusers()
     tmpfiles()

--- a/runners/org.osbuild.ubuntu1804
+++ b/runners/org.osbuild.ubuntu1804
@@ -4,8 +4,6 @@ import os
 import subprocess
 import sys
 
-import osbuild.api
-
 
 def ldconfig():
     # ld.so.conf must exist, or `ldconfig` throws a warning
@@ -38,7 +36,6 @@ def nsswitch():
 
 
 if __name__ == "__main__":
-    osbuild.api.setup_stdio()
     ldconfig()
     sysusers()
     tmpfiles()

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -92,11 +92,12 @@ class TestAPI(unittest.TestCase):
             osbuild.api.metadata(data, path=path)
             return 0
 
-        with osbuild.api.API(args, monitor, socket_address=path) as api:
+        api = osbuild.api.API(args, monitor, socket_address=path)
+        with api:
             p = mp.Process(target=metadata, args=(path, ))
             p.start()
             p.join()
             self.assertEqual(p.exitcode, 0)
-            metadata = api.metadata  # pylint: disable=no-member
-            assert metadata
-            self.assertEqual(metadata, {"meta": "42"})
+        metadata = api.metadata  # pylint: disable=no-member
+        assert metadata
+        self.assertEqual(metadata, {"meta": "42"})

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -68,6 +68,8 @@ class TestBuildRoot(test.TestBase):
         with open(logfile) as f:
             log = f.read()
         assert log
+        assert r.output
+        self.assertEqual(log, r.output)
 
     @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
     def test_bind_mounts(self):

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -71,6 +71,24 @@ class TestBuildRoot(test.TestBase):
         assert r.output
         self.assertEqual(log, r.output)
 
+    def test_output(self):
+        runner = "org.osbuild.linux"
+        libdir = os.path.abspath(os.curdir)
+        var = pathlib.Path(self.tmp.name, "var")
+        var.mkdir()
+
+        data = "42. cats are superior to dogs"
+
+        monitor = NullMonitor(sys.stderr.fileno())
+        with BuildRoot("/", runner, libdir=libdir, var=var) as root:
+            api = osbuild.api.API({}, monitor)
+            root.register_api(api)
+
+            r = root.run(["/usr/bin/echo", data], monitor)
+            self.assertEqual(r.returncode, 0)
+
+        self.assertEqual(data, r.output.strip())
+
     @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
     def test_bind_mounts(self):
         runner = "org.osbuild.linux"


### PR DESCRIPTION
Create a new `CompletedBuild` object that wraps and is very similar to the `subprocess.CompletedProcess`, i.e. it has a process member but also has short-cuts for `returncode`. Additionally, the output of the process is not only forwarded to the monitor, but also captured and then handed to `CompletedBuild`, so its output member will actually contain the full build output.

Then use that `BuildRoot.output` to get the output of the runner and modules (stages, assemblers) instead of using `api.setup_stdio` and `api.output`. Drop the latter from all runners and replace `api.output` with `BuildRoot.output`.