### PR TITLE
runners: add Fedora 34 runner

### DIFF
--- a/runners/org.osbuild.fedora34
+++ b/runners/org.osbuild.fedora34
@@ -1,0 +1,1 @@
+org.osbuild.fedora30


### PR DESCRIPTION
Fedora 33 recently branched off rawhide and thus Fedora 34 was created. Re-use Fedora 30 runner, as was done for Fedora 33.