### PR TITLE
api: add exception endpoint

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -18,13 +18,14 @@ def cleanup(*objs):
 
 
 class BuildResult:
-    def __init__(self, origin, returncode, output, metadata):
+    def __init__(self, origin, returncode, output, metadata, error):
         self.name = origin.name
         self.id = origin.id
         self.options = origin.options
         self.success = returncode == 0
         self.output = output
         self.metadata = metadata
+        self.error = error
 
     def as_dict(self):
         return vars(self)
@@ -92,7 +93,7 @@ class Stage:
                                binds=[os.fspath(tree) + ":/run/osbuild/tree"],
                                readonly_binds=ro_binds)
 
-        return BuildResult(self, r.returncode, r.output, api.metadata)
+        return BuildResult(self, r.returncode, r.output, api.metadata, api.exception)
 
 
 class Assembler:
@@ -151,7 +152,7 @@ class Assembler:
                                binds=binds,
                                readonly_binds=ro_binds)
 
-        return BuildResult(self, r.returncode, r.output, api.metadata)
+        return BuildResult(self, r.returncode, r.output, api.metadata, api.exception)
 
 
 class Pipeline:

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -79,6 +79,25 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(data, args)
 
 
+    def test_exception(self):
+        # Check that 'api.exception' correctly sets 'API.exception'
+        tmpdir = self.tmp.name
+        path = os.path.join(tmpdir, "osbuild-api")
+        args = {}
+        monitor = osbuild.monitor.BaseMonitor(sys.stderr.fileno())
+
+        def exception(path):
+            with osbuild.api.exception_handler(path):
+                raise ValueError("osbuild test exception")
+
+        api = osbuild.api.API(args, monitor, socket_address=path)
+        with api:
+            p = mp.Process(target=exception, args=(path, ))
+            p.start()
+            p.join()
+        self.assertIsNotNone(api.exception, "Exception not set")
+        self.assertEqual(api.exception["value"], "osbuild test exception")
+
     def test_metadata(self):
         # Check that `api.metadata` leads to `API.metadata` being
         # set correctly


### PR DESCRIPTION
Create a new api endpoint called exception, that communicates exception
backtraces separately back to osbuild, as opposed to dumping them into the 
normal log. Additionally, add a corresponding test to check that a call to 
api.exception correctly sets API.exception.