### PR TITLE
runners: add rhel84 runner

### DIFF
--- a/runners/org.osbuild.rhel84
+++ b/runners/org.osbuild.rhel84
@@ -1,0 +1,1 @@
+org.osbuild.rhel82


### PR DESCRIPTION
The rhel84 runner is based off of the rhel83 runner. No changes are made between them other than the name.

I am opening this as a draft since I am unsure what additional changes might need to be made to osbuild to support rhel 84.

This PR is depended on by https://github.com/osbuild/osbuild-composer/pull/1018