### PR TITLE
Integrate codespell into CI and fix uncovered spelling mistakes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,3 +94,13 @@ jobs:
         run: |
           make --always-make test-data
           git diff --exit-code -- ./test/data
+
+  codespell:
+    name: "Spell check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: codespell-project/actions-codespell@master
+        with:
+          ignore_words_list: msdos
+          skip: ./.git,coverity,rpmbuild,samples

--- a/NEWS.md
+++ b/NEWS.md
@@ -399,7 +399,7 @@ Contributions from: Christian Kellner, David Rheinsberg, Major Hayden,
     immutable directories, which Python 3 fails to clean up.
 
   * Drop custom `os-release` creation from the RHEL 8.2 runner. The
-    issue that made this neccessary got fixed upstream.
+    issue that made this necessary got fixed upstream.
 
   * Ensure the build tree is always being built even if there are no
     stages specified.

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -24,7 +24,7 @@ class BaseAPI(abc.ABC):
     This base class provides the basic scaffolding for setting
     up API endpoints, normally to be used for bi-directional
     communication from and to the sandbox. It is to be used as
-    a context manger. The communication channel will only be
+    a context manager. The communication channel will only be
     established on entering the context and will be shut down
     when the context is left.
 

--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -5,7 +5,7 @@ those not provided by the python standard library. The idea is to provide
 universal wrappers with broad access to linux APIs. Convenience helpers and
 higher-level abstractions are beyond the scope of this module.
 
-In some cases it is overly complex to provide universal access to a specifc
+In some cases it is overly complex to provide universal access to a specific
 API. Hence, the API might be restricted to a reduced subset of its
 functionality, just to make sure we can actually implement the wrappers in a
 reasonable manner.

--- a/sources/org.osbuild.files
+++ b/sources/org.osbuild.files
@@ -90,7 +90,7 @@ def fetch(url, checksum, directory):
     secrets = url.get("secrets")
     url_path = url.get("url")
     # Download to a temporary directory until we have verified the checksum. Use a
-    # subdirectory, so we avoid copying accross block devices.
+    # subdirectory, so we avoid copying across block devices.
     with tempfile.TemporaryDirectory(prefix="osbuild-unverified-file-", dir=directory) as tmpdir:
         # some mirrors are sometimes broken. retry manually, because we could be
         # redirected to a different, working, one on retry.

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -41,7 +41,7 @@ class TestStages(test.TestBase):
 
         There's a special rule for asserting differences where we don't
         know the exact before/after value. This is useful for example if
-        the content of file is dependant on current datetime. You can use this
+        the content of file is dependent on current datetime. You can use this
         feature by putting null value in difference you don't care about.
 
         Example:


### PR DESCRIPTION
Use the github [action](https://github.com/codespell-project/actions-codespell) provided by the codespell project to check the spelling on every PR. Run codespell on the source (`codespell -f -L msdos -S coverity -S rpmbuild -S samples`) and fix all uncovered mistakes.