### PR TITLE
Use api.exception in the runners and various cleanups for it

### DIFF
--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -202,6 +202,7 @@ class API(BaseAPI):
             os.close(self._output_pipe)
             self._output_pipe = None
 
+
 def exception(e, path="/run/osbuild/api/osbuild"):
     """Send exception to osbuild"""
     traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)
@@ -218,6 +219,7 @@ def exception(e, path="/run/osbuild/api/osbuild"):
 
     sys.exit(2)
 
+
 # pylint: disable=broad-except
 @contextlib.contextmanager
 def exception_handler(path="/run/osbuild/api/osbuild"):
@@ -225,6 +227,7 @@ def exception_handler(path="/run/osbuild/api/osbuild"):
         yield
     except Exception as e:
         exception(e, path)
+
 
 def arguments(path="/run/osbuild/api/osbuild"):
     """Retrieve the input arguments that were supplied to API"""

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -210,12 +210,15 @@ def exception(e, path="/run/osbuild/api/osbuild"):
     """Send exception to osbuild"""
     traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)
     with jsoncomm.Socket.new_client(path) as client:
+        with io.StringIO() as out:
+            traceback.print_tb(e.__traceback__, file=out)
+            stacktrace = out.getvalue()
         msg = {
             "method": "exception",
             "exception": {
                 "type": type(e).__name__,
                 "value": str(e),
-                "traceback": str(e.__traceback__)
+                "traceback": stacktrace
             }
         }
         client.send(msg)

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -144,7 +144,7 @@ class API(BaseAPI):
         self._output_pipe = None
         self.monitor = monitor
         self.metadata = {}
-        self.exception = None
+        self.error = None
 
     @property
     def output(self):
@@ -187,7 +187,10 @@ class API(BaseAPI):
             sock.send({"type": "fd", "fd": 0}, fds=fds)
 
     def _get_exception(self, message):
-        self.exception = message["exception"]
+        self.error = {
+            "type": "exception",
+            "data": message["exception"],
+        }
 
     def _message(self, msg, fds, sock):
         if msg["method"] == 'add-metadata':

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -213,7 +213,7 @@ def exception(e, path="/run/osbuild/api/osbuild"):
         msg = {
             "method": "exception",
             "exception": {
-                "type": str(type(e)),
+                "type": type(e).__name__,
                 "value": str(e),
                 "traceback": str(e.__traceback__)
             }

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -93,7 +93,7 @@ class Stage:
                                binds=[os.fspath(tree) + ":/run/osbuild/tree"],
                                readonly_binds=ro_binds)
 
-        return BuildResult(self, r.returncode, r.output, api.metadata, api.exception)
+        return BuildResult(self, r.returncode, r.output, api.metadata, api.error)
 
 
 class Assembler:
@@ -152,7 +152,7 @@ class Assembler:
                                binds=binds,
                                readonly_binds=ro_binds)
 
-        return BuildResult(self, r.returncode, r.output, api.metadata, api.exception)
+        return BuildResult(self, r.returncode, r.output, api.metadata, api.error)
 
 
 class Pipeline:

--- a/runners/org.osbuild.fedora30
+++ b/runners/org.osbuild.fedora30
@@ -4,6 +4,8 @@ import os
 import subprocess
 import sys
 
+import osbuild.api
+
 
 def ldconfig():
     # ld.so.conf must exist, or `ldconfig` throws a warning
@@ -36,10 +38,11 @@ def nsswitch():
 
 
 if __name__ == "__main__":
-    ldconfig()
-    sysusers()
-    tmpfiles()
-    nsswitch()
+    with osbuild.api.exception_handler():
+        ldconfig()
+        sysusers()
+        tmpfiles()
+        nsswitch()
 
-    r = subprocess.run(sys.argv[1:], check=False)
-    sys.exit(r.returncode)
+        r = subprocess.run(sys.argv[1:], check=False)
+        sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel81
+++ b/runners/org.osbuild.rhel81
@@ -4,6 +4,8 @@ import os
 import subprocess
 import sys
 
+import osbuild.api
+
 
 def ldconfig():
     # ld.so.conf must exist, or `ldconfig` throws a warning
@@ -70,12 +72,13 @@ def python_alternatives():
         pass
 
 if __name__ == "__main__":
-    ldconfig()
-    sysusers()
-    tmpfiles()
-    nsswitch()
-    os_release()
-    python_alternatives()
+    with osbuild.api.exception_handler():
+        ldconfig()
+        sysusers()
+        tmpfiles()
+        nsswitch()
+        os_release()
+        python_alternatives()
 
-    r = subprocess.run(sys.argv[1:], check=False)
-    sys.exit(r.returncode)
+        r = subprocess.run(sys.argv[1:], check=False)
+        sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel82
+++ b/runners/org.osbuild.rhel82
@@ -4,6 +4,8 @@ import os
 import subprocess
 import sys
 
+import osbuild.api
+
 
 def ldconfig():
     # ld.so.conf must exist, or `ldconfig` throws a warning
@@ -48,11 +50,12 @@ def python_alternatives():
         pass
 
 if __name__ == "__main__":
-    ldconfig()
-    sysusers()
-    tmpfiles()
-    nsswitch()
-    python_alternatives()
+    with osbuild.api.exception_handler():
+        ldconfig()
+        sysusers()
+        tmpfiles()
+        nsswitch()
+        python_alternatives()
 
-    r = subprocess.run(sys.argv[1:], check=False)
-    sys.exit(r.returncode)
+        r = subprocess.run(sys.argv[1:], check=False)
+        sys.exit(r.returncode)

--- a/runners/org.osbuild.ubuntu1804
+++ b/runners/org.osbuild.ubuntu1804
@@ -4,6 +4,8 @@ import os
 import subprocess
 import sys
 
+import osbuild.api
+
 
 def ldconfig():
     # ld.so.conf must exist, or `ldconfig` throws a warning
@@ -36,10 +38,11 @@ def nsswitch():
 
 
 if __name__ == "__main__":
-    ldconfig()
-    sysusers()
-    tmpfiles()
-    nsswitch()
+    with osbuild.api.exception_handler():
+        ldconfig()
+        sysusers()
+        tmpfiles()
+        nsswitch()
 
-    r = subprocess.run(sys.argv[1:], check=False)
-    sys.exit(r.returncode)
+        r = subprocess.run(sys.argv[1:], check=False)
+        sys.exit(r.returncode)

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -95,6 +95,7 @@ class TestAPI(unittest.TestCase):
             p = mp.Process(target=exception, args=(path, ))
             p.start()
             p.join()
+        self.assertEqual(p.exitcode, 2)
         self.assertIsNotNone(api.error, "Error not set")
         self.assertIn("type", api.error, "Error has no 'type' set")
         self.assertEqual("exception", api.error["type"], "Not an exception")

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -103,6 +103,7 @@ class TestAPI(unittest.TestCase):
             self.assertIn(field, e, f"Exception needs '{field}'")
         self.assertEqual(e["value"], "osbuild test exception")
         self.assertEqual(e["type"], "ValueError")
+        self.assertIn("exception", e["traceback"])
 
     def test_metadata(self):
         # Check that `api.metadata` leads to `API.metadata` being

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -89,6 +89,7 @@ class TestAPI(unittest.TestCase):
         def exception(path):
             with osbuild.api.exception_handler(path):
                 raise ValueError("osbuild test exception")
+            assert False, "api.exception should exit process"
 
         api = osbuild.api.API(args, monitor, socket_address=path)
         with api:

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -78,7 +78,6 @@ class TestAPI(unittest.TestCase):
             data = osbuild.api.arguments(path=path)
             self.assertEqual(data, args)
 
-
     def test_exception(self):
         # Check that 'api.exception' correctly sets 'API.exception'
         tmpdir = self.tmp.name

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -96,8 +96,13 @@ class TestAPI(unittest.TestCase):
             p = mp.Process(target=exception, args=(path, ))
             p.start()
             p.join()
-        self.assertIsNotNone(api.exception, "Exception not set")
-        self.assertEqual(api.exception["value"], "osbuild test exception")
+        self.assertIsNotNone(api.error, "Error not set")
+        self.assertIn("type", api.error, "Error has no 'type' set")
+        self.assertEqual("exception", api.error["type"], "Not an exception")
+        e = api.error["data"]
+        for field in ("type", "value", "traceback"):
+            self.assertIn(field, e, f"Exception needs '{field}'")
+        self.assertEqual(e["value"], "osbuild test exception")
 
     def test_metadata(self):
         # Check that `api.metadata` leads to `API.metadata` being

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -103,6 +103,7 @@ class TestAPI(unittest.TestCase):
         for field in ("type", "value", "traceback"):
             self.assertIn(field, e, f"Exception needs '{field}'")
         self.assertEqual(e["value"], "osbuild test exception")
+        self.assertEqual(e["type"], "ValueError")
 
     def test_metadata(self):
         # Check that `api.metadata` leads to `API.metadata` being


### PR DESCRIPTION
Various clean ups for `api.exception` and more tests for it. One bigger change is to use `API.error` instead of `API.exception` as a more generic error signalling mechanism.
Make use of it in the runners where it makes sense.