### PR TITLE
schutzbot: enable EPEL in RHEL

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -53,6 +53,11 @@ cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
 sudo cp osbuild-mock.repo /etc/yum.repos.d/osbuild-mock.repo
 sudo dnf repository-packages osbuild-mock list
 
+if [[ $ID == rhel ]]; then
+    # Set up EPEL repository (for ansible and koji)
+    sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+fi
+
 # Install the Image Builder packages.
 # Note: installing only -tests to catch missing dependencies
 retry sudo dnf -y install osbuild-composer-tests


### PR DESCRIPTION
The osbuild-composer-tests package recently started to list its actual
dependencies, which include packages from EPEL. Enable EPEL in
deploy.sh.

Based on this patch by Ondřej Budai <obudai@redhat.com>:

  https://github.com/osbuild/osbuild-composer/pull/1022