### PR TITLE
Update CI to test F33 but not F31 via Schutzi

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -32,20 +32,6 @@ pipeline {
             failFast true
 
             parallel {
-                stage('Fedora 31') {
-                    agent { label "f31cloudbase && x86_64" }
-                    environment {
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                    }
-                    steps {
-                        sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
-                        stash (
-                            includes: 'osbuild-mock.repo',
-                            name: 'fedora31'
-                        )
-                    }
-                }
                 stage('Fedora 32') {
                     agent { label "f32cloudbase && x86_64" }
                     environment {
@@ -99,23 +85,6 @@ pipeline {
             failFast false
 
             parallel {
-                stage('Fedora 31') {
-                    agent { label "f31cloudbase && x86_64 && psi" }
-                    environment {
-                        TEST_TYPE = "image"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        DISTRO_CODE = "fedora31"
-                    }
-                    steps {
-                        unstash 'fedora31'
-                        run_tests()
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora31-image')
-                        }
-                    }
-                }
                 stage('Fedora 32') {
                     agent { label "f32cloudbase && x86_64 && psi" }
                     environment {

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -46,6 +46,20 @@ pipeline {
                         )
                     }
                 }
+                stage('Fedora 33') {
+                    agent { label "f33cloudbase && x86_64" }
+                    environment {
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                    }
+                    steps {
+                        sh "schutzbot/ci_details.sh"
+                        sh "schutzbot/mockbuild.sh"
+                        stash (
+                            includes: 'osbuild-mock.repo',
+                            name: 'fedora33'
+                        )
+                    }
+                }
                 stage('RHEL 8 CDN') {
                     agent { label "rhel8cloudbase && x86_64" }
                     environment {
@@ -99,6 +113,23 @@ pipeline {
                     post {
                         always {
                             preserve_logs('fedora32-image')
+                        }
+                    }
+                }
+                stage('Fedora 33') {
+                    agent { label "f33cloudbase && x86_64 && psi" }
+                    environment {
+                        TEST_TYPE = "image"
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        DISTRO_CODE = "fedora33"
+                    }
+                    steps {
+                        unstash 'fedora33'
+                        run_tests()
+                    }
+                    post {
+                        always {
+                            preserve_logs('fedora33-image')
                         }
                     }
                 }

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -10,7 +10,7 @@ function greenprint {
 source /etc/os-release
 ARCH=$(uname -m)
 
-# Mock is only available in EPEL for RHEL.
+# mock and s3cmd are only available in EPEL for RHEL.
 if [[ $ID == rhel ]]; then
     greenprint "📦 Setting up EPEL repository"
     curl -Ls --retry 5 --output /tmp/epel.rpm \
@@ -27,13 +27,7 @@ fi
 
 # Install requirements for building RPMs in mock.
 greenprint "📦 Installing mock requirements"
-sudo dnf -y install createrepo_c make mock python3-pip rpm-build
-
-# Install s3cmd if it is not present.
-if ! s3cmd --version > /dev/null 2>&1; then
-    greenprint "📦 Installing s3cmd"
-    sudo pip3 -q install s3cmd
-fi
+sudo dnf -y install createrepo_c make mock python3-pip rpm-build s3cmd
 
 # Enable fastestmirror for mock on Fedora.
 if [[ $ID == fedora ]]; then


### PR DESCRIPTION
Fedora 33 is about to be release and Fedora 31 is about to go EOL. Adapt accordingly. The later change is also necessary to unbreak CI, because composer has dropped support for F31. 