### PR TITLE
osbuild: always return exit code

### DIFF
--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -4,9 +4,11 @@ This specifies the entrypoint of the osbuild module when run as executable. For
 compatibility we will continue to run the CLI.
 """
 
+import sys
 
 from osbuild.main_cli import osbuild_cli as main
 
 
 if __name__ == "__main__":
-    main()
+    r = main()
+    sys.exit(r)

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -172,4 +172,4 @@ def osbuild_cli():
             print()
             print(f"{RESET}{BOLD}{RED}Failed{RESET}")
 
-    sys.exit(0 if r["success"] else 1)
+    return 0 if r["success"] else 1

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -227,9 +227,6 @@ void preserve_logs(test_slug) {
     // Save the systemd journal.
     sh "sudo journalctl --boot > systemd-journald.log"
 
-    // Find any AVCs in the audit log and save those.
-    sh "sudo grep AVC /var/log/audit/audit.log > selinux-avc.log"
-
     // Make a directory for the log files and move the logs there.
     sh "mkdir ${test_slug} && mv *.log *.jpg ${test_slug}/ || true"
 

--- a/test/run/test_executable.py
+++ b/test/run/test_executable.py
@@ -1,0 +1,30 @@
+#
+# Runtime Tests for the `osbuild` executable
+#
+
+import json
+import subprocess
+import unittest
+
+from .. import test
+
+
+class TestExecutable(unittest.TestCase):
+    def setUp(self):
+        self.osbuild = test.OSBuild(self)
+
+    def test_invalid_manifest(self):
+        invalid = json.dumps({"foo": 42})
+
+        with self.osbuild as osb, self.assertRaises(subprocess.CalledProcessError) as e:
+            osb.compile(invalid, check=True)
+
+        self.assertEqual(e.exception.returncode, 2)
+
+    def test_invalid_checkpoint(self):
+        manifest = json.dumps({})
+
+        with self.osbuild as osb, self.assertRaises(subprocess.CalledProcessError) as e:
+            osb.compile(manifest, checkpoints=["f44f76973fb92446a2a33bfdb401361a47f70497"], check=True)
+
+        self.assertEqual(e.exception.returncode, 1)


### PR DESCRIPTION
osbuild_cli() sometimes returned an exit code, but at the end called
sys.exit() directly. The idea was probably to always return the code
with which the executable should exit.

Make this consistent and call sys.exit() in __main__.py, with the value
returned by osbuild_cli().