### PR TITLE
Minor fixes for pylint 2.6.0

### DIFF
--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -14,7 +14,7 @@ __all__ = [
 
 class UnexpectedDevice(Exception):
     def __init__(self, expected_minor, rdev, mode):
-        super(UnexpectedDevice, self).__init__()
+        super().__init__()
         self.expected_minor = expected_minor
         self.rdev = rdev
         self.mode = mode

--- a/osbuild/util/jsoncomm.py
+++ b/osbuild/util/jsoncomm.py
@@ -316,8 +316,8 @@ class Socket(contextlib.AbstractContextManager):
 
         try:
             payload = json.loads(msg[0])
-        except json.JSONDecodeError:
-            raise BufferError
+        except json.JSONDecodeError as e:
+            raise BufferError from e
 
         return (payload, fdset, msg[3])
 


### PR DESCRIPTION
Using pylint 2.6.0 resulted in a number of new warnings:
 
```
test_pylint (test.src.test_pylint.TestPylint) ... ************* Module osbuild.meta
osbuild/meta.py:116:31: E1136: Value 'Optional' is unsubscriptable (unsubscriptable-object)
osbuild/meta.py:214:42: E1136: Value 'Optional' is unsubscriptable (unsubscriptable-object)
osbuild/meta.py:317:40: E1136: Value 'Optional' is unsubscriptable (unsubscriptable-object)
osbuild/meta.py:393:46: E1136: Value 'Optional' is unsubscriptable (unsubscriptable-object)
************* Module osbuild.objectstore
osbuild/objectstore.py:68:22: E1136: Value 'Optional' is unsubscriptable (unsubscriptable-object)
osbuild/objectstore.py:72:28: E1136: Value 'Optional' is unsubscriptable (unsubscriptable-object)
************* Module osbuild.util.jsoncomm
osbuild/util/jsoncomm.py:320:12: W0707: Consider explicitly re-raising using the 'from' keyword (raise-missing-from)
************* Module osbuild.util.types
osbuild/util/types.py:11:11: E1136: Value 'Union' is unsubscriptable (unsubscriptable-object)
```

NB: The `E1136` error is a false positive: PyCQA/pylint#3882