### PR TITLE
schutzbot: drop RHEL 8.3 stages

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -75,23 +75,6 @@ pipeline {
                         )
                     }
                 }
-                stage('RHEL 8.3 Nightly') {
-                    agent { label "rhel83cloudbase && x86_64" }
-                    environment {
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production-beta')
-                    }
-                    steps {
-                        sh "schutzbot/ci_details.sh"
-                        retry(3) {
-                            sh "schutzbot/mockbuild.sh"
-                        }
-                        stash (
-                            includes: 'osbuild-mock.repo',
-                            name: 'rhel83'
-                        )
-                    }
-                }
             }
         }
         stage("Functional Testing") {
@@ -148,24 +131,6 @@ pipeline {
                     post {
                         always {
                             preserve_logs('rhel8-image')
-                        }
-                    }
-                }
-                stage('RHEL 8.3 Image') {
-                    agent { label "rhel83cloudbase && x86_64 && psi" }
-                    environment {
-                        TEST_TYPE = "image"
-                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production-beta')
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        DISTRO_CODE = "rhel83"
-                    }
-                    steps {
-                        unstash 'rhel83'
-                        run_tests()
-                    }
-                    post {
-                        always {
-                            preserve_logs('rhel83-image')
                         }
                     }
                 }

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -74,19 +74,6 @@ make srpm
 git clone --quiet https://github.com/osbuild/osbuild-composer osbuild-composer
 make -C osbuild-composer srpm
 
-# Update the mock configs if we are on 8.3 beta.
-if [[ $VERSION_ID == 8.3 ]]; then
-    # Remove the existing (non-beta) repos from the template.
-    sudo sed -i '/# repos/q' /etc/mock/templates/rhel-8.tpl
-
-    # Add the enabled repos to the template.
-    cat /etc/yum.repos.d/redhat.repo | sudo tee -a /etc/mock/templates/rhel-8.tpl
-
-    # We need triple quotes at the end of the template to mark the end of
-    # the repo list.
-    echo '"""' | sudo tee -a /etc/mock/templates/rhel-8.tpl
-fi
-
 # Compile RPMs in a mock chroot
 greenprint "🎁 Building RPMs with mock"
 sudo mock -r $MOCK_CONFIG --no-bootstrap-chroot \


### PR DESCRIPTION
RHEL 8.3 is already GA therefore we don't need to test it anymore!

Based on osbuild-composer 543f1f4 by Ondřej Budai <obudai@redhat.com>.