### PR TITLE
schutzbot: pin osbuild-composer

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -1,23 +1,6 @@
 #!/bin/bash
 set -euxo pipefail
 
-function retry {
-    local count=0
-    local retries=5
-    until "$@"; do
-        exit=$?
-        count=$(($count + 1))
-        if [[ $count -lt $retries ]]; then
-            echo "Retrying command..."
-            sleep 1
-        else
-            echo "Command failed after ${retries} retries. Giving up."
-            return $exit
-        fi
-    done
-    return 0
-}
-
 # Get OS details.
 source /etc/os-release
 ARCH=$(uname -m)
@@ -68,7 +51,7 @@ fi
 
 # Install the Image Builder packages.
 # Note: installing only -tests to catch missing dependencies
-retry sudo dnf -y install osbuild-composer-tests
+sudo dnf -y install osbuild-composer-tests
 
 # Set up a directory to hold repository overrides.
 sudo mkdir -p /etc/osbuild-composer/repositories

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euxo pipefail
 
+DNF_REPO_BASEURL=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com
+
+# The osbuild-composer commit to run reverse-dependency test against.
+OSBUILD_COMPOSER_COMMIT=692a8076bb4bf38dae05ce99631ebcdd3f0ab054
+
 # Get OS details.
 source /etc/os-release
 ARCH=$(uname -m)
@@ -14,15 +19,23 @@ fi
 # Add osbuild team ssh keys.
 cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
 
-# Set up a dnf repository with the RPMs we want to test
+# Set up dnf repositories with the RPMs we want to test
 sudo tee /etc/yum.repos.d/osbuild.repo << EOF
 [osbuild]
 name=osbuild ${GIT_COMMIT}
-baseurl=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/osbuild/${ID}-${VERSION_ID}/${ARCH}/${GIT_COMMIT}
+baseurl=${DNF_REPO_BASEURL}/osbuild/${ID}-${VERSION_ID}/${ARCH}/${GIT_COMMIT}
 enabled=1
 gpgcheck=0
 # Default dnf repo priority is 99. Lower number means higher priority.
 priority=5
+
+[osbuild-composer]
+name=osbuild-composer ${OSBUILD_COMPOSER_COMMIT}
+baseurl=${DNF_REPO_BASEURL}/osbuild-composer/${ID}-${VERSION_ID}/${ARCH}/${OSBUILD_COMPOSER_COMMIT}
+enabled=1
+gpgcheck=0
+# Give this a slightly lower priority, because we used to have osbuild in this repo as well.
+priority=10
 EOF
 
 if [[ $ID == rhel ]]; then

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -11,13 +11,6 @@ if [[ -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status
     sudo $RHN_REGISTRATION_SCRIPT
 fi
 
-# Remove Fedora's modular repositories to speed up dnf.
-sudo rm -f /etc/yum.repos.d/fedora*modular*
-
-# Enable fastestmirror and disable weak dependency installation to speed up
-# dnf operations.
-echo -e "fastestmirror=1\ninstall_weak_deps=0" | sudo tee -a /etc/dnf/dnf.conf
-
 # Ensure we are using the latest dnf since early revisions of Fedora 31 had
 # some dnf repo priority bugs like BZ 1733582.
 # NOTE(mhayden): We can exclude kernel updates here to save time with dracut

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -11,15 +11,6 @@ if [[ -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status
     sudo $RHN_REGISTRATION_SCRIPT
 fi
 
-# Ensure we are using the latest dnf since early revisions of Fedora 31 had
-# some dnf repo priority bugs like BZ 1733582.
-# NOTE(mhayden): We can exclude kernel updates here to save time with dracut
-# and module updates. The system will not be rebooted in CI anyway, so a
-# kernel update is not needed.
-if [[ $ID == fedora ]]; then
-    sudo dnf -y upgrade --exclude kernel --exclude kernel-core
-fi
-
 # Add osbuild team ssh keys.
 cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
 

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -11,9 +11,6 @@ if [[ -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status
     sudo $RHN_REGISTRATION_SCRIPT
 fi
 
-# Restart systemd to work around some Fedora issues in cloud images.
-sudo systemctl restart systemd-journald
-
 # Remove Fedora's modular repositories to speed up dnf.
 sudo rm -f /etc/yum.repos.d/fedora*modular*
 

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -65,14 +65,12 @@ greenprint "📤 RPMS will be uploaded to: ${REPO_URL}"
 # Build source RPMs.
 greenprint "🔧 Building source RPMs."
 make srpm
-git clone --quiet https://github.com/osbuild/osbuild-composer osbuild-composer
-make -C osbuild-composer srpm
 
 # Compile RPMs in a mock chroot
 greenprint "🎁 Building RPMs with mock"
 sudo mock -r $MOCK_CONFIG --no-bootstrap-chroot \
-    --resultdir $REPO_DIR --with=tests \
-    rpmbuild/SRPMS/*.src.rpm osbuild-composer/rpmbuild/SRPMS/*.src.rpm
+    --resultdir $REPO_DIR \
+    rpmbuild/SRPMS/*.src.rpm
 sudo chown -R $USER ${REPO_DIR}
 
 # Change the ownership of all of our repo files from root to our CI user.


### PR DESCRIPTION
Pin the osbuild-composer that schutzbot runs a reverse dependency test against. This allows to control which exact version to test against, and ensures that PRs against osbuild always run against the same version.

Now that osbuild-composer's CI uploads RPMs to a predictable destination (the same one that osbuild uses), we can use that instead of rebuilding osbuild-composer on every CI run. This should speed up the mockbuild stage considerably.

Pin it to v24 now.