### PR TITLE
Ability to run the full test suit as non-root (with root only tests being skipped)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ $(SRCDIR)/test/data/manifests/filesystem.json: $(SRCDIR)/test/data/manifests/f32
 .PHONY: test-data
 test-data: $(TEST_MANIFESTS_GEN)
 
-.PHONY: test-units
+.PHONY: test-module
 test-module:
 	@$(PYTHON3) -m unittest \
 		discover \

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -64,9 +64,10 @@ class BaseAPI(abc.ABC):
         """Called after the event loop is shut down"""
 
     @classmethod
-    def _make_socket_dir(cls):
+    def _make_socket_dir(cls, rundir: PathLike = "/run/osbuild"):
         """Called to create the temporary socket dir"""
-        return tempfile.TemporaryDirectory(prefix="api-", dir="/run/osbuild")
+        os.makedirs(rundir, exist_ok=True)
+        return tempfile.TemporaryDirectory(prefix="api-", dir=rundir)
 
     def _dispatch(self, sock: jsoncomm.Socket):
         """Called when data is available on the socket"""

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -317,7 +317,7 @@ class ObjectStore(contextlib.AbstractContextManager):
 
         # symlink the object_id (config hash) in the refs directory to the
         # treesum (content hash) in the objects directory. If a symlink by
-        # that name alreday exists, atomically replace it, but leave the
+        # that name already exists, atomically replace it, but leave the
         # backing object in place (it may be in use).
         with self.tempdir() as tmp:
             link = f"{tmp}/link"

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -321,7 +321,6 @@ class Pipeline:
         return results, output
 
     def run(self, store, monitor, libdir, output_directory):
-        os.makedirs("/run/osbuild", exist_ok=True)
         results = {"success": True}
 
         monitor.begin(self)

--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -18,6 +18,7 @@ MEBIBYTE = 1024 * 1024
 
 
 @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
+@unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
 class TestAssemblers(test.TestBase):
     @classmethod
     def setUpClass(cls):

--- a/test/run/test_boot.py
+++ b/test/run/test_boot.py
@@ -11,6 +11,7 @@ from .. import test
 
 
 @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
+@unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
 class TestBoot(test.TestBase):
     def setUp(self):
         self.osbuild = test.OSBuild(self)

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -57,6 +57,14 @@ def fileServer(directory):
         yield
 
 
+def can_setup_netns() -> bool:
+    try:
+        with netns():
+            return True
+    except:  # pylint: disable=bare-except
+        return False
+
+
 def runFileServer(barrier, directory):
     class Handler(http.server.SimpleHTTPRequestHandler):
         def __init__(self, request, client_address, server):
@@ -68,6 +76,7 @@ def runFileServer(barrier, directory):
 
 
 @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
+@unittest.skipUnless(can_setup_netns(), "network namespace setup failed")
 class TestSources(test.TestBase):
     def setUp(self):
         self.sources = os.path.join(self.locate_test_data(), "sources")

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -31,6 +31,7 @@ def find_stage(result, stageid):
 
 @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
 @unittest.skipUnless(test.TestBase.have_tree_diff(), "tree-diff missing")
+@unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
 class TestStages(test.TestBase):
 
     def assertTreeDiffsEqual(self, tree_diff1, tree_diff2):


### PR DESCRIPTION
A few of the test did not have the correct *skip unless* clauses that would make them fail when executed as non-root. Fix all of those. Additionally, do not create `/run/osbuild` eagerly, which also needs root and made `test_noop` fail, but let it be created on-demand by the `BuildRoot.run` method.