### PR TITLE
ci: send coverage data to codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    patch: no
+    project:
+      default:
+        threshold: 5%
+codecov:
+  require_ci_to_pass: yes
+comment: no

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,10 @@ jobs:
           python3 -m pytest \
             --pyargs "${{ matrix.test }}" \
             --rootdir=. \
+            --cov-report=xml --cov=osbuild \
             -v
+    - name: Send coverage to codecov.io
+      run: bash <(curl -s https://codecov.io/bash)
 
   documentation:
     name: "📚 Documentation"


### PR DESCRIPTION
Integrate with codecov. Define a threshold of 5% to pass. Coverage is cumulative, i.e. all the tests send their coverage to codecov, which will integrate them all into a total.