### PR TITLE
runners: add CentOS 8 runner

### DIFF
--- a/runners/org.osbuild.centos8
+++ b/runners/org.osbuild.centos8
@@ -1,0 +1,1 @@
+org.osbuild.rhel82


### PR DESCRIPTION
This runner is used by both CentOS 8 and CentOS Stream. CentOS is kinda weird because it specifies only number 8 in VERSION_ID in /etc/os-release unlike RHEL. Also the ID is the same for CentOS 8 and CentOS Stream.

This should work fine for now though: CentOS 8 is currently based on RHEL 8.3 and CentOS Stream on devel version of RHEL 8.4. For both RHEL 8.3 and 8.4 we use the RHEL 8.2 runner so it should be safe to assume that it's OK to base the CentOS 8 runner also on the RHEL 8.2 one.

We might need to tweak this at some point but I suggest dealing with it when that time comes.