### PR TITLE
cli: remove --source command line option

### DIFF
--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -48,6 +48,9 @@ is not listed here, **osbuild** will deny startup and exit with an error.
 --json                          output results in JSON format
 --output-directory=DIR          directory where result objects are stored
 
+NB: If neither ``--output-directory`` nor ``--checkpoint`` is specified, no
+attempt to build the manifest will be made.
+
 MANIFEST
 ========
 

--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -39,8 +39,6 @@ is not listed here, **osbuild** will deny startup and exit with an error.
 -h, --help                      print usage information and exit immediately
 --store=DIR                     directory where intermediary file system trees
                                 are stored
---sources=PATH                  json file containing a dictionary of source
-                                configuration
 --secrets=PATH                  json file containing a dictionary of secrets
                                 that are passed to sources
 -l DIR, --libdir=DIR            directory containing stages, assemblers, and

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -85,8 +85,6 @@ def parse_arguments(sys_argv):
     parser.add_argument("--store", metavar="DIRECTORY", type=os.path.abspath,
                         default=".osbuild",
                         help="directory where intermediary os trees are stored")
-    parser.add_argument("--sources", metavar="FILE", type=os.path.abspath,
-                        help="json file containing a dictionary of source configuration")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath, default="/usr/lib/osbuild",
                         help="the directory containing stages, assemblers, and the osbuild library")
     parser.add_argument("--checkpoint", metavar="ID", action="append", type=str, default=None,
@@ -119,10 +117,6 @@ def osbuild_cli():
 
     pipeline = manifest.get("pipeline", {})
     sources_options = manifest.get("sources", {})
-
-    if args.sources:
-        with open(args.sources) as f:
-            sources_options = json.load(f)
 
     pipeline = osbuild.load(pipeline, sources_options)
 


### PR DESCRIPTION
This was deprecated in favor of always having the source in the manifest. Remove the command line option and the corresponding code that would override the sources definitions.