### PR TITLE
Flatten the pipeline

### DIFF
--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -8,8 +8,8 @@ The utility module `osbuild.util` provides access to common functionality
 independent of osbuild but used across the osbuild codebase.
 """
 
-
-from .pipeline import Assembler, load, load_build, Pipeline, Stage
+from .formats.v1 import load, load_build
+from .pipeline import Assembler, Pipeline, Stage
 
 
 __all__ = [

--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -8,11 +8,12 @@ The utility module `osbuild.util` provides access to common functionality
 independent of osbuild but used across the osbuild codebase.
 """
 
-from .pipeline import Assembler, Pipeline, Stage
+from .pipeline import Assembler, Manifest, Pipeline, Stage
 
 
 __all__ = [
     "Assembler",
+    "Manifest",
     "Pipeline",
     "Stage",
 ]

--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -8,14 +8,11 @@ The utility module `osbuild.util` provides access to common functionality
 independent of osbuild but used across the osbuild codebase.
 """
 
-from .formats.v1 import load, load_build
 from .pipeline import Assembler, Pipeline, Stage
 
 
 __all__ = [
     "Assembler",
-    "load",
-    "load_build",
     "Pipeline",
     "Stage",
 ]

--- a/osbuild/formats/__init__.py
+++ b/osbuild/formats/__init__.py
@@ -1,0 +1,3 @@
+"""
+Concrete representation of manifest descriptions
+"""

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -1,9 +1,10 @@
 # Version 1 of the manifest description
 
+from typing import Dict
 from ..pipeline import Pipeline, detect_host_runner
 
 
-def load_build(description, sources_options):
+def load_build(description: Dict, sources_options: Dict):
     pipeline = description.get("pipeline")
     if pipeline:
         build_pipeline = load(pipeline, sources_options)
@@ -13,7 +14,7 @@ def load_build(description, sources_options):
     return build_pipeline, description["runner"]
 
 
-def load(description, sources_options):
+def load(description: Dict, sources_options: Dict) -> Pipeline:
     build = description.get("build")
     if build:
         build_pipeline, runner = load_build(build, sources_options)

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -8,14 +8,14 @@ from ..pipeline import Pipeline, detect_host_runner
 def load_build(description: Dict, sources_options: Dict):
     pipeline = description.get("pipeline")
     if pipeline:
-        build_pipeline = load(pipeline, sources_options)
+        build_pipeline = load_pipeline(pipeline, sources_options)
     else:
         build_pipeline = None
 
     return build_pipeline, description["runner"]
 
 
-def load(description: Dict, sources_options: Dict) -> Pipeline:
+def load_pipeline(description: Dict, sources_options: Dict) -> Pipeline:
     build = description.get("build")
     if build:
         build_pipeline, runner = load_build(build, sources_options)
@@ -32,6 +32,15 @@ def load(description: Dict, sources_options: Dict) -> Pipeline:
         pipeline.set_assembler(a["name"], a.get("options", {}))
 
     return pipeline
+
+
+def load(description: Dict) -> Pipeline:
+    """Load a manifest description"""
+
+    pipeline = description.get("pipeline", {})
+    sources = description.get("sources", {})
+
+    return load_pipeline(pipeline, sources)
 
 
 def validate(manifest: Dict, index: Index) -> ValidationResult:

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -1,0 +1,32 @@
+# Version 1 of the manifest description
+
+from ..pipeline import Pipeline, detect_host_runner
+
+
+def load_build(description, sources_options):
+    pipeline = description.get("pipeline")
+    if pipeline:
+        build_pipeline = load(pipeline, sources_options)
+    else:
+        build_pipeline = None
+
+    return build_pipeline, description["runner"]
+
+
+def load(description, sources_options):
+    build = description.get("build")
+    if build:
+        build_pipeline, runner = load_build(build, sources_options)
+    else:
+        build_pipeline, runner = None, detect_host_runner()
+
+    pipeline = Pipeline(runner, build_pipeline)
+
+    for s in description.get("stages", []):
+        pipeline.add_stage(s["name"], sources_options, s.get("options", {}))
+
+    a = description.get("assembler")
+    if a:
+        pipeline.set_assembler(a["name"], a.get("options", {}))
+
+    return pipeline

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -5,6 +5,35 @@ from osbuild.meta import Index, ValidationResult
 from ..pipeline import Pipeline, detect_host_runner
 
 
+def describe(pipeline: Pipeline, *, with_id=False) -> Dict:
+    """Create the manifest description for the pipeline"""
+    def describe_stage(stage):
+        description = {"name": stage.name}
+        if stage.options:
+            description["options"] = stage.options
+        if with_id:
+            description["id"] = stage.id
+        return description
+
+    description = {}
+    if pipeline.build:
+        build = pipeline.build
+        description["build"] = {
+            "pipeline": describe(build, with_id=with_id),
+            "runner": pipeline.runner
+        }
+
+    if pipeline.stages:
+        stages = [describe_stage(s) for s in pipeline.stages]
+        description["stages"] = stages
+
+    if pipeline.assembler:
+        assembler = describe_stage(pipeline.assembler)
+        description["assembler"] = assembler
+
+    return description
+
+
 def load_build(description: Dict, sources_options: Dict):
     pipeline = description.get("pipeline")
     if pipeline:

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -1,6 +1,7 @@
 # Version 1 of the manifest description
 
 from typing import Dict
+from osbuild.meta import Index, ValidationResult
 from ..pipeline import Pipeline, detect_host_runner
 
 
@@ -31,3 +32,55 @@ def load(description: Dict, sources_options: Dict) -> Pipeline:
         pipeline.set_assembler(a["name"], a.get("options", {}))
 
     return pipeline
+
+
+def validate(manifest: Dict, index: Index) -> ValidationResult:
+    """Validate a OSBuild manifest
+
+    This function will validate a OSBuild manifest, including
+    all its stages and assembler and build manifests. It will
+    try to validate as much as possible and not stop on errors.
+    The result is a `ValidationResult` object that can be used
+    to check the overall validation status and iterate all the
+    individual validation errors.
+    """
+
+    schema = index.get_schema("Manifest")
+    result = schema.validate(manifest)
+
+    # main pipeline
+    pipeline = manifest.get("pipeline", {})
+
+    # recursively validate the build pipeline  as a "normal"
+    # pipeline in order to validate its stages and assembler
+    # options; for this it is being re-parented in a new plain
+    # {"pipeline": ...} dictionary. NB: Any nested structural
+    # errors might be detected twice, but de-duplicated by the
+    # `ValidationResult.merge` call
+    build = pipeline.get("build", {}).get("pipeline")
+    if build:
+        res = validate({"pipeline": build}, index=index)
+        result.merge(res, path=["pipeline", "build"])
+
+    stages = pipeline.get("stages", [])
+    for i, stage in enumerate(stages):
+        name = stage["name"]
+        schema = index.get_schema("Stage", name)
+        res = schema.validate(stage)
+        result.merge(res, path=["pipeline", "stages", i])
+
+    asm = pipeline.get("assembler", {})
+    if asm:
+        name = asm["name"]
+        schema = index.get_schema("Assembler", name)
+        res = schema.validate(asm)
+        result.merge(res, path=["pipeline", "assembler"])
+
+    # sources
+    sources = manifest.get("sources", {})
+    for name, source in sources.items():
+        schema = index.get_schema("Source", name)
+        res = schema.validate(source)
+        result.merge(res, path=["sources", name])
+
+    return result

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -5,7 +5,7 @@ from osbuild.meta import Index, ValidationResult
 from ..pipeline import Manifest, Pipeline, detect_host_runner
 
 
-def describe(pipeline: Pipeline, *, with_id=False) -> Dict:
+def describe(manifest: Manifest, *, with_id=False) -> Dict:
     """Create the manifest description for the pipeline"""
     def describe_stage(stage):
         description = {"name": stage.name}
@@ -15,21 +15,30 @@ def describe(pipeline: Pipeline, *, with_id=False) -> Dict:
             description["id"] = stage.id
         return description
 
-    description = {}
-    if pipeline.build:
-        build = pipeline.build
-        description["build"] = {
-            "pipeline": describe(build, with_id=with_id),
-            "runner": pipeline.runner
-        }
+    def describe_pipeline(pipeline: Pipeline) -> Dict:
+        description = {}
+        if pipeline.build:
+            build = pipeline.build
+            description["build"] = {
+                "pipeline": describe_pipeline(build),
+                "runner": pipeline.runner
+            }
 
-    if pipeline.stages:
-        stages = [describe_stage(s) for s in pipeline.stages]
-        description["stages"] = stages
+        if pipeline.stages:
+            stages = [describe_stage(s) for s in pipeline.stages]
+            description["stages"] = stages
 
-    if pipeline.assembler:
-        assembler = describe_stage(pipeline.assembler)
-        description["assembler"] = assembler
+        if pipeline.assembler:
+            assembler = describe_stage(pipeline.assembler)
+            description["assembler"] = assembler
+        return description
+
+    description = {
+        "pipeline": describe_pipeline(manifest.pipeline)
+    }
+
+    if manifest.source_options:
+        description["sources"] = manifest.source_options
 
     return description
 

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 from osbuild.meta import Index, ValidationResult
-from ..pipeline import Pipeline, detect_host_runner
+from ..pipeline import Manifest, Pipeline, detect_host_runner
 
 
 def describe(pipeline: Pipeline, *, with_id=False) -> Dict:
@@ -63,13 +63,17 @@ def load_pipeline(description: Dict, sources_options: Dict) -> Pipeline:
     return pipeline
 
 
-def load(description: Dict) -> Pipeline:
+def load(description: Dict) -> Manifest:
     """Load a manifest description"""
 
     pipeline = description.get("pipeline", {})
     sources = description.get("sources", {})
 
-    return load_pipeline(pipeline, sources)
+    pipeline = load_pipeline(pipeline, sources)
+    manifest = Manifest(pipeline)
+    manifest.source_options = sources
+
+    return manifest
 
 
 def validate(manifest: Dict, index: Index) -> ValidationResult:

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -103,11 +103,11 @@ def parse_arguments(sys_argv):
 # pylint: disable=too-many-branches
 def osbuild_cli():
     args = parse_arguments(sys.argv)
-    manifest = parse_manifest(args.manifest_path)
+    desc = parse_manifest(args.manifest_path)
 
     # first thing after parsing is validation of the input
     index = osbuild.meta.Index(args.libdir)
-    res = fmt.validate(manifest, index)
+    res = fmt.validate(desc, index)
     if not res:
         if args.json or args.inspect:
             json.dump(res.as_dict(), sys.stdout)
@@ -116,7 +116,7 @@ def osbuild_cli():
             show_validation(res, args.manifest_path)
         return 2
 
-    pipeline = fmt.load(manifest)
+    pipeline = fmt.load(desc)
 
     if args.checkpoint:
         missed = mark_checkpoints(pipeline, args.checkpoint)
@@ -128,8 +128,8 @@ def osbuild_cli():
 
     if args.inspect:
         result = {"pipeline": fmt.describe(pipeline, with_id=True)}
-        if manifest.get("sources_options"):
-            result["sources"] = manifest["sources_options"]
+        if desc.get("sources_options"):
+            result["sources"] = desc["sources_options"]
         json.dump(result, sys.stdout)
         sys.stdout.write("\n")
         return 0

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -116,7 +116,8 @@ def osbuild_cli():
             show_validation(res, args.manifest_path)
         return 2
 
-    pipeline = fmt.load(desc)
+    manifest = fmt.load(desc)
+    pipeline = manifest.pipeline
 
     if args.checkpoint:
         missed = mark_checkpoints(pipeline, args.checkpoint)
@@ -142,7 +143,7 @@ def osbuild_cli():
     monitor = osbuild.monitor.make(monitor_name, sys.stdout.fileno())
 
     try:
-        r = pipeline.run(
+        r = manifest.build(
             args.store,
             monitor,
             args.libdir,

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -23,33 +23,6 @@ RED = "\033[31m"
 GREEN = "\033[32m"
 
 
-def mark_checkpoints(pipeline, checkpoints):
-    points = set(checkpoints)
-
-    def mark_stage(stage):
-        c = stage.id
-        if c in points:
-            stage.checkpoint = True
-            points.remove(c)
-
-    def mark_assembler(assembler):
-        c = assembler.id
-        if c in points:
-            assembler.checkpoint = True
-            points.remove(c)
-
-    def mark_pipeline(pl):
-        for stage in pl.stages:
-            mark_stage(stage)
-        if pl.assembler:
-            mark_assembler(pl.assembler)
-        if pl.build:
-            mark_pipeline(pl.build)
-
-    mark_pipeline(pipeline)
-    return points
-
-
 def parse_manifest(path):
     if path == "-":
         manifest = json.load(sys.stdin)
@@ -120,7 +93,7 @@ def osbuild_cli():
     pipeline = manifest.pipeline
 
     if args.checkpoint:
-        missed = mark_checkpoints(pipeline, args.checkpoint)
+        missed = manifest.mark_checkpoints(args.checkpoint)
         if missed:
             for checkpoint in missed:
                 print(f"Checkpoint {BOLD}{checkpoint}{RESET} not found!")

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -14,6 +14,7 @@ import sys
 import osbuild
 import osbuild.meta
 import osbuild.monitor
+from osbuild.objectstore import ObjectStore
 from osbuild.formats import v1 as fmt
 
 
@@ -114,12 +115,13 @@ def osbuild_cli():
     monitor = osbuild.monitor.make(monitor_name, sys.stdout.fileno())
 
     try:
-        r = manifest.build(
-            args.store,
-            monitor,
-            args.libdir,
-            output_directory=args.output_directory
-        )
+        with ObjectStore(args.store) as object_store:
+            r = manifest.build(
+                object_store,
+                monitor,
+                args.libdir,
+                output_directory=args.output_directory
+            )
     except KeyboardInterrupt:
         print()
         print(f"{RESET}{BOLD}{RED}Aborted{RESET}")

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -14,6 +14,7 @@ import sys
 import osbuild
 import osbuild.meta
 import osbuild.monitor
+from osbuild.formats import v1 as fmt
 
 
 RESET = "\033[0m"
@@ -106,7 +107,7 @@ def osbuild_cli():
 
     # first thing after parsing is validation of the input
     index = osbuild.meta.Index(args.libdir)
-    res = osbuild.meta.validate(manifest, index)
+    res = fmt.validate(manifest, index)
     if not res:
         if args.json or args.inspect:
             json.dump(res.as_dict(), sys.stdout)

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -116,10 +116,7 @@ def osbuild_cli():
             show_validation(res, args.manifest_path)
         return 2
 
-    pipeline = manifest.get("pipeline", {})
-    sources_options = manifest.get("sources", {})
-
-    pipeline = fmt.load(pipeline, sources_options)
+    pipeline = fmt.load(manifest)
 
     if args.checkpoint:
         missed = mark_checkpoints(pipeline, args.checkpoint)
@@ -131,8 +128,8 @@ def osbuild_cli():
 
     if args.inspect:
         result = {"pipeline": pipeline.description(with_id=True)}
-        if sources_options:
-            result["sources"] = sources_options
+        if manifest.get("sources_options"):
+            result["sources"] = manifest["sources_options"]
         json.dump(result, sys.stdout)
         sys.stdout.write("\n")
         return 0

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -91,7 +91,6 @@ def osbuild_cli():
         return 2
 
     manifest = fmt.load(desc)
-    pipeline = manifest.pipeline
 
     if args.checkpoint:
         missed = manifest.mark_checkpoints(args.checkpoint)
@@ -128,12 +127,14 @@ def osbuild_cli():
         return 130
 
     if args.json:
+        r = fmt.output(manifest, r)
         json.dump(r, sys.stdout)
         sys.stdout.write("\n")
     else:
         if r["success"]:
-            print("tree id:", pipeline.tree_id)
-            print("output id:", pipeline.output_id)
+            tree_id, output_id = fmt.get_ids(manifest)
+            print("tree id:", tree_id)
+            print("output id:", output_id)
         else:
             print()
             print(f"{RESET}{BOLD}{RED}Failed{RESET}")

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -119,7 +119,7 @@ def osbuild_cli():
     pipeline = manifest.get("pipeline", {})
     sources_options = manifest.get("sources", {})
 
-    pipeline = osbuild.load(pipeline, sources_options)
+    pipeline = fmt.load(pipeline, sources_options)
 
     if args.checkpoint:
         missed = mark_checkpoints(pipeline, args.checkpoint)

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -127,7 +127,7 @@ def osbuild_cli():
             return 1
 
     if args.inspect:
-        result = {"pipeline": pipeline.description(with_id=True)}
+        result = {"pipeline": fmt.describe(pipeline, with_id=True)}
         if manifest.get("sources_options"):
             result["sources"] = manifest["sources_options"]
         json.dump(result, sys.stdout)

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -128,9 +128,7 @@ def osbuild_cli():
             return 1
 
     if args.inspect:
-        result = {"pipeline": fmt.describe(pipeline, with_id=True)}
-        if desc.get("sources_options"):
-            result["sources"] = desc["sources_options"]
+        result = fmt.describe(manifest, with_id=True)
         json.dump(result, sys.stdout)
         sys.stdout.write("\n")
         return 0

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -4,7 +4,6 @@ import hashlib
 import os
 import subprocess
 import tempfile
-import weakref
 from typing import Optional
 
 from osbuild.util.types import PathLike
@@ -252,7 +251,7 @@ class ObjectStore(contextlib.AbstractContextManager):
         os.makedirs(self.objects, exist_ok=True)
         os.makedirs(self.refs, exist_ok=True)
         os.makedirs(self.tmp, exist_ok=True)
-        self._objs = weakref.WeakSet()
+        self._objs = set()
 
     def _get_floating(self, object_id: str) -> Optional[Object]:
         """Internal: get a non-committed object"""

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -254,9 +254,20 @@ class ObjectStore(contextlib.AbstractContextManager):
         os.makedirs(self.tmp, exist_ok=True)
         self._objs = weakref.WeakSet()
 
+    def _get_floating(self, object_id: str) -> Optional[Object]:
+        """Internal: get a non-committed object"""
+        for obj in self._objs:
+            if obj.id == object_id:
+                return obj
+        return None
+
     def contains(self, object_id):
         if not object_id:
             return False
+
+        if self._get_floating(object_id):
+            return True
+
         return os.access(self.resolve_ref(object_id), os.F_OK)
 
     def resolve_ref(self, object_id: Optional[str]) -> Optional[str]:
@@ -272,6 +283,10 @@ class ObjectStore(contextlib.AbstractContextManager):
                                            suffix=suffix)
 
     def get(self, object_id):
+        obj = self._get_floating(object_id)
+        if obj:
+            return obj
+
         if not self.contains(object_id):
             return None
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -319,7 +319,6 @@ class Pipeline:
         if obj:
             if output_directory:
                 obj.export(output_directory)
-            obj.cleanup()
 
         monitor.finish(results)
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -255,6 +255,11 @@ class Pipeline:
             if stage.checkpoint:
                 object_store.commit(tree, stage.id)
 
+        # The for loop will always have done at least iteration since
+        # both other cases, i.e. an empty list of stages or the last
+        # stage being in the store, are handled before
+        tree.id = stage.id  # pylint: disable=undefined-loop-variable
+
         return results, build_tree, tree
 
     def assemble(self, object_store, build_tree, tree, monitor, libdir):

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -147,6 +147,10 @@ class Pipeline:
         self.assembler = None
 
     @property
+    def id(self):
+        return self.tree_id or self.output_id
+
+    @property
     def tree_id(self):
         return self.stages[-1].id if self.stages else None
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -363,32 +363,3 @@ def detect_host_runner():
     """Use os-release(5) to detect the runner for the host"""
     osname = osrelease.describe_os(*osrelease.DEFAULT_PATHS)
     return "org.osbuild." + osname
-
-
-def load_build(description, sources_options):
-    pipeline = description.get("pipeline")
-    if pipeline:
-        build_pipeline = load(pipeline, sources_options)
-    else:
-        build_pipeline = None
-
-    return build_pipeline, description["runner"]
-
-
-def load(description, sources_options):
-    build = description.get("build")
-    if build:
-        build_pipeline, runner = load_build(build, sources_options)
-    else:
-        build_pipeline, runner = None, detect_host_runner()
-
-    pipeline = Pipeline(runner, build_pipeline)
-
-    for s in description.get("stages", []):
-        pipeline.add_stage(s["name"], sources_options, s.get("options", {}))
-
-    a = description.get("assembler")
-    if a:
-        pipeline.set_assembler(a["name"], a.get("options", {}))
-
-    return pipeline

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -293,34 +293,33 @@ class Pipeline:
 
         monitor.begin(self)
 
-        with objectstore.ObjectStore(store) as object_store:
-            # If the final result is already in the store, no need to attempt
-            # building it. Just fetch the cached information. If the associated
-            # tree exists, we return it as well, but we do not care if it is
-            # missing, since it is not a mandatory part of the result and would
-            # usually be needless overhead.
-            obj = object_store.get(self.output_id)
+        # If the final result is already in the store, no need to attempt
+        # building it. Just fetch the cached information. If the associated
+        # tree exists, we return it as well, but we do not care if it is
+        # missing, since it is not a mandatory part of the result and would
+        # usually be needless overhead.
+        obj = store.get(self.output_id)
 
-            if not obj:
-                results, build_tree, tree = self.build_stages(object_store,
-                                                              monitor,
-                                                              libdir)
+        if not obj:
+            results, build_tree, tree = self.build_stages(store,
+                                                          monitor,
+                                                          libdir)
 
-                if not results["success"]:
-                    return results
+            if not results["success"]:
+                return results
 
-                r, obj = self.assemble(object_store,
-                                       build_tree,
-                                       tree,
-                                       monitor,
-                                       libdir)
+            r, obj = self.assemble(store,
+                                   build_tree,
+                                   tree,
+                                   monitor,
+                                   libdir)
 
-                results.update(r)  # This will also update 'success'
+            results.update(r)  # This will also update 'success'
 
-            if obj:
-                if output_directory:
-                    obj.export(output_directory)
-                obj.cleanup()
+        if obj:
+            if output_directory:
+                obj.export(output_directory)
+            obj.cleanup()
 
         monitor.finish(results)
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -49,14 +49,6 @@ class Stage:
         m.update(json.dumps(self.options, sort_keys=True).encode())
         return m.hexdigest()
 
-    def description(self, *, with_id=False):
-        description = {"name": self.name}
-        if self.options:
-            description["options"] = self.options
-        if with_id:
-            description["id"] = self.id
-        return description
-
     def run(self,
             tree,
             runner,
@@ -112,14 +104,6 @@ class Assembler:
         m.update(json.dumps(self.base, sort_keys=True).encode())
         m.update(json.dumps(self.options, sort_keys=True).encode())
         return m.hexdigest()
-
-    def description(self, *, with_id=False):
-        description = {"name": self.name}
-        if self.options:
-            description["options"] = self.options
-        if with_id:
-            description["id"] = self.id
-        return description
 
     def run(self, tree, runner, build_tree, monitor, libdir, output_dir, var="/var/tmp"):
         with buildroot.BuildRoot(build_tree, runner, libdir, var=var) as build_root:
@@ -180,22 +164,6 @@ class Pipeline:
     def set_assembler(self, name, options=None):
         build = self.build.tree_id if self.build else None
         self.assembler = Assembler(name, build, self.tree_id, options or {})
-
-    def description(self, *, with_id=False):
-        description = {}
-        if self.build:
-            description["build"] = {
-                "pipeline": self.build.description(with_id=with_id),
-                "runner": self.runner
-            }
-        if self.stages:
-            stages = [s.description(with_id=with_id) for s in self.stages]
-            description["stages"] = stages
-        if self.assembler:
-            assembler = self.assembler.description(with_id=with_id)
-            description["assembler"] = assembler
-
-        return description
 
     def build_stages(self, object_store, monitor, libdir):
         results = {"success": True}

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -327,6 +327,17 @@ class Pipeline:
         return results
 
 
+class Manifest:
+    """A Pipeline with its source options"""
+
+    def __init__(self, pipeline: Pipeline):
+        self.pipeline = pipeline
+        self.source_options = {}
+
+    def build(self, store, monitor, libdir, output_directory):
+        return self.pipeline.run(store, monitor, libdir, output_directory)
+
+
 def detect_host_runner():
     """Use os-release(5) to detect the runner for the host"""
     osname = osrelease.describe_os(*osrelease.DEFAULT_PATHS)

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 import osbuild
 import osbuild.meta
 from osbuild.monitor import LogMonitor
+from osbuild.objectstore import ObjectStore
 from osbuild.pipeline import detect_host_runner
 from .. import test
 
@@ -67,9 +68,9 @@ class TestMonitor(unittest.TestCase):
 
             logfile = os.path.join(tmpdir, "log.txt")
 
-            with open(logfile, "w") as log:
+            with open(logfile, "w") as log, ObjectStore(storedir) as store:
                 monitor = LogMonitor(log.fileno())
-                res = pipeline.run(storedir,
+                res = pipeline.run(store,
                                    monitor,
                                    libdir=os.path.abspath(os.curdir),
                                    output_directory=outputdir)
@@ -100,10 +101,11 @@ class TestMonitor(unittest.TestCase):
             outputdir = os.path.join(tmpdir, "output")
 
             tape = TapeMonitor()
-            res = pipeline.run(storedir,
-                               tape,
-                               libdir=os.path.abspath(os.curdir),
-                               output_directory=outputdir)
+            with ObjectStore(storedir) as store:
+                res = pipeline.run(store,
+                                   tape,
+                                   libdir=os.path.abspath(os.curdir),
+                                   output_directory=outputdir)
 
         assert res
         self.assertEqual(tape.counter["begin"], 1)

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -30,8 +30,9 @@ class TestDescriptions(unittest.TestCase):
             {"build": None}
         ]
         for pipeline in cases:
+            manifest = {"pipeline": pipeline}
             with self.subTest(pipeline):
-                self.assertEqual(fmt.load(pipeline, {}).description(), {})
+                self.assertEqual(fmt.load(manifest).description(), {})
 
     def test_stage(self):
         name = "org.osbuild.test"

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -11,6 +11,7 @@ import unittest
 
 import osbuild
 import osbuild.meta
+from osbuild.formats import v1 as fmt
 from osbuild.monitor import NullMonitor
 from osbuild.pipeline import detect_host_runner
 from .. import test
@@ -174,7 +175,7 @@ class TestDescriptions(unittest.TestCase):
         index = osbuild.meta.Index(os.curdir)
 
         # an empty manifest is OK
-        res = osbuild.meta.validate({}, index)
+        res = fmt.validate({}, index)
         self.assertEqual(res.valid, True)
 
         # something totally invalid (by Ondřej Budai)
@@ -187,7 +188,7 @@ class TestDescriptions(unittest.TestCase):
             }
         }
 
-        res = osbuild.meta.validate(totally_invalid, index)
+        res = fmt.validate(totally_invalid, index)
         self.assertEqual(res.valid, False)
         # The top-level 'osbuild' is an additional property
         self.assertEqual(len(res), 1)
@@ -201,7 +202,7 @@ class TestDescriptions(unittest.TestCase):
             }
         }
 
-        res = osbuild.meta.validate(no_runner, index)
+        res = fmt.validate(no_runner, index)
         self.assertEqual(res.valid, False)
         self.assertEqual(len(res), 1)  # missing runner
         lst = res[".pipeline.build"]
@@ -227,7 +228,7 @@ class TestDescriptions(unittest.TestCase):
             }
         }
 
-        res = osbuild.meta.validate(no_runner_extra, index)
+        res = fmt.validate(no_runner_extra, index)
         self.assertEqual(res.valid, False)
         self.assertEqual(len(res), 3)
         lst = res[".pipeline.build.pipeline"]
@@ -251,7 +252,7 @@ class TestDescriptions(unittest.TestCase):
             }
         }
 
-        res = osbuild.meta.validate(stage_check, index)
+        res = fmt.validate(stage_check, index)
         self.assertEqual(res.valid, False)
         self.assertEqual(len(res), 2)
         lst = res[".pipeline.stages[0].options"]
@@ -270,7 +271,7 @@ class TestDescriptions(unittest.TestCase):
             }
         }
 
-        res = osbuild.meta.validate(assembler_check, index)
+        res = fmt.validate(assembler_check, index)
         self.assertEqual(res.valid, False)
         self.assertEqual(len(res), 2)
         lst = res[".pipeline.assembler.options"]

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -82,11 +82,11 @@ class TestDescriptions(unittest.TestCase):
         build = osbuild.Pipeline("org.osbuild.test")
         build.add_stage("org.osbuild.test", {}, {"one": 1})
 
-        pipeline = osbuild.Pipeline("org.osbuild.test", build)
+        pipeline = osbuild.Pipeline("org.osbuild.test", build.tree_id)
         pipeline.add_stage("org.osbuild.test", {}, {"one": 2})
         pipeline.set_assembler("org.osbuild.test")
 
-        manifest = osbuild.Manifest(pipeline)
+        manifest = osbuild.Manifest([build, pipeline])
 
         self.assertEqual(fmt.describe(manifest), {
             "pipeline": {

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -32,8 +32,8 @@ class TestDescriptions(unittest.TestCase):
         for pipeline in cases:
             manifest = {"pipeline": pipeline}
             with self.subTest(pipeline):
-                desc = fmt.describe(fmt.load(manifest).pipeline)
-                self.assertEqual(desc, {})
+                desc = fmt.describe(fmt.load(manifest))
+                self.assertEqual(desc["pipeline"], {})
 
     @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
     def test_stage_run(self):
@@ -86,26 +86,30 @@ class TestDescriptions(unittest.TestCase):
         pipeline.add_stage("org.osbuild.test", {}, {"one": 2})
         pipeline.set_assembler("org.osbuild.test")
 
-        self.assertEqual(fmt.describe(pipeline), {
-            "build": {
-                "pipeline": {
-                    "stages": [
-                        {
-                            "name": "org.osbuild.test",
-                            "options": {"one": 1}
-                        }
-                    ]
+        manifest = osbuild.Manifest(pipeline)
+
+        self.assertEqual(fmt.describe(manifest), {
+            "pipeline": {
+                "build": {
+                    "pipeline": {
+                        "stages": [
+                            {
+                                "name": "org.osbuild.test",
+                                "options": {"one": 1}
+                            }
+                        ]
+                    },
+                    "runner": "org.osbuild.test"
                 },
-                "runner": "org.osbuild.test"
-            },
-            "stages": [
-                {
-                    "name": "org.osbuild.test",
-                    "options": {"one": 2}
+                "stages": [
+                    {
+                        "name": "org.osbuild.test",
+                        "options": {"one": 2}
+                    }
+                ],
+                "assembler": {
+                    "name": "org.osbuild.test"
                 }
-            ],
-            "assembler": {
-                "name": "org.osbuild.test"
             }
         })
 

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -31,7 +31,7 @@ class TestDescriptions(unittest.TestCase):
         ]
         for pipeline in cases:
             with self.subTest(pipeline):
-                self.assertEqual(osbuild.load(pipeline, {}).description(), {})
+                self.assertEqual(fmt.load(pipeline, {}).description(), {})
 
     def test_stage(self):
         name = "org.osbuild.test"

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -32,19 +32,8 @@ class TestDescriptions(unittest.TestCase):
         for pipeline in cases:
             manifest = {"pipeline": pipeline}
             with self.subTest(pipeline):
-                self.assertEqual(fmt.load(manifest).description(), {})
-
-    def test_stage(self):
-        name = "org.osbuild.test"
-        options = {"one": 1}
-        cases = [
-            (osbuild.Stage(name, {}, None, None, {}), {"name": name}),
-            (osbuild.Stage(name, {}, None, None, None), {"name": name}),
-            (osbuild.Stage(name, {}, None, None, options), {"name": name, "options": options}),
-        ]
-        for stage, description in cases:
-            with self.subTest(description):
-                self.assertEqual(stage.description(), description)
+                desc = fmt.describe(fmt.load(manifest))
+                self.assertEqual(desc, {})
 
     @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
     def test_stage_run(self):
@@ -66,18 +55,6 @@ class TestDescriptions(unittest.TestCase):
 
         self.assertEqual(res.success, True)
         self.assertEqual(res.id, stage.id)
-
-    def test_assembler(self):
-        name = "org.osbuild.test"
-        options = {"one": 1}
-        cases = [
-            (osbuild.Assembler(name, None, None, {}), {"name": name}),
-            (osbuild.Assembler(name, None, None, None), {"name": name}),
-            (osbuild.Assembler(name, None, None, options), {"name": name, "options": options}),
-        ]
-        for assembler, description in cases:
-            with self.subTest(description):
-                self.assertEqual(assembler.description(), description)
 
     @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
     def test_assembler_run(self):
@@ -109,7 +86,7 @@ class TestDescriptions(unittest.TestCase):
         pipeline.add_stage("org.osbuild.test", {}, {"one": 2})
         pipeline.set_assembler("org.osbuild.test")
 
-        self.assertEqual(pipeline.description(), {
+        self.assertEqual(fmt.describe(pipeline), {
             "build": {
                 "pipeline": {
                     "stages": [

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -32,7 +32,7 @@ class TestDescriptions(unittest.TestCase):
         for pipeline in cases:
             manifest = {"pipeline": pipeline}
             with self.subTest(pipeline):
-                desc = fmt.describe(fmt.load(manifest))
+                desc = fmt.describe(fmt.load(manifest).pipeline)
                 self.assertEqual(desc, {})
 
     @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")

--- a/test/test.py
+++ b/test/test.py
@@ -354,8 +354,8 @@ class OSBuild(contextlib.AbstractContextManager):
 
         manifest_json = json.loads(manifest_data)
 
-        manifest_parsed = fmt.load(manifest_json)
-        return manifest_parsed.tree_id
+        manifest = fmt.load(manifest_json)
+        return manifest.pipeline.tree_id
 
     @contextlib.contextmanager
     def map_object(self, obj):

--- a/test/test.py
+++ b/test/test.py
@@ -355,7 +355,8 @@ class OSBuild(contextlib.AbstractContextManager):
         manifest_json = json.loads(manifest_data)
 
         manifest = fmt.load(manifest_json)
-        return manifest.pipeline.tree_id
+        tree_id, _ = fmt.get_ids(manifest)
+        return tree_id
 
     @contextlib.contextmanager
     def map_object(self, obj):

--- a/test/test.py
+++ b/test/test.py
@@ -353,10 +353,8 @@ class OSBuild(contextlib.AbstractContextManager):
         """
 
         manifest_json = json.loads(manifest_data)
-        manifest_pipeline = manifest_json.get("pipeline", {})
-        manifest_sources = manifest_json.get("sources", {})
 
-        manifest_parsed = fmt.load(manifest_pipeline, manifest_sources)
+        manifest_parsed = fmt.load(manifest_json)
         return manifest_parsed.tree_id
 
     @contextlib.contextmanager

--- a/test/test.py
+++ b/test/test.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import unittest
 
-import osbuild
+from osbuild.formats import v1 as fmt
 from osbuild.util import linux
 
 
@@ -356,7 +356,7 @@ class OSBuild(contextlib.AbstractContextManager):
         manifest_pipeline = manifest_json.get("pipeline", {})
         manifest_sources = manifest_json.get("sources", {})
 
-        manifest_parsed = osbuild.load(manifest_pipeline, manifest_sources)
+        manifest_parsed = fmt.load(manifest_pipeline, manifest_sources)
         return manifest_parsed.tree_id
 
     @contextlib.contextmanager


### PR DESCRIPTION
This depends on #552 

Instead of having build pipelines nested within the pipeline it is the build pipeline for, the nested structure is transferred into a flat list of pipelines. As a result the recursion is gone and all the pipelines and trees are build one after the other. This is now possible since floating objects are kept alive by the store itself and all trees that are being built are transparently via them. The immediate result dictionary changed accordingly. To keep the JSON output of osbuild the same, the result is now routed through a format specific converter. 

Additionally, the v1 format module gained a function to retrieve the global `tree_id` and `output_id`. With the new models those global ids will go away eventually and thus need to go through the format specific code.