### PR TITLE
📜 test-data: ensure that `make test-data` always regenerate manifests used for testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
       uses: osbuild/containers/ghci/actions/ghci-osbuild@ghci/v1
       with:
         run: |
-          make --always-make test-data
+          make test-data
           git diff --exit-code -- ./test/data
 
   codespell:

--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,7 @@ TEST_MANIFESTS_MPP = $(wildcard $(SRCDIR)/test/data/manifests/*.mpp.json) \
 		     $(wildcard $(SRCDIR)/test/data/stages/*/*.mpp.json)
 TEST_MANIFESTS_GEN = $(TEST_MANIFESTS_MPP:%.mpp.json=%.json)
 
+.PHONY: $(TEST_MANIFESTS_GEN)
 $(TEST_MANIFESTS_GEN): %.json: %.mpp.json
 	$(SRCDIR)/tools/mpp-depsolve.py <"$<" \
 		| $(SRCDIR)/tools/mpp-import-pipeline.py >"$@" \


### PR DESCRIPTION
Mark `$(TEST_MANIFESTS_GEN)` target as `.PHONY`.

Currently the `test-data` make target does not always trigger regenerating of manifests used for testing various osbuild parts, although it is marked as .PHONY. The reason that its dependency `$(TEST_MANIFESTS_GEN)` is not marked as `.PHONY` and therefore it is not run if the files already exist in repository.

Due to the above reason, CI is actually running `make --always-make test-data` to always regenerate manifests. The appropriate CI step has been updated as part of this change.