### PR TITLE
Include new packages and modules in the packages

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -119,6 +119,9 @@ install -p -m 0755 $(find runners -type f -or -type l) %{buildroot}%{pkgdir}/run
 mkdir -p %{buildroot}%{pkgdir}/sources
 install -p -m 0755 $(find sources -type f) %{buildroot}%{pkgdir}/sources
 
+mkdir -p %{buildroot}%{pkgdir}/inputs
+install -p -m 0755 $(find inputs -type f) %{buildroot}%{pkgdir}/inputs
+
 # mount point for bind mounting the osbuild library
 mkdir -p %{buildroot}%{pkgdir}/osbuild
 

--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -8,11 +8,10 @@ The utility module `osbuild.util` provides access to common functionality
 independent of osbuild but used across the osbuild codebase.
 """
 
-from .pipeline import Assembler, Manifest, Pipeline, Stage
+from .pipeline import Manifest, Pipeline, Stage
 
 
 __all__ = [
-    "Assembler",
     "Manifest",
     "Pipeline",
     "Stage",

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -66,7 +66,7 @@ class BaseMonitor(abc.ABC):
     def stage(self, stage: osbuild.Stage):
         """Called when a stage is being built"""
 
-    def assembler(self, assembler: osbuild.Assembler):
+    def assembler(self, assembler: osbuild.Stage):
         """Called when an assembler is being built"""
 
     def result(self, result: osbuild.pipeline.BuildResult):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     name="osbuild",
     version="23",
     description="A build system for OS images",
-    packages=["osbuild", "osbuild.util"],
+    packages=["osbuild", "osbuild.formats", "osbuild.util"],
     license='Apache-2.0',
     install_requires=[
         "jsonschema",

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -38,7 +38,7 @@ class TapeMonitor(osbuild.monitor.BaseMonitor):
         self.counter["stages"] += 1
         self.stages.add(stage.id)
 
-    def assembler(self, assembler: osbuild.Assembler):
+    def assembler(self, assembler: osbuild.Stage):
         self.counter["assembler"] += 1
         self.asm = assembler.id
 


### PR DESCRIPTION
Include the input modules in the RPM package and the `osbuild.formats` in the sub-package (introduce by #561). Maybe we should just use `setuptools.find_packages()` for the latter. Also, we need to have CI catch those issues.

As a bonus is also removes the now unneeded `Assembler` class.