### PR TITLE
Properly serialise results in case of error and add format specific tests

### DIFF
--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -110,8 +110,14 @@ def output(manifest: Manifest, res: Dict) -> Dict:
     """Convert a result into the v1 format"""
 
     def result_for_pipeline(pipeline):
-        current = res[pipeline.id]
-        retval = {"success": current["success"]}
+        # The pipeline might not have been built one of its
+        # dependencies, i.e. its build pipeline, failed to
+        # build. We thus need to be tolerant of a missing
+        # result but still need to to recurse
+        current = res.get(pipeline.id, {})
+        retval = {
+            "success": current.get("success", False)
+        }
         if pipeline.build:
             build = manifest[pipeline.build]
             retval["build"] = result_for_pipeline(build)

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -11,8 +11,33 @@ import osbuild.meta
 from osbuild.formats import v1 as fmt
 
 
-class TestFormatV1(unittest.TestCase):
+BASIC_PIPELINE = {
+    "pipeline": {
+        "build": {
+            "pipeline": {
+                "stages": [
+                    {
+                        "name": "org.osbuild.test",
+                        "options": {"one": 1}
+                    }
+                ]
+            },
+            "runner": "org.osbuild.test"
+        },
+        "stages": [
+            {
+                "name": "org.osbuild.test",
+                "options": {"one": 2}
+            }
+        ],
+        "assembler": {
+            "name": "org.osbuild.noop"
+        }
+    }
+}
 
+
+class TestFormatV1(unittest.TestCase):
 
     def test_canonical(self):
         """Degenerate case. Make sure we always return the same canonical
@@ -89,30 +114,7 @@ class TestFormatV1(unittest.TestCase):
 
         manifest = osbuild.Manifest([build, pipeline], {})
 
-        self.assertEqual(fmt.describe(manifest), {
-            "pipeline": {
-                "build": {
-                    "pipeline": {
-                        "stages": [
-                            {
-                                "name": "org.osbuild.test",
-                                "options": {"one": 1}
-                            }
-                        ]
-                    },
-                    "runner": "org.osbuild.test"
-                },
-                "stages": [
-                    {
-                        "name": "org.osbuild.test",
-                        "options": {"one": 2}
-                    }
-                ],
-                "assembler": {
-                    "name": "org.osbuild.noop"
-                }
-            }
-        })
+        self.assertEqual(fmt.describe(manifest), BASIC_PIPELINE)
 
     def test_validation(self):
         index = osbuild.meta.Index(os.curdir)

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -72,7 +72,6 @@ class TestFormatV1(unittest.TestCase):
         # load the manifest description, that will check all
         # the stages can be found in the index and have valid
         # arguments, i.e. the schema is correct
-
         manifest = fmt.load(description, index)
         self.assertIsNotNone(manifest)
 
@@ -100,19 +99,12 @@ class TestFormatV1(unittest.TestCase):
         want = description["pipeline"]["assembler"]
         self.assertEqual(have.name, want["name"])
 
-    def test_pipeline(self):
+
+    def test_describe(self):
         index = osbuild.meta.Index(os.curdir)
 
-        test_info = index.get_module_info("Stage", "org.osbuild.test")
-        build = osbuild.Pipeline("org.osbuild.test")
-        build.add_stage(test_info, {"one": 1})
-
-        pipeline = osbuild.Pipeline("org.osbuild.test", build.tree_id)
-        pipeline.add_stage(test_info, {"one": 2})
-        info = index.get_module_info("Assembler", "org.osbuild.noop")
-        pipeline.set_assembler(info)
-
-        manifest = osbuild.Manifest([build, pipeline], {})
+        manifest = fmt.load(BASIC_PIPELINE, index)
+        self.assertIsNotNone(manifest)
 
         self.assertEqual(fmt.describe(manifest), BASIC_PIPELINE)
 

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -1,0 +1,180 @@
+#
+# Tests specific for version 1 of the format
+#
+
+import os
+import unittest
+
+import osbuild
+import osbuild.meta
+from osbuild.formats import v1 as fmt
+
+
+class TestFormatV1(unittest.TestCase):
+
+    def test_canonical(self):
+        """Degenerate case. Make sure we always return the same canonical
+        description when passing empty or null values."""
+
+        index = osbuild.meta.Index(os.curdir)
+
+        cases = [
+            {},
+            {"assembler": None},
+            {"stages": []},
+            {"build": {}},
+            {"build": None}
+        ]
+
+        for pipeline in cases:
+            manifest = {"pipeline": pipeline}
+            with self.subTest(pipeline):
+                desc = fmt.describe(fmt.load(manifest, index))
+                self.assertEqual(desc["pipeline"], {})
+
+    def test_pipeline(self):
+        index = osbuild.meta.Index(os.curdir)
+
+        test_info = index.get_module_info("Stage", "org.osbuild.test")
+        build = osbuild.Pipeline("org.osbuild.test")
+        build.add_stage(test_info, {"one": 1})
+
+        pipeline = osbuild.Pipeline("org.osbuild.test", build.tree_id)
+        pipeline.add_stage(test_info, {"one": 2})
+        info = index.get_module_info("Assembler", "org.osbuild.noop")
+        pipeline.set_assembler(info)
+
+        manifest = osbuild.Manifest([build, pipeline], {})
+
+        self.assertEqual(fmt.describe(manifest), {
+            "pipeline": {
+                "build": {
+                    "pipeline": {
+                        "stages": [
+                            {
+                                "name": "org.osbuild.test",
+                                "options": {"one": 1}
+                            }
+                        ]
+                    },
+                    "runner": "org.osbuild.test"
+                },
+                "stages": [
+                    {
+                        "name": "org.osbuild.test",
+                        "options": {"one": 2}
+                    }
+                ],
+                "assembler": {
+                    "name": "org.osbuild.noop"
+                }
+            }
+        })
+
+    def test_validation(self):
+        index = osbuild.meta.Index(os.curdir)
+
+        # an empty manifest is OK
+        res = fmt.validate({}, index)
+        self.assertEqual(res.valid, True)
+
+        # something totally invalid (by Ondřej Budai)
+        totally_invalid = {
+            "osbuild": {
+                "state": "awesome",
+                "but": {
+                    "input-validation": 1
+                }
+            }
+        }
+
+        res = fmt.validate(totally_invalid, index)
+        self.assertEqual(res.valid, False)
+        # The top-level 'osbuild' is an additional property
+        self.assertEqual(len(res), 1)
+
+        # This is missing the runner
+        no_runner = {
+            "pipeline": {
+                "build": {
+                    "pipeline": {}
+                }
+            }
+        }
+
+        res = fmt.validate(no_runner, index)
+        self.assertEqual(res.valid, False)
+        self.assertEqual(len(res), 1)  # missing runner
+        lst = res[".pipeline.build"]
+        self.assertEqual(len(lst), 1)
+
+        # de-dup issues: the manifest checking will report
+        # the extra element and the recursive build pipeline
+        # check will also report that same error; make sure
+        # they get properly de-duplicated
+        no_runner_extra = {
+            "pipeline": {
+                "build": {  # missing runner
+                    "pipeline": {
+                        "extra": True,  # should not be there
+                        "stages": [{
+                            "name": "org.osbuild.chrony",
+                            "options": {
+                                "timeservers": "string"  # should be an array
+                            }
+                        }]
+                    }
+                }
+            }
+        }
+
+        res = fmt.validate(no_runner_extra, index)
+        self.assertEqual(res.valid, False)
+        self.assertEqual(len(res), 3)
+        lst = res[".pipeline.build.pipeline"]
+        self.assertEqual(len(lst), 1)  # should only have one
+        lst = res[".pipeline.build.pipeline.stages[0].options.timeservers"]
+        self.assertEqual(len(lst), 1)  # should only have one
+
+        # stage issues
+        stage_check = {
+            "pipeline": {
+                "stages": [{
+                    "name": "org.osbuild.grub2",
+                    "options": {
+                        "uefi": {
+                            "install": False,
+                            # missing "vendor"
+                        },
+                        # missing rootfs or root_fs_uuid
+                    }
+                }]
+            }
+        }
+
+        res = fmt.validate(stage_check, index)
+        self.assertEqual(res.valid, False)
+        self.assertEqual(len(res), 2)
+        lst = res[".pipeline.stages[0].options"]
+        self.assertEqual(len(lst), 1)  #  missing rootfs
+        lst = res[".pipeline.stages[0].options.uefi"]
+        self.assertEqual(len(lst), 1)  #  missing "osname"
+
+        assembler_check = {
+            "pipeline": {
+                "assembler": {
+                    "name": "org.osbuild.tar",
+                    "options": {
+                        "compression": "foobar"
+                    }
+                }
+            }
+        }
+
+        res = fmt.validate(assembler_check, index)
+        self.assertEqual(res.valid, False)
+        self.assertEqual(len(res), 2)
+        lst = res[".pipeline.assembler.options"]
+        self.assertEqual(len(lst), 1)  #  missing "filename"
+        lst = res[".pipeline.assembler.options.compression"]
+        self.assertEqual(len(lst), 1)  #  wrong compression method

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -11,7 +11,6 @@ import unittest
 
 import osbuild
 import osbuild.meta
-from osbuild.formats import v1 as fmt
 from osbuild.monitor import NullMonitor
 from osbuild.objectstore import ObjectStore
 from osbuild.pipeline import detect_host_runner
@@ -19,24 +18,6 @@ from .. import test
 
 
 class TestDescriptions(unittest.TestCase):
-    def test_canonical(self):
-        """Degenerate case. Make sure we always return the same canonical
-        description when passing empty or null values."""
-
-        index = osbuild.meta.Index(os.curdir)
-
-        cases = [
-            {},
-            {"assembler": None},
-            {"stages": []},
-            {"build": {}},
-            {"build": None}
-        ]
-        for pipeline in cases:
-            manifest = {"pipeline": pipeline}
-            with self.subTest(pipeline):
-                desc = fmt.describe(fmt.load(manifest, index))
-                self.assertEqual(desc["pipeline"], {})
 
     @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
     def test_stage_run(self):
@@ -59,45 +40,6 @@ class TestDescriptions(unittest.TestCase):
 
         self.assertEqual(res.success, True)
         self.assertEqual(res.id, stage.id)
-
-    def test_pipeline(self):
-        index = osbuild.meta.Index(os.curdir)
-
-        test_info = index.get_module_info("Stage", "org.osbuild.test")
-        build = osbuild.Pipeline("org.osbuild.test")
-        build.add_stage(test_info, {"one": 1})
-
-        pipeline = osbuild.Pipeline("org.osbuild.test", build.tree_id)
-        pipeline.add_stage(test_info, {"one": 2})
-        info = index.get_module_info("Assembler", "org.osbuild.noop")
-        pipeline.set_assembler(info)
-
-        manifest = osbuild.Manifest([build, pipeline], {})
-
-        self.assertEqual(fmt.describe(manifest), {
-            "pipeline": {
-                "build": {
-                    "pipeline": {
-                        "stages": [
-                            {
-                                "name": "org.osbuild.test",
-                                "options": {"one": 1}
-                            }
-                        ]
-                    },
-                    "runner": "org.osbuild.test"
-                },
-                "stages": [
-                    {
-                        "name": "org.osbuild.test",
-                        "options": {"one": 2}
-                    }
-                ],
-                "assembler": {
-                    "name": "org.osbuild.noop"
-                }
-            }
-        })
 
     def test_moduleinfo(self):
         index = osbuild.meta.Index(os.curdir)
@@ -138,111 +80,3 @@ class TestDescriptions(unittest.TestCase):
         self.assertFalse(res)
         res = schema.validate([1, 2, 3])
         self.assertTrue(res)
-
-    def test_validation(self):
-        index = osbuild.meta.Index(os.curdir)
-
-        # an empty manifest is OK
-        res = fmt.validate({}, index)
-        self.assertEqual(res.valid, True)
-
-        # something totally invalid (by Ondřej Budai)
-        totally_invalid = {
-            "osbuild": {
-                "state": "awesome",
-                "but": {
-                    "input-validation": 1
-                }
-            }
-        }
-
-        res = fmt.validate(totally_invalid, index)
-        self.assertEqual(res.valid, False)
-        # The top-level 'osbuild' is an additional property
-        self.assertEqual(len(res), 1)
-
-        # This is missing the runner
-        no_runner = {
-            "pipeline": {
-                "build": {
-                    "pipeline": {}
-                }
-            }
-        }
-
-        res = fmt.validate(no_runner, index)
-        self.assertEqual(res.valid, False)
-        self.assertEqual(len(res), 1)  # missing runner
-        lst = res[".pipeline.build"]
-        self.assertEqual(len(lst), 1)
-
-        # de-dup issues: the manifest checking will report
-        # the extra element and the recursive build pipeline
-        # check will also report that same error; make sure
-        # they get properly de-duplicated
-        no_runner_extra = {
-            "pipeline": {
-                "build": {  # missing runner
-                    "pipeline": {
-                        "extra": True,  # should not be there
-                        "stages": [{
-                            "name": "org.osbuild.chrony",
-                            "options": {
-                                "timeservers": "string"  # should be an array
-                            }
-                        }]
-                    }
-                }
-            }
-        }
-
-        res = fmt.validate(no_runner_extra, index)
-        self.assertEqual(res.valid, False)
-        self.assertEqual(len(res), 3)
-        lst = res[".pipeline.build.pipeline"]
-        self.assertEqual(len(lst), 1)  # should only have one
-        lst = res[".pipeline.build.pipeline.stages[0].options.timeservers"]
-        self.assertEqual(len(lst), 1)  # should only have one
-
-        # stage issues
-        stage_check = {
-            "pipeline": {
-                "stages": [{
-                    "name": "org.osbuild.grub2",
-                    "options": {
-                        "uefi": {
-                            "install": False,
-                            # missing "vendor"
-                        },
-                        # missing rootfs or root_fs_uuid
-                    }
-                }]
-            }
-        }
-
-        res = fmt.validate(stage_check, index)
-        self.assertEqual(res.valid, False)
-        self.assertEqual(len(res), 2)
-        lst = res[".pipeline.stages[0].options"]
-        self.assertEqual(len(lst), 1)  #  missing rootfs
-        lst = res[".pipeline.stages[0].options.uefi"]
-        self.assertEqual(len(lst), 1)  #  missing "osname"
-
-        assembler_check = {
-            "pipeline": {
-                "assembler": {
-                    "name": "org.osbuild.tar",
-                    "options": {
-                        "compression": "foobar"
-                    }
-                }
-            }
-        }
-
-        res = fmt.validate(assembler_check, index)
-        self.assertEqual(res.valid, False)
-        self.assertEqual(len(res), 2)
-        lst = res[".pipeline.assembler.options"]
-        self.assertEqual(len(lst), 1)  #  missing "filename"
-        lst = res[".pipeline.assembler.options.compression"]
-        self.assertEqual(len(lst), 1)  #  wrong compression method


### PR DESCRIPTION
When the build fails, not all pipelines might have been built and those pipelines will be missing from the results. Currently the code assumes that all pipelines will have a result and this will crash when trying to find an id for a pipeline that did not get built.

Refactor and rework the format specific test and add a new one for the output formatting.

