### PR TITLE
devcontainer: support for vs code devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM fedora
+RUN dnf install -y \
+    fish \
+    git \
+    jq \
+    make \
+    qemu-img \
+    osbuild \
+    osbuild-ostree \
+    pylint \
+    python3-autopep8 \
+    python3-devel \
+    python3-docutils \
+    python3-iniparse \
+    python3-jsonschema \
+    python3-pip \
+    python3-pylint \
+    python3-pytest \
+    rpm-build \
+    selinux-policy-devel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "osbuild",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+  },
+  "runArgs": [
+    "--privileged"
+  ],
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/fish",
+    "python.pythonPath": "/usr/bin/python",
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pyTestEnabled": true,
+    "python.testing.pyTestArgs": [
+      "test"
+    ]
+  },
+  "extensions": [
+    "editorconfig.editorconfig",
+    "laurenttreguier.rpm-spec",
+    "ms-python.python",
+    "ms-python.vscode-pylance"
+  ]
+}


### PR DESCRIPTION
Add a support for developing osbuild via Visual Studio Code
Remote Containers[1]. VS Code, if the extension is installed,
will automatically build the specified container via the
supplied Dockerfile and start a a VS Code server instance in
it and connect to it.
The container has the dependencies to develop osbuild, which
includes running the test and building images. For this the
container is started with `--privileged` since osbuild needs
various capabilities.
NB: not all extensions that are installed on the host are
automatically installed; instead a handful of basic ones that
are needed for python development are pre-installed.

[1] https://code.visualstudio.com/docs/remote/containers