### PR TITLE
test: Fix temporary network revert in tests

### DIFF
--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -34,9 +34,9 @@ def netns():
     with open("/proc/self/ns/net") as oldnet:
         # Create a new namespace and enter it.
         libc.unshare(CLONE_NEWNET)
-        # Up the loopback device in the new namespace.
-        subprocess.run(["ip", "link", "set", "up", "dev", "lo"], check=True)
         try:
+            # Up the loopback device in the new namespace.
+            subprocess.run(["ip", "link", "set", "up", "dev", "lo"], check=True)
             yield
         finally:
             # Revert to the old namespace, dropping our


### PR DESCRIPTION
The netns() function sets up a new namespace for tests.  The function is
also used to determine whether those tests can be run (using
unittest.skipUnless()).  A bug in the function made the changes stick if
the function failed early.  Specifically, when the "ip link" line fails,
the function exits without reverting to the old namespace.

Since the code is used in "skipUnless()", it's run during test
collection, which means that even if the relevant tests aren't selected,
they affect the environment for other tests.