### PR TITLE
Introduce assembler pipelines and identify pipelines

### DIFF
--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -76,6 +76,7 @@ def load_pipeline(description: Dict, index: Index, manifest: Manifest) -> Pipeli
         asm.inputs = {
             "tree": Input(info, {"pipeline": {"id": pipeline.tree_id}})
         }
+        pipeline.export = True
 
     return pipeline
 

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -49,7 +49,7 @@ def describe(manifest: Manifest, *, with_id=False) -> Dict:
 def load_assembler(description: Dict, index: Index, manifest: Manifest):
     pipeline = manifest["tree"]
 
-    build, base, runner = pipeline.build, pipeline.tree_id, pipeline.runner
+    build, base, runner = pipeline.build, pipeline.id, pipeline.runner
     name, options = description["name"], description.get("options", {})
 
     # Add a pipeline with one stage for our assembler
@@ -93,7 +93,7 @@ def load_pipeline(description: Dict, index: Index, manifest: Manifest, n: int = 
     else:
         name = "-".join(["build"] * n)
 
-    build_id = build_pipeline and build_pipeline.tree_id
+    build_id = build_pipeline and build_pipeline.id
     pipeline = manifest.add_pipeline(name, runner, build_id)
 
     for s in description.get("stages", []):
@@ -128,7 +128,7 @@ def load(description: Dict, index: Index) -> Manifest:
 def get_ids(manifest: Manifest) -> Tuple[Optional[str], Optional[str]]:
     pipeline = manifest["tree"]
     assembler = manifest.get("assembler")
-    return pipeline.tree_id, assembler and assembler.tree_id
+    return pipeline.id, assembler and assembler.id
 
 
 def output(manifest: Manifest, res: Dict) -> Dict:

--- a/osbuild/inputs.py
+++ b/osbuild/inputs.py
@@ -37,6 +37,7 @@ class Input:
         self.info = info
         self.options = options or {}
 
+    @property
     def name(self) -> str:
         return self.info.name
 

--- a/osbuild/inputs.py
+++ b/osbuild/inputs.py
@@ -17,6 +17,7 @@ osbuild is the path. The input options are just passed to the
 """
 
 
+import hashlib
 import importlib
 import json
 import os
@@ -36,6 +37,13 @@ class Input:
     def __init__(self, info: ModuleInfo, options: Dict):
         self.info = info
         self.options = options or {}
+        self.id = self.calc_id()
+
+    def calc_id(self):
+        m = hashlib.sha256()
+        m.update(json.dumps(self.name, sort_keys=True).encode())
+        m.update(json.dumps(self.options, sort_keys=True).encode())
+        return m.hexdigest()
 
     @property
     def name(self) -> str:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -348,6 +348,9 @@ class Manifest:
                 return pl
         return None
 
+    def __contains__(self, name_or_id: str) -> bool:
+        return self.get(name_or_id) is not None
+
     def __getitem__(self, name_or_id: str) -> Pipeline:
         pl = self.get(name_or_id)
         if pl:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -116,6 +116,7 @@ class Pipeline:
         self.runner = runner
         self.stages = []
         self.assembler = None
+        self.export = False
 
     @property
     def id(self):
@@ -275,7 +276,7 @@ class Pipeline:
 
             results.update(r)  # This will also update 'success'
 
-        if obj:
+        if self.export and obj:
             if output_directory:
                 obj.export(output_directory)
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -122,14 +122,21 @@ class Pipeline:
 
     @property
     def id(self):
-        return self.tree_id
+        """
+        Pipeline id: corresponds to the `id` of the last stage
 
-    @property
-    def tree_id(self):
+        In contrast to `name` this identifies the pipeline via
+        the tree, i.e. the content, it produces. Therefore two
+        pipelines that produce the same `tree`, i.e. have the
+        same exact stages and build pipeline, will have the
+        same `id`; thus the `id`, in contrast to `name` does
+        not uniquely identify a pipeline.
+        In case a Pipeline has no stages, its `id` is `None`.
+        """
         return self.stages[-1].id if self.stages else None
 
     def add_stage(self, info, options, sources_options=None):
-        stage = Stage(info, sources_options, self.build, self.tree_id, options or {})
+        stage = Stage(info, sources_options, self.build, self.id, options or {})
         self.stages.append(stage)
         if self.assembler:
             self.assembler.base = stage.id
@@ -160,7 +167,7 @@ class Pipeline:
 
         # Check if the tree that we are supposed to build does
         # already exist. If so, short-circuit here
-        tree = object_store.get(self.tree_id)
+        tree = object_store.get(self.id)
 
         if tree:
             return results, build_tree, tree
@@ -222,7 +229,7 @@ class Pipeline:
         # tree exists, we return it as well, but we do not care if it is
         # missing, since it is not a mandatory part of the result and would
         # usually be needless overhead.
-        obj = store.get(self.tree_id)
+        obj = store.get(self.id)
 
         if not obj:
             results, _, obj = self.build_stages(store, monitor, libdir)

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -2,7 +2,7 @@ import contextlib
 import hashlib
 import json
 import os
-from typing import Dict, List
+from typing import Dict
 
 from .api import API
 from . import buildroot
@@ -287,9 +287,14 @@ class Pipeline:
 class Manifest:
     """Representation of a pipeline and its sources"""
 
-    def __init__(self, pipelines: List[Pipeline], source_options: Dict):
-        self.pipelines = pipelines
+    def __init__(self, source_options: Dict):
+        self.pipelines = []
         self.sources = source_options
+
+    def add_pipeline(self, runner: str, build: str) -> Pipeline:
+        pipeline = Pipeline(runner, build)
+        self.pipelines.append(pipeline)
+        return pipeline
 
     def build(self, store, monitor, libdir, output_directory):
         results = {"success": True}

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -53,6 +53,9 @@ class Stage:
         m.update(json.dumps(self.build, sort_keys=True).encode())
         m.update(json.dumps(self.base, sort_keys=True).encode())
         m.update(json.dumps(self.options, sort_keys=True).encode())
+        if self.inputs:
+            data = {n: i.id for n, i in self.inputs.items()}
+            m.update(json.dumps(data, sort_keys=True).encode())
         return m.hexdigest()
 
     def run(self, tree, runner, build_tree, store, monitor, libdir):

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -3,7 +3,7 @@ import contextlib
 import hashlib
 import json
 import os
-from typing import Dict, Iterator
+from typing import Dict, Iterator, Optional
 
 from .api import API
 from . import buildroot
@@ -339,14 +339,20 @@ class Manifest:
 
         return points
 
-    def __getitem__(self, name_or_id: str) -> Pipeline:
+    def get(self, name_or_id: str) -> Optional[Pipeline]:
         pl = self.pipelines.get(name_or_id)
         if pl:
             return pl
         for pl in self.pipelines.values():
             if pl.id == name_or_id:
                 return pl
-        raise KeyError("{name_or_id} not found")
+        return None
+
+    def __getitem__(self, name_or_id: str) -> Pipeline:
+        pl = self.get(name_or_id)
+        if pl:
+            return pl
+        raise KeyError(f"'{name_or_id}' not found")
 
     def __iter__(self) -> Iterator[Pipeline]:
         return iter(self.pipelines.values())

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -21,6 +21,17 @@ BASIC_PIPELINE = {
     "pipeline": {
         "build": {
             "pipeline": {
+                "build": {
+                    "pipeline": {
+                        "stages": [
+                            {
+                                "name": "org.osbuild.noop",
+                                "options": {"zero": 0}
+                            }
+                        ]
+                    },
+                    "runner": "org.osbuild.linux"
+                },
                 "stages": [
                     {
                         "name": "org.osbuild.test",
@@ -95,14 +106,27 @@ class TestFormatV1(unittest.TestCase):
         manifest = fmt.load(description, index)
         self.assertIsNotNone(manifest)
 
-        # We have to have a build pipeline and a main pipeline
+        # We have to have two build pipelines and a main pipeline
         self.assertTrue(manifest.pipelines)
-        self.assertTrue(len(manifest.pipelines) == 2)
+        self.assertTrue(len(manifest.pipelines) == 3)
 
+        # access the individual pipelines via their names
+
+        # the inner most build pipeline
+        build = description["pipeline"]["build"]["pipeline"]["build"]
+        pl = manifest["build-build"]
+        have = pl.stages[0]
+        want = build["pipeline"]["stages"][0]
+        check_stage(have, want)
+
+        runner = build["runner"]
+
+        # the build pipeline for the 'tree' pipeline
         build = description["pipeline"]["build"]
         pl = manifest["build"]
         have = pl.stages[0]
         want = build["pipeline"]["stages"][0]
+        self.assertEqual(pl.runner, runner)
         check_stage(have, want)
 
         runner = build["runner"]

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -62,7 +62,6 @@ class TestFormatV1(unittest.TestCase):
         storedir = pathlib.Path(tmpdir, "store")
         monitor = NullMonitor(sys.stderr.fileno())
         libdir = os.path.abspath(os.curdir)
-        print(libdir)
         store = ObjectStore(storedir)
         outdir = pathlib.Path(tmpdir, "out")
         outdir.mkdir()
@@ -94,7 +93,7 @@ class TestFormatV1(unittest.TestCase):
         # Load a pipeline and check the resulting manifest
         def check_stage(have: osbuild.Stage, want: Dict):
             self.assertEqual(have.name, want["name"])
-            self.assertEqual(have.options, want["options"])
+            self.assertEqual(have.options, want.get("options", {}))
 
         index = osbuild.meta.Index(os.curdir)
 
@@ -108,7 +107,7 @@ class TestFormatV1(unittest.TestCase):
 
         # We have to have two build pipelines and a main pipeline
         self.assertTrue(manifest.pipelines)
-        self.assertTrue(len(manifest.pipelines) == 3)
+        self.assertTrue(len(manifest.pipelines) == 4)
 
         # access the individual pipelines via their names
 
@@ -131,17 +130,19 @@ class TestFormatV1(unittest.TestCase):
 
         runner = build["runner"]
 
-        # main pipeline is the next one
+        # the main, aka 'tree', pipeline
         pl = manifest["tree"]
         have = pl.stages[0]
         want = description["pipeline"]["stages"][0]
         self.assertEqual(pl.runner, runner)
         check_stage(have, want)
 
-        # the assembler
-        have = pl.assembler
+        # the assembler pipeline
+        pl = manifest["assembler"]
+        have = pl.stages[0]
         want = description["pipeline"]["assembler"]
-        self.assertEqual(have.name, want["name"])
+        self.assertEqual(pl.runner, runner)
+        check_stage(have, want)
 
 
     def test_describe(self):

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -100,7 +100,7 @@ class TestFormatV1(unittest.TestCase):
         self.assertTrue(len(manifest.pipelines) == 2)
 
         build = description["pipeline"]["build"]
-        pl = manifest.pipelines[0]
+        pl = manifest["build"]
         have = pl.stages[0]
         want = build["pipeline"]["stages"][0]
         check_stage(have, want)
@@ -108,7 +108,7 @@ class TestFormatV1(unittest.TestCase):
         runner = build["runner"]
 
         # main pipeline is the next one
-        pl = manifest.pipelines[1]
+        pl = manifest["tree"]
         have = pl.stages[0]
         want = description["pipeline"]["stages"][0]
         self.assertEqual(pl.runner, runner)

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -58,7 +58,7 @@ class TestMonitor(unittest.TestCase):
         index = osbuild.meta.Index(os.curdir)
 
         runner = detect_host_runner()
-        pipeline = osbuild.Pipeline(runner=runner)
+        pipeline = osbuild.Pipeline("pipeline", runner=runner)
         info = index.get_module_info("Stage", "org.osbuild.noop")
         pipeline.add_stage(info, {
             "isthisthereallife": False
@@ -93,7 +93,7 @@ class TestMonitor(unittest.TestCase):
         runner = detect_host_runner()
         index = osbuild.meta.Index(os.curdir)
 
-        pipeline = osbuild.Pipeline(runner=runner)
+        pipeline = osbuild.Pipeline("pipeline", runner=runner)
         noop_info = index.get_module_info("Stage", "org.osbuild.noop")
         pipeline.add_stage(noop_info, {
             "isthisthereallife": False

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -38,10 +38,6 @@ class TapeMonitor(osbuild.monitor.BaseMonitor):
         self.counter["stages"] += 1
         self.stages.add(stage.id)
 
-    def assembler(self, assembler: osbuild.Stage):
-        self.counter["assembler"] += 1
-        self.asm = assembler.id
-
     def result(self, result: osbuild.pipeline.BuildResult):
         self.counter["result"] += 1
         self.results.add(result.id)
@@ -63,8 +59,6 @@ class TestMonitor(unittest.TestCase):
         pipeline.add_stage(info, {
             "isthisthereallife": False
         })
-        info = index.get_module_info("Assembler", "org.osbuild.noop")
-        pipeline.set_assembler(info)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             storedir = os.path.join(tmpdir, "store")
@@ -84,7 +78,6 @@ class TestMonitor(unittest.TestCase):
 
             assert res
             self.assertIn(pipeline.stages[0].id, log)
-            self.assertIn(pipeline.assembler.id, log)
             self.assertIn("isthisthereallife", log)
 
     @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
@@ -101,8 +94,6 @@ class TestMonitor(unittest.TestCase):
         pipeline.add_stage(noop_info, {
             "isthisjustfantasy": True
         })
-        info = index.get_module_info("Assembler", "org.osbuild.noop")
-        pipeline.set_assembler(info)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             storedir = os.path.join(tmpdir, "store")
@@ -119,10 +110,8 @@ class TestMonitor(unittest.TestCase):
         self.assertEqual(tape.counter["begin"], 1)
         self.assertEqual(tape.counter["finish"], 1)
         self.assertEqual(tape.counter["stages"], 2)
-        self.assertEqual(tape.counter["assembler"], 1)
         self.assertEqual(tape.counter["stages"], 2)
-        self.assertEqual(tape.counter["result"], 3)
+        self.assertEqual(tape.counter["result"], 2)
         self.assertIn(pipeline.stages[0].id, tape.stages)
-        self.assertIn(pipeline.assembler.id, tape.asm)
         self.assertIn("isthisthereallife", tape.output)
         self.assertIn("isthisjustfantasy", tape.output)


### PR DESCRIPTION

This converts the assembler phase of the `Pipeline`[1] with a new pipeline that has the previous assembler as the first and only stage. This was possible to do since the `Assembler` previously got converted into a `Stage`, and that stage has the tree as `Input`; so this stage just got moved to a newly created `Pipeline`. 
Additionally, all pipelines in the manifest now have to have a name assigned. This is currently used in the version 1 format code (`formats/v1`) to identify the pipeline that builds the tree and the pipeline that corresponds to the assembler. 
The inputs of a stage are now included in the `id` calculation. NB: This, and the move of the assembler to a new pipeline, changes the `id` of the assembler.

[1] That is the main pipeline, since for build pipelines the assembler is not run, even if defined.

Replacs #554 