### PR TITLE
tar assembler: include SELinux, ACLs and extended attributes

### DIFF
--- a/assemblers/org.osbuild.tar
+++ b/assemblers/org.osbuild.tar
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 """
-Assemble a tar archive
-
 Assembles the tree into a tar archive named `filename`.
 
 Uses the buildhost's `tar` command, like: `tar -cf $FILENAME -C $TREE`

--- a/assemblers/org.osbuild.tar
+++ b/assemblers/org.osbuild.tar
@@ -13,6 +13,10 @@ Known options for `compression`: "bzip2", "xz", "lzip", "lzma", "lzop", "gzip".
 Note that using `compression` does not add an extension to `filename`, so the
 caller is responsible for making sure that `compression` and `filename` match.
 
+By default POSIX ACLs, SELinux contexts and extended attributes are included,
+in order to preserve the tree as closely as possible. It is possible to opt
+out of any of those by supplying the corresponding option.
+
 Buildhost commands used: `tar` and any named `compression` program.
 """
 
@@ -35,6 +39,21 @@ SCHEMA = """
     "description": "Name of compression program",
     "type": "string",
     "enum": ["bzip2", "xz", "lzip", "lzma", "lzop", "gzip"]
+  },
+  "acls": {
+      "description": "Enable support for POSIX ACLs",
+      "type": "boolean",
+      "default": true
+  },
+  "selinux": {
+      "description": "Enable support for SELinux contexts",
+      "type": "boolean",
+      "default": true
+  },
+  "xattrs": {
+      "description": "Enable support for extended attributes",
+      "type": "boolean",
+      "default": true
   }
 }
 """
@@ -57,11 +76,14 @@ def main(tree, output_dir, options):
     }
 
     # SELinux context, ACLs and extended attributes
-    extra_args += [
-        "--selinux",
-        "--acls",
-        "--xattrs", "--xattrs-include", "*",
-    ]
+    if options.get("acls", True):
+        extra_args += ["--acls"]
+
+    if options.get("selinux", True):
+        extra_args += ["--selinux"]
+
+    if options.get("xattrs", True):
+        extra_args += ["--xattrs", "--xattrs-include", "*"]
 
     # Set up the tar command.
     tar_cmd = [

--- a/assemblers/org.osbuild.tar
+++ b/assemblers/org.osbuild.tar
@@ -58,6 +58,13 @@ def main(tree, output_dir, options):
         "XZ_OPT": "--threads 0"
     }
 
+    # SELinux context, ACLs and extended attributes
+    extra_args += [
+        "--selinux",
+        "--acls",
+        "--xattrs", "--xattrs-include", "*",
+    ]
+
     # Set up the tar command.
     tar_cmd = [
         "tar",

--- a/tools/tree-diff
+++ b/tools/tree-diff
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import contextlib
 import hashlib
 import json
 import os
@@ -32,11 +33,14 @@ def stat_diff(stat1, stat2, path, differences):
 
 
 def selinux_diff(path1, path2, path, differences):
-    try:
+    label1, label2 = "", ""
+
+    with contextlib.suppress(OSError):
         label1 = os.getxattr(path1, b"security.selinux", follow_symlinks=False).decode()
+
+    with contextlib.suppress(OSError):
         label2 = os.getxattr(path2, b"security.selinux", follow_symlinks=False).decode()
-    except OSError:
-        return True
+
     if label1 != label2:
         props = differences.setdefault(path, {})
         props["selinux"] = [label1.strip('\n\0'), label2.strip('\n\0')]


### PR DESCRIPTION
All of those are opt-in for `tar`, so lets opt in. Only open question is, if it should also be opt-in for the assembler itself. The current code assumes that if you have a tree with any of those properties (selinux, acls, extended attributes), you would want them preserved. Of course that might break on systems/build-roots that have a tar that does not understand any of those options.

Closes #570 