### PR TITLE
Convert stages to use inputs instead of sources 

### DIFF
--- a/inputs/org.osbuild.files
+++ b/inputs/org.osbuild.files
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+"""
+Inputs for individual files
+
+Provides all the files, named via their content hash, specified
+via `references` in a new directory.
+
+The returned data in `refs` is a dictionary where the keys are
+the content hash of a file and the values dictionaries with
+metadata for it. The input itself currently does not set any
+metadata itself, but will forward any metadata set via the
+`metadata` property. Keys in that must start with a prefix,
+like `rpm.` to avoid namespace clashes. This is enforced via
+schema validation.
+"""
+
+
+import json
+import sys
+import subprocess
+
+from osbuild.objectstore import StoreClient
+
+
+SCHEMA = r"""
+"additionalProperties": false,
+"required": ["origin", "references"],
+"properties": {
+  "origin": {
+    "description": "The origin of the input (must be 'org.osbuild.source')",
+    "type": "string",
+    "enum": ["org.osbuild.source"]
+  },
+  "references": {
+    "description": "Checksums of files to use as files input",
+    "oneOf": [{
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }, {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "metadata": {
+              "description": "Additinal metadata to forward to the stage",
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^\\w+[.]{1}\\w+$": {
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }]
+  }
+}
+"""
+
+
+def main():
+    args = json.load(sys.stdin)
+    refs = args["refs"]
+
+    store = StoreClient(connect_to=args["api"]["store"])
+    source = store.source("org.osbuild.files")
+    output = store.mkdtemp(prefix="files-input-")
+
+    for checksum in refs:
+        try:
+            subprocess.run(
+                [
+                    "ln",
+                    f"{source}/{checksum}",
+                    f"{output}/{checksum}",
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            json.dump({"error": e.output}, sys.stdout)
+            return 1
+
+
+    reply = {
+        "path": output,
+        "data": {
+          "refs": refs
+        }
+    }
+
+    json.dump(reply, sys.stdout)
+    return 0
+
+
+if __name__ == '__main__':
+    r = main()
+    sys.exit(r)

--- a/inputs/org.osbuild.ostree
+++ b/inputs/org.osbuild.ostree
@@ -1,0 +1,121 @@
+#!/usr/bin/python3
+"""
+Inputs for ostree commits
+
+Pull the commits specified by `references` into a newly created
+repository. Optionally, if `ref` was specified, create an new
+reference for that commit.
+
+The returned data in `refs` is a dictionary where the keys are
+commit ids and the values are dictionries. The latter will
+contain `ref` it was specified.
+"""
+
+
+import os
+import json
+import sys
+import subprocess
+
+from osbuild.objectstore import StoreClient
+
+
+SCHEMA = """
+"additionalProperties": false,
+"required": ["origin", "references"],
+"properties": {
+  "origin": {
+    "description": "The origin of the input (must be 'org.osbuild.source')",
+    "type": "string",
+    "enum": ["org.osbuild.source"]
+  },
+  "references": {
+    "description": "Commit identifier",
+    "oneOf": [{
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }, {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ref": {
+                "type": "string",
+                "description": "OSTree reference to create for this commit"
+            }
+          }
+        }
+      }
+    }]
+  }
+}
+"""
+
+
+def ostree(*args, _input=None, **kwargs):
+    args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
+    print("ostree " + " ".join(args), file=sys.stderr)
+    subprocess.run(["ostree"] + args,
+                   encoding="utf-8",
+                   stdout=sys.stderr,
+                   input=_input,
+                   check=True)
+
+
+def export(checksums, cache, output):
+    repo_cache = os.path.join(cache, "repo")
+
+    repo_out = os.path.join(output, "repo")
+    ostree("init", mode="archive", repo=repo_out)
+
+    refs = {}
+    for commit, options in checksums.items():
+        # Transfer the commit: remote → cache
+        print(f"exporting {commit}", file=sys.stderr)
+
+        ostree("pull-local", repo_cache, commit,
+               repo=repo_out)
+
+        ref = options.get("ref")
+        if ref:
+            ostree("refs", "--create", ref, commit,
+                   repo=repo_out)
+
+        refs[commit] = options
+
+    reply = {
+        "path": repo_out,
+        "data": {
+            "refs": refs
+        }
+    }
+
+    json.dump(reply, sys.stdout)
+
+
+def main():
+    args = json.load(sys.stdin)
+    refs = args["refs"]
+
+    origin = args["origin"]
+    store = StoreClient(connect_to=args["api"]["store"])
+    source = store.source("org.osbuild.files")
+    output = store.mkdtemp(prefix="files-output")
+
+    # input verification must have happened via schema
+    # validation to ensure that `origin` is a source
+    source = store.source("org.osbuild.ostree")
+
+    export(refs, source, output)
+    return 0
+
+
+if __name__ == '__main__':
+    r = main()
+    sys.exit(r)

--- a/inputs/org.osbuild.tree
+++ b/inputs/org.osbuild.tree
@@ -2,8 +2,10 @@
 """
 Tree inputs
 
-Resolve the given pipeline `id` to a path and return that. If
-`id` is `null` or the empty string it returns an empty tree.
+Open the tree produced by the pipeline supplied via the
+first and only entry in `references`. The tree is opened
+in read only mode. If the id is `null` or the empty 
+string it returns an empty tree.
 """
 
 
@@ -15,30 +17,53 @@ from osbuild.objectstore import StoreClient
 
 SCHEMA = """
 "additionalProperties": false,
-"required": ["pipeline"],
+"required": ["origin", "references"],
 "properties": {
-  "pipeline": {
-    "description": "The Pipeline that built the desired tree",
-    "type": "object",
-    "required": ["id"],
-    "additionalProperties": false,
-    "properties": {
-      "id": {
-        "description": "Identifier for the pipeline",
+  "origin": {
+    "description": "The origin of the input (must be 'org.osbuild.pipeline')",
+    "type": "string",
+    "enum": ["org.osbuild.pipeline"]
+  },
+  "references": {
+    "description": "Exactly one pipeline identifier to ues as tree input",
+    "oneOf": [{
+      "type": "array",
+      "additionalItems": false,
+      "items": [{
         "type": "string"
-      }
-    }
+      }]
+    }, {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+         ".*": {
+           "type": "object",
+           "additionalProperties": false
+         }
+       },
+       "minProperties": 1,
+       "maxProperties": 1
+    }]
   }
 }
 """
 
 
+def error(msg):
+    json.dump({"error": msg}, sys.stdout)
+    sys.exit(1)
+
+
 def main():
     args = json.load(sys.stdin)
-    options = args["options"]
+    refs = args["refs"]
+
+    # input verification *must* have been done via schema
+    # verification. It is expected that origin is a pipeline
+    # and we have exactly one reference, i.e. a pipeline id
+    pid, _ = refs.popitem()
 
     store = StoreClient(connect_to=args["api"]["store"])
-    pid = options["pipeline"]["id"]
 
     if not pid:
         path = store.mkdtemp(prefix="empty")
@@ -46,8 +71,7 @@ def main():
         path = store.read_tree(pid)
 
     if not path:
-        json.dump({"error": "Could find target"}, sys.stdout)
-        return 1
+        error(f"Could not find pipeline with id '{pid}'")
 
     json.dump({"path": path}, sys.stdout)
     return 0

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -2,7 +2,6 @@
 
 from typing import Dict, Optional, Tuple
 from osbuild.meta import Index, ValidationResult
-from ..inputs import Input
 from ..pipeline import Manifest, Pipeline, detect_host_runner
 
 
@@ -64,9 +63,8 @@ def load_assembler(description: Dict, index: Index, manifest: Manifest):
 
     stage = pipeline.add_stage(info, options, {})
     info = index.get_module_info("Input", "org.osbuild.tree")
-    ip = Input(info, "org.osbuild.pipeline", {})
+    ip = stage.add_input("tree", info, "org.osbuild.pipeline")
     ip.add_reference(base)
-    stage.inputs = {"tree": ip}
     return pipeline
 
 

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -96,6 +96,12 @@ def load_stage(description: Dict, index: Index, pipeline: Pipeline):
                     options = {"metadata": {"rpm.check_gpg": gpg}}
                 pkg = pkg["checksum"]
             ip.add_reference(pkg, options)
+    elif stage.name == "org.osbuild.ostree":
+        info = index.get_module_info("Input", "org.osbuild.ostree")
+        ip = stage.add_input("commits", info, "org.osbuild.source")
+        commit, ref = opts["commit"], opts.get("ref")
+        options = {"ref": ref} if ref else None
+        ip.add_reference(commit, options)
 
 
 def load_pipeline(description: Dict, index: Index, manifest: Manifest, n: int = 0) -> Pipeline:

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -64,10 +64,9 @@ def load_assembler(description: Dict, index: Index, manifest: Manifest):
 
     stage = pipeline.add_stage(info, options, {})
     info = index.get_module_info("Input", "org.osbuild.tree")
-    stage.inputs = {
-        "tree": Input(info, {"pipeline": {"id": base}})
-    }
-
+    ip = Input(info, "org.osbuild.pipeline", {})
+    ip.add_reference(base)
+    stage.inputs = {"tree": ip}
     return pipeline
 
 

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -80,6 +80,13 @@ def load_build(description: Dict, index: Index, manifest: Manifest, n: int):
     return build_pipeline, description["runner"]
 
 
+def load_stage(description: Dict, index: Index, pipeline: Pipeline):
+    name = description["name"]
+    opts = description.get("options", {})
+    info = index.get_module_info("Stage", name)
+    pipeline.add_stage(info, opts)
+
+
 def load_pipeline(description: Dict, index: Index, manifest: Manifest, n: int = 0) -> Pipeline:
     build = description.get("build")
     if build:
@@ -99,9 +106,8 @@ def load_pipeline(description: Dict, index: Index, manifest: Manifest, n: int = 
     build_id = build_pipeline and build_pipeline.id
     pipeline = manifest.add_pipeline(name, runner, build_id)
 
-    for s in description.get("stages", []):
-        info = index.get_module_info("Stage", s["name"])
-        pipeline.add_stage(info, s.get("options", {}))
+    for stage in description.get("stages", []):
+        load_stage(stage, index, pipeline)
 
     return pipeline
 

--- a/osbuild/inputs.py
+++ b/osbuild/inputs.py
@@ -25,7 +25,6 @@ import subprocess
 
 from typing import Dict, Optional, Tuple
 
-from .meta import ModuleInfo
 from .objectstore import StoreServer
 
 
@@ -34,7 +33,7 @@ class Input:
     A single input with its corresponding options.
     """
 
-    def __init__(self, info: ModuleInfo, origin: str, options: Dict):
+    def __init__(self, info, origin: str, options: Dict):
         self.info = info
         self.origin = origin
         self.refs = {}

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -10,6 +10,7 @@ from . import buildroot
 from . import objectstore
 from . import remoteloop
 from . import sources
+from .inputs import Input
 from .sources import Source
 from .util import osrelease
 
@@ -58,6 +59,11 @@ class Stage:
             data = {n: i.id for n, i in self.inputs.items()}
             m.update(json.dumps(data, sort_keys=True).encode())
         return m.hexdigest()
+
+    def add_input(self, name, info, origin, options=None):
+        ip = Input(info, origin, options or {})
+        self.inputs[name] = ip
+        return ip
 
     def run(self, tree, runner, build_tree, store, monitor, libdir):
         with contextlib.ExitStack() as cm:

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -1,7 +1,59 @@
+import os
+import importlib
 import json
 import subprocess
+
 from . import api
+from .objectstore import ObjectStore
 from .util import jsoncomm
+from .util.types import PathLike
+
+
+class Source:
+    """
+    A single source with is corresponding options.
+    """
+    def __init__(self, info, options) -> None:
+        self.info = info
+        self.options = options
+
+    def download(self, store: ObjectStore, libdir: PathLike):
+        source = self.info.name
+        cache = os.path.join(store.store, "sources", source)
+        msg = {
+            "options": self.options,
+            "cache": cache,
+            "output": None,
+            "checksums": [],
+            "libdir": os.fspath(libdir)
+        }
+
+        # We want the `osbuild` python package that contains this
+        # very module, which might be different from the system wide
+        # installed one, to be accessible to the Input programs so
+        # we detect our origin and set the `PYTHONPATH` accordingly
+        modorigin = importlib.util.find_spec("osbuild").origin
+        modpath = os.path.dirname(modorigin)
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.path.dirname(modpath)
+
+        r = subprocess.run([self.info.path],
+                           env=env,
+                           input=json.dumps(msg),
+                           stdout=subprocess.PIPE,
+                           encoding="utf-8",
+                           check=False)
+
+        try:
+            reply = json.loads(r.stdout)
+        except ValueError:
+            raise RuntimeError(f"{source}: error: {r.stderr}") from None
+
+        if "error" in reply:
+            raise RuntimeError(f"{source}: " + reply["error"])
+
+        if r.returncode != 0:
+            raise RuntimeError(f"{source}: error {r.returncode}")
 
 
 class SourcesServer(api.BaseAPI):

--- a/sources/org.osbuild.files
+++ b/sources/org.osbuild.files
@@ -158,12 +158,7 @@ def get_rhsm_secrets():
     raise RuntimeError("no matching rhsm key and cert")
 
 
-def main(options, checksums, cache, output):
-    urls = options.get("urls", {})
-
-    os.makedirs(cache, exist_ok=True)
-    os.makedirs(output, exist_ok=True)
-
+def download(checksums, urls, cache):
     with concurrent.futures.ProcessPoolExecutor(max_workers=4) as executor:
         requested_urls = []
         rhsm_secrets = None
@@ -200,6 +195,10 @@ def main(options, checksums, cache, output):
             json.dump({"error": e.args[0]}, sys.stdout)
             return 1
 
+        return 0
+
+
+def export(checksums, cache, output):
     for checksum in checksums:
         try:
             subprocess.run(
@@ -219,7 +218,31 @@ def main(options, checksums, cache, output):
     return 0
 
 
+def main(options, checksums, cache, output):
+    urls = options.get("urls", {})
+
+    download_only = not output
+
+    if urls:
+        if not checksums and download_only:
+            checksums = [k for k, _ in urls.items()]
+
+        os.makedirs(cache, exist_ok=True)
+        res = download(checksums, urls, cache)
+        if res != 0:
+            return res
+
+    if download_only:
+        json.dump({}, sys.stdout)
+        return 0
+
+    os.makedirs(output, exist_ok=True)
+    res = export(checksums, cache, output)
+
+    return res
+
+
 if __name__ == '__main__':
     args = json.load(sys.stdin)
-    r = main(args["options"], args["checksums"], args["cache"], args["output"])
+    r = main(args["options"], args["checksums"], args["cache"], args.get("output"))
     sys.exit(r)

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -63,12 +63,7 @@ def ostree(*args, _input=None, **kwargs):
                    check=True)
 
 
-def main(options, checksums, cache, output):
-    commits = options["commits"]
-
-    os.makedirs(output, exist_ok=True)
-    os.makedirs(cache, exist_ok=True)
-
+def download(commits, checksums, cache):
     # Prepare the cache and the output repo
     repo_cache = os.path.join(cache, "repo")
     ostree("init", mode="archive", repo=repo_cache)
@@ -78,51 +73,63 @@ def main(options, checksums, cache, output):
     # explicitly here.
     ostree("config", "set", "repo.locking", "true", repo=repo_cache)
 
-    repo_out = os.path.join(output, "repo")
-    ostree("init", mode="archive", repo=repo_out)
-
     for commit in checksums:
         remote = commits[commit]["remote"]
         url = remote["url"]
         gpg = remote.get("gpgkeys", [])
         uid = str(uuid.uuid4())
 
-        ostree("remote", "add",
-               "--no-gpg-verify",
-               uid, url,
-               repo=repo_cache)
+        verify_args = []
+        if not gpg:
+            verify_args = ["--no-gpg-verify"]
 
-        # this temporary remote is needed to verify
-        # the commit signatures via gpg below
         ostree("remote", "add",
-               uid, repo_cache,
-               repo=repo_out)
+               uid, url,
+               *verify_args,
+               repo=repo_cache)
 
         for key in gpg:
             ostree("remote", "gpg-import", "--stdin", uid,
-                   repo=repo_out, _input=key)
+                   repo=repo_cache, _input=key)
 
         # Transfer the commit: remote → cache
         print(f"pulling {commit}", file=sys.stderr)
         ostree("pull", uid, commit, repo=repo_cache)
 
-        # Transfer the commit: cache → output
-        verify_args = []
-        if gpg:
-            verify_args = ["--gpg-verify", "--remote", uid]
-
-        ostree("pull-local", repo_cache, commit,
-               *verify_args,
-               repo=repo_out)
-
         # Remove the temporary remotes again
         ostree("remote", "delete", uid,
                repo=repo_cache)
 
-        ostree("remote", "delete", uid,
+
+def export(checksums, cache, output):
+    repo_cache = os.path.join(cache, "repo")
+
+    repo_out = os.path.join(output, "repo")
+    ostree("init", mode="archive", repo=repo_out)
+
+    for commit in checksums:
+        # Transfer the commit: remote → cache
+        print(f"exporting {commit}", file=sys.stderr)
+
+        ostree("pull-local", repo_cache, commit,
                repo=repo_out)
 
     json.dump({}, sys.stdout)
+
+
+def main(options, checksums, cache, output):
+    commits = options["commits"]
+
+    os.makedirs(cache, exist_ok=True)
+    download(commits, checksums, cache)
+
+    if not output:
+        json.dump({}, sys.stdout)
+        return 0
+
+    os.makedirs(output, exist_ok=True)
+    export(checksums, cache, output)
+
     return 0
 
 

--- a/stages/org.osbuild.ostree
+++ b/stages/org.osbuild.ostree
@@ -27,7 +27,6 @@ import sys
 import subprocess
 
 import osbuild.api
-import osbuild.sources
 from osbuild.util import selinux
 
 
@@ -217,31 +216,36 @@ def populate_var(sysroot):
             raise RuntimeError(f"Failed to provision /var/{target}")
 
 
+def parse_input(inputs):
+    commits = inputs["commits"]
+    data = commits["data"]
+    refs = data["refs"]
+    assert refs, "Need at least one commit"
+    return commits["path"], data["refs"]
+
+
 # pylint: disable=too-many-statements
-def main(tree, sources, options):
-    commit = options["commit"]
+def main(tree, inputs, options):
+    source_repo, commits = parse_input(inputs)
     osname = options["osname"]
     rootfs = options.get("rootfs")
     mounts = options.get("mounts", [])
     kopts = options.get("kernel_opts", [])
-    ref = options.get("ref", commit)
     remotes = options.get("remotes", [])
     pop_var = options.get("populate_var", False)
 
     ostree("admin", "init-fs", "--modern", tree,
            sysroot=tree)
 
-    print(f"Fetching ostree commit {commit}")
-    osbuild.sources.get("org.osbuild.ostree", [commit])
+    ref, commit = None, None  # keep pylint happy
+    for commit, data in commits.items():
+        ref = data.get("ref", commit)
 
-    source_repo = f"{sources}/org.osbuild.ostree/repo"
-
-    ostree("pull-local", source_repo, commit,
-           repo=f"{tree}/ostree/repo")
-
-    if ref != commit:
-        ostree("refs", "--create", ref, commit,
+        ostree("pull-local", source_repo, ref,
                repo=f"{tree}/ostree/repo")
+
+    #NB: if there are multiple commits, we deploy only
+    # the latest one
 
     ostree("admin", "os-init", osname, sysroot=tree)
     # this created a state root at `osname`
@@ -335,6 +339,6 @@ def main(tree, sources, options):
 if __name__ == '__main__':
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
-             stage_args["sources"],
+             stage_args["inputs"],
              stage_args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -36,7 +36,6 @@ import subprocess
 import sys
 import tempfile
 
-import osbuild.sources
 from osbuild import api
 
 
@@ -80,16 +79,6 @@ SCHEMA = """
 """
 
 
-def packages_from_legacy(legacy):
-    packages = []
-    for package in legacy:
-        if isinstance(package, dict):
-            packages.append(package)
-        else:
-            packages.append({"checksum": package, "check_gpg": False})
-    return packages
-
-
 def generate_package_metadata(tree):
     query = r"""\{
     "name": "%{NAME}",
@@ -118,9 +107,17 @@ def generate_package_metadata(tree):
     return json.loads(jsdata)
 
 
-def main(tree, sources, options):
-    packages = packages_from_legacy(options.get("packages", []))
-    checksums = [p["checksum"] for p in packages]
+def parse_input(inputs):
+    packages = inputs["packages"]
+    path = packages["path"]
+    data = packages["data"]
+    refs = data["refs"]
+    return path, refs
+
+
+def main(tree, inputs, options):
+    pkgpath, packages = parse_input(inputs)
+
     for key in options.get("gpgkeys", []):
         with tempfile.NamedTemporaryFile(prefix="gpgkey.", mode="w") as keyfile:
             keyfile.write(key)
@@ -132,17 +129,14 @@ def main(tree, sources, options):
             ], check=True)
         print("imported gpg key")
 
-    print("fetching sources")
-    osbuild.sources.get("org.osbuild.files", checksums)
-
-    for pkg in packages:
-        if pkg.get("check_gpg"):
+    for checksum, data in packages.items():
+        if data.get("rpm.check_gpg"):
             subprocess.run([
                 "rpmkeys",
                 "--root", tree,
                 "--checksig",
-                pkg["checksum"]
-            ], cwd=f"{sources}/org.osbuild.files", stdout=subprocess.DEVNULL, check=True)
+                checksum
+            ], cwd=pkgpath, stdout=subprocess.DEVNULL, check=True)
 
     script = f"""
         set -e
@@ -165,7 +159,7 @@ def main(tree, sources, options):
     subprocess.run(["/bin/sh", "-c", script], check=True)
 
     with tempfile.NamedTemporaryFile(prefix="manifest.", mode='w') as manifest:
-        manifest.writelines(c+'\n' for c in checksums)
+        manifest.writelines(c+'\n' for c in packages)
         manifest.flush()
         subprocess.run([
             "rpm",
@@ -175,7 +169,7 @@ def main(tree, sources, options):
             # verifying again (see /usr/lib/rpm/macros for more info)
             "--define", "_pkgverify_level none",
             "--install", manifest.name
-        ], cwd=f"{sources}/org.osbuild.files", check=True)
+        ], cwd=pkgpath, check=True)
 
     # remove temporary machine ID if it was created by us
     if not machine_id_set_previously:
@@ -197,5 +191,5 @@ def main(tree, sources, options):
 
 if __name__ == '__main__':
     args = api.arguments()
-    r = main(args["tree"], args["sources"], args["options"])
+    r = main(args["tree"], args["inputs"], args["options"])
     sys.exit(r)

--- a/test/data/stages/rpm/metadata.json
+++ b/test/data/stages/rpm/metadata.json
@@ -1,5 +1,5 @@
 {
-  "9b0987bd54cd0303d5eb3fba0286ce116be6b60c0282ade989645b5b7f8620e2": {
+  "9415f5f6316e954318d716b5c92bd69e26a4ae475593ffef32ea0a52cc90b9e8": {
     "packages": [
       {
         "name": "libgcc",

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -250,6 +250,10 @@ class TestFormatV1(unittest.TestCase):
         res = fmt.validate({}, index)
         self.assertEqual(res.valid, True)
 
+        # the basic test manifest
+        res = fmt.validate(BASIC_PIPELINE, index)
+        self.assertEqual(res.valid, True)
+
         # something totally invalid (by Ondřej Budai)
         totally_invalid = {
             "osbuild": {

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -52,7 +52,7 @@ BASIC_PIPELINE = {
                 },
                 "stages": [
                     {
-                        "name": "org.osbuild.test",
+                        "name": "org.osbuild.noop",
                         "options": {"one": 1}
                     }
                 ]
@@ -61,7 +61,7 @@ BASIC_PIPELINE = {
         },
         "stages": [
             {
-                "name": "org.osbuild.test",
+                "name": "org.osbuild.noop",
                 "options": {"one": 2}
             }
         ],

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -18,6 +18,24 @@ from .. import test
 
 
 BASIC_PIPELINE = {
+    "sources": {
+        "org.osbuild.files": {
+            "urls": {
+                "sha256:6eeebf21f245bf0d6f58962dc49b6dfb51f55acb6a595c6b9cbe9628806b80a4":
+                "https://internet/curl-7.69.1-1.fc32.x86_64.rpm",
+            }
+        },
+        "org.osbuild.ostree": {
+            "commits": {
+                "439911411ce7868a7b058c2a660e421991eb2df10e2bdce1fa559bd4390105d1": {
+                    "remote": {
+                        "url": "file:///repo",
+                        "gpgkeys": ["data"]
+                    }
+                }
+            }
+        }
+    },
     "pipeline": {
         "build": {
             "pipeline": {

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -46,7 +46,7 @@ class TestDescriptions(unittest.TestCase):
 
         info = index.get_module_info("Stage", "org.osbuild.noop")
 
-        manifest = Manifest({})
+        manifest = Manifest()
 
         # each pipeline gets a noop stage with different
         # options so that their ids are different


### PR DESCRIPTION
This PR converts the `org.osbuild.rpm` and `org.osbuild.ostree` stages to use `Inputs` instead of sources. For this two new inputs are created: `org.osbuild.files` and `org.osbuild.ostree`. All (two) existing sources are refactored so they are now internally split into a _download_ and a _export_ part. If no `output` directory is provided to a source it will just download. This is used to pre-fetch all specified resources in a manifest before any pipeline is being built. For the above mentioned stages, the v1 loading code creates `Inputs` based on the stage options and the code in the stages is refactored to use the provided inputs.

TODO:
 - [ ] more tests
 - [x] update documentation of the stages
 - [x] add documentation of the inputs
