### PR TITLE
Introduce format meta information and detection code

### DIFF
--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -1,8 +1,18 @@
-# Version 1 of the manifest description
+""" Version 1 of the manifest description
 
+This is the first version of the osbuild manifest description,
+that has a "main" pipeline that consists of zero or more stages
+to create a tree and optionally one assembler that assembles
+the created tree into an artefact. The pipeline can have any
+number of nested build pipelines. A sources section is used
+to fetch resources.
+"""
 from typing import Dict, Optional, Tuple
 from osbuild.meta import Index, ValidationResult
 from ..pipeline import Manifest, Pipeline, detect_host_runner
+
+
+VERSION = "1"
 
 
 def describe(manifest: Manifest, *, with_id=False) -> Dict:

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -15,7 +15,6 @@ import osbuild
 import osbuild.meta
 import osbuild.monitor
 from osbuild.objectstore import ObjectStore
-from osbuild.formats import v1 as fmt
 
 
 RESET = "\033[0m"
@@ -74,13 +73,21 @@ def parse_arguments(sys_argv):
     return parser.parse_args(sys_argv[1:])
 
 
-# pylint: disable=too-many-branches
+# pylint: disable=too-many-branches,too-many-return-statements
 def osbuild_cli():
     args = parse_arguments(sys.argv)
     desc = parse_manifest(args.manifest_path)
 
-    # first thing after parsing is validation of the input
     index = osbuild.meta.Index(args.libdir)
+
+    # detect the format from the manifest description
+    info = index.detect_format_info(desc)
+    if not info:
+        print("Unsupported manifest format")
+        return 2
+    fmt = info.module
+
+    # first thing is validation of the manifest
     res = fmt.validate(desc, index)
     if not res:
         if args.json or args.inspect:

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -171,6 +171,22 @@ class TestFormatV1(unittest.TestCase):
 
         self.assertEqual(fmt.describe(manifest), BASIC_PIPELINE)
 
+    def test_format_info(self):
+        index = osbuild.meta.Index(os.curdir)
+
+        lst = index.list_formats()
+        self.assertIn("osbuild.formats.v1", lst)
+
+        # an empty manifest is format "1"
+        info = index.detect_format_info({})
+        self.assertEqual(info.version, "1")
+        self.assertEqual(info.module, fmt)
+
+        # the basic test manifest
+        info = index.detect_format_info(BASIC_PIPELINE)
+        self.assertEqual(info.version, "1")
+        self.assertEqual(info.module, fmt)
+
     @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
     def test_format_output(self):
         """Test that output formatting is as expected"""


### PR DESCRIPTION
Add a `FormatInfo` that provides meta information about formats, together with `Index.list_formats` and `Index.get_format_info` to list and obtain said `FormatInfo`. Additionally a `Index.detect_format_info` can be used to infer format information from manifest descriptions.