### PR TITLE
Fix BuildRoot constructor arguments

### DIFF
--- a/inputs/org.osbuild.tree
+++ b/inputs/org.osbuild.tree
@@ -4,7 +4,7 @@ Tree inputs
 
 Open the tree produced by the pipeline supplied via the
 first and only entry in `references`. The tree is opened
-in read only mode. If the id is `null` or the empty 
+in read only mode. If the id is `null` or the empty
 string it returns an empty tree.
 """
 

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -59,7 +59,7 @@ class BuildRoot(contextlib.AbstractContextManager):
     only when exiting the context manager.
     """
 
-    def __init__(self, root, runner, libdir, path="/run/osbuild", var="/var/tmp"):
+    def __init__(self, root, runner, libdir, var, path="/run/osbuild"):
         self._exitstack = None
         self._rootdir = root
         self._rundir = path

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -59,10 +59,10 @@ class BuildRoot(contextlib.AbstractContextManager):
     only when exiting the context manager.
     """
 
-    def __init__(self, root, runner, libdir, var, path="/run/osbuild"):
+    def __init__(self, root, runner, libdir, var, *, rundir="/run/osbuild"):
         self._exitstack = None
         self._rootdir = root
-        self._rundir = path
+        self._rundir = rundir
         self._vardir = var
         self._libdir = libdir
         self._runner = runner

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -30,7 +30,7 @@ class TestBuildRoot(test.TestBase):
         var.mkdir()
 
         monitor = NullMonitor(sys.stderr.fileno())
-        with BuildRoot("/", runner, libdir, var=var) as root:
+        with BuildRoot("/", runner, libdir, var) as root:
 
             r = root.run(["/usr/bin/true"], monitor)
             self.assertEqual(r.returncode, 0)
@@ -50,7 +50,7 @@ class TestBuildRoot(test.TestBase):
 
         logfile = os.path.join(self.tmp.name, "log.txt")
 
-        with BuildRoot("/", runner, libdir, var=var) as root, \
+        with BuildRoot("/", runner, libdir, var) as root, \
              open(logfile, "w") as log:
 
             monitor = LogMonitor(log.fileno())
@@ -73,7 +73,7 @@ class TestBuildRoot(test.TestBase):
         data = "42. cats are superior to dogs"
 
         monitor = NullMonitor(sys.stderr.fileno())
-        with BuildRoot("/", runner, libdir, var=var) as root:
+        with BuildRoot("/", runner, libdir, var) as root:
 
             r = root.run(["/usr/bin/echo", data], monitor)
             self.assertEqual(r.returncode, 0)
@@ -93,7 +93,7 @@ class TestBuildRoot(test.TestBase):
         scripts = os.path.join(self.locate_test_data(), "scripts")
 
         monitor = NullMonitor(sys.stderr.fileno())
-        with BuildRoot("/", runner, libdir, var=var) as root:
+        with BuildRoot("/", runner, libdir, var) as root:
 
             ro_binds = [f"{scripts}:/scripts"]
 
@@ -127,7 +127,7 @@ class TestBuildRoot(test.TestBase):
         scripts = os.path.join(self.locate_test_data(), "scripts")
 
         monitor = NullMonitor(sys.stderr.fileno())
-        with BuildRoot("/", runner, libdir, var=var) as root:
+        with BuildRoot("/", runner, libdir, var) as root:
 
             ro_binds = [f"{scripts}:/scripts"]
 


### PR DESCRIPTION
Commit d028ea5 introduced bug when introducing the `store` argument to `Stage.run`, instead of passing `var=var`, i.e. `var` is being passed as keyword argument, it is now being passed as a positional one. Since the `path=/run/osbuild` keyword argument comes before the `var=/var/tmp` argument, `var` is now being passed as `path` instead of var. 
Since `var` is always being passed in throughout the entire codebase, make it a positional argument, and move it before `path`.

This also means that we have been using `var`, i.e. the store, as the run dir, and `/var/tmp` as the tmp dir. The latter is interfered with by `systemd`, which cleans it up from time to time. Thus this could be a possible reason for [rhbz#1927343](https://bugzilla.redhat.com/show_bug.cgi?id=1927343).