### PR TITLE
ci: trigger schutzbot from github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,3 +107,21 @@ jobs:
         with:
           ignore_words_list: msdos
           skip: ./.git,coverity,rpmbuild,samples
+
+  schutzbot:
+    name: "🍌 Trigger Schutzbot"
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/library/python:3.7
+    steps:
+      - uses: actions/checkout@v2
+      - name: Trigger Schutzbot
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WEBHOOK_PAYLOAD: ${{ toJSON(github.event) }}
+          SQS_REGION: us-east-1
+          SQS_QUEUE_URL: "https://sqs.us-east-1.amazonaws.com/933752197999/schutzbot_webhook_sqs-staging"
+        run: |
+          #!/bin/bash
+          pip3 install boto3 botocore
+          schutzbot/send_webhook.py

--- a/schutzbot/send_webhook.py
+++ b/schutzbot/send_webhook.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# Trigger a webhook event for Schutzbot using AWS SQS.
+import json
+import os
+
+import boto3
+from botocore import UNSIGNED
+from botocore.client import Config
+
+WEBHOOK_PAYLOAD = os.environ.get("WEBHOOK_PAYLOAD")
+EVENT_NAME = os.environ.get("EVENT_NAME")
+SQS_QUEUE_URL = os.environ.get("SQS_QUEUE_URL")
+SQS_REGION = os.environ.get("SQS_REGION")
+
+sqs = boto3.client(
+    'sqs',
+    region_name=SQS_REGION,
+    config=Config(
+        signature_version=UNSIGNED
+    )
+)
+
+payload = json.loads(WEBHOOK_PAYLOAD)
+message = {
+    'headers': {'X-Github-Event': EVENT_NAME},
+    'payload': payload
+}
+
+response = sqs.send_message(
+    QueueUrl=SQS_QUEUE_URL,
+    MessageBody=json.dumps(message)
+)


### PR DESCRIPTION
Previously, we had a webhook relay. It received a notification from Github
and sent it to AWS SQS. Now, the webhook is dead. The new method (already used
in osbuild-composer and image-builder) is to send the notification directly
from a github action to AWS SQS.