### PR TITLE
org.osbuild.oci-archive: support additional layers

### DIFF
--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -5,6 +5,10 @@ Assemble an OCI image archive
 Assemble an Open Container Initiative[1] image[2] archive, i.e. a
 tarball whose contents is in the OCI image layout.
 
+The content of the container will consist of the base layer provided
+via the `base` layer. On top of that further inputs provided via the
+`layer.X` inputs that are sorted in ascending order.
+
 Currently the only required options are `filename` and `architecture`.
 The execution parameters for the image, which then should form the base
 for the container, can be given via `config`. They have the same format
@@ -34,7 +38,7 @@ import osbuild.api
 DEFAULT_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 
-SCHEMA_2 = """
+SCHEMA_2 = r"""
 "options": {
   "additionalProperties": false,
   "required": ["architecture", "filename"],
@@ -104,7 +108,13 @@ SCHEMA_2 = """
       "type": "object",
       "additionalProperties": true
     }
-  }
+  },
+  "patternProperties": {
+    "layer\\.[1-9]\\d*": {
+      "type": "object",
+        "additionalProperties": true
+      }
+   }
 }
 """
 
@@ -208,7 +218,7 @@ def config_from_options(options):
     return config
 
 
-def create_oci_dir(tree, output_dir, options):
+def create_oci_dir(inputs, output_dir, options):
     architecture = options["architecture"]
 
     config = {
@@ -237,11 +247,12 @@ def create_oci_dir(tree, output_dir, options):
     os.makedirs(blobs)
 
     ## layers / rootfs
+    for ip in sorted(inputs.keys()):
+        tree = inputs[ip]["path"]
+        digest, info = blobs_add_layer(blobs, tree)
 
-    digest, info = blobs_add_layer(blobs, tree)
-
-    config["rootfs"]["diff_ids"] = [digest]
-    manifest["layers"].append(info)
+        config["rootfs"]["diff_ids"] = [digest]
+        manifest["layers"].append(info)
 
     ## write config
     info = blobs_add_json(blobs, config, "config")
@@ -262,15 +273,13 @@ def create_oci_dir(tree, output_dir, options):
 
 
 def main(inputs, output_dir, options):
-    base = inputs["base"]["path"]
-
     filename = options["filename"]
 
     with tempfile.TemporaryDirectory(dir=output_dir) as tmpdir:
         workdir = os.path.join(tmpdir, "output")
         os.makedirs(workdir)
 
-        create_oci_dir(base, workdir, options)
+        create_oci_dir(inputs, workdir, options)
 
         command = [
             "tar",

--- a/test/data/manifests/fedora-ostree-container.json
+++ b/test/data/manifests/fedora-ostree-container.json
@@ -893,7 +893,13 @@
           "options": {
             "language": "en_US"
           }
-        },
+        }
+      ]
+    },
+    {
+      "name": "container-ostree",
+      "build": "name:build",
+      "stages": [
         {
           "type": "org.osbuild.ostree.init",
           "options": {
@@ -931,6 +937,13 @@
               "origin": "org.osbuild.pipeline",
               "references": [
                 "name:container-tree"
+              ]
+            },
+            "layer.1": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:container-ostree"
               ]
             }
           },

--- a/test/data/manifests/fedora-ostree-container.mpp.json
+++ b/test/data/manifests/fedora-ostree-container.mpp.json
@@ -169,7 +169,13 @@
           "options": {
             "language": "en_US"
           }
-        },
+        }
+      ]
+    },
+    {
+      "name": "container-ostree",
+      "build": "name:build",
+      "stages": [
         {
           "type": "org.osbuild.ostree.init",
           "options": {
@@ -207,6 +213,13 @@
               "origin": "org.osbuild.pipeline",
               "references": [
                 "name:container-tree"
+              ]
+            },
+            "layer.1": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:container-ostree"
               ]
             }
           },

--- a/test/initrd.py
+++ b/test/initrd.py
@@ -71,7 +71,7 @@ class Initrd:
         with self.open() as image:
             hdr = read_header(image)
             if hdr.startswith(b'\x71\xc7') or hdr == b'070701':
-                cmd = f"cpio --extract --quiet --to-stdout -- 'early_cpio'"
+                cmd = "cpio --extract --quiet --to-stdout -- 'early_cpio'"
                 data = self.run(cmd, image)
                 self.early_cpio = data == '1'
 


### PR DESCRIPTION
In addition to the required base layer, provided via the the input of the same name, the oci-archive stage now accepts up to nine additional layers that get added on top of each other, sorted in ascending order, i.e. `layer.1` to `layer.9`.

Adapt the `fedora-ostree-container` example manifest so that the ostree commit is now in a separate layer, which makes it possible to share the base layer between different commits container.