### PR TITLE
MPP: properly support multiple repos in mpp-depsolve

### DIFF
--- a/osbuild/treesum.py
+++ b/osbuild/treesum.py
@@ -1,7 +1,10 @@
 import errno
 import json
 import os
+import stat
 
+
+#pylint: disable=too-many-branches
 def treesum(m, dir_fd):
     """Compute a content hash of a filesystem tree
 
@@ -52,7 +55,9 @@ def treesum(m, dir_fd):
                         # hash a page at a time (using f with fd as default is a hack to please pylint)
                         for byte_block in iter(lambda f=fd: os.read(f, 4096), b""):
                             m.update(byte_block)
+                    elif stat.S_ISCHR(stat_result.st_mode) or stat.S_ISBLK(stat_result.st_mode):
+                        m.update(json.dumps({"dev": stat_result.st_rdev}).encode())
                     else:
-                        raise ValueError("Found unexpected filetype on OS image")
+                        raise ValueError("Found unexpected filetype on OS image.")
                 finally:
                     os.close(fd)


### PR DESCRIPTION
Although MPP supported having multiple repo entries for each depsolve block, in reality that didn't actually work because the same (global) `baseurl` was used for all packages.
Now the `basurl` can still be (optionally) specified globally, but also overridden by the repo block and the package paths will be relative to that.