### PR TITLE
ci: convert to new immutable ci images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,9 @@ jobs:
     - name: "Clone Repository"
       uses: actions/checkout@v2
     - name: "Run Tests"
-      uses: osbuild/containers/src/actions/ghci-osbuild@v1
+      uses: osbuild/containers/src/actions/privdocker@e4de123f43b95e99dfe8eed0bd5a1cd58db50715
       with:
+        image: ghcr.io/osbuild/osbuild-ci:f32-202102190856
         run: |
           python3 -m pytest \
             --pyargs "${{ matrix.test }}" \
@@ -92,8 +93,9 @@ jobs:
     - name: "Clone Repository"
       uses: actions/checkout@v2
     - name: "Regenerate Test Data"
-      uses: osbuild/containers/ghci/actions/ghci-osbuild@ghci/v1
+      uses: osbuild/containers/src/actions/privdocker@e4de123f43b95e99dfe8eed0bd5a1cd58db50715
       with:
+        image: ghcr.io/osbuild/osbuild-ci:f32-202102190856
         run: |
           make test-data
           git diff --exit-code -- ./test/data


### PR DESCRIPTION
Use the new immutable image infrastructure from `osbuild/containers`.
While at it, also switch over to the new github-actions helper, now that
we no longer run `systemd-nspawn` in our tests.

The old image was renamed from `ghci-osbuild` to `osbuild-ci` to avoid
accidentally replacing old images. The new infrastructure uses immutable
images, so downstream will no longer get automatic updates, unless the
`latest` tags are used.

Note that this also switches to a new Dockerfile, so I might need some tries to get this working again.