### PR TITLE
schutzbot/mock: add more distros

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -52,11 +52,42 @@ pipeline {
                         sh "schutzbot/mockbuild.sh"
                     }
                 }
+                stage('Fedora 33 aarch64') {
+                    agent { label "f33cloudbase && aarch64 && aws" }
+                    environment {
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                    }
+                    steps {
+                        sh "schutzbot/ci_details.sh"
+                        sh "schutzbot/mockbuild.sh"
+                    }
+                }
                 stage('RHEL 8 CDN') {
                     agent { label "rhel8cloudbase && x86_64" }
                     environment {
                         AWS_CREDS = credentials('aws-credentials-osbuildci')
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
+                    }
+                    steps {
+                        sh "schutzbot/ci_details.sh"
+                        sh "schutzbot/mockbuild.sh"
+                    }
+                }
+                stage('RHEL 8.4') {
+                    agent { label "rhel84cloudbase && x86_64 && psi" }
+                    environment {
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        RHEL84_NIGHTLY_REPO = credentials('rhel84-nightly-repo')
+                    }
+                    steps {
+                        sh "schutzbot/ci_details.sh"
+                        sh "schutzbot/mockbuild.sh"
+                    }
+                }
+                stage('CS8') {
+                    agent { label "cs8cloudbase && x86_64 && aws" }
+                    environment {
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
                     }
                     steps {
                         sh "schutzbot/ci_details.sh"


### PR DESCRIPTION
This builds osbuild in F33aarch64 as well as RHEL8.4 and CentOS8. No tests are currently run.

With the mockbuilds in place we will be able to run composer CI against osbuild master, when necessary.