### PR TITLE
stages/oci-archive: do not include selinux labels

### DIFF
--- a/assemblers/org.osbuild.oci-archive
+++ b/assemblers/org.osbuild.oci-archive
@@ -142,7 +142,7 @@ def blobs_add_layer(blobs: str, tree: str):
 
     command = [
         "tar",
-        "--selinux",
+        "--no-selinux",
         "--acls",
         "--xattrs",
         "-cf", layer_file,

--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -165,7 +165,7 @@ def blobs_add_layer(blobs: str, tree: str):
 
     command = [
         "tar",
-        "--selinux",
+        "--no-selinux",
         "--acls",
         "--xattrs",
         "-cf", layer_file,


### PR DESCRIPTION
Instead of including SELinux labels for the content layers via the `--selinux` tar option, make sure selinux labels are not included by using the `--no-selinux` option.
The inclusion of the labels was a mistake, since they should be determined by the target system because selinux labels are not namespaced. On RHEL/Fedora the SELinux label used is something like `system_u:object_r:container_ro_file_t:s0` for all the files in the container.
Including the label was leading to permission problems because the files had a different label on the host and programs inside the container get `EACCES`, i.e. Permission denied, errors when accessing files with the different label. 
Interestingly this does not happen on Fedora 33 but only on RHEL.
One possibility is that the overlayfs kernel driver in RHEL is behaving differently on RHEL than on Fedora.