### PR TITLE
schutzbot/mock: fix centos stream 8 build

### DIFF
--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -14,7 +14,7 @@ ARCH=$(uname -m)
 MOCK_CONFIG="${ID}-${VERSION_ID%.*}-$(uname -m)"
 
 if [[ $ID == centos ]]; then
-  MOCK_CONFIG="centos-stream-$(uname -m)"
+  MOCK_CONFIG="centos-stream-8-$(uname -m)"
 fi
 
 # The commit this script operates on.


### PR DESCRIPTION
The centos stream 8 config was renamed in mock-core-config, see:
https://github.com/rpm-software-management/mock/commit/75cd9eb52df899d40ae7d82ceb96146bf61bdc88