### PR TITLE
stages/grub2: set GRUB_CMDLINE_LINUX default

### DIFF
--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -388,7 +388,10 @@ def main(tree, options):
     if write_defaults:
         os.makedirs(f"{tree}/etc/default", exist_ok=True)
         with open(f"{tree}/etc/default/grub", "w") as default:
-            default.write("GRUB_TIMEOUT=0\n"
+            # NB: The "GRUB_CMDLINE_LINUX" variable contains the kernel command
+            # line but without the `root=` part, thus we just use `kernel_opts`.
+            default.write(f'GRUB_CMDLINE_LINUX="{kernel_opts}"\n'
+                          "GRUB_TIMEOUT=0\n"
                           "GRUB_ENABLE_BLSCFG=true\n")
 
     os.makedirs(f"{tree}/boot/grub2", exist_ok=True)


### PR DESCRIPTION
Set the `GRUB_CMDLINE_LINUX` variable in `/etc/default/grub` to the kernel command line options. This is used by `grub2-mkconfig` to assemble the full kernel command line when generating the menu entires. NB: `GRUB_CMDLINE_LINUX` does NOT include the root fs bits (`root=...`), since that is generated by `grub2-mkconfig` itself.

Manually tested this change by building a `fedora-boot` image and checking that the config variable is present in `/etc/default/grub` and also that `grub2-mkconfig` will pick it up properly.