### PR TITLE
Drop Fedora 32 support

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -32,16 +32,6 @@ pipeline {
             failFast true
 
             parallel {
-                stage('Fedora 32') {
-                    agent { label "f32cloudbase && x86_64" }
-                    environment {
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                    }
-                    steps {
-                        sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
-                    }
-                }
                 stage('Fedora 33') {
                     agent { label "f33cloudbase && x86_64" }
                     environment {
@@ -122,22 +112,6 @@ pipeline {
             failFast false
 
             parallel {
-                stage('Fedora 32') {
-                    agent { label "f32cloudbase && x86_64 && psi" }
-                    environment {
-                        TEST_TYPE = "image"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        DISTRO_CODE = "fedora32"
-                    }
-                    steps {
-                        run_tests()
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora32-image')
-                        }
-                    }
-                }
                 stage('Fedora 33') {
                     agent { label "f33cloudbase && x86_64 && psi" }
                     environment {


### PR DESCRIPTION
Fedora 32 will be EOL on May 18th, so I think it's pretty safe to stop rebasing there.

The source for the EOL date: https://fedorapeople.org/groups/schedule/f-34/f-34-key-tasks.html