### PR TITLE
ci: update images to F33

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: "Run Tests"
       uses: osbuild/containers/src/actions/privdocker@e4de123f43b95e99dfe8eed0bd5a1cd58db50715
       with:
-        image: ghcr.io/osbuild/osbuild-ci:f32-202102190856
+        image: ghcr.io/osbuild/osbuild-ci:latest-202102191311
         run: |
           python3 -m pytest \
             --pyargs "${{ matrix.test }}" \
@@ -97,7 +97,7 @@ jobs:
     - name: "Regenerate Test Data"
       uses: osbuild/containers/src/actions/privdocker@e4de123f43b95e99dfe8eed0bd5a1cd58db50715
       with:
-        image: ghcr.io/osbuild/osbuild-ci:f32-202102190856
+        image: ghcr.io/osbuild/osbuild-ci:latest-202102191311
         run: |
           make test-data
           git diff --exit-code -- ./test/data


### PR DESCRIPTION
We explicitly pinned the F32 CI images in the past due to update issues
in F33. However, those have been resolved and we should switch back to
the most recent Fedora CI images.

This commits switches all instances of the osbuild-ci image back to the
latest stream, snapshot taken on 2021-02-19 13:11 (latest-202102191311).