### PR TITLE
Correctly report assembler errors

### DIFF
--- a/assemblers/org.osbuild.error
+++ b/assemblers/org.osbuild.error
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+"""
+Return an error
+
+Error assembler. Return the given error. Very much like the error stage this
+is useful for testing, debugging, and wasting time.
+"""
+
+
+import sys
+
+import osbuild.api
+
+
+SCHEMA = """
+"additionalProperties": false,
+"properties": {
+  "returncode": {
+    "description": "What to return code to use",
+    "type": "number",
+    "default": 255
+  }
+}
+"""
+
+
+def main(options):
+    errno = options.get("returncode", 255)
+    print(f"Error assembler will now return error: {errno}")
+    return errno
+
+
+if __name__ == '__main__':
+    args = osbuild.api.arguments()
+    r = main(args.get("options", {}))
+    sys.exit(r)

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -216,18 +216,23 @@ def output(manifest: Manifest, res: Dict) -> Dict:
         stages = current.get("stages")
         if stages:
             retval["stages"] = stages
-        assembler = current.get("assembler")
-        if assembler:
-            retval["assembler"] = assembler
         return retval
 
     result = result_for_pipeline(manifest["tree"])
 
     assembler = manifest.get("assembler")
-    if assembler:
-        current = res.get(assembler.id)
-        if current:
-            result["assembler"] = current["stages"][0]
+    if not assembler:
+        return result
+
+    current = res.get(assembler.id)
+    # if there was an error before getting to the assembler
+    # pipeline, there might not be a result present
+    if not current:
+        return result
+
+    result["assembler"] = current["stages"][0]
+    if not result["assembler"]["success"]:
+        result["success"] = False
 
     return result
 

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -259,6 +259,38 @@ class TestFormatV1(unittest.TestCase):
         self.assertIn("success", result["build"])
         self.assertFalse(result["build"]["success"])
 
+        # check we get results for the assembler pipeline
+        description = {
+            "pipeline": {
+                "stages": [
+                    {
+                        "name": "org.osbuild.noop"
+                    },
+                ],
+                "assembler": {
+                    "name": "org.osbuild.error"
+                }
+            }
+        }
+
+        manifest = fmt.load(description, index)
+        self.assertIsNotNone(manifest)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            res = self.build_manifest(manifest, tmpdir)
+
+        self.assertIsNotNone(res)
+        result = fmt.output(manifest, res)
+        self.assertIsNotNone(result)
+
+        self.assertIn("assembler", result)
+        self.assertIn("success", result["assembler"])
+        self.assertFalse(result["assembler"]["success"])
+
+        # check the overall result is False as well
+        self.assertIn("success", result)
+        self.assertFalse(result["success"], result)
+
     def test_validation(self):
         index = osbuild.meta.Index(os.curdir)
 


### PR DESCRIPTION
If the assembler in a v1 format failed, this would not propagate properly to the main `success` entry in the result dictionary. Fix that and add tests to check for this.