### PR TITLE
Fix /etc/machine-id permissions

### DIFF
--- a/inputs/org.osbuild.ostree
+++ b/inputs/org.osbuild.ostree
@@ -28,7 +28,7 @@ SCHEMA = """
     "enum": ["org.osbuild.ostree"]
   },
   "origin": {
-    "description": "The origin of the input (must be 'org.osbuild.source')",
+    "description": "The origin of the input (pipeline or source)",
     "type": "string",
     "enum": ["org.osbuild.source", "org.osbuild.pipeline"]
   },
@@ -108,8 +108,7 @@ def main():
 
     origin = args["origin"]
     store = StoreClient(connect_to=args["api"]["store"])
-    source = store.source("org.osbuild.files")
-    output = store.mkdtemp(prefix="files-output")
+    output = store.mkdtemp(prefix="ostree-output")
 
     if origin == "org.osbuild.pipeline":
         for ref, options in refs.items():

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -254,7 +254,6 @@ def main(tree, inputs, options):
 
     subprocess.run(["/bin/sh", "-c", script], check=True)
 
-
     extra_args = []
 
     if options.get("exclude", {}).get("docs"):
@@ -284,12 +283,11 @@ def main(tree, inputs, options):
         enable_dracut(masked_files)
         remove_unowned_etc_kernel(tree)
 
-    # remove temporary machine ID if it was created by us
+    # if we created a temporary machine id, replace it with an empty one
     if not machine_id_set_previously:
-        print("deleting the fake machine id")
+        print("replacing fake machine id with empty one")
         machine_id_file = pathlib.Path(f"{tree}/etc/machine-id")
-        machine_id_file.unlink()
-        machine_id_file.touch()
+        machine_id_file.write_bytes(b"")
 
     # remove random seed from the tree if exists
     with contextlib.suppress(FileNotFoundError):


### PR DESCRIPTION
Instead of deleting and re-creating `/etc/machine-id`, just truncate it to an empty file. This should let the mode be `0444`, which is the mode that systemd also creates it with.

Also has minor fixes for the ostree input.