### PR TITLE
source/ostree: fix download only case

### DIFF
--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -128,14 +128,24 @@ def export(checksums, cache, output):
 
 def main(commits, options, checksums, cache, output):
     cache = os.path.join(cache, "org.osbuild.ostree")
+    download_only = not output
 
     if not commits:
         commits = options.get("commits", {})
 
-    os.makedirs(cache, exist_ok=True)
-    download(commits, checksums, cache)
+    if commits:
+        if not checksums and download_only:
+            checksums = [k for k, _ in commits.items()]
 
-    if not output:
+        os.makedirs(cache, exist_ok=True)
+        try:
+            download(commits, checksums, cache)
+        except subprocess.CalledProcessError as e:
+            output = e.output.strip()
+            json.dump({"error": output}, sys.stdout)
+            return 1
+
+    if download_only:
         json.dump({}, sys.stdout)
         return 0
 
@@ -151,5 +161,5 @@ if __name__ == '__main__':
              source_args["options"],
              source_args["checksums"],
              source_args["cache"],
-             source_args["output"])
+             source_args.get("output"))
     sys.exit(r)

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -67,7 +67,8 @@ def ostree(*args, _input=None, **kwargs):
     print("ostree " + " ".join(args), file=sys.stderr)
     subprocess.run(["ostree"] + args,
                    encoding="utf-8",
-                   stdout=sys.stderr,
+                   stdout=subprocess.PIPE,
+                   stderr=subprocess.STDOUT,
                    input=_input,
                    check=True)
 


### PR DESCRIPTION
Source, for compatability reasons, have two modes: download only and download and export. The difference is the arguments that are passed to the source: For download only, the `output` param is empty. In this case also `checksums` *can* be empty and if so it means everything, i.e. the commits, should be fetched. The latter was not properly handled so far. Adjust the logic, which now closely mimics that of the `org.osbuild.curl` source to fix this case.
