### PR TITLE
stages/preptree: move home dirs to var/home

### DIFF
--- a/stages/org.osbuild.ostree.preptree
+++ b/stages/org.osbuild.ostree.preptree
@@ -140,6 +140,14 @@ def main(tree, options):
         move("boot", root, tree)
         move("var", root, tree)
 
+        # move /home over to /var in case it is not empty
+        # rpm-ostree compose postprocess will convert the
+        # home dirs (and sub-dirs) to systemd-tmpfiles.
+        # NB: files and their content will not be converted
+
+        if any(os.scandir(f"{root}/home")):
+            move("home", root, f"{tree}/var")
+
         for name in ["bin", "lib", "lib32", "lib64", "sbin"]:
             if os.path.lexists(f"{root}/{name}"):
                 move(name, root, tree)


### PR DESCRIPTION
Since `/home` will not end up in the commit¹  move the home directories to `/var/home`. This is done after the new root file system has been initialized, and only if `/home` is not empty.

¹ it is neither copied back in the preptree stage itself, nor would it be picked up by rpm-ostree compose tree postprocess were it copied back.