### PR TITLE
Fix issue with changing content in /etc/passwd and /etc/groups in OSTree deployments

### DIFF
--- a/inputs/org.osbuild.ostree.checkout
+++ b/inputs/org.osbuild.ostree.checkout
@@ -1,0 +1,114 @@
+#!/usr/bin/python3
+"""
+Inputs for checkouts of ostree commits
+
+This input takes a number of commits and will check them out to a
+temporary directory. The name of the directory is the commit id.
+Internally uses `ostree checkout`
+"""
+
+
+import os
+import json
+import sys
+import subprocess
+
+from osbuild import inputs
+
+
+SCHEMA = """
+"additionalProperties": false,
+"required": ["type", "origin", "references"],
+"properties": {
+  "type": {
+    "enum": ["org.osbuild.ostree.checkout"]
+  },
+  "origin": {
+    "description": "The origin of the input",
+    "type": "string",
+    "enum": ["org.osbuild.source", "org.osbuild.pipeline"]
+  },
+  "references": {
+    "description": "Commit identifier to check out",
+    "oneOf": [{
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }, {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      }
+    }]
+  }
+}
+"""
+
+
+def ostree(*args, _input=None, **kwargs):
+    args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
+    print("ostree " + " ".join(args), file=sys.stderr)
+    subprocess.run(["ostree"] + args,
+                   encoding="utf-8",
+                   stdout=sys.stderr,
+                   input=_input,
+                   check=True)
+
+
+def checkout(checksums, cache, output):
+    repo_cache = os.path.join(cache, "repo")
+
+    refs = []
+    for commit in checksums:
+        print(f"checkout {commit}", file=sys.stderr)
+
+        dest = os.path.join(output, commit)
+
+        ostree("checkout", commit, dest,
+               repo=repo_cache)
+
+        refs.append(commit)
+
+    return refs
+
+
+class OSTreeCheckoutInput(inputs.InputService):
+
+    def map(self, store, origin, refs, target, _options):
+
+        refs = []
+
+        if origin == "org.osbuild.pipeline":
+            for ref, options in refs.items():
+                source = store.read_tree(ref)
+                with open(os.path.join(source, "compose.json"), "r") as f:
+                    compose = json.load(f)
+                commit_id = compose["ostree-commit"]
+                refs.append(checkout({commit_id: options}, source, target))
+        else:
+            source = store.source("org.osbuild.ostree")
+            refs = checkout(refs, source, target)
+
+        reply = {
+          "path": target,
+          "data": {
+            "refs": {ref: {"path": ref} for ref in refs}
+          }
+        }
+
+        return reply
+
+
+def main():
+    service = OSTreeCheckoutInput.from_args(sys.argv[1:])
+    service.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/stages/org.osbuild.ostree.passwd
+++ b/stages/org.osbuild.ostree.passwd
@@ -1,0 +1,92 @@
+#!/usr/bin/python3
+"""
+Populate buildroot with /etc/passwd and /etc/group from an OSTree checkout
+
+Using the OSTree checkout provided as in input, copy /usr/etc/passwd and
+/usr/lib/passwd, merge them and store the result into /etc/passwd in the
+buildroot. Do the same for /etc/group file.
+
+The use case for this stage is when one wants to preserve UIDs and GIDs
+which might change when the system is build from scratch. Creating these
+files before any RPMs (or other packages) are installed will prevent changes
+in UIDs and GIDs.
+"""
+
+import os
+import sys
+import subprocess
+
+import osbuild.api
+
+from osbuild.util.ostree import PasswdLike
+
+
+SCHEMA_2 = """
+"options": {
+  "additionalProperties": false
+},
+"inputs": {
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["commits"],
+  "properties": {
+    "commits": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}
+"""
+
+
+def ostree(*args, _input=None, **kwargs):
+    args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
+    print("ostree " + " ".join(args), file=sys.stderr)
+    subprocess.run(["ostree"] + args,
+                   encoding="utf-8",
+                   stdout=sys.stderr,
+                   input=_input,
+                   check=True)
+
+
+def parse_input(inputs):
+    commits = inputs["commits"]
+    source_root = commits["path"]
+    data = commits["data"]
+    refs = data["refs"]
+    assert refs, "Need at least one commit"
+    assert len(refs) == 1, "Only one commit is currently supported"
+    return source_root, refs
+
+
+# pylint: disable=too-many-statements
+def main(tree, inputs, _options):
+    source_root, refs = parse_input(inputs)
+
+    os.makedirs(os.path.join(tree, "etc"), exist_ok=True)
+    # Only once ref (commit) is currently supported, so this loop will run exactly once
+    for commit, data in refs.items():
+        ref = data.get("path", commit).lstrip("/")
+        checkout_root = os.path.join(source_root, ref)
+
+        # Merge /usr/etc/passwd with /usr/lib/passwd from the checkout and store it in the buildroot
+        # "tree" directory. Entries in /usr/etc/passwd have a precedence, but the file does not
+        # necessarily exist.
+        passwd = PasswdLike.from_file(os.path.join(checkout_root, "usr/etc/passwd"), allow_missing_file=True)
+        passwd.merge_with_file(os.path.join(checkout_root, "usr/lib/passwd"), allow_missing_file=False)
+        passwd.dump_to_file(os.path.join(tree, "etc/passwd"))
+
+        # Merge /usr/etc/group with /usr/lib/group from the checkout and store it in the buildroot
+        # "tree" directory. Entries in /usr/etc/group have a precedence, but the file does not
+        # necessarily exist.
+        passwd = PasswdLike.from_file(os.path.join(checkout_root, "usr/etc/group"), allow_missing_file=True)
+        passwd.merge_with_file(os.path.join(checkout_root, "usr/lib/group"), allow_missing_file=False)
+        passwd.dump_to_file(os.path.join(tree, "etc/group"))
+
+
+if __name__ == '__main__':
+    stage_args = osbuild.api.arguments()
+    r = main(stage_args["tree"],
+             stage_args["inputs"],
+             stage_args["options"])
+    sys.exit(r)


### PR DESCRIPTION
See commit messages for further explanation.

Reproducer for testing the passwd and group merge (doesn't really verify the issue with kernel-rt, which should be tested in `osbuild-composer` instead):
```bash
#!/bin/bash

set -ex

TMPDIR=$(mktemp --directory)

pushd "${TMPDIR}"
ostree --repo=ostree-passwd init
mkdir -p tree/usr/lib
mkdir -p tree/usr/etc
cat > tree/usr/lib/passwd << STOPHERE
root:x:0:0:root:/root:/bin/bash
bin:x:1:1:bin:/bin:/sbin/nologin
STOPHERE
cat > tree/usr/etc/passwd << STOPHERE
bin:x:8:8:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin
STOPHERE
cat > tree/usr/lib/group << STOPHERE
root:x:0:
bin:x:1:
STOPHERE
cat > tree/usr/etc/group << STOPHERE
bin:x:8:
daemon:x:2:
STOPHERE

COMMIT=$(ostree --repo=ostree-passwd commit --branch=foo tree/)
popd

cat > "${TMPDIR}/manifest.json" << STOPHERE
{
    "version": "2",
    "sources": {
        "org.osbuild.ostree": {
            "items": {
              "${COMMIT}": {
                "remote": {
                  "url": "file://${TMPDIR}/ostree-passwd"
                }
              }
            }
          }
    },
    "pipelines": [
        {
            "name": "ostree-passwd",
            "stages": [
                {
                    "type": "org.osbuild.ostree.passwd",
                    "inputs": {
                        "commits": {
                            "type": "org.osbuild.ostree.checkout",
                            "origin": "org.osbuild.source",
                            "references": [
                                "${COMMIT}"
                            ]
                        }
                    }
                }
            ]
        }
    ]
}
STOPHERE

sudo rm -rf .osbuild/*
REF=$(sudo osbuild --output-directory /tmp --libdir . --json "${TMPDIR}"/manifest.json | jq --raw-output '.log."ostree-passwd"[0]."id"')
sudo osbuild --checkpoint="${REF}" --libdir . "${TMPDIR}"/manifest.json
cat ".osbuild/refs/${REF}/etc/passwd"
cat ".osbuild/refs/${REF}/etc/group"

```