### PR TITLE
stages/oci-archive: write history entries

### DIFF
--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -221,15 +221,18 @@ def config_from_options(options):
 def create_oci_dir(inputs, output_dir, options):
     architecture = options["architecture"]
 
+    now = datetime.datetime.utcnow().isoformat() + "Z"
+
     config = {
-        "created": datetime.datetime.utcnow().isoformat() + "Z",
+        "created": now,
         "architecture": architecture,
         "os": "linux",
         "config": config_from_options(options["config"]),
         "rootfs": {
             "type": "layers",
             "diff_ids": []
-        }
+        },
+        "history": []
     }
 
     manifest = {
@@ -251,8 +254,12 @@ def create_oci_dir(inputs, output_dir, options):
         tree = inputs[ip]["path"]
         digest, info = blobs_add_layer(blobs, tree)
 
-        config["rootfs"]["diff_ids"] = [digest]
         manifest["layers"].append(info)
+        config["rootfs"]["diff_ids"] = [digest]
+        config["history"].append({
+            "created": now,
+            "created_by": f"/bin/sh -c #(nop) osbuild input '{ip}'"
+        })
 
     ## write config
     info = blobs_add_json(blobs, config, "config")


### PR DESCRIPTION
According to the OCI Image [Format Specification][1] history entries for layers in the container are optional; but when trying to push a container quay.io via skopeo (copy oci-archive:… docker://quay) it will fail with "Cannot convert an image with 0 history entries". This seems to come from the [containers/image][2] library when the container is converted back from the docker distribution format to `oci-archive` on quay.io. Thus it seems that when `skopeo` converts the image to the docker format for the distribution it does not fill any the history entries, which are then assumed and required to be there when converting back.
To fix this, insert history entries for each layer that is created.

[1]: https://github.com/opencontainers/image-spec/blob/master/config.md
[2]: https://github.com/containers/image/