### PR TITLE
stages/oci-archive: include limited set of xattrs

### DIFF
--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -126,6 +126,14 @@ MEDIA_TYPES = {
 }
 
 
+# The extended attributes that should be recorded for the
+# contents of file system layers:
+#  - user.*: user specified extended attributes
+#  - security.ima: Integrity Measurement Architecture (IMA)
+#  - security.capability: Linux capabilities(7)
+XATTRS_WANT = r"^(user.|security\.ima|security\.capability)"
+
+
 def sha256sum(path: str) -> str:
     ret = subprocess.run(["sha256sum", path],
                          stdout=subprocess.PIPE,
@@ -168,6 +176,7 @@ def blobs_add_layer(blobs: str, tree: str):
         "--no-selinux",
         "--acls",
         "--xattrs",
+        "--xattrs-include=" + XATTRS_WANT,
         "-cf", layer_file,
         "-C", tree,
     ] + os.listdir(tree)
@@ -284,6 +293,8 @@ def main(inputs, output_dir, options):
         command = [
             "tar",
             "--remove-files",
+            "--no-selinux",
+            "--no-xattrs",
             "-cf", os.path.join(output_dir, filename),
             f"--directory={workdir}",
         ] + os.listdir(workdir)


### PR DESCRIPTION
Only include a very specific set of extended attributes:
  - `user.*`: user specified extended attributes
  - `security.ima`: Integrity Measurement Architecture (IMA)
  - `security.capability`: Linux capabilities(7)

This follows what [containers/storage][1] and [containers/buildah][2] are doing. It is important to note that we DO NOT want selinux related extended attributes (`security.selinux`) in there, which seems to be pulled in by some versions of `tar` even if that was seemingly excluded via `--no-selinux`. Therefore we also exclude selinux and xattrs explicitly from the wrapping container to make sure they are never included.

[1]: https://github.com/containers/storage/blob/35ebda8ae27dc130c18517cd1e14ad85407ae22f/pkg/archive/archive.go#L399
[2]: https://github.com/containers/buildah/blob/214e4c93350563cef06aa713a4bd6fa6ed35c636/copier/xattrs.go#L19