### PR TITLE
Revert "stages/rpm: truncate the machine id"

### DIFF
--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -289,11 +289,12 @@ def main(tree, inputs, options):
         enable_dracut(masked_files)
         remove_unowned_etc_kernel(tree)
 
-    # if we created a temporary machine id, replace it with an empty one
+    # remove temporary machine ID if it was created by us
     if not machine_id_set_previously:
-        print("replacing fake machine id with empty one")
+        print("deleting the fake machine id")
         machine_id_file = pathlib.Path(f"{tree}/etc/machine-id")
-        machine_id_file.write_bytes(b"")
+        machine_id_file.unlink()
+        machine_id_file.touch()
 
     # remove random seed from the tree if exists
     with contextlib.suppress(FileNotFoundError):


### PR DESCRIPTION
This reverts commit 59184b23a24d302eeec627a656f1acefff7d6597 (introduced in PR #609).

This change breaks current testing and is not critical.
We will reintroduce it later when there is time to adapt the tests.