### PR TITLE
assemblers/qemu: support for qcow2 compat version

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -59,6 +59,10 @@ SCHEMA = """
     "type": "string",
     "enum": ["raw", "raw.xz", "qcow2", "vdi", "vmdk", "vpc", "vhdx"]
   },
+  "qcow2_compat": {
+    "description": "The qcow2-compatibility-version to use",
+    "type": "string"
+  },
   "filename": {
     "description": "Image filename",
     "type": "string"
@@ -690,6 +694,11 @@ def main(tree, output_dir, options, loop_client):
             "vpc": ["-o", "subformat=fixed,force_size"],
             "vhdx": []
         }
+
+        compat = options.get("qcow2_compat")
+        if compat:
+            extra_args["qcow2"] += ["-o", f"compat={compat}"]
+
         subprocess.run([
             "qemu-img",
             "convert",


### PR DESCRIPTION
Add a new option `qcow2_compat` which can be used explicitly select the compatibility level of the `qcow2` file format. Qemu version 1.1 introduced extensions to the format that became the default with 1.7, which are not readable by qemu < 1.1. Thus if the resulting qcow2 should be read by such older qemu versions, the compatibility level needs to be set to 0.10.

This is actually based on work by @ondrejbudai in composer.