### PR TITLE
Prepare release of osbuild 28

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,44 @@
 # OSBuild - Build-Pipelines for Operating System Artifacts
 
+## CHANGES WITH 28:
+
+ * Add a new option to the `org.osbuild.qemu` assembler that controls
+   the qcow2 format version (`qcow2_compat`).
+
+ * Add history entries to the layers of OCI archives produced by the
+   `org.osbuild.oci-archive` stage. This fixes push failures to quay.io.
+
+ * Include only a specific, limited set of xattrs in OCI archives produced by
+   the `org.osbuild.oci-archive` stage. This is specifically meant to exclude
+   SELinux-related attributes (`security.selinux`) which are sometimes added
+   even when invoking  `tar` with the `--no-selinux` option.
+
+ * The package metadata for the `org.osbuild.rpm` stage is now sorted by
+   package name, to provide a stable sorting of the array independent of
+   the `rpm` output.
+
+ * Add a new runner for Fedora 35 (`org.osbuild.fedora35`) which is
+   currently a symlink to the Fedora 30 runner.
+
+ * The `org.osbuild.ostree` input now uses `ostree-output` as temporary
+   directory and its description got fixed to reflect that it does
+   indeed support pipeline and source inputs.
+
+ * devcontainer: Include more packages needed for the Python extension and
+   various tools to ease debugging and development in general. Preserve
+   the fish history across container rebuilds.
+
+ * Stage tests are writing the prodcued metadata to `/tmp` so the actual
+   data can be inspected in case there is a deviation.
+
+ * CI: Start running images tests against 8.4 and execute image_tests directly
+   from osbuild-composer-tests. Base CI images have been updated to Fedora 33.
+
+Contributions from: Achilleas Koutsou, Alexander Todorov, Christian Kellner,
+                    David Rheinsberg
+
+— Berlin, 2021-04-08
+
 ## CHANGES WITH 27:
 
  * Add new `org.osbuild.resolv-conf` stage that can be used to

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -1,7 +1,7 @@
 %global         forgeurl https://github.com/osbuild/osbuild
 %global         selinuxtype targeted
 
-Version:        27
+Version:        28
 
 %forgemeta
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="osbuild",
-    version="27",
+    version="28",
     description="A build system for OS images",
     packages=["osbuild", "osbuild.formats", "osbuild.util"],
     license='Apache-2.0',


### PR DESCRIPTION
This should sync up with 27.2, i.e. contain at least everything that 27.2 contains.