### PR TITLE
`stages/oci-archive`: support for annotations

### DIFF
--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -20,6 +20,14 @@ Manifest annotations can be included via the `annotation` options. Any
 `key`, `value` pair is allowed, with the exception of the pre-defined
 `org.osbuild` and `org.opencontainer` namespaces.
 
+Specific annotations can be used to indicate that a container contains
+an OSTree commit via the following:
+  - `org.osbuild.layer`: The layer containing the OSTree repository
+  - `org.osbuild.repo`: Path inside the container to the repository
+  - `org.osbuild.ref`: OSTree reference of the commit inside the repo
+The `org.osbuild.layer` value can either bey a index (starting at 0),
+or a digest in the form of <algorithm>:<checksum>.
+
 The final resulting tarball, aka a "orci-archive", can be imported via
 podman[3] with `podman pull oci-archive:<archive>`.
 
@@ -103,6 +111,20 @@ SCHEMA_2 = r"""
     },
     "annotations": {
       "type": "object",
+      "properties": {
+        "org.osbuild.ostree.layer": {
+          "description": "The layer that contains the OSTree repository",
+          "type": "string"
+        },
+        "org.osbuild.ostree.repo": {
+          "description": "Path to the OSTree repository inside the layer",
+          "type": "string"
+        },
+        "org.osbuild.ostree.ref": {
+          "description": "Reference of the OSTree commit in the repository",
+          "type": "string"
+        }
+      },
       "additionalProperties": false,
       "patternProperties": {
         "^(?!org.osbuild|org.opencontainer).+": {

--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -16,6 +16,10 @@ as the `config` option for the "OCI Image Configuration" (see [2]),
 except those that map to the "Go type map[string]struct{}", which are
 represented as array of strings.
 
+Manifest annotations can be included via the `annotation` options. Any
+`key`, `value` pair is allowed, with the exception of the pre-defined
+`org.osbuild` and `org.opencontainer` namespaces.
+
 The final resulting tarball, aka a "orci-archive", can be imported via
 podman[3] with `podman pull oci-archive:<archive>`.
 
@@ -94,6 +98,15 @@ SCHEMA_2 = r"""
         },
         "WorkingDir": {
           "type": "string"
+        }
+      }
+    },
+    "annotations": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!org.osbuild|org.opencontainer).+": {
+           "type": "string"
         }
       }
     }
@@ -249,6 +262,10 @@ def create_oci_dir(inputs, output_dir, options):
         "config": None,
         "layers": []
     }
+
+    annotations = options.get("annotations", {})
+    if annotations:
+        manifest["annotations"] = annotations
 
     index = {
         "schemaVersion": 2,

--- a/test/data/manifests/fedora-ostree-container.json
+++ b/test/data/manifests/fedora-ostree-container.json
@@ -1021,6 +1021,11 @@
               "ExposedPorts": [
                 "80"
               ]
+            },
+            "annotations": {
+              "org.osbuild.ostree.repo": "/var/www/html/repo",
+              "org.osbuild.ostree.ref": "fedora/x86_64/osbuild",
+              "org.osbuild.ostree.layer": "1"
             }
           }
         }

--- a/test/data/manifests/fedora-ostree-container.mpp.json
+++ b/test/data/manifests/fedora-ostree-container.mpp.json
@@ -234,6 +234,11 @@
               "ExposedPorts": [
                 "80"
               ]
+            },
+            "annotations": {
+              "org.osbuild.ostree.repo": "/var/www/html/repo",
+              "org.osbuild.ostree.ref": "fedora/x86_64/osbuild",
+              "org.osbuild.ostree.layer": "1"
             }
           }
         }


### PR DESCRIPTION
Add support for arbitrary manifest annotations: allow anything with the exception of the `org.osbuild` and `org.opencontainer` prefixes. The former is reserved by us, the latter by the OCI image specification. The latter specifies a set of pre defined keys, which are not yet supported by osbuild but will be in the future, partly via more generic options (creation time).

Define a set of pre-defined ostree related annotations that can and should be used to indicate that a container image contains an OSTree commit. This can be used by other tools to inspect and extract the commit more easily.