### PR TITLE
Introduce host services convert inputs

### DIFF
--- a/inputs/org.osbuild.files
+++ b/inputs/org.osbuild.files
@@ -34,6 +34,26 @@ SCHEMA = r"""
         "additionalProperties": false
       }
     }
+  },
+  "plain-ref": {
+    "type": "array",
+    "items": {
+      "type": "string"
+    }
+  },
+  "object-ref": {
+    "type": "object",
+    "additionalProperties": false,
+    "minProperties": 1,
+    "patternProperties": {
+      ".*": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "metadata": {"$ref": "#/definitions/metadata"}
+        }
+      }
+    }
   }
 },
 "required": ["type", "origin", "references"],
@@ -48,25 +68,10 @@ SCHEMA = r"""
   },
   "references": {
     "description": "Checksums of files to use as files input",
-    "oneOf": [{
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    }, {
-      "type": "object",
-      "additionalProperties": false,
-      "minProperties": 1,
-      "patternProperties": {
-        ".*": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "metadata": {"$ref": "#/definitions/metadata"}
-          }
-        }
-      }
-    }]
+    "oneOf": [
+      {"$ref": "#/definitions/plain-ref"},
+      {"$ref": "#/definitions/object-ref"}
+    ]
   }
 }
 """

--- a/inputs/org.osbuild.files
+++ b/inputs/org.osbuild.files
@@ -14,12 +14,10 @@ like `rpm.` to avoid namespace clashes. This is enforced via
 schema validation.
 """
 
-
-import json
 import sys
 import subprocess
 
-from osbuild.objectstore import StoreClient
+from osbuild import inputs
 
 
 SCHEMA = r"""
@@ -77,16 +75,12 @@ SCHEMA = r"""
 """
 
 
-def main():
-    args = json.load(sys.stdin)
-    refs = args["refs"]
-    target = args["target"]
+class FilesInput(inputs.InputService):
 
-    store = StoreClient(connect_to=args["api"]["store"])
-    source = store.source("org.osbuild.files")
+    def map(self, store, _origin, refs, target, _options):
 
-    for checksum in refs:
-        try:
+        source = store.source("org.osbuild.files")
+        for checksum in refs:
             subprocess.run(
                 [
                     "ln",
@@ -95,21 +89,20 @@ def main():
                 ],
                 check=True,
             )
-        except subprocess.CalledProcessError as e:
-            json.dump({"error": e.output}, sys.stdout)
-            return 1
 
-    reply = {
-        "path": target,
-        "data": {
-            "refs": refs
+        reply = {
+            "path": target,
+            "data": {
+                "refs": refs
+            }
         }
-    }
+        return reply
 
-    json.dump(reply, sys.stdout)
-    return 0
+
+def main():
+    service = FilesInput.from_args(sys.argv[1:])
+    service.main()
 
 
 if __name__ == '__main__':
-    r = main()
-    sys.exit(r)
+    main()

--- a/inputs/org.osbuild.files
+++ b/inputs/org.osbuild.files
@@ -24,6 +24,18 @@ from osbuild.objectstore import StoreClient
 
 SCHEMA = r"""
 "additionalProperties": false,
+"definitions": {
+  "metadata": {
+    "description": "Additional metadata to forward to the stage",
+    "type": "object",
+    "additionalProperties": false,
+    "patternProperties": {
+      "^\\w+[.]{1}\\w+$": {
+        "additionalProperties": false
+      }
+    }
+  }
+},
 "required": ["type", "origin", "references"],
 "properties": {
   "type": {
@@ -50,16 +62,7 @@ SCHEMA = r"""
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "metadata": {
-              "description": "Additinal metadata to forward to the stage",
-              "type": "object",
-              "additionalProperties": false,
-              "patternProperties": {
-                "^\\w+[.]{1}\\w+$": {
-                  "additionalProperties": false
-                }
-              }
-            }
+            "metadata": {"$ref": "#/definitions/metadata"}
           }
         }
       }
@@ -90,7 +93,6 @@ def main():
         except subprocess.CalledProcessError as e:
             json.dump({"error": e.output}, sys.stdout)
             return 1
-
 
     reply = {
         "path": output,

--- a/inputs/org.osbuild.files
+++ b/inputs/org.osbuild.files
@@ -80,10 +80,10 @@ SCHEMA = r"""
 def main():
     args = json.load(sys.stdin)
     refs = args["refs"]
+    target = args["target"]
 
     store = StoreClient(connect_to=args["api"]["store"])
     source = store.source("org.osbuild.files")
-    output = store.mkdtemp(prefix="files-input-")
 
     for checksum in refs:
         try:
@@ -91,7 +91,7 @@ def main():
                 [
                     "ln",
                     f"{source}/{checksum}",
-                    f"{output}/{checksum}",
+                    f"{target}/{checksum}",
                 ],
                 check=True,
             )
@@ -100,9 +100,9 @@ def main():
             return 1
 
     reply = {
-        "path": output,
+        "path": target,
         "data": {
-          "refs": refs
+            "refs": refs
         }
     }
 

--- a/inputs/org.osbuild.noop
+++ b/inputs/org.osbuild.noop
@@ -8,9 +8,9 @@ it to the stage.
 
 
 import json
+import os
 import sys
-
-from osbuild.objectstore import StoreClient
+import uuid
 
 
 SCHEMA = """
@@ -21,10 +21,12 @@ SCHEMA = """
 def main():
     args = json.load(sys.stdin)
     refs = args["refs"]
+    target = args["target"]
 
-    store = StoreClient(connect_to=args["api"]["store"])
+    uid = str(uuid.uuid4())
+    path = os.path.join(target, uid)
+    os.makedirs(path)
 
-    path = store.mkdtemp(prefix="empty")
     data = {"path": path, "data": {"refs": refs}}
     json.dump(data, sys.stdout)
     return 0

--- a/inputs/org.osbuild.noop
+++ b/inputs/org.osbuild.noop
@@ -7,31 +7,38 @@ it to the stage.
 """
 
 
-import json
 import os
 import sys
 import uuid
 
+from osbuild import inputs
 
 SCHEMA = """
 "additionalProperties": true
 """
 
 
+class NoopInput(inputs.InputService):
+
+    def map(self, _store, _origin, refs, target, _options):
+
+        uid = str(uuid.uuid4())
+        path = os.path.join(target, uid)
+        os.makedirs(path)
+
+        reply = {
+            "path": target,
+            "data": {
+                "refs": refs
+            }
+        }
+        return reply
+
+
 def main():
-    args = json.load(sys.stdin)
-    refs = args["refs"]
-    target = args["target"]
-
-    uid = str(uuid.uuid4())
-    path = os.path.join(target, uid)
-    os.makedirs(path)
-
-    data = {"path": path, "data": {"refs": refs}}
-    json.dump(data, sys.stdout)
-    return 0
+    service = NoopInput.from_args(sys.argv[1:])
+    service.main()
 
 
 if __name__ == '__main__':
-    r = main()
-    sys.exit(r)
+    main()

--- a/inputs/org.osbuild.ostree
+++ b/inputs/org.osbuild.ostree
@@ -17,7 +17,7 @@ import json
 import sys
 import subprocess
 
-from osbuild.objectstore import StoreClient
+from osbuild import inputs
 
 
 SCHEMA = """
@@ -99,31 +99,31 @@ def export(checksums, cache, output):
         }
     }
 
-    json.dump(reply, sys.stdout)
+    return reply
+
+
+class OSTreeInput(inputs.InputService):
+
+    def map(self, store, origin, refs, target, _options):
+
+        if origin == "org.osbuild.pipeline":
+            for ref, options in refs.items():
+                source = store.read_tree(ref)
+                with open(os.path.join(source, "compose.json"), "r") as f:
+                    compose = json.load(f)
+                commit_id = compose["ostree-commit"]
+                reply = export({commit_id: options}, source, target)
+        else:
+            source = store.source("org.osbuild.ostree")
+            reply = export(refs, source, target)
+
+        return reply
 
 
 def main():
-    args = json.load(sys.stdin)
-    refs = args["refs"]
-    target = args["target"]
-
-    origin = args["origin"]
-    store = StoreClient(connect_to=args["api"]["store"])
-
-    if origin == "org.osbuild.pipeline":
-        for ref, options in refs.items():
-            source = store.read_tree(ref)
-            with open(os.path.join(source, "compose.json"), "r") as f:
-                compose = json.load(f)
-            commit_id = compose["ostree-commit"]
-            export({commit_id: options}, source, target)
-    else:
-        source = store.source("org.osbuild.ostree")
-        export(refs, source, target)
-
-    return 0
+    service = OSTreeInput.from_args(sys.argv[1:])
+    service.main()
 
 
 if __name__ == '__main__':
-    r = main()
-    sys.exit(r)
+    main()

--- a/inputs/org.osbuild.ostree
+++ b/inputs/org.osbuild.ostree
@@ -105,10 +105,10 @@ def export(checksums, cache, output):
 def main():
     args = json.load(sys.stdin)
     refs = args["refs"]
+    target = args["target"]
 
     origin = args["origin"]
     store = StoreClient(connect_to=args["api"]["store"])
-    output = store.mkdtemp(prefix="ostree-output")
 
     if origin == "org.osbuild.pipeline":
         for ref, options in refs.items():
@@ -116,10 +116,10 @@ def main():
             with open(os.path.join(source, "compose.json"), "r") as f:
                 compose = json.load(f)
             commit_id = compose["ostree-commit"]
-            export({commit_id: options}, source, output)
+            export({commit_id: options}, source, target)
     else:
         source = store.source("org.osbuild.ostree")
-        export(refs, source, output)
+        export(refs, source, target)
 
     return 0
 

--- a/inputs/org.osbuild.tree
+++ b/inputs/org.osbuild.tree
@@ -8,11 +8,9 @@ in read only mode. If the id is `null` or the empty
 string it returns an empty tree.
 """
 
-
-import json
 import sys
 
-from osbuild.objectstore import StoreClient
+from osbuild import inputs
 
 
 SCHEMA = """
@@ -52,33 +50,29 @@ SCHEMA = """
 """
 
 
-def error(msg):
-    json.dump({"error": msg}, sys.stdout)
-    sys.exit(1)
+class TreeInput(inputs.InputService):
+
+    def map(self, store, _origin, refs, target, _options):
+
+        # input verification *must* have been done via schema
+        # verification. It is expected that origin is a pipeline
+        # and we have exactly one reference, i.e. a pipeline id
+        pid, _ = refs.popitem()
+
+        if pid:
+            path = store.read_tree_at(pid, target)
+
+        if not path:
+            raise ValueError(f"Unknown pipeline '{pid}'")
+
+        reply = {"path": target}
+        return reply
 
 
 def main():
-    args = json.load(sys.stdin)
-    refs = args["refs"]
-    target = args["target"]
-
-    # input verification *must* have been done via schema
-    # verification. It is expected that origin is a pipeline
-    # and we have exactly one reference, i.e. a pipeline id
-    pid, _ = refs.popitem()
-
-    store = StoreClient(connect_to=args["api"]["store"])
-
-    if pid:
-        path = store.read_tree_at(pid, target)
-
-    if not path:
-        error(f"Could not find pipeline with id '{pid}'")
-
-    json.dump({"path": target}, sys.stdout)
-    return 0
+    service = TreeInput.from_args(sys.argv[1:])
+    service.main()
 
 
 if __name__ == '__main__':
-    r = main()
-    sys.exit(r)
+    main()

--- a/inputs/org.osbuild.tree
+++ b/inputs/org.osbuild.tree
@@ -60,6 +60,7 @@ def error(msg):
 def main():
     args = json.load(sys.stdin)
     refs = args["refs"]
+    target = args["target"]
 
     # input verification *must* have been done via schema
     # verification. It is expected that origin is a pipeline
@@ -68,15 +69,13 @@ def main():
 
     store = StoreClient(connect_to=args["api"]["store"])
 
-    if not pid:
-        path = store.mkdtemp(prefix="empty")
-    else:
-        path = store.read_tree(pid)
+    if pid:
+        path = store.read_tree_at(pid, target)
 
     if not path:
         error(f"Could not find pipeline with id '{pid}'")
 
-    json.dump({"path": path}, sys.stdout)
+    json.dump({"path": target}, sys.stdout)
     return 0
 
 

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -221,6 +221,7 @@ class BuildRoot(contextlib.AbstractContextManager):
             "--new-session",
             "--setenv", "PATH", "/usr/sbin:/usr/bin",
             "--setenv", "PYTHONPATH", "/run/osbuild/lib",
+            "--setenv", "PYTHONUNBUFFERED", "1",
             "--unshare-ipc",
             "--unshare-pid",
             "--unshare-net"

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -235,7 +235,6 @@ class BuildRoot(contextlib.AbstractContextManager):
                                 stdin=subprocess.DEVNULL,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT,
-                                encoding="utf-8",
                                 close_fds=True)
 
         data = io.StringIO()
@@ -250,7 +249,8 @@ class BuildRoot(contextlib.AbstractContextManager):
             data.write(txt)
             monitor.log(txt)
 
-        txt, _ = proc.communicate()
+        buf, _ = proc.communicate()
+        txt = buf.decode("utf-8")
         monitor.log(txt)
         data.write(txt)
         output = data.getvalue()

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -33,13 +33,13 @@ def describe(manifest: Manifest, *, with_id=False) -> Dict:
         desc = {
             "type": ip.info.name,
             "origin": origin,
-            }
+        }
         if ip.options:
             desc["options"] = ip.options
 
         refs = {}
         for name, ref in ip.refs.items():
-            if  origin == "org.osbuild.pipeline":
+            if origin == "org.osbuild.pipeline":
                 name = pipeline_ref(name)
             refs[name] = ref
 

--- a/osbuild/host.py
+++ b/osbuild/host.py
@@ -1,0 +1,474 @@
+"""
+Functionality provided by the host
+
+The biggest functionality this module provides are so called host
+services:
+
+Stages run inside a container to isolate them from the host which
+the build is run on. This means that the stages do not have direct
+access to certain features offered by the host system, like access
+to the network, devices as well as the osbuild store itself.
+
+Host services are a way to provide functionality to stages that is
+restricted to the host and not directly available in the container.
+
+A service itself is an executable that gets spawned by osbuild on-
+demand and communicates with osbuild via a simple JSON based IPC
+protocol. To ease the development of such services the `Service`
+class of this module can be used, which sets up and handles the
+communication with the host.
+
+On the host side a `ServiceManager` can be used to spawn and manage
+concret services. Specifically it functions as a context manager
+and will shut down services when the context is exited.
+
+The `ServiceClient` class provides a client for the services and can
+thus be used to interact with the service from the host side.
+
+A note about host service lifetimes: The host service lifetime is
+meant to be bound to service it provides, e.g. when the service
+provides data to a stage, it is meant that this data is accessible
+for exactly as long as the binary is run and all resources must be
+freed when the service is stopped.
+The idea behind this design is to ensure that no resources get
+leaked because only the host service itself is responsible for
+their clean up, independent of any control of osbuild.
+"""
+
+import abc
+import argparse
+import asyncio
+import importlib
+import io
+import os
+import signal
+import subprocess
+import sys
+import threading
+import traceback
+from collections import OrderedDict
+from typing import Any, Dict, List, Optional, Tuple
+
+from osbuild.util.jsoncomm import FdSet, Socket
+
+
+class ProtocolError(Exception):
+    """Errors concerning the communication between host and service"""
+
+
+class RemoteError(Exception):
+    """A RemoteError indicates an unexpected error in the service"""
+
+    def __init__(self, name, value, stack) -> None:
+        self.name = name
+        self.value = value
+        self.stack = stack
+        msg = f"{name}: {value}\n {stack}"
+        super().__init__(msg)
+
+
+class ServiceProtocol:
+    """
+    Wire protocol between host and service
+
+    The ServicePortocol specifies the wire protocol between the host
+    and the service. It contains methods to translate messages into
+    their wire format and back.
+    """
+
+    @staticmethod
+    def decode_message(msg: Dict) -> Tuple[str, Dict]:
+        t = msg.get("type")
+        if not t:
+            raise ProtocolError("'type' field missing")
+
+        d = msg.get("data")
+        if not d:
+            raise ProtocolError("'data' field missing")
+        return t, d
+
+    @staticmethod
+    def encode_method(name: str, arguments: List):
+        msg = {
+            "type": "method",
+            "data": {
+                "name": name,
+                "args": arguments,
+            }
+        }
+        return msg
+
+    @staticmethod
+    def decode_method(data: Dict):
+        name = data.get("name")
+        if not name:
+            raise ProtocolError("'name' field missing")
+
+        args = data.get("args", [])
+        return name, args
+
+    @staticmethod
+    def encode_reply(reply: Any):
+        msg = {
+            "type": "reply",
+            "data": {
+                "reply": reply
+            }
+        }
+        return msg
+
+    @staticmethod
+    def decode_reply(msg: Dict) -> Any:
+        data = msg.get("reply")
+        return data
+
+    @staticmethod
+    def encode_exception(value, tb):
+        backtrace = "".join(traceback.format_tb(tb))
+        msg = {
+            "type": "exception",
+            "data": {
+                "name": value.__class__.__name__,
+                "value": str(value),
+                "backtrace": backtrace
+            }
+        }
+        return msg
+
+    @staticmethod
+    def decode_exception(data):
+        name = data["name"]
+        value = data["value"]
+        tb = data["backtrace"]
+
+        return RemoteError(name, value, tb)
+
+
+class Service(abc.ABC):
+    """
+    Host service
+
+    This abstract base class provides all the base functionality to
+    implement a host service. Specifically, it handles all setting
+    the service itself and the communction with the host up.
+
+    The `dispatch` methods needs to be implemented by dervining
+    classes to handle remote method calls.
+
+    The `stop` method should be implemented to tear down state and
+    free resources.
+    """
+
+    protocol = ServiceProtocol
+
+    def __init__(self, args: argparse.Namespace):
+
+        self.sock = Socket.new_from_fd(args.service_fd)
+        self.id = args.service_id
+
+    @classmethod
+    def from_args(cls, argv):
+        """Create a service object given an argument vector"""
+
+        parser = cls.prepare_argument_parser()
+        args = parser.parse_args(argv)
+        return cls(args)
+
+    @classmethod
+    def prepare_argument_parser(cls):
+        """Prepare the command line argument parser"""
+
+        name = __class__.__name__
+
+        desc = f"osbuild {name} host service"
+        parser = argparse.ArgumentParser(description=desc)
+
+        parser.add_argument("--service-fd", metavar="FD", type=int,
+                            help="service file descriptor")
+        parser.add_argument("--service-id", metavar="ID", type=str,
+                            help="service identifier")
+        return parser
+
+    @abc.abstractmethod
+    def dispatch(self, method: str, args: Any, fds: FdSet):
+        """Handle remote method calls
+
+        This method must be overridden in order to handle remote
+        method calls. The incoming arguments are the method name,
+        `method` and its arguments, `args`, together with an set
+        of file descriptors (optional). The reply to this method
+        will form the return value of the remote call.
+        """
+
+    def stop(self):
+        """Service is stopping
+
+        This method will be called when the service is stopping,
+        and should be overridden to tear down state and free
+        resources allocated by the service.
+
+        NB: This method might be called at any time due to signals,
+        even during the handling method calls.
+        """
+
+    def main(self):
+        """Main service entry point
+
+        This method should be invoked in the service executable
+        to actually run the service. After additional setup this
+        will call the `serve` method to wait for remote method
+        calls.
+        """
+        def handle_sigterm(_signo, _stack_frame):
+            sys.exit(0)  # will raise SystemExit
+
+        signal.signal(signal.SIGTERM, handle_sigterm)
+
+        try:
+            self.serve()
+        finally:
+            self.stop()
+
+    def serve(self):
+        """Serve remote requests
+
+        Wait for remote method calls and translate them into
+        calls to `dispatch`.
+        """
+
+        while True:
+            msg, fds, _ = self.sock.recv()
+            if not msg:
+                break
+
+            try:
+                reply, fds = self._handle_message(msg, fds)
+
+            except:  # pylint: disable=bare-except
+                fds = None
+                _, val, tb = sys.exc_info()
+                reply = self.protocol.encode_exception(val, tb)
+
+            self.sock.send(reply, fds=fds)
+
+    def _handle_message(self, msg, fds):
+        """
+        Internal method called by `service` to handle new messages
+        """
+
+        kind, data = self.protocol.decode_message(msg)
+
+        if kind != "method":
+            raise ProtocolError(f"unknown message type: {kind}")
+
+        name, args = self.protocol.decode_method(data)
+        ret, fds = self.dispatch(name, args, fds)
+        msg = self.protocol.encode_reply(ret)
+
+        return msg, fds
+
+
+class ServiceClient:
+    """
+    Host service client
+
+    Can be used to remotely call methods on the host services. Normally
+    return from the `ServiceManager` when starting a new host service.
+    """
+    protocol = ServiceProtocol
+
+    def __init__(self, uid, proc, sock):
+        self.uid = uid
+        self.proc = proc
+        self.sock = sock
+
+    def call(self, method: str, args: Optional[Any] = None) -> Any:
+        """Remotely call a method and return the result"""
+
+        ret, _ = self.call_with_fds(method, args)
+        return ret
+
+    def call_with_fds(self, method: str,
+                      args: Optional[Any] = None,
+                      fds: Optional[List] = None) -> Tuple[Any, FdSet]:
+        """
+        Remotely call a method and return the result, including file
+        descriptors.
+        """
+
+        msg = self.protocol.encode_method(method, args)
+
+        ret, fds, _ = self.sock.send_and_recv(msg, fds=fds)
+
+        kind, data = self.protocol.decode_message(ret)
+
+        if kind == "reply":
+            ret = self.protocol.decode_reply(data)
+            return ret, fds
+        if kind == "exception":
+            error = self.protocol.decode_exception(data)
+            raise error
+
+        raise ProtocolError(f"unknown message type: {kind}")
+
+    def stop(self):
+        """
+        Stop the host service associated with this client.
+        """
+
+        self.sock.close()
+        self.proc.wait()
+
+
+class ServiceManager:
+    """
+    Host service manager
+
+    Manager, i.e. `start` and `stop` host services. Must be used as a
+    context manager. When the context is active, host services can be
+    started via the `start` method.
+
+    When a `monitor` is provided, stdout and stderr of the service will
+    be forwarded to the monitor via `monitor.log`, otherwise sys.stdout
+    is used.
+    """
+
+    def __init__(self, *, monitor=None):
+        self.services = OrderedDict()
+        self.monitor = monitor
+
+        self.barrier = threading.Barrier(2)
+        self.event_loop = None
+        self.thread = None
+
+    @property
+    def running(self):
+        """Return whether the service manager is running"""
+        return self.event_loop is not None
+
+    @staticmethod
+    def make_env():
+        # We want the `osbuild` python package that contains this
+        # very module, which might be different from the system wide
+        # installed one, to be accessible to the Input programs so
+        # we detect our origin and set the `PYTHONPATH` accordingly
+        modorigin = importlib.util.find_spec("osbuild").origin
+        modpath = os.path.dirname(modorigin)
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.path.dirname(modpath)
+        env["PYTHONUNBUFFERED"] = "1"
+        return env
+
+    def start(self, uid, cmd, extra_args=None) -> ServiceClient:
+        """
+        Start a new host service
+
+        Create a new host service with the unique identifier `uid` by
+        spawning the executable provided via `cmd` with optional extra
+        arguments `extra_args`.
+
+        The return value is a `ServiceClient` instance that is already
+        connected to the service and can thus be used to call methods.
+
+        NB: Must be called with an active context
+        """
+
+        assert self.running, "ServiceManager not running"
+
+        if uid in self.services:
+            raise ValueError(f"{uid} already started")
+
+        ours, theirs = Socket.new_pair()
+        env = self.make_env()
+
+        try:
+            fd = theirs.fileno()
+            argv = [
+                cmd,
+                "--service-id", uid,
+                "--service-fd", str(fd)
+            ]
+
+            if extra_args:
+                argv += extra_args
+
+            proc = subprocess.Popen(argv,
+                                    env=env,
+                                    stdin=subprocess.DEVNULL,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT,
+                                    bufsize=0,
+                                    pass_fds=(fd, ),
+                                    close_fds=True)
+
+            service = ServiceClient(uid, proc, ours)
+            self.services[uid] = service
+            ours = None
+
+            stdout = io.TextIOWrapper(proc.stdout,
+                                      encoding="utf-8",
+                                      line_buffering=True)
+
+            name = os.path.basename(cmd)
+
+            def reader():
+                return self._stdout_ready(name, uid, stdout)
+
+            self.event_loop.add_reader(stdout, reader)
+
+        finally:
+            if ours:
+                ours.close()
+
+        return service
+
+    def stop(self, uid):
+        """
+        Stop a service given its unique identifier, `uid`
+        """
+
+        service = self.services.get(uid)
+        if not service:
+            raise ValueError(f"unknown service: {uid}")
+
+        service.stop()
+
+    def _stdout_ready(self, name, uid, stdout):
+        txt = stdout.readline()
+        if not txt:
+            self.event_loop.remove_reader(stdout)
+            return
+
+        msg = f"{uid} ({name}): {txt}"
+        if self.monitor:
+            self.monitor.log(msg)
+        else:
+            print(msg, end="")
+
+    def _thread_main(self):
+        self.barrier.wait()
+        asyncio.set_event_loop(self.event_loop)
+        self.event_loop.run_forever()
+
+    def __enter__(self):
+        # We are not re-entrant, so complain if re-entered.
+        assert not self.running
+
+        self.event_loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self._thread_main)
+
+        self.barrier.reset()
+        self.thread.start()
+        self.barrier.wait()
+
+        return self
+
+    def __exit__(self, *args):
+        # Stop all registered services
+        while self.services:
+            _, srv = self.services.popitem()
+            srv.stop()
+
+        self.event_loop.call_soon_threadsafe(self.event_loop.stop)
+        self.thread.join()
+        self.event_loop.close()

--- a/osbuild/inputs.py
+++ b/osbuild/inputs.py
@@ -46,15 +46,11 @@ class Input:
 
     def calc_id(self):
         m = hashlib.sha256()
-        m.update(json.dumps(self.name, sort_keys=True).encode())
+        m.update(json.dumps(self.info.name, sort_keys=True).encode())
         m.update(json.dumps(self.origin, sort_keys=True).encode())
         m.update(json.dumps(self.refs, sort_keys=True).encode())
         m.update(json.dumps(self.options, sort_keys=True).encode())
         return m.hexdigest()
-
-    @property
-    def name(self) -> str:
-        return self.info.name
 
     def run(self, storeapi: StoreServer) -> Tuple[str, Dict]:
         name = self.info.name

--- a/osbuild/inputs.py
+++ b/osbuild/inputs.py
@@ -33,8 +33,9 @@ class Input:
     A single input with its corresponding options.
     """
 
-    def __init__(self, info, origin: str, options: Dict):
+    def __init__(self, info, name, origin: str, options: Dict):
         self.info = info
+        self.name = name
         self.origin = origin
         self.refs = {}
         self.options = options or {}
@@ -47,6 +48,7 @@ class Input:
     def calc_id(self):
         m = hashlib.sha256()
         m.update(json.dumps(self.info.name, sort_keys=True).encode())
+        m.update(json.dumps(self.name, sort_keys=True).encode())
         m.update(json.dumps(self.origin, sort_keys=True).encode())
         m.update(json.dumps(self.refs, sort_keys=True).encode())
         m.update(json.dumps(self.options, sort_keys=True).encode())

--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -278,6 +278,15 @@ class ModuleInfo:
     Normally this class is instantiated via its `load` method.
     """
 
+    # Known modules and their corresponding directory name
+    MODULES = {
+        "Assembler": "assemblers",
+        "Device": "devices",
+        "Input": "inputs",
+        "Source": "sources",
+        "Stage": "stages",
+    }
+
     def __init__(self, klass: str, name: str, path: str, info: Dict):
         self.name = name
         self.type = klass
@@ -354,7 +363,7 @@ class ModuleInfo:
         def targets(a):
             return [t.id for t in filter_type(a.targets, ast.Name)]
 
-        base = cls.module_class_to_directory(klass)
+        base = cls.MODULES.get(klass)
         if not base:
             raise ValueError(f"Unsupported type: {klass}")
 
@@ -384,17 +393,6 @@ class ModuleInfo:
             'info': "\n".join(doclist[1:])
         }
         return cls(klass, name, path, info)
-
-    @staticmethod
-    def module_class_to_directory(klass: str) -> str:
-        mapping = {
-            "Assembler": "assemblers",
-            "Input": "inputs",
-            "Source": "sources",
-            "Stage": "stages",
-        }
-
-        return mapping.get(klass)
 
 
 class FormatInfo:
@@ -469,7 +467,7 @@ class Index:
 
     def list_modules_for_class(self, klass: str) -> List[str]:
         """List all available modules for the given `klass`"""
-        module_path = ModuleInfo.module_class_to_directory(klass)
+        module_path = ModuleInfo.MODULES.get(klass)
 
         if not module_path:
             raise ValueError(f"Unsupported nodule class: {klass}")
@@ -507,7 +505,7 @@ class Index:
             with contextlib.suppress(FileNotFoundError):
                 with open(path, "r") as f:
                     schema = json.load(f)
-        elif klass in ["Assembler", "Input", "Source", "Stage"]:
+        elif klass in ModuleInfo.MODULES:
             info = self.get_module_info(klass, name)
             if info:
                 schema = info.get_schema(version)

--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -383,12 +383,11 @@ class ModuleInfo:
         targets = [(t, a) for a in assigns for t in targets(a)]
         values = {k: value(v) for k, v in targets if k in names}
 
-
         info = {
             'schema': {
                 "1": values.get("SCHEMA", ""),
                 "2": values.get("SCHEMA_2")
-                },
+            },
             'desc': doclist[0],
             'info': "\n".join(doclist[1:])
         }

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -7,6 +7,7 @@ from typing import Dict, Iterator, List, Optional
 
 from .api import API
 from . import buildroot
+from . import host
 from . import objectstore
 from . import remoteloop
 from .inputs import Input
@@ -95,8 +96,11 @@ class Stage:
             storeapi = objectstore.StoreServer(store)
             cm.enter_context(storeapi)
 
+            mgr = host.ServiceManager(monitor=monitor)
+            cm.enter_context(mgr)
+
             for key, ip in self.inputs.items():
-                path, data = ip.run(storeapi, inputs_tmpdir)
+                path, data = ip.run(mgr, storeapi, inputs_tmpdir)
                 path = os.path.join(inputs_mapped, path)
                 inputs[key] = {"path": path, "data": data}
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -70,12 +70,8 @@ class Stage:
             build_root = buildroot.BuildRoot(build_tree, runner, libdir, store.tmp)
             cm.enter_context(build_root)
 
-            sources_tmp = store.tempdir(prefix="osbuild-sources-output-")
-            sources_output = cm.enter_context(sources_tmp)
-
             args = {
                 "tree": "/run/osbuild/tree",
-                "sources": "/run/osbuild/sources",
                 "options": self.options,
                 "inputs": {},
                 "meta": {
@@ -84,8 +80,7 @@ class Stage:
             }
 
             ro_binds = [
-                f"{self.info.path}:/run/osbuild/bin/{self.name}",
-                f"{sources_output}:/run/osbuild/sources"
+                f"{self.info.path}:/run/osbuild/bin/{self.name}"
             ]
 
             storeapi = objectstore.StoreServer(store)

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -60,7 +60,7 @@ class Stage:
         return m.hexdigest()
 
     def add_input(self, name, info, origin, options=None):
-        ip = Input(info, origin, options or {})
+        ip = Input(info, name, origin, options or {})
         self.inputs[name] = ip
         return ip
 

--- a/osbuild/util/jsoncomm.py
+++ b/osbuild/util/jsoncomm.py
@@ -393,3 +393,13 @@ class Socket(contextlib.AbstractContextManager):
 
         n = self._socket.sendmsg([serialized], cmsg, 0)
         assert n == len(serialized)
+
+    def send_and_recv(self, payload: object, *, fds: Optional[list] = None):
+        """Send a message and wait for a reply
+
+        This is a convenience helper that combines `send` and `recv`.
+        See the individual methods for details about the parameters.
+        """
+
+        self.send(payload, fds=fds)
+        return self.recv()

--- a/osbuild/util/jsoncomm.py
+++ b/osbuild/util/jsoncomm.py
@@ -272,6 +272,27 @@ class Socket(contextlib.AbstractContextManager):
 
         return cls(a, None), cls(b, None)
 
+    @classmethod
+    def new_from_fd(cls, fd: int, *, blocking=True, close_fd=True):
+        """Create a socket for an existing file descriptor
+
+        Duplicate the file descriptor and return a `Socket` for it.
+        The blocking mode can be set via `blocking`. If `close_fd`
+        is True (the default) `fd` will be closed.
+
+        Parameters
+        ----------
+        fd
+            The file descriptor to use.
+        blocking
+            The blocking mode for the socket pair.
+        """
+        sock = socket.fromfd(fd, socket.AF_UNIX, socket.SOCK_SEQPACKET)
+        sock.setblocking(blocking)
+        if close_fd:
+            os.close(fd)
+        return cls(sock, None)
+
     def fileno(self) -> int:
         assert self._socket is not None
         return self._socket.fileno()

--- a/osbuild/util/jsoncomm.py
+++ b/osbuild/util/jsoncomm.py
@@ -254,6 +254,24 @@ class Socket(contextlib.AbstractContextManager):
 
         return cls(sock, (unlink, path[1]))
 
+    @classmethod
+    def new_pair(cls, *, blocking=True):
+        """Create a connected socket pair
+
+        Create a pair of connected sockets and return both as a tuple.
+
+        Parameters
+        ----------
+        blocking
+            The blocking mode for the socket pair.
+        """
+        a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_SEQPACKET)
+
+        a.setblocking(blocking)
+        b.setblocking(blocking)
+
+        return cls(a, None), cls(b, None)
+
     def fileno(self) -> int:
         assert self._socket is not None
         return self._socket.fileno()

--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -18,8 +18,11 @@
 
     "inputs": {
       "title": "Collection of inputs for a stage",
-      "additionalProperties": {
-        "$ref": "#/definitions/input"
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z][a-zA-Z0-9_\\-\\.]{0,254}": {
+          "$ref": "#/definitions/input"
+        }
       }
     },
 

--- a/test/data/stages/rpm/metadata.json
+++ b/test/data/stages/rpm/metadata.json
@@ -1,5 +1,5 @@
 {
-  "9415f5f6316e954318d716b5c92bd69e26a4ae475593ffef32ea0a52cc90b9e8": {
+  "95dc7e0e424a3d3f8765ff1a5e960f49dc5e3d0f259bbf720034ac854bf49726": {
     "packages": [
       {
         "name": "acl",

--- a/test/mod/test_host.py
+++ b/test/mod/test_host.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+
+#
+# Runtime Tests for Host Services
+#
+
+import sys
+from typing import Any
+
+import pytest
+
+from osbuild import host
+from osbuild.util.jsoncomm import FdSet
+
+
+class ServiceTest(host.Service):
+
+    def dispatch(self, method: str, args: Any, fds: FdSet):
+        ret, fds = None, None
+
+        if method == "exception":
+            raise ValueError("Remote Exception")
+        if method == "echo":
+            ret = args
+        elif method == "identify":
+            ret = self.id
+        else:
+            raise host.ProtocolError("unknown method:", method)
+
+        return ret, fds
+
+
+def test_basic():
+    with host.ServiceManager() as mgr:
+        for i in range(3):
+            client = mgr.start(str(i), __file__)
+
+            args = ["an", "argument"]
+            res = client.call("echo", args)
+
+            assert args == res
+
+            remote_id = client.call("identify")
+            assert remote_id == str(i)
+
+            with pytest.raises(ValueError, match=f"{str(i)}"):
+                _ = mgr.start(str(i), __file__)
+
+        for i in range(3):
+            client = mgr.services[str(i)]
+            client.stop()
+
+
+def test_exception():
+    with host.ServiceManager() as mgr:
+        client = mgr.start("exception", __file__)
+        with pytest.raises(host.RemoteError, match=r"Remote Exception"):
+            client.call("exception")
+
+
+def main():
+    service = ServiceTest.from_args(sys.argv[1:])
+    service.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/mod/test_util_jsoncomm.py
+++ b/test/mod/test_util_jsoncomm.py
@@ -176,3 +176,13 @@ class TestUtilJsonComm(unittest.TestCase):
 
         conn = listener.accept()
         self.assertIsNone(conn)
+
+    def test_socket_pair(self):
+        #
+        # Test creating a socket pair and sending, receiving of a simple message
+        a, b = jsoncomm.Socket.new_pair()
+
+        ping = {"osbuild": "yes"}
+        a.send(ping)
+        pong, _, _ = b.recv()
+        self.assertEqual(ping, pong)

--- a/test/mod/test_util_jsoncomm.py
+++ b/test/mod/test_util_jsoncomm.py
@@ -203,3 +203,16 @@ class TestUtilJsonComm(unittest.TestCase):
         a.send(ping)
         pong, _, _ = b.recv()
         self.assertEqual(ping, pong)
+
+    def test_send_and_recv(self):
+        #
+        # Test for the send and receive helper method
+
+        a, b = jsoncomm.Socket.new_pair()
+
+        ping = {"osbuild": "yes"}
+        a.send(ping)
+        pong, _, _ = b.send_and_recv(ping)
+        self.assertEqual(ping, pong)
+        pong, _, _ = a.recv()
+        self.assertEqual(ping, pong)

--- a/test/mod/test_util_jsoncomm.py
+++ b/test/mod/test_util_jsoncomm.py
@@ -186,3 +186,20 @@ class TestUtilJsonComm(unittest.TestCase):
         a.send(ping)
         pong, _, _ = b.recv()
         self.assertEqual(ping, pong)
+
+    def test_from_fd(self):
+        #
+        # Test creating a Socket from an existing file descriptor
+        a, x = jsoncomm.Socket.new_pair()
+        fd = os.dup(x.fileno())
+
+        b = jsoncomm.Socket.new_from_fd(fd)
+
+        # x should be closed and thus raise "Bad file descriptor"
+        with self.assertRaises(OSError):
+            os.write(fd, b"test")
+
+        ping = {"osbuild": "yes"}
+        a.send(ping)
+        pong, _, _ = b.recv()
+        self.assertEqual(ping, pong)


### PR DESCRIPTION
Host services are a way to provide functionality to stages that is restricted to the host and not directly available in the container, such as providing input to stages, devices access and mounting. 
Convert inputs to use host services.

See individual commits for more details.