### PR TITLE
ci: remove RHEL 8.4 and Fedora 32

### DIFF
--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -32,16 +32,6 @@ pipeline {
             failFast true
 
             parallel {
-                stage('Fedora 32') {
-                    agent { label "f32cloudbase && x86_64" }
-                    environment {
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                    }
-                    steps {
-                        sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
-                    }
-                }
                 stage('Fedora 33') {
                     agent { label "f33cloudbase && x86_64" }
                     environment {
@@ -122,26 +112,6 @@ pipeline {
             failFast false
 
             parallel {
-                stage('Fedora 32') {
-                    agent { label "f32cloudbase && x86_64 && psi" }
-                    environment {
-                        TEST_TYPE = "image"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        DISTRO_CODE = "fedora32"
-                        AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials('psi-openstack-creds')
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        run_tests()
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora32-image')
-                        }
-                    }
-                }
                 stage('Fedora 33') {
                     agent { label "f33cloudbase && x86_64 && psi" }
                     environment {

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -84,17 +84,6 @@ pipeline {
                         sh "schutzbot/mockbuild.sh"
                     }
                 }
-                stage('RHEL 8.4') {
-                    agent { label "rhel84cloudbase && x86_64 && psi" }
-                    environment {
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        RHEL84_NIGHTLY_REPO = credentials('rhel84-nightly-repo')
-                    }
-                    steps {
-                        sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
-                    }
-                }
                 stage('RHEL 8.5') {
                     agent { label "rhel85cloudbase && x86_64 && psi" }
                     environment {
@@ -191,26 +180,6 @@ pipeline {
                     post {
                         always {
                             preserve_logs('rhel8-image')
-                        }
-                    }
-                }
-                stage('RHEL 8.4') {
-                    agent { label "rhel84cloudbase && x86_64 && psi" }
-                    environment {
-                        TEST_TYPE = "image"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        DISTRO_CODE = "rhel8"
-                        AWS_IMAGE_TEST_CREDS = credentials('aws-credentials-osbuild-image-test')
-                        AZURE_CREDS = credentials('azure')
-                        OPENSTACK_CREDS = credentials('psi-openstack-creds')
-                        VCENTER_CREDS = credentials('vmware-vcenter-credentials')
-                    }
-                    steps {
-                        run_tests()
-                    }
-                    post {
-                        always {
-                            preserve_logs('rhel84-image')
                         }
                     }
                 }

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -69,16 +69,8 @@ greenprint "📤 RPMS will be uploaded to: ${REPO_URL}"
 # Build source RPMs.
 greenprint "🔧 Building source RPMs."
 make srpm
-# rhel 8.4 and 8.5 will run off of the internal repos and does not have a redhat subscription
-if [[ $VERSION_ID == 8.4 ]]; then
-    greenprint "📋 Updating RHEL 8 mock template for unsubscribed image"
-    sudo sed -i '/# repos/q' /etc/mock/templates/rhel-8.tpl
-    # remove the subscription check
-    sudo sed -i "s/config_opts\['redhat_subscription_required'\] = True/config_opts['redhat_subscription_required'] = False/" /etc/mock/templates/rhel-8.tpl
-    cat "$RHEL84_NIGHTLY_REPO" | sudo tee -a /etc/mock/templates/rhel-8.tpl > /dev/null
-    # We need triple quotes at the end of the template to mark the end of the repo list.
-    echo '"""' | sudo tee -a /etc/mock/templates/rhel-8.tpl
-elif [[ $VERSION_ID == 8.5 ]]; then
+# rhel 8.5 will run off of the internal repos and does not have a redhat subscription
+if [[ $VERSION_ID == 8.5 ]]; then
     greenprint "📋 Updating RHEL 8 mock template for unsubscribed image"
     sudo sed -i '/# repos/q' /etc/mock/templates/rhel-8.tpl
     # remove the subscription check


### PR DESCRIPTION
RHEL 8.4 is now GA, so we don't need any extra tests for it. This should also
make the CI more reliable because having two distros with the same DISTRO_CODE
caused some tests to fail randomly (they used the same intermediate
artifacts).

Also, remove Fedora 32 because it's EOL.