### PR TITLE
meta: proper schema parsing error reporting

### DIFF
--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -278,6 +278,14 @@ class ModuleInfo:
     Normally this class is instantiated via its `load` method.
     """
 
+    # Known modules and their corresponding directory name
+    MODULES = {
+        "Assembler": "assemblers",
+        "Input": "inputs",
+        "Source": "sources",
+        "Stage": "stages",
+    }
+
     def __init__(self, klass: str, name: str, path: str, info: Dict):
         self.name = name
         self.type = klass
@@ -354,7 +362,7 @@ class ModuleInfo:
         def targets(a):
             return [t.id for t in filter_type(a.targets, ast.Name)]
 
-        base = cls.module_class_to_directory(klass)
+        base = cls.MODULES.get(klass)
         if not base:
             raise ValueError(f"Unsupported type: {klass}")
 
@@ -384,17 +392,6 @@ class ModuleInfo:
             'info': "\n".join(doclist[1:])
         }
         return cls(klass, name, path, info)
-
-    @staticmethod
-    def module_class_to_directory(klass: str) -> str:
-        mapping = {
-            "Assembler": "assemblers",
-            "Input": "inputs",
-            "Source": "sources",
-            "Stage": "stages",
-        }
-
-        return mapping.get(klass)
 
 
 class FormatInfo:
@@ -469,7 +466,7 @@ class Index:
 
     def list_modules_for_class(self, klass: str) -> List[str]:
         """List all available modules for the given `klass`"""
-        module_path = ModuleInfo.module_class_to_directory(klass)
+        module_path = ModuleInfo.MODULES.get(klass)
 
         if not module_path:
             raise ValueError(f"Unsupported nodule class: {klass}")
@@ -507,7 +504,7 @@ class Index:
             with contextlib.suppress(FileNotFoundError):
                 with open(path, "r") as f:
                     schema = json.load(f)
-        elif klass in ["Assembler", "Input", "Source", "Stage"]:
+        elif klass in ModuleInfo.MODULES:
             info = self.get_module_info(klass, name)
             if info:
                 schema = info.get_schema(version)

--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -382,12 +382,11 @@ class ModuleInfo:
         targets = [(t, a) for a in assigns for t in targets(a)]
         values = {k: value(v) for k, v in targets if k in names}
 
-
         info = {
             'schema': {
                 "1": values.get("SCHEMA", ""),
                 "2": values.get("SCHEMA_2")
-                },
+            },
             'desc': doclist[0],
             'info': "\n".join(doclist[1:])
         }


### PR DESCRIPTION
Parse the JSON directly from the AST node when parsing the module file, because the AST node contains the line number of the schema variable and thus we can resolve the correct line number for errors within the JSON. Convert the `JSONDecodeError` to a `SyntaxError`:

Before:
```
Traceback (most recent call last):
  File "/workspaces/osbuild/osbuild/meta.py", line 331, in get_schema
    opts = self._make_options(version)
  [...]
  File "/usr/lib64/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 2 column 1 (char 14)
```

After:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  [...]
    raise SyntaxError(msg, detail) from None
  File "stages/org.osbuild.ostree.init-fs", line 31
    additionalProperties: False
    ^
SyntaxError: Invalid schema: Expecting property name enclosed in double quotes
```