### PR TITLE
aarch64: use single qemu-img thread

### DIFF
--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -699,6 +699,11 @@ def main(tree, output_dir, options, loop_client):
         if compat:
             extra_args["qcow2"] += ["-o", f"compat={compat}"]
 
+        coroutines = os.environ.get("OSBUILD_QEMU_IMG_COROUTINES")
+        if coroutines:
+            print(f"qemu-img coroutines: {coroutines}")
+            extra_args[fmt] += ["-m", coroutines]
+
         subprocess.run([
             "qemu-img",
             "convert",

--- a/runners/org.osbuild.rhel82
+++ b/runners/org.osbuild.rhel82
@@ -37,7 +37,6 @@ def nsswitch():
         pass
 
 
-
 def python_alternatives():
     """/usr/bin/python3 is a symlink to /etc/alternatives/python3, which points
     to /usr/bin/python3.6 by default. Recreate the link in /etc, so that
@@ -48,6 +47,7 @@ def python_alternatives():
         os.symlink("/usr/bin/python3.6", "/etc/alternatives/python3")
     except FileExistsError:
         pass
+
 
 if __name__ == "__main__":
     with osbuild.api.exception_handler():

--- a/runners/org.osbuild.rhel82
+++ b/runners/org.osbuild.rhel82
@@ -49,7 +49,7 @@ def python_alternatives():
         pass
 
 
-if __name__ == "__main__":
+def main():
     with osbuild.api.exception_handler():
         ldconfig()
         sysusers()
@@ -59,3 +59,7 @@ if __name__ == "__main__":
 
         r = subprocess.run(sys.argv[1:], check=False)
         sys.exit(r.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/runners/org.osbuild.rhel82
+++ b/runners/org.osbuild.rhel82
@@ -1,10 +1,24 @@
 #!/usr/libexec/platform-python
 
 import os
+import platform
 import subprocess
 import sys
 
 import osbuild.api
+
+
+def quirks():
+    # Platform specific quirks
+    env = os.environ.copy()
+
+    if platform.machine() == "aarch64":
+        # Work around a bug in qemu-img on aarch64 that can lead to qemu-img
+        # hangs when more then one coroutine is use (which is the default)
+        # See https://bugs.launchpad.net/qemu/+bug/1805256
+        env["OSBUILD_QEMU_IMG_COROUTINES"] = "1"
+
+    return env
 
 
 def ldconfig():
@@ -57,7 +71,11 @@ def main():
         nsswitch()
         python_alternatives()
 
-        r = subprocess.run(sys.argv[1:], check=False)
+        env = quirks()
+
+        r = subprocess.run(sys.argv[1:],
+                           env=env,
+                           check=False)
         sys.exit(r.returncode)
 
 


### PR DESCRIPTION
Work around a bug on `aarch64`[1] where `qemu-img` would hang about a third of the time. To be able to activate the work-around only when it is required, e.g. for certain distributions distribution, introduce an environment variable, `OSBUILD_QEMU_IMG_COROUTINES`, that is set in the runner and then picked up in the assembler.

[1] https://bugs.launchpad.net/qemu/+bug/1805256

Based on work by @major in #483. 
Closes #482.