### PR TITLE
stages: extend `org.osbuild.sysconfig` to create network-scripts/ifcfg-* files

### DIFF
--- a/stages/org.osbuild.sysconfig
+++ b/stages/org.osbuild.sysconfig
@@ -17,6 +17,35 @@ Network supports the params:
   - networking(NETWORKING) of type boolean
   - no_zero_conf(NOZEROCONF) of type boolean
 
+Network-scripts supports the params:
+  - ifcfg - this parameter allows creation of 'ifcfg-*' files under
+    'network-scripts' subdirectory. 'ifcfg' type is object (dictionary) with
+    all of its keys specifying the interface name and resulting in creation
+    of configuration files with the same name and prefix 'ifcfg-'.
+    - Network interface name constraints are:
+      - maximum length of IFNAMSIZ (including the terminating null byte)
+      - name accepted by dev_valid_name() function from kernel net/core/dev.c
+    - Currently supported subset of configuration options in ifcfg files is:
+      - bootproto(BOOTPROTO) of type string with allowed values:
+        - none
+        - bootp
+        - dhcp
+        - static
+        - ibft
+        - autoip
+        - shared
+      - device(DEVICE) of type string
+      - ipv6init(IPV6INIT) of type boolean
+      - onboot(ONBOOT) of type boolean
+      - peerdns(PEERDNS) of type boolean
+      - type(TYPE) of type string with allowed values:
+        - Ethernet
+        - Wireless
+        - InfiniBand
+        - Bridge
+        - Bond
+        - Vlan
+      - userctl(USERCTL) of type boolean
 
 This stage will overwrite existing files.
 
@@ -28,7 +57,7 @@ import os
 import osbuild.api
 
 
-SCHEMA = """
+SCHEMA = r"""
 "additionalProperties": false,
 "properties": {
   "kernel": {
@@ -60,6 +89,71 @@ SCHEMA = """
         "description": "Disables the zero configuration network suite"
       }
     }
+  },
+  "network-scripts": {
+    "additionalProperties": false,
+    "type": "object",
+    "description": "sysconfig network-scripts options",
+    "properties": {
+      "ifcfg": {
+        "additionalProperties": false,
+        "type": "object",
+        "description": "Keys are interface names, values are objects containing interface configuration.",
+        "patternProperties": {
+        "^[^/:.\\s]{1,2}[^/:\\s]{0,13}$": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "bootproto": {
+              "type": "string",
+              "enum": [
+                "none",
+                "bootp",
+                "dhcp",
+                "static",
+                "ibft",
+                "autoip",
+                "shared"
+              ],
+              "description": "Method used for IPv4 protocol configuration."
+            },
+            "device": {
+              "type": "string",
+              "description": "Interface name of the device."
+            },
+            "ipv6init": {
+              "type": "boolean",
+              "description": "Whether to initialize this device for IPv6 addressing."
+            },
+            "onboot": {
+              "type": "boolean",
+              "description": "Whether the connection should be autoconnected."
+            },
+            "peerdns": {
+              "type": "boolean",
+              "description": "Whether to modify /etc/resolv.conf."
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "Ethernet",
+                "Wireless",
+                "InfiniBand",
+                "Bridge",
+                "Bond",
+                "Vlan"
+              ],
+              "description": "Base type of the connection."
+            },
+            "userctl": {
+              "type": "boolean",
+              "description": "Whether non-root users are allowed to control the device."
+            }
+          }
+          }
+        }
+      }
+    }
   }
 }
 """
@@ -79,10 +173,7 @@ def configure_kernel(tree, kernel_options):
                 kernel_file.write(f"DEFAULTKERNEL={value}\n")
             else:
                 # schema does not currently allow any additional properties but it may at some point
-                print(f"Error: unknown property {option} specified for sysconfig kernel config.")
-                return 1
-
-    return 0
+                raise ValueError(f"Error: unknown property {option} specified for sysconfig kernel config.")
 
 
 def configure_network(tree, network_options):
@@ -94,10 +185,47 @@ def configure_network(tree, network_options):
                 network_file.write(f"NOZEROCONF={bool_to_string(value)}\n")
             else:
                 # schema does not currently allow any additional properties but it may at some point
-                print(f"Error: unknown property {option} specified for sysconfig network config.")
-                return 1
+                raise ValueError(f"Error: unknown property {option} specified for sysconfig network config.")
 
-    return 0
+
+def configure_network_scripts(tree, network_scripts_options):
+    if not network_scripts_options:
+        return
+
+    # if the network-scripts dir does not yet exist create it
+    os.makedirs(f"{tree}/etc/sysconfig/network-scripts", exist_ok=True)
+
+    network_scripts_ifcfg_options = network_scripts_options.get("ifcfg", {})
+
+    configure_network_scripts_ifcfg(tree, network_scripts_ifcfg_options)
+
+
+def configure_network_scripts_ifcfg(tree, network_scripts_ifcfg_options):
+    for ifname, ifconfig in network_scripts_ifcfg_options.items():
+        lines = []
+        for option, value in ifconfig.items():
+            if option == "device":
+                lines.append(f'DEVICE="{value}"\n')
+            elif option == "bootproto":
+                lines.append(f'BOOTPROTO="{value}"\n')
+            elif option == "onboot":
+                lines.append(f'ONBOOT="{bool_to_string(value)}"\n')
+            elif option == "type":
+                lines.append(f'TYPE="{value}"\n')
+            elif option == "userctl":
+                lines.append(f'USERCTL="{bool_to_string(value)}"\n')
+            elif option == "peerdns":
+                lines.append(f'PEERDNS="{bool_to_string(value)}"\n')
+            elif option == "ipv6init":
+                lines.append(f'IPV6INIT="{bool_to_string(value)}"\n')
+            else:
+                # schema does not currently allow any additional properties but it may at some point
+                raise ValueError(f"Error: unknown property {option} specified for sysconfig network-scripts/ifcfg "
+                    "config.")
+
+        if lines:
+            with open(f"{tree}/etc/sysconfig/network-scripts/ifcfg-{ifname}", 'w') as ifcfg_file:
+                ifcfg_file.writelines(lines)
 
 
 def main(tree, options):
@@ -106,11 +234,11 @@ def main(tree, options):
 
     kernel_options = options.get("kernel", {})
     network_options = options.get("network", {})
+    network_scripts_options = options.get("network-scripts", {})
 
-    if configure_kernel(tree, kernel_options):
-        return 1
-    if configure_network(tree, network_options):
-        return 1
+    configure_kernel(tree, kernel_options)
+    configure_network(tree, network_options)
+    configure_network_scripts(tree, network_scripts_options)
 
     return 0
 

--- a/test/data/stages/sysconfig/b.json
+++ b/test/data/stages/sysconfig/b.json
@@ -267,6 +267,28 @@
           "network": {
             "networking": true,
             "no_zero_conf": true
+          },
+          "network-scripts": {
+            "ifcfg": {
+              "eth0": {
+                "device": "eth0",
+                "bootproto": "dhcp",
+                "onboot": true,
+                "type": "Ethernet",
+                "userctl": true,
+                "peerdns": true,
+                "ipv6init": false
+              },
+              "eth1": {
+                "device": "eth1",
+                "bootproto": "dhcp",
+                "onboot": true,
+                "type": "Ethernet",
+                "userctl": false,
+                "peerdns": true,
+                "ipv6init": true
+              }
+            }
           }
         }
       }

--- a/test/data/stages/sysconfig/b.mpp.json
+++ b/test/data/stages/sysconfig/b.mpp.json
@@ -17,6 +17,28 @@
           "network": {
             "networking": true,
             "no_zero_conf": true
+          },
+          "network-scripts": {
+            "ifcfg": {
+              "eth0": {
+                "device": "eth0",
+                "bootproto": "dhcp",
+                "onboot": true,
+                "type": "Ethernet",
+                "userctl": true,
+                "peerdns": true,
+                "ipv6init": false
+              },
+              "eth1": {
+                "device": "eth1",
+                "bootproto": "dhcp",
+                "onboot": true,
+                "type": "Ethernet",
+                "userctl": false,
+                "peerdns": true,
+                "ipv6init": true
+              }
+            }
           }
         }
       }

--- a/test/data/stages/sysconfig/diff.json
+++ b/test/data/stages/sysconfig/diff.json
@@ -1,5 +1,9 @@
 {
-  "added_files": [],
+  "added_files": [
+    "/etc/sysconfig/network-scripts",
+    "/etc/sysconfig/network-scripts/ifcfg-eth0",
+    "/etc/sysconfig/network-scripts/ifcfg-eth1"
+  ],
   "deleted_files": [],
   "differences": {
     "/etc/sysconfig/network": {


### PR DESCRIPTION
Extend the `org.osbuild.sysconfig` stage to create `ifcfg-*` files under `network-scripts` subdirectory. It is possible to set only values currently set in RHEL AMI images, specifically:
 - BOOTPROTO
 - DEVICE
 - IPV6INIT
 - ONBOOT
 - PEERDNS
 - TYPE
 - USERCTL

Change all `configure_*` functions to raise ValueError exception, instead of returning values. As a follow up change, remove all checks of the returned value from these functions.

Update the `org.osbuild.sysconfig` stage test case to create ifcfg configuration files for two interfaces.

The schema string has been changed to raw string to prevent `DeprecationWarning: invalid escape sequence \s` warnings.