### PR TITLE
mockbuild: use s3cmd put instead of sync to speed up the RPM upload

### DIFF
--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -100,5 +100,5 @@ createrepo_c "${REPO_DIR}"
 # Upload repository to S3.
 greenprint "☁ Uploading RPMs to S3"
 pushd repo
-    s3cmd --acl-public sync . s3://${REPO_BUCKET}/
+    s3cmd --acl-public put --recursive . s3://${REPO_BUCKET}/
 popd


### PR DESCRIPTION
s3cmd sync actually downloads metadata for all objects in a s3 bucket.
We have built a lot of RPMs, thus this takes 5 minutes on AWS and 25 minutes
on my laptop (!!!).

Let's use recursive put instead. This doesn't delete any files on the remote
side. As we upload RPMs only once, this also shouldn't fail on "the
object already exists". Using this method, we should be able to upload the
RPMs in seconds.

The same patch was applied in osbuild-composer cf73edd2