### PR TITLE
stages/rpm: allow setting the dbpath

### DIFF
--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -48,6 +48,10 @@ from osbuild import api
 SCHEMA = """
 "additionalProperties": false,
 "properties": {
+   "dbpath": {
+     "desription": "Use the given path as RPM database",
+     "type": "string"
+  },
   "disable_dracut": {
     "description": "Prevent dracut from running",
     "type": "boolean"
@@ -114,6 +118,10 @@ SCHEMA_2 = """
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "dbpath": {
+      "desription": "Use the given path as RPM database",
+      "type": "string"
+    },
     "gpgkeys": {
       "description": "Array of GPG key contents to import",
       "type": "array",
@@ -174,7 +182,7 @@ SCHEMA_2 = """
 OSTREE_BOOTED_MARKER = "run/ostree-booted"
 
 
-def generate_package_metadata(tree):
+def generate_package_metadata(tree, rpm_args):
     query = r"""\{
     "name": "%{NAME}",
     "version": "%{VERSION}",
@@ -189,6 +197,7 @@ def generate_package_metadata(tree):
 
     cmd = [
         "rpm",
+        *rpm_args,
         "-qa",
         "--root", tree,
         "--qf=" + query
@@ -226,10 +235,12 @@ def enable_dracut(masked_files):
         os.unlink(path)
 
 
-def remove_unowned_etc_kernel(tree):
+def remove_unowned_etc_kernel(tree, rpm_args):
     # if installed, /etc/kernel is owned by systemd-udev; but
     # in case the directory is un-owned, remove it again
+
     res = subprocess.run(["rpm",
+                          *rpm_args,
                           "--root", tree,
                           "-qf", "/etc/kernel"],
                          stdout=subprocess.PIPE,
@@ -268,8 +279,16 @@ def create_machine_id_if_needed(tree):
     return True
 
 
+# pylint: disable=too-many-branches
 def main(tree, inputs, options):
     pkgpath, packages = parse_input(inputs)
+
+    dbpath = options.get("dbpath")
+
+    rpm_args = []
+    if dbpath:
+        print(f"dbpath set to '{dbpath}'")
+        rpm_args += ["--dbpath", dbpath]
 
     for key in options.get("gpgkeys", []):
         with tempfile.NamedTemporaryFile(prefix="gpgkey.", mode="w") as keyfile:
@@ -277,6 +296,7 @@ def main(tree, inputs, options):
             keyfile.flush()
             subprocess.run([
                 "rpmkeys",
+                *rpm_args,
                 "--root", tree,
                 "--import", keyfile.name
             ], check=True)
@@ -286,6 +306,7 @@ def main(tree, inputs, options):
         if data.get("rpm.check_gpg"):
             subprocess.run([
                 "rpmkeys",
+                *rpm_args,
                 "--root", tree,
                 "--checksig",
                 filename
@@ -306,7 +327,6 @@ def main(tree, inputs, options):
             f.write("")
 
     extra_args = []
-
     if options.get("exclude", {}).get("docs"):
         extra_args += ["--excludedocs"]
 
@@ -329,6 +349,7 @@ def main(tree, inputs, options):
         subprocess.run([
             "rpm",
             "--verbose",
+            *rpm_args,
             "--root", tree,
             *extra_args,
             # All digests and signatures of the rpms has been verified,
@@ -342,6 +363,7 @@ def main(tree, inputs, options):
         path = os.path.join(tree, key.lstrip("/"))
         subprocess.run([
             "rpmkeys",
+            *rpm_args,
             "--root", tree,
             "--import", path
         ], check=True)
@@ -350,7 +372,7 @@ def main(tree, inputs, options):
     # re-enabled dracut
     if no_dracut:
         enable_dracut(masked_files)
-        remove_unowned_etc_kernel(tree)
+        remove_unowned_etc_kernel(tree, rpm_args)
 
     # remove temporary machine ID if it was created by us
     if machine_id_created:
@@ -367,7 +389,7 @@ def main(tree, inputs, options):
         os.unlink(f"{tree}/var/lib/systemd/random-seed")
 
     # generate the metadata
-    md = generate_package_metadata(tree)
+    md = generate_package_metadata(tree, rpm_args)
     api.metadata(md)
 
     return 0

--- a/stages/org.osbuild.rpm.macros
+++ b/stages/org.osbuild.rpm.macros
@@ -60,7 +60,7 @@ def main(tree, options):
     with open(path, "w", encoding="utf-8") as f:
         for k, v in options["macros"].items():
             value = make_value(k, v)
-            line = f"%{k} {value}"
+            line = f"%{k} {value}\n"
             f.write(line)
 
 

--- a/stages/org.osbuild.rpm.macros
+++ b/stages/org.osbuild.rpm.macros
@@ -33,6 +33,10 @@ SCHEMA = r"""
         "items": {
           "type": "string"
         }
+      },
+      "_dbpath": {
+        "description": "Specify the rpm database path.",
+        "type": "string"
       }
     }
   }

--- a/test/data/manifests/fedora-ostree-commit.json
+++ b/test/data/manifests/fedora-ostree-commit.json
@@ -379,11 +379,21 @@
       "build": "name:build",
       "stages": [
         {
+          "type": "org.osbuild.rpm.macros",
+          "options": {
+            "filename": "/usr/lib/rpm/macros.d/macros.osbuild",
+            "macros": {
+              "_dbpath": "/usr/share/rpm"
+            }
+          }
+        },
+        {
           "type": "org.osbuild.rpm",
           "options": {
             "gpgkeys": [
               "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF1RVqsBEADWMBqYv/G1r4PwyiPQCfg5fXFGXV1FCZ32qMi9gLUTv1CX7rYy\nH4Inj93oic+lt1kQ0kQCkINOwQczOkm6XDkEekmMrHknJpFLwrTK4AS28bYF2RjL\nM+QJ/dGXDMPYsP0tkLvoxaHr9WTRq89A+AmONcUAQIMJg3JxXAAafBi2UszUUEPI\nU35MyufFt2ePd1k/6hVAO8S2VT72TxXSY7Ha4X2J0pGzbqQ6Dq3AVzogsnoIi09A\n7fYutYZPVVAEGRUqavl0th8LyuZShASZ38CdAHBMvWV4bVZghd/wDV5ev3LXUE0o\nitLAqNSeiDJ3grKWN6v0qdU0l3Ya60sugABd3xaE+ROe8kDCy3WmAaO51Q880ZA2\niXOTJFObqkBTP9j9+ZeQ+KNE8SBoiH1EybKtBU8HmygZvu8ZC1TKUyL5gwGUJt8v\nergy5Bw3Q7av520sNGD3cIWr4fBAVYwdBoZT8RcsnU1PP67NmOGFcwSFJ/LpiOMC\npZ1IBvjOC7KyKEZY2/63kjW73mB7OHOd18BHtGVkA3QAdVlcSule/z68VOAy6bih\nE6mdxP28D4INsts8w6yr4G+3aEIN8u0qRQq66Ri5mOXTyle+ONudtfGg3U9lgicg\nz6oVk17RT0jV9uL6K41sGZ1sH/6yTXQKagdAYr3w1ix2L46JgzC+/+6SSwARAQAB\ntDFGZWRvcmEgKDMyKSA8ZmVkb3JhLTMyLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJdUVarAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRBsEwJtEslE0LdAD/wKdAMtfzr7O2y06/sOPnrb3D39Y2DXbB8y0iEmRdBL29Bq\n5btxwmAka7JZRJVFxPsOVqZ6KARjS0/oCBmJc0jCRANFCtM4UjVHTSsxrJfuPkel\nvrlNE9tcR6OCRpuj/PZgUa39iifF/FTUfDgh4Q91xiQoLqfBxOJzravQHoK9VzrM\nNTOu6J6l4zeGzY/ocj6DpT+5fdUO/3HgGFNiNYPC6GVzeiA3AAVR0sCyGENuqqdg\nwUxV3BIht05M5Wcdvxg1U9x5I3yjkLQw+idvX4pevTiCh9/0u+4g80cT/21Cxsdx\n7+DVHaewXbF87QQIcOAing0S5QE67r2uPVxmWy/56TKUqDoyP8SNsV62lT2jutsj\nLevNxUky011g5w3bc61UeaeKrrurFdRs+RwBVkXmtqm/i6g0ZTWZyWGO6gJd+HWA\nqY1NYiq4+cMvNLatmA2sOoCsRNmE9q6jM/ESVgaH8hSp8GcLuzt9/r4PZZGl5CvU\neldOiD221u8rzuHmLs4dsgwJJ9pgLT0cUAsOpbMPI0JpGIPQ2SG6yK7LmO6HFOxb\nAkz7IGUt0gy1MzPTyBvnB+WgD1I+IQXXsJbhP5+d+d3mOnqsd6oDM/grKBzrhoUe\noNadc9uzjqKlOrmrdIR3Bz38SSiWlde5fu6xPqJdmGZRNjXtcyJlbSPVDIloxw==\n=QWRO\n-----END PGP PUBLIC KEY BLOCK-----\n"
             ],
+            "dbpath": "/usr/share/rpm",
             "ostree_booted": true
           },
           "inputs": {

--- a/test/data/manifests/fedora-ostree-commit.mpp.json
+++ b/test/data/manifests/fedora-ostree-commit.mpp.json
@@ -22,11 +22,21 @@
       "build": "name:build",
       "stages": [
         {
+          "type": "org.osbuild.rpm.macros",
+          "options": {
+            "filename": "/usr/lib/rpm/macros.d/macros.osbuild",
+            "macros": {
+              "_dbpath": "/usr/share/rpm"
+            }
+          }
+        },
+        {
           "type": "org.osbuild.rpm",
           "options": {
             "gpgkeys": [
               "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF1RVqsBEADWMBqYv/G1r4PwyiPQCfg5fXFGXV1FCZ32qMi9gLUTv1CX7rYy\nH4Inj93oic+lt1kQ0kQCkINOwQczOkm6XDkEekmMrHknJpFLwrTK4AS28bYF2RjL\nM+QJ/dGXDMPYsP0tkLvoxaHr9WTRq89A+AmONcUAQIMJg3JxXAAafBi2UszUUEPI\nU35MyufFt2ePd1k/6hVAO8S2VT72TxXSY7Ha4X2J0pGzbqQ6Dq3AVzogsnoIi09A\n7fYutYZPVVAEGRUqavl0th8LyuZShASZ38CdAHBMvWV4bVZghd/wDV5ev3LXUE0o\nitLAqNSeiDJ3grKWN6v0qdU0l3Ya60sugABd3xaE+ROe8kDCy3WmAaO51Q880ZA2\niXOTJFObqkBTP9j9+ZeQ+KNE8SBoiH1EybKtBU8HmygZvu8ZC1TKUyL5gwGUJt8v\nergy5Bw3Q7av520sNGD3cIWr4fBAVYwdBoZT8RcsnU1PP67NmOGFcwSFJ/LpiOMC\npZ1IBvjOC7KyKEZY2/63kjW73mB7OHOd18BHtGVkA3QAdVlcSule/z68VOAy6bih\nE6mdxP28D4INsts8w6yr4G+3aEIN8u0qRQq66Ri5mOXTyle+ONudtfGg3U9lgicg\nz6oVk17RT0jV9uL6K41sGZ1sH/6yTXQKagdAYr3w1ix2L46JgzC+/+6SSwARAQAB\ntDFGZWRvcmEgKDMyKSA8ZmVkb3JhLTMyLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJdUVarAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRBsEwJtEslE0LdAD/wKdAMtfzr7O2y06/sOPnrb3D39Y2DXbB8y0iEmRdBL29Bq\n5btxwmAka7JZRJVFxPsOVqZ6KARjS0/oCBmJc0jCRANFCtM4UjVHTSsxrJfuPkel\nvrlNE9tcR6OCRpuj/PZgUa39iifF/FTUfDgh4Q91xiQoLqfBxOJzravQHoK9VzrM\nNTOu6J6l4zeGzY/ocj6DpT+5fdUO/3HgGFNiNYPC6GVzeiA3AAVR0sCyGENuqqdg\nwUxV3BIht05M5Wcdvxg1U9x5I3yjkLQw+idvX4pevTiCh9/0u+4g80cT/21Cxsdx\n7+DVHaewXbF87QQIcOAing0S5QE67r2uPVxmWy/56TKUqDoyP8SNsV62lT2jutsj\nLevNxUky011g5w3bc61UeaeKrrurFdRs+RwBVkXmtqm/i6g0ZTWZyWGO6gJd+HWA\nqY1NYiq4+cMvNLatmA2sOoCsRNmE9q6jM/ESVgaH8hSp8GcLuzt9/r4PZZGl5CvU\neldOiD221u8rzuHmLs4dsgwJJ9pgLT0cUAsOpbMPI0JpGIPQ2SG6yK7LmO6HFOxb\nAkz7IGUt0gy1MzPTyBvnB+WgD1I+IQXXsJbhP5+d+d3mOnqsd6oDM/grKBzrhoUe\noNadc9uzjqKlOrmrdIR3Bz38SSiWlde5fu6xPqJdmGZRNjXtcyJlbSPVDIloxw==\n=QWRO\n-----END PGP PUBLIC KEY BLOCK-----\n"
             ],
+            "dbpath": "/usr/share/rpm",
             "ostree_booted": true
           },
           "inputs": {

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -379,11 +379,21 @@
       "build": "name:build",
       "stages": [
         {
+          "type": "org.osbuild.rpm.macros",
+          "options": {
+            "filename": "/usr/lib/rpm/macros.d/macros.osbuild",
+            "macros": {
+              "_dbpath": "/usr/share/rpm"
+            }
+          }
+        },
+        {
           "type": "org.osbuild.rpm",
           "options": {
             "gpgkeys": [
               "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBF1RVqsBEADWMBqYv/G1r4PwyiPQCfg5fXFGXV1FCZ32qMi9gLUTv1CX7rYy\nH4Inj93oic+lt1kQ0kQCkINOwQczOkm6XDkEekmMrHknJpFLwrTK4AS28bYF2RjL\nM+QJ/dGXDMPYsP0tkLvoxaHr9WTRq89A+AmONcUAQIMJg3JxXAAafBi2UszUUEPI\nU35MyufFt2ePd1k/6hVAO8S2VT72TxXSY7Ha4X2J0pGzbqQ6Dq3AVzogsnoIi09A\n7fYutYZPVVAEGRUqavl0th8LyuZShASZ38CdAHBMvWV4bVZghd/wDV5ev3LXUE0o\nitLAqNSeiDJ3grKWN6v0qdU0l3Ya60sugABd3xaE+ROe8kDCy3WmAaO51Q880ZA2\niXOTJFObqkBTP9j9+ZeQ+KNE8SBoiH1EybKtBU8HmygZvu8ZC1TKUyL5gwGUJt8v\nergy5Bw3Q7av520sNGD3cIWr4fBAVYwdBoZT8RcsnU1PP67NmOGFcwSFJ/LpiOMC\npZ1IBvjOC7KyKEZY2/63kjW73mB7OHOd18BHtGVkA3QAdVlcSule/z68VOAy6bih\nE6mdxP28D4INsts8w6yr4G+3aEIN8u0qRQq66Ri5mOXTyle+ONudtfGg3U9lgicg\nz6oVk17RT0jV9uL6K41sGZ1sH/6yTXQKagdAYr3w1ix2L46JgzC+/+6SSwARAQAB\ntDFGZWRvcmEgKDMyKSA8ZmVkb3JhLTMyLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQI4BBMBAgAiBQJdUVarAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK\nCRBsEwJtEslE0LdAD/wKdAMtfzr7O2y06/sOPnrb3D39Y2DXbB8y0iEmRdBL29Bq\n5btxwmAka7JZRJVFxPsOVqZ6KARjS0/oCBmJc0jCRANFCtM4UjVHTSsxrJfuPkel\nvrlNE9tcR6OCRpuj/PZgUa39iifF/FTUfDgh4Q91xiQoLqfBxOJzravQHoK9VzrM\nNTOu6J6l4zeGzY/ocj6DpT+5fdUO/3HgGFNiNYPC6GVzeiA3AAVR0sCyGENuqqdg\nwUxV3BIht05M5Wcdvxg1U9x5I3yjkLQw+idvX4pevTiCh9/0u+4g80cT/21Cxsdx\n7+DVHaewXbF87QQIcOAing0S5QE67r2uPVxmWy/56TKUqDoyP8SNsV62lT2jutsj\nLevNxUky011g5w3bc61UeaeKrrurFdRs+RwBVkXmtqm/i6g0ZTWZyWGO6gJd+HWA\nqY1NYiq4+cMvNLatmA2sOoCsRNmE9q6jM/ESVgaH8hSp8GcLuzt9/r4PZZGl5CvU\neldOiD221u8rzuHmLs4dsgwJJ9pgLT0cUAsOpbMPI0JpGIPQ2SG6yK7LmO6HFOxb\nAkz7IGUt0gy1MzPTyBvnB+WgD1I+IQXXsJbhP5+d+d3mOnqsd6oDM/grKBzrhoUe\noNadc9uzjqKlOrmrdIR3Bz38SSiWlde5fu6xPqJdmGZRNjXtcyJlbSPVDIloxw==\n=QWRO\n-----END PGP PUBLIC KEY BLOCK-----\n"
             ],
+            "dbpath": "/usr/share/rpm",
             "ostree_booted": true
           },
           "inputs": {


### PR DESCRIPTION
Allows to specify a different database path for the `rpm` stage. Will create a macro where the `_dbpath` is set, so that `rpm` and other tools can find the db.