### PR TITLE
stages/qemu: honour coroutines env variable

### DIFF
--- a/stages/org.osbuild.qemu
+++ b/stages/org.osbuild.qemu
@@ -163,6 +163,11 @@ def main(inputs, output, options):
     if callable(extra_args):
         extra_args = extra_args(fmt)
 
+    coroutines = os.environ.get("OSBUILD_QEMU_IMG_COROUTINES")
+    if coroutines:
+        print(f"qemu-img coroutines: {coroutines}")
+        extra_args += ["-m", coroutines]
+
     cmd = [
         "qemu-img", "convert",
         "-O", fmt["type"],


### PR DESCRIPTION
The `OSBUILD_QEMU_IMG_COROUTINES` was introduced to allow specifying the number of coroutines used in `qemu-img convert` by the runner, or `osbuild` directly. This can be useful in various scenarios, but is specifically used by the rhel 8.2+ runner to limit the number of coroutines used for Aarch64 to one, since a bug in `qemu-img` leads to random hangs on that platform.