### PR TITLE
stages/sfdisk: use device not file

### DIFF
--- a/stages/org.osbuild.sfdisk
+++ b/stages/org.osbuild.sfdisk
@@ -4,7 +4,6 @@ Partition a target using sfdisk(8)
 """
 
 import json
-import os
 import subprocess
 import sys
 
@@ -12,53 +11,62 @@ import sys
 import osbuild.api
 
 
-SCHEMA = """
-"additionalProperties": false,
-"required": ["filename", "label", "uuid"],
-"properties": {
-  "filename": {
-    "description": "Image filename",
-    "type": "string"
-  },
-  "uuid": {
-    "description": "UUID for the disk image's partition table",
-    "type": "string"
-  },
-  "label": {
-    "description": "The type of the partition table",
-    "type": "string",
-    "enum": ["mbr", "dos", "gpt"]
-  },
-  "partitions": {
-    "description": "Partition layout ",
-    "type": "array",
-    "items": {
-      "description": "Description of one partition",
+SCHEMA_2 = r"""
+"devices": {
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["device"],
+  "properties": {
+    "device": {
       "type": "object",
-      "properties": {
-        "bootable": {
-          "description": "Mark the partition as bootable (dos)",
-          "type": "boolean"
-        },
-        "name": {
-          "description": "The partition name (GPT)",
-          "type": "string"
-        },
-        "size": {
-          "description": "The size of this partition",
-          "type": "integer"
-        },
-        "start": {
-          "description": "The start offset of this partition",
-          "type": "integer"
-        },
-        "type": {
-          "description": "The partition type (UUID or identifier)",
-          "type": "string"
-        },
-        "uuid": {
-           "description": "UUID of the partition (GPT)",
-           "type": "string"
+      "additionalProperties": true
+    }
+  }
+},
+"options": {
+  "additionalProperties": false,
+  "required": ["label", "uuid"],
+  "properties": {
+    "uuid": {
+      "description": "UUID for the disk image's partition table",
+      "type": "string"
+    },
+    "label": {
+      "description": "The type of the partition table",
+      "type": "string",
+      "enum": ["mbr", "dos", "gpt"]
+    },
+    "partitions": {
+      "description": "Partition layout ",
+      "type": "array",
+      "items": {
+        "description": "Description of one partition",
+        "type": "object",
+        "properties": {
+          "bootable": {
+            "description": "Mark the partition as bootable (dos)",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The partition name (GPT)",
+            "type": "string"
+          },
+          "size": {
+            "description": "The size of this partition",
+            "type": "integer"
+          },
+          "start": {
+            "description": "The start offset of this partition",
+            "type": "integer"
+          },
+          "type": {
+            "description": "The partition type (UUID or identifier)",
+            "type": "string"
+          },
+          "uuid": {
+            "description": "UUID of the partition (GPT)",
+            "type": "string"
+          }
         }
       }
     }
@@ -173,25 +181,24 @@ def partition_from_json(js) -> Partition:
     return p
 
 
-def main(tree, options):
-    filename = options["filename"]
+def main(devices, options):
+    device = devices["device"]["path"]
+
     ptuuid = options["uuid"]
     pttype = options["label"]
     partitions = options.get("partitions")
 
-    dest = os.path.join(tree, filename.lstrip("/"))
-
     parts = [partition_from_json(p) for p in partitions]
     pt = PartitionTable(pttype, ptuuid, parts)
 
-    pt.write_to(dest)
+    pt.write_to(device)
 
-    subprocess.run(["sfdisk", "--json", dest],
+    subprocess.run(["sfdisk", "--json", device],
                    encoding='utf-8',
                    check=False)
 
 
 if __name__ == '__main__':
     args = osbuild.api.arguments()
-    ret = main(args["tree"], args["options"])
+    ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.sfdisk
+++ b/stages/org.osbuild.sfdisk
@@ -145,7 +145,7 @@ class PartitionTable:
 
         print(command)
 
-        subprocess.run(["sfdisk", "-q", target],
+        subprocess.run(["sfdisk", "-q", "--no-tell-kernel", target],
                        input=command,
                        encoding='utf-8',
                        check=True)

--- a/stages/org.osbuild.sfdisk
+++ b/stages/org.osbuild.sfdisk
@@ -173,22 +173,17 @@ def partition_from_json(js) -> Partition:
     return p
 
 
-def partition_table_from_options(options) -> PartitionTable:
-    ptuuid = options["uuid"]
-    pttype = options.get("label", "dos")
-    partitions = options.get("partitions")
-
-    if pttype == "mbr":
-        pttype = "dos"
-
-    parts = [partition_from_json(p) for p in partitions]
-    return PartitionTable(pttype, ptuuid, parts)
-
-
 def main(tree, options):
     filename = options["filename"]
+    ptuuid = options["uuid"]
+    pttype = options["label"]
+    partitions = options.get("partitions")
+
     dest = os.path.join(tree, filename.lstrip("/"))
-    pt = partition_table_from_options(options)
+
+    parts = [partition_from_json(p) for p in partitions]
+    pt = PartitionTable(pttype, ptuuid, parts)
+
     pt.write_to(dest)
 
     subprocess.run(["sfdisk", "--json", dest],

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -840,8 +840,15 @@
         },
         {
           "type": "org.osbuild.sfdisk",
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            }
+          },
           "options": {
-            "filename": "disk.img",
             "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
             "label": "gpt",
             "partitions": [

--- a/test/data/manifests/fedora-ostree-image.mpp.json
+++ b/test/data/manifests/fedora-ostree-image.mpp.json
@@ -171,8 +171,15 @@
         },
         {
           "type": "org.osbuild.sfdisk",
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            }
+          },
           "options": {
-            "filename": "disk.img",
             "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
             "label": "gpt",
             "partitions": [


### PR DESCRIPTION
Instead of operating directly on a file, which was previously specified by `filename`, operate on a device. This is more flexible since a file can be accessed via a loop back device; but the inverse is obviously not true, like other devices can not be accessed via a plain file.
Therefore, re-factor the stage to use a device and adapt the existing test (`fedora-ostree-image`).