### PR TITLE
assemblers/ostree: fix copying of `var`

### DIFF
--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -81,7 +81,7 @@ TOPLEVEL_LINKS = {
 
 def copy(name, source, dest):
     subprocess.run(["cp", "--reflink=auto", "-a",
-                    os.path.join(source, name),
+                    os.path.join(source, name, "."),
                     os.path.join(dest, name)],
                    check=True)
 


### PR DESCRIPTION
In the ostree assembler, `var`, `usr` and `boot` are copied from the built tree to a newly initialized and ostree-conforming root filesystem. The way in which `cp` was called resulted in the source being created inside the target, if the latter existed. This was the case for `var` resulting in `var/var`. Use `cp ${source}/. {target}` to fix that.