### PR TITLE
stages/ostree.preptree: Link to rpm-ostree code

### DIFF
--- a/stages/org.osbuild.ostree.preptree
+++ b/stages/org.osbuild.ostree.preptree
@@ -65,7 +65,9 @@ SCHEMA = """
 """
 
 
+# Corresponds to https://github.com/coreos/rpm-ostree/blob/7b9a20b20ecd5a2ceb11ca9edf86984dc3065183/rust/src/composepost.rs#L58
 TOPLEVEL_DIRS = ["dev", "proc", "run", "sys", "sysroot", "var"]
+# Corresponds to https://github.com/coreos/rpm-ostree/blob/7b9a20b20ecd5a2ceb11ca9edf86984dc3065183/rust/src/composepost.rs#L123
 TOPLEVEL_LINKS = {
     "home": "var/home",
     "media": "run/media",
@@ -81,8 +83,9 @@ def move(name, source, dest):
     os.rename(os.path.join(source, name), os.path.join(dest, name))
 
 
+# See https://ostreedev.github.io/ostree/adapting-existing/
 def init_rootfs(root, tmp_is_dir):
-    """Initialize a pristine root file-system"""
+    """Initialize a root filesystem in OSTree layout."""
 
     fd = os.open(root, os.O_DIRECTORY)
 


### PR DESCRIPTION
This code was clearly influenced/copied from rpm-ostree,
since it's now duplicated let's cross-link to help ensure that
if someone wants to change this they hopefully consider changing
rpm-ostree too.