### PR TITLE
spec: install devices and mounts

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -119,8 +119,14 @@ install -p -m 0755 $(find runners -type f -or -type l) %{buildroot}%{pkgdir}/run
 mkdir -p %{buildroot}%{pkgdir}/sources
 install -p -m 0755 $(find sources -type f) %{buildroot}%{pkgdir}/sources
 
+mkdir -p %{buildroot}%{pkgdir}/devices
+install -p -m 0755 $(find devices -type f) %{buildroot}%{pkgdir}/devices
+
 mkdir -p %{buildroot}%{pkgdir}/inputs
 install -p -m 0755 $(find inputs -type f) %{buildroot}%{pkgdir}/inputs
+
+mkdir -p %{buildroot}%{pkgdir}/mounts
+install -p -m 0755 $(find mounts -type f) %{buildroot}%{pkgdir}/mounts
 
 # mount point for bind mounting the osbuild library
 mkdir -p %{buildroot}%{pkgdir}/osbuild


### PR DESCRIPTION
The new modules for devices and mounts need to be installed so that they actually end up in the rpm.