### PR TITLE
 `stages/copy`: small fixes for the url parsing

### DIFF
--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -27,27 +27,27 @@ SCHEMA_2 = r"""
   "required": ["paths"],
   "properties": {
     "paths": {
-    "description": "Array of items to copy",
-    "type": "array",
-    "minItems": 1,
-    "items": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["from", "to"],
-      "properties": {
-        "from": {
-          "type": "string",
-          "description": "The source",
-          "pattern": "^input:\/\/[^\/]+\/"
-        },
-        "to": {
-          "type": "string",
-          "description": "The destination",
-          "pattern": "^(tree|mount):\/\/[^\/]+\/"
+      "description": "Array of items to copy",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["from", "to"],
+        "properties": {
+          "from": {
+            "type": "string",
+            "description": "The source",
+            "pattern": "^input:\/\/[^\/]+\/"
+          },
+          "to": {
+            "type": "string",
+            "description": "The destination",
+            "pattern": "^(tree|mount):\/\/[^\/]+\/"
+          }
         }
       }
     }
-  }
   }
 },
 "devices": {

--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -83,7 +83,7 @@ def parse_input(url: ParseResult, args: Dict):
     if root is None:
         raise ValueError(f"Unknown input '{root}'")
 
-    return os.path.join(root, url.path.lstrip("/"))
+    return root
 
 
 def parse_location(location, args):

--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -41,9 +41,18 @@ SCHEMA_2 = r"""
             "pattern": "^input:\/\/[^\/]+\/"
           },
           "to": {
-            "type": "string",
-            "description": "The destination",
-            "pattern": "^(tree|mount):\/\/[^\/]+\/"
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "The destination, if a mount",
+                "pattern": "^mount:\/\/[^\/]+\/"
+              },
+              {
+                "type": "string",
+                "description": "The destination, if a tree",
+                "pattern": "^tree:\/\/\/"
+              }
+            ]
           }
         }
       }


### PR DESCRIPTION
The path for inputs:// was appended twice, the tree:/// does not take a network location.