### PR TITLE
build: reintroduce Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,16 @@
+# https://packit.dev/docs/configuration/
+
+specfile_path: osbuild.spec
+
+synced_files:
+    - osbuild.spec
+    - .packit.yaml
+
+upstream_package_name: osbuild
+downstream_package_name: osbuild
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets: fedora-all


### PR DESCRIPTION
Let's try again if the service works and can help us release osbuild into Fedora.