### PR TITLE
test: isolate command and arguments in use of subprocess.run

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -395,7 +395,7 @@ class OSBuild(contextlib.AbstractContextManager):
         to_path = os.path.join(target, "sources", source)
         os.makedirs(to_path, exist_ok=True)
 
-        subprocess.run(["cp", "--reflink=auto", "-a",
-                        os.path.join(from_path, "."),
-                        to_path],
-                       check=True)
+        subprocess.run([
+            "cp", "--reflink=auto", "-a",
+            os.path.join(from_path, "."), to_path
+        ], check=True)

--- a/test/test.py
+++ b/test/test.py
@@ -175,10 +175,10 @@ class TestBase(unittest.TestCase):
         """
 
         try:
-            r = subprocess.run(["rpm-ostree", "--version"],
-                               encoding="utf-8",
-                               stdout=subprocess.PIPE,
-                               check=False)
+            r = subprocess.run(
+                ["rpm-ostree", "--version"],
+                encoding="utf-8", stdout=subprocess.PIPE, check=False
+            )
         except FileNotFoundError:
             return False
 
@@ -236,10 +236,11 @@ class OSBuild(contextlib.AbstractContextManager):
             cache = tempfile.TemporaryDirectory(dir="/var/tmp")
             self._cachedir = self._exitstack.enter_context(cache)
             if self._cache_from is not None:
-                subprocess.run(["cp", "--reflink=auto", "-a",
-                                os.path.join(self._cache_from, "."),
-                                self._cachedir],
-                               check=True)
+                subprocess.run([
+                    "cp", "--reflink=auto", "-a",
+                    os.path.join(self._cache_from, "."),
+                    self._cachedir
+                ], check=True)
 
             # Keep our ExitStack for `__exit__()`.
             self._exitstack = self._exitstack.pop_all()


### PR DESCRIPTION
The command and its arguments are the most important part of the arguments to `subprocess.run`, so they should be highlighted in the indentation.

This was originally going to be a trivial spelling fix as a test of the process of contributing to `osbuild`, but your comments and docstrings are all impeccably spelled!

Signed-off-by: Paul Wayper <paulway@redhat.com>