### PR TITLE
objectstore: eagerly unmount bind-mounts

### DIFF
--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -44,7 +44,7 @@ def mount(source, target, bind=True, ro=True, private=True, mode="0755"):
         raise RuntimeError(f"{msg} (code: {code})")
 
 
-def umount(target, lazy=True):
+def umount(target, lazy=False):
     args = []
     if lazy:
         args += ["--lazy"]


### PR DESCRIPTION
In the object store, temporary bind mounts are used when accessing the content, i.e. the individual trees. Their unmount is currently done with the `--lazy` flag. The use of this flag goes way back to commit da121beda1570f9b43fda75f3aefbba2c848d7f2, which sadly does not mention why the flag was introduced. Since the tree and files in the tree will be used by consequent stages it seems reasonable to do the un-mounting eagerly and thus this reverts back to that behavior.