### PR TITLE
buildroot: mount /sys as read-only

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -177,7 +177,7 @@ class BuildRoot(contextlib.AbstractContextManager):
 
         # Setup API file-systems.
         mounts += ["--proc", "/proc"]
-        mounts += ["--bind", "/sys", "/sys"]
+        mounts += ["--ro-bind", "/sys", "/sys"]
         mounts += ["--ro-bind-try", "/sys/fs/selinux", "/sys/fs/selinux"]
 
         # There was a bug in mke2fs (fixed in versionv 1.45.7) where mkfs.ext4


### PR DESCRIPTION
This will prevent any modification of anything in `/sys`. It will also prevent `udevadm tigger` to run, which needs /sys writeable. This is a desired effect, since uevents are not delivered to the contained environment, so `udevadm trigger` might hang. This is to counter issues like https://github.com/osbuild/image-builder/issues/206

I have tested it locally, specifically with a rhel based artefact that contains `rng-tools` and it seems to not cause any issues.

