### PR TITLE
devcontainer: add pyyaml dependency

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
 FROM fedora:latest
 RUN dnf install -y \
+    bat \
     findutils \
     fish \
     fpaste \
     git \
+    glibc-langpack-en \
     hostname \
     jq \
     libguestfs-tools libguestfs \
@@ -26,10 +28,12 @@ RUN dnf install -y \
     python3-pycodestyle \
     python3-pylint \
     python3-pytest \
+    python3-pyyaml \
     rpm-build \
     rpmlint \
     selinux-policy-devel \
     skopeo \
+    strace \
     the_silver_searcher \
     tree
 


### PR DESCRIPTION
This is needed for the pylint to work correctly with the new cloud-init stage.
While there, add some more utilities useful for debugging. Also add glibc-langpack-en needed for `en_GB`.