### PR TITLE
mpp: Use the right format for the file secrets

### DIFF
--- a/tools/mpp.py
+++ b/tools/mpp.py
@@ -378,7 +378,7 @@ class ManifestFile:
             if secretes:
                 data = {
                     "url": url,
-                    "secrets": secretes
+                    "secrets": { "name": secretes }
                 }
             else:
                 data = url


### PR DESCRIPTION
I was getting:

.sources.org.osbuild.curl.items.sha256:02c8f76fd8b13972c541e4fa3bd2101681b7d4baa1320e3101bc4167b5531685:
  {'url': 'https://cdn.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/Packages/e/elfutils-libelf-0.182-3.el8.aarch64.rpm', 'secrets': 'org.osbuild.rhsm'} is not valid under any of the given schemas

Because the secrets key should have an object, not a string value.