### PR TITLE
ci: Start building on 8.5 aarch64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,7 @@ RPM:
         REGISTER: "true"
       - RUNNER:
           - aws/rhel-8.5-x86_64
+          - aws/rhel-8.5-aarch64
         INTERNAL_NETWORK: "true"
 
 Testing:


### PR DESCRIPTION
we need the RPM before we can even start testing osbuild-composer on
aarch64.