### PR TITLE
Pass arguments to stages as a plain file

### DIFF
--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -139,10 +139,9 @@ class API(BaseAPI):
 
     endpoint = "osbuild"
 
-    def __init__(self, args, monitor, *, socket_address=None):
+    def __init__(self, args, *, socket_address=None):
         super().__init__(socket_address)
         self.input = args
-        self.monitor = monitor
         self.metadata = {}
         self.error = None
 

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -207,32 +207,11 @@ def exception_handler(path="/run/osbuild/api/osbuild"):
         exception(e, path)
 
 
-def arguments(path="/run/osbuild/api/osbuild"):
+def arguments(path="/run/osbuild/api/arguments"):
     """Retrieve the input arguments that were supplied to API"""
-    with jsoncomm.Socket.new_client(path) as client:
-        req = {"method": "get-arguments"}
-        client.send(req)
-        msg, fds, _ = client.recv()
-        assert msg["type"] == "fd"
-        fd = msg["fd"]
-        with os.fdopen(fds.steal(fd), encoding="utf-8") as f:
-            data = json.load(f)
-
-        # Root relative paths: since paths are different on the
-        # host and in the container they are transmitted not as
-        # absolute but relative paths. For all items that have
-        # registered roots, re-root their path entries here
-        for name, root in data.get("paths", {}).items():
-            group = data.get(name)
-            if not group or not isinstance(group, dict):
-                continue
-            for item in group.values():
-                path = item.get("path")
-                if not path:
-                    continue
-                item["path"] = os.path.join(root, path)
-
-        return data
+    with open(path, "r", encoding="utf-8") as fp:
+        data = json.load(fp)
+    return data
 
 
 def metadata(data: Dict, path="/run/osbuild/api/osbuild"):

--- a/osbuild/host.py
+++ b/osbuild/host.py
@@ -257,7 +257,10 @@ class Service(abc.ABC):
                 _, val, tb = sys.exc_info()
                 reply = self.protocol.encode_exception(val, tb)
 
-            self.sock.send(reply, fds=fds)
+            try:
+                self.sock.send(reply, fds=fds)
+            except BrokenPipeError:
+                break
 
     def _handle_message(self, msg, fds):
         """

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -82,8 +82,7 @@ class Stage:
     def run(self, tree, runner, build_tree, store, monitor, libdir):
         with contextlib.ExitStack() as cm:
 
-            build_root = buildroot.BuildRoot(
-                build_tree, runner, libdir, store.tmp)
+            build_root = buildroot.BuildRoot(build_tree, runner, libdir, store.tmp)
             cm.enter_context(build_root)
 
             inputs_tmpdir = store.tempdir(prefix="inputs-")

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -147,7 +147,7 @@ class Stage:
                 data = mount.mount(mgr, abspath, mounts_tmpdir)
                 mounts[key] = data
 
-            api = API(args, monitor)
+            api = API(args)
             build_root.register_api(api)
 
             rls = remoteloop.LoopServer()

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -172,7 +172,7 @@ class Stage:
 
             self.prepare_arguments(args, args_path)
 
-            api = API(args)
+            api = API()
             build_root.register_api(api)
 
             rls = remoteloop.LoopServer()

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -85,16 +85,19 @@ class Stage:
             build_root = buildroot.BuildRoot(build_tree, runner, libdir, store.tmp)
             cm.enter_context(build_root)
 
-            inputs_tmpdir = store.tempdir(prefix="inputs-")
-            inputs_tmpdir = cm.enter_context(inputs_tmpdir)
+            tmpdir = store.tempdir(prefix="buildroot-tmp-")
+            tmpdir = cm.enter_context(tmpdir)
+
+            inputs_tmpdir = os.path.join(tmpdir, "inputs")
+            os.makedirs(inputs_tmpdir)
             inputs_mapped = "/run/osbuild/inputs"
             inputs = {}
 
             devices_mapped = "/dev"
             devices = {}
 
-            mounts_tmpdir = store.tempdir(prefix="mounts-")
-            mounts_tmpdir = cm.enter_context(mounts_tmpdir)
+            mounts_tmpdir = os.path.join(tmpdir, "mounts")
+            os.makedirs(mounts_tmpdir)
             mounts_mapped = "/run/osbuild/mounts"
             mounts = {}
 

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -72,9 +72,8 @@ class TestAPI(unittest.TestCase):
         tmpdir = self.tmp.name
         path = os.path.join(tmpdir, "osbuild-api")
         args = {"options": {"answer": 42}}
-        monitor = osbuild.monitor.BaseMonitor(sys.stderr.fileno())
 
-        with osbuild.api.API(args, monitor, socket_address=path) as _:
+        with osbuild.api.API(args, socket_address=path) as _:
             data = osbuild.api.arguments(path=path)
             self.assertEqual(data, args)
 
@@ -83,14 +82,13 @@ class TestAPI(unittest.TestCase):
         tmpdir = self.tmp.name
         path = os.path.join(tmpdir, "osbuild-api")
         args = {}
-        monitor = osbuild.monitor.BaseMonitor(sys.stderr.fileno())
 
         def exception(path):
             with osbuild.api.exception_handler(path):
                 raise ValueError("osbuild test exception")
             assert False, "api.exception should exit process"
 
-        api = osbuild.api.API(args, monitor, socket_address=path)
+        api = osbuild.api.API(args, socket_address=path)
         with api:
             p = mp.Process(target=exception, args=(path, ))
             p.start()
@@ -112,14 +110,13 @@ class TestAPI(unittest.TestCase):
         tmpdir = self.tmp.name
         path = os.path.join(tmpdir, "osbuild-api")
         args = {}
-        monitor = osbuild.monitor.BaseMonitor(sys.stderr.fileno())
 
         def metadata(path):
             data = {"meta": "42"}
             osbuild.api.metadata(data, path=path)
             return 0
 
-        api = osbuild.api.API(args, monitor, socket_address=path)
+        api = osbuild.api.API(args, socket_address=path)
         with api:
             p = mp.Process(target=metadata, args=(path, ))
             p.start()

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -4,7 +4,6 @@
 
 import os
 import multiprocessing as mp
-import sys
 import tempfile
 import unittest
 
@@ -68,27 +67,17 @@ class TestAPI(unittest.TestCase):
                 with api:
                     pass
 
-    def test_get_arguments(self):
-        tmpdir = self.tmp.name
-        path = os.path.join(tmpdir, "osbuild-api")
-        args = {"options": {"answer": 42}}
-
-        with osbuild.api.API(args, socket_address=path) as _:
-            data = osbuild.api.arguments(path=path)
-            self.assertEqual(data, args)
-
     def test_exception(self):
         # Check that 'api.exception' correctly sets 'API.exception'
         tmpdir = self.tmp.name
         path = os.path.join(tmpdir, "osbuild-api")
-        args = {}
 
         def exception(path):
             with osbuild.api.exception_handler(path):
                 raise ValueError("osbuild test exception")
             assert False, "api.exception should exit process"
 
-        api = osbuild.api.API(args, socket_address=path)
+        api = osbuild.api.API(socket_address=path)
         with api:
             p = mp.Process(target=exception, args=(path, ))
             p.start()
@@ -109,14 +98,13 @@ class TestAPI(unittest.TestCase):
         # set correctly
         tmpdir = self.tmp.name
         path = os.path.join(tmpdir, "osbuild-api")
-        args = {}
 
         def metadata(path):
             data = {"meta": "42"}
             osbuild.api.metadata(data, path=path)
             return 0
 
-        api = osbuild.api.API(args, socket_address=path)
+        api = osbuild.api.API(socket_address=path)
         with api:
             p = mp.Process(target=metadata, args=(path, ))
             p.start()


### PR DESCRIPTION
Instead of using the JSONCOMM RCP mechanism, write the arguments to a file which is then bind-mounted into the container. Adapt `api.arguments` to just read that file, so nothing changes for the stages.