### PR TITLE
objectstore: use recursive bind mounts

### DIFF
--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -254,7 +254,13 @@ class HostTree:
     @contextlib.contextmanager
     def read(self):
         with self.store.tempdir() as tmp:
-            mount("/", tmp)
+            # Create a bare bones root file system
+            # with just /usr mounted from the host
+            usr = os.path.join(tmp, "usr")
+            os.makedirs(usr)
+
+            mount(tmp, tmp)  # ensure / is read-only
+            mount("/usr", usr)
             try:
                 yield tmp
             finally:

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -19,16 +19,16 @@ __all__ = [
 
 def mount(source, target, bind=True, ro=True, private=True, mode="0755"):
     options = []
-    if bind:
-        options += ["bind"]
     if ro:
         options += ["ro"]
     if mode:
         options += [mode]
 
     args = []
+    if bind:
+        args += ["--rbind"]
     if private:
-        args += ["--make-private"]
+        args += ["--make-rprivate"]
     if options:
         args += ["-o", ",".join(options)]
 
@@ -49,7 +49,7 @@ def umount(target, lazy=False):
     if lazy:
         args += ["--lazy"]
     subprocess.run(["sync", "-f", target], check=True)
-    subprocess.run(["umount"] + args + [target], check=True)
+    subprocess.run(["umount", "-R"] + args + [target], check=True)
 
 
 class Object:


### PR DESCRIPTION
I have re-done the initial attempt. While we are still recursively bind-mounting trees in the `objectstore`, we also _only_ grab `/usr` from the host. This ensures we are not accidentally messing with other bits of the host. See the commit messages.