### PR TITLE
mpp: support `skip_if_unavailable` and multiple image definitions

### DIFF
--- a/stages/org.osbuild.qemu
+++ b/stages/org.osbuild.qemu
@@ -26,69 +26,69 @@ SCHEMA_2 = r"""
     "type": "object",
     "required": ["type"],
     "additionalProperties": false,
-	  "properties": {
-	    "type": {
-	      "description": "The type of the format, here 'qcow2'",
-	      "type": "string",
-	      "enum": ["qcow2"]
-	    },
-	    "compat": {
-	      "description": "The qcow2-compatibility-version to use",
-	      "type": "string"
-	    }
-	  }
+    "properties": {
+      "type": {
+        "description": "The type of the format, here 'qcow2'",
+        "type": "string",
+        "enum": ["qcow2"]
+      },
+      "compat": {
+        "description": "The qcow2-compatibility-version to use",
+        "type": "string"
+      }
+    }
   },
   "vdi": {
     "description": "Create a vdi image",
     "type": "object",
     "required": ["type"],
     "additionalProperties": false,
-	  "properties": {
-	    "type": {
-	      "description": "The type of the format, here 'vdi'",
-	      "type": "string",
-	      "enum": ["vdi"]
-	    }
-	  }
+    "properties": {
+      "type": {
+        "description": "The type of the format, here 'vdi'",
+        "type": "string",
+        "enum": ["vdi"]
+      }
+    }
   },
   "vmdk": {
     "description": "Create a vmdk image",
     "type": "object",
     "required": ["type"],
     "additionalProperties": false,
-	  "properties": {
-	    "type": {
-	      "description": "The type of the format, here 'vmdk'",
-	      "type": "string",
-	      "enum": ["vmdk"]
-	    }
-	  }
+    "properties": {
+      "type": {
+        "description": "The type of the format, here 'vmdk'",
+        "type": "string",
+        "enum": ["vmdk"]
+      }
+    }
   },
   "vpc": {
     "description": "Create a vpc image",
     "type": "object",
     "required": ["type"],
     "additionalProperties": false,
-	  "properties": {
-	    "type": {
-	      "description": "The type of the format, here 'vpc'",
-	      "type": "string",
-	      "enum": ["vpc"]
-	    }
-	  }
+    "properties": {
+      "type": {
+        "description": "The type of the format, here 'vpc'",
+        "type": "string",
+        "enum": ["vpc"]
+      }
+    }
   },
   "vhdx": {
     "description": "Create a vhdx image",
     "type": "object",
     "required": ["type"],
     "additionalProperties": false,
-	  "properties": {
-	    "type": {
-	      "description": "The type of the format, here 'vhdx'",
-	      "type": "string",
-	      "enum": ["vhdx"]
-	    }
-	  }
+    "properties": {
+      "type": {
+        "description": "The type of the format, here 'vhdx'",
+        "type": "string",
+        "enum": ["vhdx"]
+      }
+    }
   }
 },
 "inputs": {

--- a/test/data/manifests/fedora-ostree-image.mpp.json
+++ b/test/data/manifests/fedora-ostree-image.mpp.json
@@ -1,6 +1,7 @@
 {
   "version": "2",
   "mpp-define-image": {
+    "id": "image",
     "size": "10737418240",
     "table": {
       "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -691,7 +691,8 @@ class ManifestFile:
 
         del self.root["mpp-define-image"]
 
-        self.vars["image"] = Image.from_dict(desc)
+        name = desc.get("id", "image")
+        self.vars[name] = Image.from_dict(desc)
 
 
 class ManifestFileV1(ManifestFile):

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -283,7 +283,8 @@ class DepSolver:
         skip_keys = ["id", "secrets"]
         supported = ["baseurl", "metalink", "mirrorlist",
                      "enabled", "metadata_expire", "gpgcheck", "username", "password", "priority",
-                     "sslverify", "sslcacert", "sslclientkey", "sslclientcert"]
+                     "sslverify", "sslcacert", "sslclientkey", "sslclientcert",
+                     "skip_if_unavailable"]
 
         for key in desc.keys():
             if key in skip_keys:


### PR DESCRIPTION
Add `skip_if_unavailable` as an supported attribute for the repository configuration.

Support more than one image definition by introducing a `id` attribute which can be used to specify how the variable for the definition is called.