### PR TITLE
ci: upload rpms built in RHEL 8 CDN buildroot into rhel-8-cdn directory

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -21,11 +21,21 @@ fi
 # Add osbuild team ssh keys.
 cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
 
+# Distro version that this script is running on.
+DISTRO_VERSION=${ID}-${VERSION_ID}
+
+if [[ "$ID" == rhel ]] && sudo subscription-manager status; then
+  # If this script runs on subscribed RHEL, install content built using CDN
+  # repositories.
+  DISTRO_VERSION=rhel-${VERSION_ID%.*}-cdn
+fi
+
 # Set up dnf repositories with the RPMs we want to test
+# TODO: use DISTRO_VERSION also for osbuild-composer (not yet supported though)
 sudo tee /etc/yum.repos.d/osbuild.repo << EOF
 [osbuild]
 name=osbuild ${CI_COMMIT_SHA}
-baseurl=${DNF_REPO_BASEURL}/osbuild/${ID}-${VERSION_ID}/${ARCH}/${CI_COMMIT_SHA}
+baseurl=${DNF_REPO_BASEURL}/osbuild/${DISTRO_VERSION}/${ARCH}/${CI_COMMIT_SHA}
 enabled=1
 gpgcheck=0
 # Default dnf repo priority is 99. Lower number means higher priority.

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -24,7 +24,7 @@ COMMIT=$(git rev-parse HEAD)
 REPO_BUCKET=osbuild-composer-repos
 
 # Public URL for the S3 bucket with our artifacts.
-MOCK_REPO_BASE_URL="http://osbuild-composer-repos.s3.amazonaws.com"
+MOCK_REPO_BASE_URL="http://${REPO_BUCKET}.s3.amazonaws.com"
 
 # Relative path of the repository – used for constructing both the local and
 # remote paths below, so that they're consistent.

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -10,6 +10,14 @@ function greenprint {
 source /etc/os-release
 ARCH=$(uname -m)
 
+# Register RHEL if we are provided with a registration script and intend to do that.
+REGISTER="${REGISTER:-'false'}"
+if [[ $REGISTER == "true" && -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
+    greenprint "🪙 Registering RHEL instance"
+    sudo chmod +x "$RHN_REGISTRATION_SCRIPT"
+    sudo "$RHN_REGISTRATION_SCRIPT"
+fi
+
 # Mock configuration file to use for building RPMs.
 MOCK_CONFIG="${ID}-${VERSION_ID%.*}-$(uname -m)"
 
@@ -48,14 +56,6 @@ if [[ $ID == rhel || $ID == centos ]] && ! rpm -q epel-release; then
     curl -Ls --retry 5 --output /tmp/epel.rpm \
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
     sudo rpm -Uvh /tmp/epel.rpm
-fi
-
-# Register RHEL if we are provided with a registration script and intend to do that.
-REGISTER="${REGISTER:-'false'}"
-if [[ $REGISTER == "true" && -n "${RHN_REGISTRATION_SCRIPT:-}" ]] && ! sudo subscription-manager status; then
-    greenprint "🪙 Registering RHEL instance"
-    sudo chmod +x "$RHN_REGISTRATION_SCRIPT"
-    sudo "$RHN_REGISTRATION_SCRIPT"
 fi
 
 # Install requirements for building RPMs in mock.

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -34,9 +34,19 @@ REPO_BUCKET=osbuild-composer-repos
 # Public URL for the S3 bucket with our artifacts.
 MOCK_REPO_BASE_URL="http://${REPO_BUCKET}.s3.amazonaws.com"
 
+# Distro version in whose buildroot was the RPM built.
+DISTRO_VERSION=${ID}-${VERSION_ID}
+
+if [[ "$ID" == rhel ]] && sudo subscription-manager status; then
+  # If this script runs on a subscribed RHEL, the RPMs are actually built
+  # using the latest CDN content, therefore rhel-*-cdn is used as the distro
+  # version.
+  DISTRO_VERSION=rhel-${VERSION_ID%.*}-cdn
+fi
+
 # Relative path of the repository – used for constructing both the local and
 # remote paths below, so that they're consistent.
-REPO_PATH=osbuild/${ID}-${VERSION_ID}/${ARCH}/${COMMIT}
+REPO_PATH=osbuild/${DISTRO_VERSION}/${ARCH}/${COMMIT}
 
 # Directory to hold the RPMs temporarily before we upload them.
 REPO_DIR=repo/${REPO_PATH}


### PR DESCRIPTION
Let's explain how RPMs for RHEL are built:

We use a subscribed RHEL 8.x machine and mock build these on it. Mock
initializes its own buildroot based on the latest RHEL 8 CDN content, see[1].
This means that the minor version of the buildroot is independent of the minor
version of the host.

However, we currently upload RPMs to a directory whose name consists also of
the minor version of the host. Our hosts are currently running RHEL 8.3 so
the RPMs are uploaded into rhel-8.3 directory despite them being built in the
RHEL 8.4 buildroot (RHEL 8 CDN buildroot specifically). This means that
we cannot guarantee that they are installable on RHEL 8.3 which is weird.

This PR adds a special case for hosts that run on subscribed RHEL and
thus build RPMs in a buildroot constructed from RHEL CDN. These RPMs are
now uploaded into rhel-8-cdn directory. This change more accurately reflects
the way we build our RPMs and removes some confusion.

(one extra clean-up commit is also included)