### PR TITLE
docs: add --export option to the osbuild man page

### DIFF
--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -45,6 +45,7 @@ is not listed here, **osbuild** will deny startup and exit with an error.
                                 the osbuild library
 --checkpoint=CHECKPOINT         stage to commit to the object store during
                                 build (can be passed multiple times)
+--export=OBJECT                 object to export (can be passed multiple times)
 --json                          output results in JSON format
 --output-directory=DIR          directory where result objects are stored
 --inspect                       return the manifest in JSON format including


### PR DESCRIPTION
This is used to export an image but isn't present in the osbuild man page.