### PR TITLE
test/data: use UTF-8 locale on all manifests

### DIFF
--- a/test/data/manifests/fedora-boot.json
+++ b/test/data/manifests/fedora-boot.json
@@ -660,7 +660,7 @@
       {
         "name": "org.osbuild.locale",
         "options": {
-          "language": "en_US"
+          "language": "en_US.UTF-8"
         }
       },
       {

--- a/test/data/manifests/fedora-boot.mpp.json
+++ b/test/data/manifests/fedora-boot.mpp.json
@@ -47,7 +47,7 @@
       {
         "name": "org.osbuild.locale",
         "options": {
-          "language": "en_US"
+          "language": "en_US.UTF-8"
         }
       },
       {

--- a/test/data/manifests/fedora-container.json
+++ b/test/data/manifests/fedora-container.json
@@ -527,7 +527,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         }
       ]

--- a/test/data/manifests/fedora-container.mpp.json
+++ b/test/data/manifests/fedora-container.mpp.json
@@ -70,7 +70,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         }
       ]

--- a/test/data/manifests/fedora-ostree-bootiso.json
+++ b/test/data/manifests/fedora-ostree-bootiso.json
@@ -776,7 +776,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         },
         {
@@ -1695,7 +1695,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         },
         {

--- a/test/data/manifests/fedora-ostree-bootiso.mpp.json
+++ b/test/data/manifests/fedora-ostree-bootiso.mpp.json
@@ -89,7 +89,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         },
         {
@@ -383,7 +383,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         },
         {

--- a/test/data/manifests/fedora-ostree-commit.json
+++ b/test/data/manifests/fedora-ostree-commit.json
@@ -661,7 +661,7 @@
       {
         "name": "org.osbuild.locale",
         "options": {
-          "language": "en_US"
+          "language": "en_US.UTF-8"
         }
       },
       {

--- a/test/data/manifests/fedora-ostree-commit.mpp.json
+++ b/test/data/manifests/fedora-ostree-commit.mpp.json
@@ -46,7 +46,7 @@
       {
         "name": "org.osbuild.locale",
         "options": {
-          "language": "en_US"
+          "language": "en_US.UTF-8"
         }
       },
       {

--- a/test/data/manifests/fedora-ostree-container.json
+++ b/test/data/manifests/fedora-ostree-container.json
@@ -726,7 +726,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         },
         {
@@ -978,7 +978,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         }
       ]

--- a/test/data/manifests/fedora-ostree-container.mpp.json
+++ b/test/data/manifests/fedora-ostree-container.mpp.json
@@ -57,7 +57,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         },
         {
@@ -167,7 +167,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         }
       ]

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -720,7 +720,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         },
         {

--- a/test/data/manifests/fedora-ostree-image.mpp.json
+++ b/test/data/manifests/fedora-ostree-image.mpp.json
@@ -177,7 +177,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         },
         {

--- a/test/data/manifests/fedora-ostree-tarball.json
+++ b/test/data/manifests/fedora-ostree-tarball.json
@@ -726,7 +726,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         },
         {

--- a/test/data/manifests/fedora-ostree-tarball.mpp.json
+++ b/test/data/manifests/fedora-ostree-tarball.mpp.json
@@ -57,7 +57,7 @@
         {
           "type": "org.osbuild.locale",
           "options": {
-            "language": "en_US"
+            "language": "en_US.UTF-8"
           }
         },
         {


### PR DESCRIPTION
The manifests set a "en_US" locale but this causes gnome-terminal to not
run due a non UTF-8 locale being used, which is an unsupported config:

gnome-terminal-server[1899]: Non UTF-8 locale (ISO-8859-1) is not supported!

Reported-by: Stephen Smoogen <ssmoogen@redhat.com>