### PR TITLE
assembler/ostree.commit: fix copying of links

### DIFF
--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -81,8 +81,8 @@ TOPLEVEL_LINKS = {
 
 def copy(name, source, dest):
     subprocess.run(["cp", "--reflink=auto", "-a",
-                    os.path.join(source, name, "."),
-                    os.path.join(dest, name)],
+                    os.path.join(source, name),
+                    "-t", os.path.join(dest)],
                    check=True)
 
 


### PR DESCRIPTION
Commit 92cc269 fixed a bug where `/var` was copied into `/var` resulting in `/var/var`. Sadly the fix broke copying links, like `bin -> usr/bin`, where now the content of the link would be copied but not the link itself. Use the `-t` command line flag for `cp` which should ensure that we copy links as links but also copy the contents for `/var` should the target dir, i.e. `/var` already exist.

cc @henrywang 