### PR TITLE
format/v2: add an option to specify mounts as an array

### DIFF
--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -63,9 +63,32 @@
 
     "mounts": {
       "title": "Collection of mount points for a stage",
-      "additionalProperties": {
-        "$ref": "#/definitions/mount"
-      }
+      "oneOf": [
+        {
+          "description": "Older format, not recommended because the order of object keys might be undefined",
+          "additionalProperties": {
+            "$ref": "#/definitions/mount"
+          }
+        },
+        {
+          "description": "Recommended format",
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "allOf": [
+              {
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string"}
+                }
+              },
+              {
+                "$ref": "#/definitions/mount"
+              }
+            ]
+          }
+        }
+      ]
     },
 
     "mount": {

--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -64,8 +64,15 @@ SCHEMA_2 = r"""
   "additionalProperties": true
 },
 "mounts": {
-  "type": "object",
-  "additionalProperties": true
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": true
+    },
+    {
+      "type": "array"
+    }
+  ]
 },
 "inputs": {
   "type": "object",

--- a/stages/org.osbuild.zipl.inst
+++ b/stages/org.osbuild.zipl.inst
@@ -47,15 +47,15 @@ SCHEMA_2 = r"""
   }
 },
 "mounts": {
-  "type": "object",
-  "additionalProperties": true,
-  "required": ["root"],
-  "properties": {
-    "root": {
+  "oneOf": [
+    {
       "type": "object",
       "additionalProperties": true
+    },
+    {
+      "type": "array"
     }
-  }
+  ]
 }
 """
 


### PR DESCRIPTION
In general, applications shouldn't rely on the order of keys in a JSON object.
For example, Go doesn't care about the order at all. When unmarshalling
an object, it just puts all items into a map that are always unordered. When
marshalling a map, it always sorts the keys to produce a predictable json
output.

This commit adds an option to specify mounts in an array, thus guaranteeing
order stability.

Schemas of both stages that use mounts (org.osbuild.copy and
org.osbuild.zipl.inst) were adjusted.

org.osbuild.zipl.inst now accepts mounts with an arbitrary name, previously
the mount must have been named "root".

(Marking as a draft, I still want to test this.)