### PR TITLE
Support explicit sorting of devices and mount dicts

### DIFF
--- a/mounts/org.osbuild.noop
+++ b/mounts/org.osbuild.noop
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+"""
+No-op mount service
+
+Does not mount anything, but only creates an empty directory.
+Useful for testing.
+
+Host commands used: mount
+"""
+
+import os
+import sys
+from typing import Dict
+
+from osbuild import mounts
+
+
+SCHEMA = """
+"additionalProperties": false
+"""
+
+
+class NoOpMount(mounts.MountService):
+
+    def mount(self, _source: str, root: str, target: str, _options: Dict):
+
+        mountpoint = os.path.join(root, target.lstrip("/"))
+
+        os.makedirs(mountpoint, exist_ok=True)
+        self.mountpoint = mountpoint
+
+        return mountpoint
+
+    def umount(self):
+        self.mountpoint = None
+
+    def sync(self):
+        pass
+
+
+def main():
+    service = NoOpMount.from_args(sys.argv[1:])
+    service.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -26,7 +26,7 @@
     "device": {
       "title": "Device for a stage",
       "additionalProperties": false,
-      "required": ["type", "options"],
+      "required": ["type"],
       "properties": {
         "type": { "type": "string" },
         "options": {

--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -32,6 +32,9 @@
         "options": {
           "type": "object",
           "additionalProperties": true
+        },
+        "order": {
+          "type": "integer"
         }
       }
     },
@@ -83,6 +86,9 @@
         "options": {
           "type": "object",
           "additionalProperties": true
+        },
+        "order": {
+          "type": "integer"
         }
       }
     },

--- a/stages/org.osbuild.noop
+++ b/stages/org.osbuild.noop
@@ -17,7 +17,13 @@ SCHEMA_2 = """
 "options": {
   "additionalProperties": true
 },
+"devices": {
+  "additionalProperties": true
+},
 "inputs": {
+  "additionalProperties": true
+},
+"mounts": {
   "additionalProperties": true
 }
 """

--- a/test/mod/test_fmt_v2.py
+++ b/test/mod/test_fmt_v2.py
@@ -173,3 +173,65 @@ class TestFormatV1(unittest.TestCase):
 
         res = fmt.validate(desc, self.index)
         self.assert_validation(res)
+
+    def test_sort_by_order(self):
+        PIPELINE = {
+            "version": "2",
+            "pipelines": [
+                {
+                    "name": "test",
+                    "stages": [
+                        {
+                            "type": "org.osbuild.noop",
+                            "devices": {
+                                "boot": {
+                                    "type": "org.osbuild.zero",
+                                    "order": 2
+                                },
+                                "root": {
+                                    "type": "org.osbuild.zero",
+                                    "order": 1
+                                }
+                            },
+                            "mounts": {
+                                "boot": {
+                                    "type": "org.osbuild.noop",
+                                    "source": "boot",
+                                    "target": "/boot",
+                                    "order": 2
+                                },
+                                "root": {
+                                    "type": "org.osbuild.noop",
+                                    "source": "root",
+                                    "target": "/",
+                                    "order": 1
+                                },
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        manifest, _ = self.load_manifest(PIPELINE)
+        self.assertIsNotNone(manifest)
+
+        test = manifest["test"]
+        self.assertIsNotNone(test)
+
+        stages = test.stages
+        self.assertIsNotNone(stages)
+        self.assertEqual(len(stages), 1)
+
+        stage = stages[0]
+        self.assertIsNotNone(stage)
+
+        devices = stage.devices
+        self.assertIsNotNone(devices)
+        self.assertEqual(len(devices), 2)
+        self.assertEqual(list(devices.keys()), ["root", "boot"])
+
+        mounts = stage.mounts
+        self.assertIsNotNone(mounts)
+        self.assertEqual(len(mounts), 2)
+        self.assertEqual(list(mounts.keys()), ["root", "boot"])

--- a/test/mod/test_fmt_v2.py
+++ b/test/mod/test_fmt_v2.py
@@ -65,6 +65,32 @@ BASIC_PIPELINE = {
                                 "name:tree": {}
                             }
                         }
+                    },
+                    "devices": {
+                        "root": {
+                            "type": "org.osbuild.loopback",
+                            "options": {
+                                "filename": "empty.img"
+                            }
+                        },
+                        "boot": {
+                            "type": "org.osbuild.loopback",
+                            "options": {
+                                "filename": "empty.img"
+                            }
+                        },
+                    },
+                    "mounts": {
+                        "root": {
+                            "type": "org.osbuild.noop",
+                            "source": "root",
+                            "target": "/",
+                        },
+                        "boot": {
+                            "type": "org.osbuild.noop",
+                            "source": "boot",
+                            "target": "/boot",
+                        },
                     }
                 }
             ]


### PR DESCRIPTION
Introduce an optional `order` field that allows to explicitly specify the order of the devices and mounts. This is needed since the order of elements of a dictionary is not specified in JSON and more importantly not specified in Go.