### PR TITLE
Mounts are arrays

### DIFF
--- a/mounts/org.osbuild.noop
+++ b/mounts/org.osbuild.noop
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+"""
+No-op mount service
+
+Does not mount anything, but only creates an empty directory.
+Useful for testing.
+
+Host commands used: mount
+"""
+
+import os
+import sys
+from typing import Dict
+
+from osbuild import mounts
+
+
+SCHEMA = """
+"additionalProperties": false
+"""
+
+
+class NoOpMount(mounts.MountService):
+
+    def mount(self, _source: str, root: str, target: str, _options: Dict):
+
+        mountpoint = os.path.join(root, target.lstrip("/"))
+
+        os.makedirs(mountpoint, exist_ok=True)
+        self.mountpoint = mountpoint
+
+        return mountpoint
+
+    def umount(self):
+        self.mountpoint = None
+
+    def sync(self):
+        pass
+
+
+def main():
+    service = NoOpMount.from_args(sys.argv[1:])
+    service.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -77,7 +77,7 @@ def describe(manifest: Manifest, *, with_id=False) -> Dict:
         desc = {
             "name": mnt.name,
             "type": mnt.info.name,
-            "device": mnt.device.name,
+            "source": mnt.device.name,
             "target": mnt.target
         }
 

--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -26,7 +26,7 @@
     "device": {
       "title": "Device for a stage",
       "additionalProperties": false,
-      "required": ["type", "options"],
+      "required": ["type"],
       "properties": {
         "type": { "type": "string" },
         "options": {

--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -63,16 +63,16 @@
 
     "mounts": {
       "title": "Collection of mount points for a stage",
-      "additionalProperties": {
-        "$ref": "#/definitions/mount"
-      }
+      "type": "array",
+      "items": { "$ref": "#/definitions/mount"}
     },
 
     "mount": {
       "title": "Mount point for a stage",
       "additionalProperties": false,
-      "required": ["type", "source", "target"],
+      "required": ["name", "type", "source", "target"],
       "properties": {
+        "name": { "type": "string" },
         "type": { "type": "string" },
         "source": {
           "type": "string"

--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -64,8 +64,7 @@ SCHEMA_2 = r"""
   "additionalProperties": true
 },
 "mounts": {
-  "type": "object",
-  "additionalProperties": true
+  "type": "array"
 },
 "inputs": {
   "type": "object",

--- a/stages/org.osbuild.noop
+++ b/stages/org.osbuild.noop
@@ -17,7 +17,13 @@ SCHEMA_2 = """
 "options": {
   "additionalProperties": true
 },
+"devices": {
+  "additionalProperties": true
+},
 "inputs": {
+  "additionalProperties": true
+},
+"mounts": {
   "additionalProperties": true
 }
 """

--- a/stages/org.osbuild.zipl.inst
+++ b/stages/org.osbuild.zipl.inst
@@ -47,15 +47,8 @@ SCHEMA_2 = r"""
   }
 },
 "mounts": {
-  "type": "object",
-  "additionalProperties": true,
-  "required": ["root"],
-  "properties": {
-    "root": {
-      "type": "object",
-      "additionalProperties": true
-    }
-  }
+  "type": "array",
+  "minItems": 1
 }
 """
 

--- a/test/data/manifests/fedora-ostree-bootiso.json
+++ b/test/data/manifests/fedora-ostree-bootiso.json
@@ -1763,13 +1763,14 @@
               }
             }
           },
-          "mounts": {
-            "root": {
+          "mounts": [
+            {
+              "name": "root",
               "type": "org.osbuild.ext4",
               "source": "root",
               "target": "/"
             }
-          }
+          ]
         }
       ]
     },
@@ -1935,13 +1936,14 @@
               }
             }
           },
-          "mounts": {
-            "efi": {
+          "mounts": [
+            {
+              "name": "efi",
               "type": "org.osbuild.fat",
               "source": "efi",
               "target": "/"
             }
-          }
+          ]
         },
         {
           "type": "org.osbuild.copy",

--- a/test/data/manifests/fedora-ostree-bootiso.mpp.json
+++ b/test/data/manifests/fedora-ostree-bootiso.mpp.json
@@ -534,13 +534,14 @@
               }
             }
           },
-          "mounts": {
-            "root": {
+          "mounts": [
+            {
+              "name": "root",
               "type": "org.osbuild.ext4",
               "source": "root",
               "target": "/"
             }
-          }
+          ]
         }
       ]
     },
@@ -720,13 +721,14 @@
               }
             }
           },
-          "mounts": {
-            "efi": {
+          "mounts": [
+            {
+              "name": "efi",
               "type": "org.osbuild.fat",
               "source": "efi",
               "target": "/"
             }
-          }
+          ]
         },
         {
           "type": "org.osbuild.copy",

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -1080,23 +1080,26 @@
               }
             }
           },
-          "mounts": {
-            "root": {
+          "mounts": [
+            {
+              "name": "root",
               "type": "org.osbuild.xfs",
               "source": "root",
               "target": "/"
             },
-            "boot": {
+            {
+              "name": "boot",
               "type": "org.osbuild.ext4",
               "source": "boot",
               "target": "/boot"
             },
-            "efi": {
+            {
+              "name": "efi",
               "type": "org.osbuild.fat",
               "source": "efi",
               "target": "/boot/efi"
             }
-          }
+          ]
         },
         {
           "type": "org.osbuild.grub2.inst",

--- a/test/data/manifests/fedora-ostree-image.mpp.json
+++ b/test/data/manifests/fedora-ostree-image.mpp.json
@@ -534,23 +534,26 @@
               }
             }
           },
-          "mounts": {
-            "root": {
+          "mounts": [
+            {
+              "name": "root",
               "type": "org.osbuild.xfs",
               "source": "root",
               "target": "/"
             },
-            "boot": {
+            {
+              "name": "boot",
               "type": "org.osbuild.ext4",
               "source": "boot",
               "target": "/boot"
             },
-            "efi": {
+            {
+              "name": "efi",
               "type": "org.osbuild.fat",
               "source": "efi",
               "target": "/boot/efi"
             }
-          }
+          ]
         },
         {
           "type": "org.osbuild.grub2.inst",

--- a/test/mod/test_fmt_v2.py
+++ b/test/mod/test_fmt_v2.py
@@ -65,7 +65,35 @@ BASIC_PIPELINE = {
                                 "name:tree": {}
                             }
                         }
-                    }
+                    },
+                    "devices": {
+                        "root": {
+                            "type": "org.osbuild.loopback",
+                            "options": {
+                                "filename": "empty.img"
+                            }
+                        },
+                        "boot": {
+                            "type": "org.osbuild.loopback",
+                            "options": {
+                                "filename": "empty.img"
+                            }
+                        },
+                    },
+                    "mounts": [
+                        {
+                            "name": "root",
+                            "type": "org.osbuild.noop",
+                            "source": "root",
+                            "target": "/",
+                        },
+                        {
+                            "name": "boot",
+                            "type": "org.osbuild.noop",
+                            "source": "boot",
+                            "target": "/boot",
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
The order of entries in a dictionary is not specified by the JSON standard and hard to control when marshalling dictionaries in Go. Since the order of mounts is important and the wrong order leads to wrong mount trees change the `mounts` field to an array. This breaks existing manifests but after careful deliberation it was concluded that the original schema with mounts as dictionaries is not something we want to support. Apologies to everyone.