### PR TITLE
Create only one configuration file in cloud-init, dracut, modprobe stages

### DIFF
--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -2,18 +2,12 @@
 """
 Configure cloud-init
 
-The 'config' option allows to create cloud-init `.cfg` configuration
-files under `/etc/cloud/cloud.cfg.d`. Its value is a dictionary which keys
-represent filenames of `.cfg` configuration files, which will be created.
-Value of each configuration file key is a dictionary representing the
-cloud-init configuration.
+The 'config' option allows to configure cloud-init by creating a
+configuration file under `/etc/cloud/cloud.cfg.d` with the name
+specified by `filename`.
 
 Constrains:
-  - If 'config' option is specified, it must contain at least one definition
-    of a configuration file.
   - Each configuration file definition must contain at least one configuration
-    section definition, which is not empty (must be setting a configuration
-    option).
 
 Currently supported subset of cloud-init configuration:
   - 'system_info' section
@@ -31,36 +25,33 @@ import osbuild.api
 
 SCHEMA = r"""
 "additionalProperties": false,
+"required": ["config", "filename"],
 "properties": {
+  "filename": {
+    "type": "string",
+    "description": "Name of the cloud-init configuration file.",
+    "pattern": "^[\\w.-]{1,251}\\.cfg$"
+  },
   "config": {
     "additionalProperties": false,
     "type": "object",
-    "description": "cloud-init configuration file.",
-    "minProperties": 1,
-    "patternProperties": {
-      "^[\\w.-]{1,251}\\.cfg$": {
+    "description": "cloud-init configuration",
+    "properties": {
+      "system_info": {
         "additionalProperties": false,
         "type": "object",
-        "description": "cloud-init configuration file.",
+        "description": "'system_info' configuration section.",
         "minProperties": 1,
         "properties": {
-          "system_info": {
+          "default_user": {
             "additionalProperties": false,
             "type": "object",
-            "description": "'system_info' configuration section.",
+            "description": "Configuration of the 'default' user created by cloud-init.",
             "minProperties": 1,
             "properties": {
-              "default_user": {
-                "additionalProperties": false,
-                "type": "object",
-                "description": "Configuration of the 'default' user created by cloud-init.",
-                "minProperties": 1,
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "username of the 'default' user."
-                  }
-                }
+              "name": {
+                "type": "string",
+                "description": "username of the 'default' user."
               }
             }
           }
@@ -72,20 +63,16 @@ SCHEMA = r"""
 """
 
 
-# Writes the passed `options` object as is into the configuration file in YAML format.
-# The validity of the `options` content is assured by the SCHEMA.
-def create_configuration_file(tree, filename, options):
+# Writes the passed `config` object as is into the configuration file in YAML format.
+# The validity of the `config` content is assured by the SCHEMA.
+def main(tree, options):
+    filename = options.get("filename")
+    config = options.get("config", {})
+
     config_files_dir = f"{tree}/etc/cloud/cloud.cfg.d"
 
     with open(f"{config_files_dir}/{filename}", "w") as f:
-        yaml.dump(options, f)
-
-
-def main(tree, options):
-    configuration_files_options = options.get("config", {})
-
-    for configuration_file, configuration_options in configuration_files_options.items():
-        create_configuration_file(tree, configuration_file, configuration_options)
+        yaml.dump(config, f)
 
     return 0
 

--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -2,15 +2,15 @@
 """
 Configure cloud-init
 
-'configuration_files' option allows to create cloud-init `.cfg` configuration
+The 'config' option allows to create cloud-init `.cfg` configuration
 files under `/etc/cloud/cloud.cfg.d`. Its value is a dictionary which keys
 represent filenames of `.cfg` configuration files, which will be created.
 Value of each configuration file key is a dictionary representing the
 cloud-init configuration.
 
 Constrains:
-  - If 'configuration_files' option is specified, it must contain at least one
-    definition of a configuration file.
+  - If 'config' option is specified, it must contain at least one definition
+    of a configuration file.
   - Each configuration file definition must contain at least one configuration
     section definition, which is not empty (must be setting a configuration
     option).
@@ -32,10 +32,10 @@ import osbuild.api
 SCHEMA = r"""
 "additionalProperties": false,
 "properties": {
-  "configuration_files": {
+  "config": {
     "additionalProperties": false,
     "type": "object",
-    "description": "cloud-init configuration files.",
+    "description": "cloud-init configuration file.",
     "minProperties": 1,
     "patternProperties": {
       "^[\\w.-]{1,251}\\.cfg$": {
@@ -82,7 +82,7 @@ def create_configuration_file(tree, filename, options):
 
 
 def main(tree, options):
-    configuration_files_options = options.get("configuration_files", {})
+    configuration_files_options = options.get("config", {})
 
     for configuration_file, configuration_options in configuration_files_options.items():
         create_configuration_file(tree, configuration_file, configuration_options)

--- a/stages/org.osbuild.dracut.conf
+++ b/stages/org.osbuild.dracut.conf
@@ -2,7 +2,7 @@
 """
 Configure dracut.
 
-'configuration_files' option allows to create dracut configuration files under
+The 'config' option allows to create dracut configuration files under
 `/usr/lib/dracut/dracut.conf.d/`. Only a subset of configuration options is
 supported, with the intention to provide functional parity with
 `org.osbuild.dracut` stage.
@@ -39,7 +39,7 @@ import osbuild.api
 SCHEMA = r"""
 "additionalProperties": false,
 "properties": {
-  "configuration_files": {
+  "config": {
     "additionalProperties": false,
     "type": "object",
     "description": "dracut configuration files.",
@@ -188,7 +188,7 @@ def create_configuration_file(tree, filename, options):
 
 
 def main(tree, options):
-    configuration_files_options = options.get("configuration_files", {})
+    configuration_files_options = options.get("config", {})
 
     for configuration_file, configuration_options in configuration_files_options.items():
         create_configuration_file(tree, configuration_file, configuration_options)

--- a/stages/org.osbuild.dracut.conf
+++ b/stages/org.osbuild.dracut.conf
@@ -2,20 +2,13 @@
 """
 Configure dracut.
 
-The 'config' option allows to create dracut configuration files under
-`/usr/lib/dracut/dracut.conf.d/`. Only a subset of configuration options is
-supported, with the intention to provide functional parity with
-`org.osbuild.dracut` stage.
-
-Each stage option represents a "*.conf" file, which will be created. Its value
-is a dictionary with keys representing the allowed `dracut.conf` options
-representing the option value. The value type is specific to each configuration
-option and may be string, list of strings or boolean value.
+The 'config' option allows to create a dracut configuration file under
+`/usr/lib/dracut/dracut.conf.d/` with the name `filename`. Only a subset
+of configuration options is supported, with the intention to provide
+functional parity with `org.osbuild.dracut` stage.
 
 Constrains:
-  - At least one configuration file must be defined in the stage options.
   - At least one configuration option must be specified for each configuration
-    file.
 
 Supported configuration options:
   - compress
@@ -38,96 +31,94 @@ import osbuild.api
 
 SCHEMA = r"""
 "additionalProperties": false,
+"required": ["config", "filename"],
 "properties": {
+  "filename": {
+    "type": "string",
+    "description": "Name of the dracut configuration file.",
+    "pattern": "^[\\w.-]{1,250}\\.conf$"
+  },
   "config": {
     "additionalProperties": false,
     "type": "object",
-    "description": "dracut configuration files.",
+    "description": "dracut configuration.",
     "minProperties": 1,
-    "patternProperties": {
-      "^[\\w.-]{1,250}\\.conf$": {
-        "additionalProperties": false,
-        "type": "object",
-        "description": "dracut configuration file.",
-        "minProperties": 1,
-        "properties": {
-          "compress": {
-            "description": "Compress the generated initramfs using the passed compression program.",
-            "type": "string"
-          },
-          "dracutmodules": {
-            "description": "Exact list of dracut modules to use.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "A dracut module, e.g. base, nfs, network ..."
-            }
-          },
-          "add_dracutmodules": {
-            "description": "Additional dracut modules to include.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "A dracut module, e.g. base, nfs, network ..."
-            }
-          },
-          "omit_dracutmodules": {
-            "description": "Dracut modules to not include.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "A dracut module, e.g. base, nfs, network ..."
-            }
-          },
-          "drivers": {
-            "description": "Kernel modules to exclusively include.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "A kernel module without the .ko extension."
-            }
-          },
-          "add_drivers": {
-            "description": "Add a specific kernel modules.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "A kernel module without the .ko extension."
-            }
-          },
-          "force_drivers": {
-            "description": "Add driver and ensure that they are tried to be loaded.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "A kernel module without the .ko extension."
-            }
-          },
-          "filesystems": {
-            "description": "Kernel filesystem modules to exclusively include.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "A kernel module without the .ko extension."
-            }
-          },
-          "install_items": {
-            "description": "Install the specified files.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "Specify additional files to include in the initramfs."
-            }
-          },
-          "early_microcode": {
-            "description": "Combine early microcode with the initramfs.",
-            "type": "boolean"
-          },
-          "reproducible": {
-            "description": "Create reproducible images.",
-            "type": "boolean"
-          }
+    "properties": {
+      "compress": {
+        "description": "Compress the generated initramfs using the passed compression program.",
+        "type": "string"
+      },
+      "dracutmodules": {
+        "description": "Exact list of dracut modules to use.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "A dracut module, e.g. base, nfs, network ..."
         }
+      },
+      "add_dracutmodules": {
+        "description": "Additional dracut modules to include.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "A dracut module, e.g. base, nfs, network ..."
+        }
+      },
+      "omit_dracutmodules": {
+        "description": "Dracut modules to not include.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "A dracut module, e.g. base, nfs, network ..."
+        }
+      },
+      "drivers": {
+        "description": "Kernel modules to exclusively include.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "A kernel module without the .ko extension."
+        }
+      },
+      "add_drivers": {
+        "description": "Add a specific kernel modules.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "A kernel module without the .ko extension."
+        }
+      },
+      "force_drivers": {
+        "description": "Add driver and ensure that they are tried to be loaded.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "A kernel module without the .ko extension."
+        }
+      },
+      "filesystems": {
+        "description": "Kernel filesystem modules to exclusively include.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "A kernel module without the .ko extension."
+        }
+      },
+      "install_items": {
+        "description": "Install the specified files.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "Specify additional files to include in the initramfs."
+        }
+      },
+      "early_microcode": {
+        "description": "Combine early microcode with the initramfs.",
+        "type": "boolean"
+      },
+      "reproducible": {
+        "description": "Create reproducible images.",
+        "type": "boolean"
       }
     }
   }
@@ -158,7 +149,10 @@ def bool_option_writer(f, option, value):
     f.write(f'{option}="{bool_to_string(value)}"\n')
 
 
-def create_configuration_file(tree, filename, options):
+def main(tree, options):
+    config = options["config"]
+    filename = options["filename"]
+
     config_files_dir = f"{tree}/usr/lib/dracut/dracut.conf.d"
 
     SUPPORTED_OPTIONS = {
@@ -179,21 +173,12 @@ def create_configuration_file(tree, filename, options):
     }
 
     with open(f"{config_files_dir}/{filename}", "w") as f:
-        for option, value in options.items():
+        for option, value in config.items():
             try:
                 writter_func = SUPPORTED_OPTIONS[option]
                 writter_func(f, option, value)
             except KeyError as e:
                 raise ValueError(f"unsupported configuration option '{option}'") from e
-
-
-def main(tree, options):
-    configuration_files_options = options.get("config", {})
-
-    for configuration_file, configuration_options in configuration_files_options.items():
-        create_configuration_file(tree, configuration_file, configuration_options)
-
-    return 0
 
 
 if __name__ == '__main__':

--- a/stages/org.osbuild.modprobe
+++ b/stages/org.osbuild.modprobe
@@ -2,10 +2,8 @@
 """
 Configure modprobe
 
-The option 'configuration_files' allows to create `.conf` configuration files
-for modprobe in `/usr/lib/modprobe.d`. At least one configuration file must
-be defined. Value os the options is a dictionary with keys being the names
-of `.conf` files which will be created. Value of each key is a list
+The 'config' option allows the creation of one ore more `.conf` configuration
+files for modprobe in `/usr/lib/modprobe.d`. The value of each key is a list
 of "command" objects with at least the 'command' property and additional
 properties specific for each command type. The list must contain at least one
 "command" object.
@@ -26,7 +24,7 @@ import osbuild.api
 SCHEMA = r"""
 "additionalProperties": false,
 "properties": {
-  "configuration_files": {
+  "config": {
     "additionalProperties": false,
     "type": "object",
     "description": "modprobe configuration files.",
@@ -85,7 +83,7 @@ def create_configuration_files(tree, configuration_files_options):
 
 
 def main(tree, options):
-    configuration_files_options = options.get("configuration_files", {})
+    configuration_files_options = options.get("config", {})
 
     create_configuration_files(tree, configuration_files_options)
 

--- a/stages/org.osbuild.modprobe
+++ b/stages/org.osbuild.modprobe
@@ -2,11 +2,8 @@
 """
 Configure modprobe
 
-The 'config' option allows the creation of one ore more `.conf` configuration
-files for modprobe in `/usr/lib/modprobe.d`. The value of each key is a list
-of "command" objects with at least the 'command' property and additional
-properties specific for each command type. The list must contain at least one
-"command" object.
+The 'config' option allows the creation of a `.conf` configuration
+file for modprobe in `/usr/lib/modprobe.d` with the name `filename`.
 
 Currently supported "command" objects are:
   - for 'blacklist' command
@@ -23,69 +20,60 @@ import osbuild.api
 
 SCHEMA = r"""
 "additionalProperties": false,
+"required": ["commands", "filename"],
 "properties": {
-  "config": {
+  "filename": {
+    "type": "string",
+    "description": "Name of the modprobe configuration file.",
+    "pattern": "^[\\w.-]{1,250}\\.conf$"
+  },
+  "commands": {
     "additionalProperties": false,
-    "type": "object",
-    "description": "modprobe configuration files.",
-    "minProperties": 1,
-    "patternProperties": {
-      "^[\\w.-]{1,250}\\.conf$": {
-        "additionalProperties": false,
-        "type": "array",
-        "description": "modprobe configuration file.",
-        "items": {
-          "anyOf": [
-            {
-              "additionalProperties": false,
-              "type": "object",
-              "description": "'blacklist' command",
-              "required": ["command", "modulename"],
-              "properties": {
-                "command": {
-                  "type": "string",
-                  "enum": ["blacklist"],
-                  "description": "modprobe command."
-                },
-                "modulename": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "name of the module to blacklist."
-                }
-              }
+    "type": "array",
+    "description": "Array of modprobe commands",
+    "minLength": 1,
+    "items": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "description": "'blacklist' command",
+          "required": ["command","modulename"],
+          "properties": {
+            "command": {
+              "type": "string",
+              "enum": ["blacklist"],
+              "description": "modprobe command."
+            },
+            "modulename": {
+              "type": "string",
+              "minLength": 1,
+              "description": "name of the module to blacklist."
             }
-          ]
+          }
         }
-      }
+      ]
     }
   }
 }
 """
 
 
-def create_configuration_files(tree, configuration_files_options):
-    if not configuration_files_options:
-        return
+def main(tree, options):
+    config_file = options["filename"]
 
     config_dir = f"{tree}/usr/lib/modprobe.d"
     os.makedirs(config_dir, exist_ok=True)
 
-    for config_file, config_commands in configuration_files_options.items():
-        lines = []
-        for config_command in config_commands:
-            if config_command["command"] == "blacklist":
-                lines.append(f'{config_command["command"]} {config_command["modulename"]}\n')
-            else:
-                raise ValueError()
+    lines = []
+    for config_command in options["commands"]:
+        if config_command["command"] == "blacklist":
+            lines.append(f'{config_command["command"]} {config_command["modulename"]}\n')
+        else:
+            raise ValueError()
 
-        with open(f"{config_dir}/{config_file}", "w") as f:
-            f.writelines(lines)
-
-
-def main(tree, options):
-    configuration_files_options = options.get("config", {})
-
-    create_configuration_files(tree, configuration_files_options)
+    with open(f"{config_dir}/{config_file}", "w") as f:
+        f.writelines(lines)
 
     return 0
 

--- a/stages/org.osbuild.systemd
+++ b/stages/org.osbuild.systemd
@@ -24,10 +24,8 @@ the following subset of options:
     - 'Environment' option
 """
 
-import os
 import subprocess
 import sys
-import configparser
 
 import osbuild.api
 
@@ -53,65 +51,9 @@ SCHEMA = r"""
   "default_target": {
     "type": "string",
     "description": "The default target to boot into"
-  },
-  "unit_dropins": {
-    "additionalProperties": false,
-    "type": "object",
-    "description": "Systemd unit drop-in configurations.",
-    "patternProperties": {
-      "^[\\w:.\\\\-]+[@]{0,1}[\\w:.\\\\-]*\\.service$": {
-        "additionalProperties": false,
-        "type": "object",
-        "description": "Drop-in configurations for a '.service' unit.",
-        "patternProperties": {
-          "^[\\w.-]{1,250}\\.conf$": {
-            "additionalProperties": false,
-            "type": "object",
-            "description": "Drop-in configuration for a '.service' unit.",
-            "properties": {
-              "Service": {
-                "additionalProperties": false,
-                "type": "object",
-                "description": "'Service' configuration section of a unit file.",
-                "properties": {
-                  "Environment": {
-                    "type": "string",
-                    "description": "Sets environment variables for executed process."
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
   }
 }
 """
-
-
-def configure_unit_dropins(tree, unit_dropins_options):
-    for unit, unit_dropins in unit_dropins_options.items():
-        # ensure the unit name + ".d" does not exceed maximum filename length
-        if len(unit+".d") > 255:
-            raise ValueError(f"Error: the {unit} unit drop-in directory exceeds the maximum filename length.")
-
-        unit_dropins_dir = f"{tree}/usr/lib/systemd/system/{unit}.d"
-        os.makedirs(unit_dropins_dir, exist_ok=True)
-
-        for dropin_file, dropin_config in unit_dropins.items():
-            config = configparser.ConfigParser()
-            # prevent conversion of the option name to lowercase
-            config.optionxform = lambda option: option
-
-            for section, options in dropin_config.items():
-                if not config.has_section(section):
-                    config.add_section(section)
-                for option, value in options.items():
-                    config.set(section, option, str(value))
-
-            with open(f"{unit_dropins_dir}/{dropin_file}", "w") as f:
-                config.write(f, space_around_delimiters=False)
 
 
 def main(tree, options):
@@ -119,7 +61,6 @@ def main(tree, options):
     disabled_services = options.get("disabled_services", [])
     masked_services = options.get("masked_services", [])
     default_target = options.get("default_target")
-    unit_dropins_options = options.get("unit_dropins", {})
 
     for service in enabled_services:
         subprocess.run(["systemctl", "--root", tree, "enable", service], check=True)
@@ -132,8 +73,6 @@ def main(tree, options):
 
     if default_target:
         subprocess.run(["systemctl", "--root", tree, "set-default", default_target], check=True)
-
-    configure_unit_dropins(tree, unit_dropins_options)
 
     return 0
 

--- a/stages/org.osbuild.systemd-logind
+++ b/stages/org.osbuild.systemd-logind
@@ -2,7 +2,7 @@
 """
 Configure systemd-logind
 
-The 'configuration_dropins' option allows to create systemd-logind configuration
+The 'config' option allows to create one or more systemd-logind configuration
 drop-in files in `/usr/lib/systemd/logind.conf.d`. Value of this option is
 an dictionary with keys specifying the name od the `.conf` drop-in configuration
 file to create. The dictionary must have at least one `.conf` file defined.
@@ -28,7 +28,7 @@ import osbuild.api
 SCHEMA = r"""
 "additionalProperties": false,
 "properties": {
-  "configuration_dropins": {
+  "config": {
     "additionalProperties": false,
     "type": "object",
     "description": "systemd-logind configuration drop-ins.",
@@ -84,7 +84,7 @@ def create_configuration_dropins(tree, configuration_dropins_options):
 
 
 def main(tree, options):
-    configuration_dropins_options = options.get("configuration_dropins", {})
+    configuration_dropins_options = options.get("config", {})
 
     create_configuration_dropins(tree, configuration_dropins_options)
 

--- a/stages/org.osbuild.systemd-logind
+++ b/stages/org.osbuild.systemd-logind
@@ -2,12 +2,9 @@
 """
 Configure systemd-logind
 
-The 'config' option allows to create one or more systemd-logind configuration
-drop-in files in `/usr/lib/systemd/logind.conf.d`. Value of this option is
-an dictionary with keys specifying the name od the `.conf` drop-in configuration
-file to create. The dictionary must have at least one `.conf` file defined.
-Value of each such key is dictionary representing the systemd-logind
-configuration.
+The 'config' option allows to create a systemd-logind configuration
+drop-in file in `/usr/lib/systemd/logind.conf.d` with the name
+`filename`.
 
 Drop-in configuration files can currently specify the following subset of
 options:
@@ -27,31 +24,29 @@ import osbuild.api
 
 SCHEMA = r"""
 "additionalProperties": false,
+"required": ["config", "filename"],
 "properties": {
+  "filename": {
+    "type": "string",
+    "description": "Name of the systemd-logind drop-in.",
+    "pattern": "^[\\w.-]{1,250}\\.conf$"
+  },
   "config": {
     "additionalProperties": false,
     "type": "object",
-    "description": "systemd-logind configuration drop-ins.",
+    "description": "systemd-logind configuration",
     "minProperties": 1,
-    "patternProperties": {
-      "^[\\w.-]{1,250}\\.conf$": {
+    "properties": {
+      "Login": {
         "additionalProperties": false,
         "type": "object",
-        "description": "Drop-in configuration for systemd-logind.",
-        "required": ["Login"],
+        "description": "'Login' configuration section.",
+        "minProperties": 1,
         "properties": {
-          "Login": {
-            "additionalProperties": false,
-            "type": "object",
-            "description": "'Login' configuration section.",
-            "minProperties": 1,
-            "properties": {
-              "NAutoVTs": {
-                "type": "integer",
-                "minimum": 0,
-                "description": "Configures how many virtual terminals (VTs) to allocate by default."
-              }
-            }
+          "NAutoVTs": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Configures how many virtual terminals (VTs) to allocate by default."
           }
         }
       }
@@ -61,32 +56,25 @@ SCHEMA = r"""
 """
 
 
-def create_configuration_dropins(tree, configuration_dropins_options):
-    if not configuration_dropins_options:
-        return
+def main(tree, options):
+    dropin_file = options["filename"]
+    dropin_config = options["config"]
 
     dropins_dir = f"{tree}/usr/lib/systemd/logind.conf.d"
     os.makedirs(dropins_dir, exist_ok=True)
 
-    for dropin_file, dropin_config in configuration_dropins_options.items():
-        config = configparser.ConfigParser()
-        # prevent conversion of the option name to lowercase
-        config.optionxform = lambda option: option
+    config = configparser.ConfigParser()
+    # prevent conversion of the option name to lowercase
+    config.optionxform = lambda option: option
 
-        for section, options in dropin_config.items():
-            if not config.has_section(section):
-                config.add_section(section)
-            for option, value in options.items():
-                config.set(section, option, str(value))
+    for section, opts in dropin_config.items():
+        if not config.has_section(section):
+            config.add_section(section)
+        for option, value in opts.items():
+            config.set(section, option, str(value))
 
-        with open(f"{dropins_dir}/{dropin_file}", "w") as f:
-            config.write(f, space_around_delimiters=False)
-
-
-def main(tree, options):
-    configuration_dropins_options = options.get("config", {})
-
-    create_configuration_dropins(tree, configuration_dropins_options)
+    with open(f"{dropins_dir}/{dropin_file}", "w") as f:
+        config.write(f, space_around_delimiters=False)
 
     return 0
 

--- a/stages/org.osbuild.systemd.unit
+++ b/stages/org.osbuild.systemd.unit
@@ -1,0 +1,91 @@
+#!/usr/bin/python3
+"""
+Configure Systemd services via unit file dropins
+
+This stage allows to create Systemd unit drop-in configuration files in
+`/usr/lib/systemd/system/<unit_name>.d/`. The `unit` property specifies the
+'.service' file to be modified using the drop-ins. These names are validated
+using the same rules as specified by systemd.unit(5) and they must contain the
+'.service' suffix (other types of unit files are not supported).
+The `filename` must end in `.conf` and specifies the name to use for the
+drop-in file.
+
+The Drop-in configuration can currently specify the following subset
+of options:
+  - 'Service' section
+    - 'Environment' option
+"""
+
+import os
+import sys
+import configparser
+
+import osbuild.api
+
+
+SCHEMA = r"""
+"additionalProperties": false,
+"required": ["unit", "dropin", "config"],
+"properties": {
+  "unit": {
+    "type": "string",
+    "pattern": "^[\\w:.\\\\-]+[@]{0,1}[\\w:.\\\\-]*\\.service$"
+  },
+  "dropin": {
+    "type": "string",
+    "pattern": "^[\\w.-]{1,250}\\.conf$"
+  },
+  "config": {
+    "additionalProperties": false,
+    "type": "object",
+    "description": "Drop-in configuration for a '.service' unit.",
+    "properties": {
+      "Service": {
+        "additionalProperties": false,
+        "type": "object",
+        "description": "'Service' configuration section of a unit file.",
+        "properties": {
+          "Environment": {
+            "type": "string",
+            "description": "Sets environment variables for executed process."
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def main(tree, options):
+    unit = options["unit"]
+    dropin_file = options["dropin"]
+    cfg = options["config"]
+
+    # ensure the unit name + ".d" does not exceed maximum filename length
+    if len(unit+".d") > 255:
+        raise ValueError(f"Error: the {unit} unit drop-in directory exceeds the maximum filename length.")
+
+    unit_dropins_dir = f"{tree}/usr/lib/systemd/system/{unit}.d"
+    os.makedirs(unit_dropins_dir, exist_ok=True)
+
+    config = configparser.ConfigParser()
+    # prevent conversion of the option name to lowercase
+    config.optionxform = lambda option: option
+
+    for section, opts in cfg.items():
+        if not config.has_section(section):
+            config.add_section(section)
+        for option, value in opts.items():
+            config.set(section, option, str(value))
+
+    with open(f"{unit_dropins_dir}/{dropin_file}", "w") as f:
+        config.write(f, space_around_delimiters=False)
+
+    return 0
+
+
+if __name__ == '__main__':
+    args = osbuild.api.arguments()
+    r = main(args["tree"], args["options"])
+    sys.exit(r)

--- a/test/data/stages/cloud-init/b.json
+++ b/test/data/stages/cloud-init/b.json
@@ -506,7 +506,7 @@
       {
         "name": "org.osbuild.cloud-init",
         "options": {
-          "configuration_files": {
+          "config": {
             "00-default_user.cfg": {
               "system_info": {
                 "default_user": {

--- a/test/data/stages/cloud-init/b.json
+++ b/test/data/stages/cloud-init/b.json
@@ -506,12 +506,11 @@
       {
         "name": "org.osbuild.cloud-init",
         "options": {
+          "filename": "00-default_user.cfg",
           "config": {
-            "00-default_user.cfg": {
-              "system_info": {
-                "default_user": {
-                  "name": "ec2-user"
-                }
+            "system_info": {
+              "default_user": {
+                "name": "ec2-user"
               }
             }
           }

--- a/test/data/stages/cloud-init/b.mpp.json
+++ b/test/data/stages/cloud-init/b.mpp.json
@@ -32,12 +32,11 @@
       {
         "name": "org.osbuild.cloud-init",
         "options": {
+          "filename": "00-default_user.cfg",
           "config": {
-            "00-default_user.cfg": {
-              "system_info": {
-                "default_user": {
-                  "name": "ec2-user"
-                }
+            "system_info": {
+              "default_user": {
+                "name": "ec2-user"
               }
             }
           }

--- a/test/data/stages/cloud-init/b.mpp.json
+++ b/test/data/stages/cloud-init/b.mpp.json
@@ -32,7 +32,7 @@
       {
         "name": "org.osbuild.cloud-init",
         "options": {
-          "configuration_files": {
+          "config": {
             "00-default_user.cfg": {
               "system_info": {
                 "default_user": {

--- a/test/data/stages/dracut.conf/b.json
+++ b/test/data/stages/dracut.conf/b.json
@@ -457,7 +457,7 @@
       {
         "name": "org.osbuild.dracut.conf",
         "options": {
-          "configuration_files": {
+          "config": {
             "sgdisk.conf": {
               "install_items": [
                 "sgdisk"

--- a/test/data/stages/dracut.conf/b.json
+++ b/test/data/stages/dracut.conf/b.json
@@ -457,12 +457,11 @@
       {
         "name": "org.osbuild.dracut.conf",
         "options": {
+          "filename": "sgdisk.conf",
           "config": {
-            "sgdisk.conf": {
-              "install_items": [
-                "sgdisk"
-              ]
-            }
+            "install_items": [
+              "sgdisk"
+            ]
           }
         }
       }

--- a/test/data/stages/dracut.conf/b.mpp.json
+++ b/test/data/stages/dracut.conf/b.mpp.json
@@ -32,7 +32,7 @@
       {
         "name": "org.osbuild.dracut.conf",
         "options": {
-          "configuration_files": {
+          "config": {
             "sgdisk.conf": {
               "install_items": [
                 "sgdisk"

--- a/test/data/stages/dracut.conf/b.mpp.json
+++ b/test/data/stages/dracut.conf/b.mpp.json
@@ -32,12 +32,11 @@
       {
         "name": "org.osbuild.dracut.conf",
         "options": {
+          "filename": "sgdisk.conf",
           "config": {
-            "sgdisk.conf": {
-              "install_items": [
-                "sgdisk"
-              ]
-            }
+            "install_items": [
+              "sgdisk"
+            ]
           }
         }
       }

--- a/test/data/stages/modprobe/b.json
+++ b/test/data/stages/modprobe/b.json
@@ -457,24 +457,29 @@
       {
         "name": "org.osbuild.modprobe",
         "options": {
-          "config": {
-            "disallow-modules.conf": [
-              {
-                "command": "blacklist",
-                "modulename": "nouveau"
-              },
-              {
-                "command": "blacklist",
-                "modulename": "floppy"
-              }
-            ],
-            "disallow-additional-modules.conf": [
-              {
-                "command": "blacklist",
-                "modulename": "my-module"
-              }
-            ]
-          }
+          "filename": "disallow-modules.conf",
+          "commands": [
+            {
+              "command": "blacklist",
+              "modulename": "nouveau"
+            },
+            {
+              "command": "blacklist",
+              "modulename": "floppy"
+            }
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.modprobe",
+        "options": {
+          "filename": "disallow-additional-modules.conf",
+          "commands": [
+            {
+              "command": "blacklist",
+              "modulename": "my-module"
+            }
+          ]
         }
       }
     ]

--- a/test/data/stages/modprobe/b.json
+++ b/test/data/stages/modprobe/b.json
@@ -457,7 +457,7 @@
       {
         "name": "org.osbuild.modprobe",
         "options": {
-          "configuration_files": {
+          "config": {
             "disallow-modules.conf": [
               {
                 "command": "blacklist",

--- a/test/data/stages/modprobe/b.mpp.json
+++ b/test/data/stages/modprobe/b.mpp.json
@@ -32,24 +32,29 @@
       {
         "name": "org.osbuild.modprobe",
         "options": {
-          "config": {
-            "disallow-modules.conf": [
-              {
-                "command": "blacklist",
-                "modulename": "nouveau"
-              },
-              {
-                "command": "blacklist",
-                "modulename": "floppy"
-              }
-            ],
-            "disallow-additional-modules.conf": [
-              {
-                "command": "blacklist",
-                "modulename": "my-module"
-              }
-            ]
-          }
+          "filename": "disallow-modules.conf",
+          "commands": [
+            {
+              "command": "blacklist",
+              "modulename": "nouveau"
+            },
+            {
+              "command": "blacklist",
+              "modulename": "floppy"
+            }
+          ]
+        }
+      },
+      {
+        "name": "org.osbuild.modprobe",
+        "options": {
+          "filename": "disallow-additional-modules.conf",
+          "commands": [
+            {
+              "command": "blacklist",
+              "modulename": "my-module"
+            }
+          ]
         }
       }
     ]

--- a/test/data/stages/modprobe/b.mpp.json
+++ b/test/data/stages/modprobe/b.mpp.json
@@ -23,30 +23,32 @@
                 "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/"
               }
             ],
-            "packages": ["kmod"]
+            "packages": [
+              "kmod"
+            ]
           }
         }
       },
       {
         "name": "org.osbuild.modprobe",
         "options": {
-          "configuration_files": {
-              "disallow-modules.conf": [
-                {
-                  "command": "blacklist",
-                  "modulename": "nouveau"
-                },
-                {
-                  "command": "blacklist",
-                  "modulename": "floppy"
-                }
-              ],
-              "disallow-additional-modules.conf": [
-                {
-                  "command": "blacklist",
-                  "modulename": "my-module"
-                }
-              ]
+          "config": {
+            "disallow-modules.conf": [
+              {
+                "command": "blacklist",
+                "modulename": "nouveau"
+              },
+              {
+                "command": "blacklist",
+                "modulename": "floppy"
+              }
+            ],
+            "disallow-additional-modules.conf": [
+              {
+                "command": "blacklist",
+                "modulename": "my-module"
+              }
+            ]
           }
         }
       }

--- a/test/data/stages/systemd-logind/b.json
+++ b/test/data/stages/systemd-logind/b.json
@@ -457,11 +457,10 @@
       {
         "name": "org.osbuild.systemd-logind",
         "options": {
+          "filename": "10-ec2-getty-fix.conf",
           "config": {
-            "10-ec2-getty-fix.conf": {
-              "Login": {
-                "NAutoVTs": 0
-              }
+            "Login": {
+              "NAutoVTs": 0
             }
           }
         }

--- a/test/data/stages/systemd-logind/b.json
+++ b/test/data/stages/systemd-logind/b.json
@@ -457,7 +457,7 @@
       {
         "name": "org.osbuild.systemd-logind",
         "options": {
-          "configuration_dropins": {
+          "config": {
             "10-ec2-getty-fix.conf": {
               "Login": {
                 "NAutoVTs": 0

--- a/test/data/stages/systemd-logind/b.mpp.json
+++ b/test/data/stages/systemd-logind/b.mpp.json
@@ -32,11 +32,10 @@
       {
         "name": "org.osbuild.systemd-logind",
         "options": {
+          "filename": "10-ec2-getty-fix.conf",
           "config": {
-            "10-ec2-getty-fix.conf": {
-              "Login": {
-                "NAutoVTs": 0
-              }
+            "Login": {
+              "NAutoVTs": 0
             }
           }
         }

--- a/test/data/stages/systemd-logind/b.mpp.json
+++ b/test/data/stages/systemd-logind/b.mpp.json
@@ -32,7 +32,7 @@
       {
         "name": "org.osbuild.systemd-logind",
         "options": {
-          "configuration_dropins": {
+          "config": {
             "10-ec2-getty-fix.conf": {
               "Login": {
                 "NAutoVTs": 0

--- a/test/data/stages/systemd.unit/a.json
+++ b/test/data/stages/systemd.unit/a.json
@@ -458,20 +458,6 @@
             "sha256:0ebe43a9bef7ec2dc4cb98350fbde2e55dae886f905e2d9cea837da3fb613c87"
           ]
         }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "nftables"
-          ],
-          "masked_services": [
-            "ldconfig"
-          ],
-          "disabled_services": [
-            "sshd"
-          ]
-        }
       }
     ]
   },

--- a/test/data/stages/systemd.unit/a.mpp.json
+++ b/test/data/stages/systemd.unit/a.mpp.json
@@ -30,20 +30,6 @@
             ]
           }
         }
-      },
-      {
-        "name": "org.osbuild.systemd",
-        "options": {
-          "enabled_services": [
-            "nftables"
-          ],
-          "masked_services": [
-            "ldconfig"
-          ],
-          "disabled_services": [
-            "sshd"
-          ]
-        }
       }
     ]
   }

--- a/test/data/stages/systemd.unit/b.json
+++ b/test/data/stages/systemd.unit/b.json
@@ -460,17 +460,15 @@
         }
       },
       {
-        "name": "org.osbuild.systemd",
+        "name": "org.osbuild.systemd.unit",
         "options": {
-          "enabled_services": [
-            "nftables"
-          ],
-          "masked_services": [
-            "ldconfig"
-          ],
-          "disabled_services": [
-            "sshd"
-          ]
+          "unit": "nm-cloud-setup.service",
+          "dropin": "10-rh-enable-for-ec2.conf",
+          "config": {
+            "Service": {
+              "Environment": "NM_CLOUD_SETUP_EC2=yes"
+            }
+          }
         }
       }
     ]

--- a/test/data/stages/systemd.unit/b.mpp.json
+++ b/test/data/stages/systemd.unit/b.mpp.json
@@ -32,17 +32,15 @@
         }
       },
       {
-        "name": "org.osbuild.systemd",
+        "name": "org.osbuild.systemd.unit",
         "options": {
-          "enabled_services": [
-            "nftables"
-          ],
-          "masked_services": [
-            "ldconfig"
-          ],
-          "disabled_services": [
-            "sshd"
-          ]
+          "unit": "nm-cloud-setup.service",
+          "dropin": "10-rh-enable-for-ec2.conf",
+          "config": {
+            "Service": {
+              "Environment": "NM_CLOUD_SETUP_EC2=yes"
+            }
+          }
         }
       }
     ]

--- a/test/data/stages/systemd.unit/diff.json
+++ b/test/data/stages/systemd.unit/diff.json
@@ -1,0 +1,8 @@
+{
+  "added_files": [
+    "/usr/lib/systemd/system/nm-cloud-setup.service.d",
+    "/usr/lib/systemd/system/nm-cloud-setup.service.d/10-rh-enable-for-ec2.conf"
+  ],
+  "deleted_files": [],
+  "differences": {}
+}

--- a/test/data/stages/systemd/diff.json
+++ b/test/data/stages/systemd/diff.json
@@ -1,9 +1,7 @@
 {
   "added_files": [
     "/etc/systemd/system/ldconfig.service",
-    "/etc/systemd/system/multi-user.target.wants/nftables.service",
-    "/usr/lib/systemd/system/nm-cloud-setup.service.d",
-    "/usr/lib/systemd/system/nm-cloud-setup.service.d/10-rh-enable-for-ec2.conf"
+    "/etc/systemd/system/multi-user.target.wants/nftables.service"
   ],
   "deleted_files": [
     "/etc/systemd/system/multi-user.target.wants/sshd.service"


### PR DESCRIPTION
Instead of creating multiple files per stage, create only one configuration file. This generally makes the stage and its schema easier to read and gives us more flexibility to add options on the top-level, per file, like the directory the file it is created in or a top-level comment explaining the content.