### PR TITLE
stages/cloud-init: configuration file must contain at least one option

### DIFF
--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -36,6 +36,7 @@ SCHEMA = r"""
     "additionalProperties": false,
     "type": "object",
     "description": "cloud-init configuration",
+    "minProperties": 1,
     "properties": {
       "system_info": {
         "additionalProperties": false,


### PR DESCRIPTION
Add back a schema constrain, that at least one configuration must be specified for the configuration file.

This has been forgotten/missed as part of https://github.com/osbuild/osbuild/pull/739.