### PR TITLE
devices/loopback:

### DIFF
--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -60,8 +60,6 @@ class LoopbackService(devices.DeviceService):
         self.ctl = loop.LoopControl()
 
     def make_loop(self, fd: int, offset, sizelimit):
-        lo = loop.Loop(self.ctl.get_unbound())
-
         if not sizelimit:
             stat = os.fstat(fd)
             sizelimit = stat.st_size - offset
@@ -69,6 +67,10 @@ class LoopbackService(devices.DeviceService):
             sizelimit *= self.sector_size
 
         while True:
+            # Getting an unbound loopback device and attaching a backing
+            # file descriptor to it is racy, so we must use a retry loop
+            lo = loop.Loop(self.ctl.get_unbound())
+
             try:
                 lo.set_fd(fd)
             except OSError as e:


### PR DESCRIPTION
Getting unbound loop devices is racy, so we do it in a retry loop:in case of a recoverable error, like when the loop device signalsit is busy, we close the it and try another one. Indeed the code,closed the loop device but did in fact not open a new one and wewould therefore see file descriptor cannot be a negative integererrors when trying in `lo.set_fd(fd)` since `lo` is in fact closednow and thus indeed '-1'.

Open a new loop device at the beginning of the retry-loop to fixthis issue.

Should fix #743 