### PR TITLE
Loop controller improvements

### DIFF
--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -114,6 +114,11 @@ class LoopbackService(devices.DeviceService):
         self.ctl.close()
 
         if self.lo:
+            # clear the fd. Since it might not immediately be
+            # cleared (due to a race with udev or some other
+            # process still having a reference to the loop dev)
+            # we give it some time and wait for the clearing
+            self.lo.clear_fd_wait(self.fd, 30)
             self.lo.close()
             self.lo = None
 

--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -66,29 +66,10 @@ class LoopbackService(devices.DeviceService):
         else:
             sizelimit *= self.sector_size
 
-        while True:
-            # Getting an unbound loopback device and attaching a backing
-            # file descriptor to it is racy, so we must use a retry loop
-            lo = loop.Loop(self.ctl.get_unbound())
-
-            try:
-                lo.set_fd(fd)
-            except OSError as e:
-                lo.close()
-                if e.errno == errno.EBUSY:
-                    continue
-                raise e
-            # `set_status` returns EBUSY when the pages from the previously
-            # bound file have not been fully cleared yet.
-            try:
-                lo.set_status(offset=offset,
-                              sizelimit=sizelimit,
-                              autoclear=True)
-            except BlockingIOError:
-                lo.clear_fd()
-                lo.close()
-                continue
-            break
+        lo = self.ctl.loop_for_fd(fd,
+                                  offset=offset,
+                                  sizelimit=sizelimit,
+                                  autoclear=True)
 
         return lo
 

--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -69,6 +69,7 @@ class LoopbackService(devices.DeviceService):
         lo = self.ctl.loop_for_fd(fd,
                                   offset=offset,
                                   sizelimit=sizelimit,
+                                  partscan=False,
                                   autoclear=True)
 
         return lo

--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -46,6 +46,10 @@ SCHEMA = """
     "type": "number",
     "description": "Sector size (in bytes)",
     "default": 512
+  },
+  "lock": {
+    "type": "boolean",
+    "description": "Lock the device after opening it"
   }
 }
 """
@@ -59,14 +63,14 @@ class LoopbackService(devices.DeviceService):
         self.lo = None
         self.ctl = loop.LoopControl()
 
-    def make_loop(self, fd: int, offset, sizelimit):
+    def make_loop(self, fd: int, offset, sizelimit, lock):
         if not sizelimit:
             stat = os.fstat(fd)
             sizelimit = stat.st_size - offset
         else:
             sizelimit *= self.sector_size
 
-        lo = self.ctl.loop_for_fd(fd,
+        lo = self.ctl.loop_for_fd(fd, lock=lock,
                                   offset=offset,
                                   sizelimit=sizelimit,
                                   partscan=False,
@@ -79,13 +83,14 @@ class LoopbackService(devices.DeviceService):
         self.sector_size = options.get("sector-size", 512)
         start = options.get("start", 0) * self.sector_size
         size = options.get("size")
+        lock = options.get("lock", False)
 
         path = os.path.join(tree, filename.lstrip("/"))
 
         self.fd = os.open(path, os.O_RDWR | os.O_CLOEXEC)
         print(f"file '{filename}'' opened as {self.fd}")
         try:
-            self.lo = self.make_loop(self.fd, start, size)
+            self.lo = self.make_loop(self.fd, start, size, lock)
         except Exception as error:  # pylint: disable: broad-except
             self.close()
             raise error from None

--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -127,6 +127,10 @@ class LoopbackService(devices.DeviceService):
         return res
 
     def close(self):
+        # Calling `close` is valid on closed
+        # `LoopControl` and `Loop` objects
+        self.ctl.close()
+
         if self.lo:
             self.lo.close()
             self.lo = None

--- a/osbuild/devices.py
+++ b/osbuild/devices.py
@@ -80,5 +80,8 @@ class DeviceService(host.Service):
         if method == "open":
             r = self.open(args["dev"], args["tree"], args["options"])
             return r, None
+        if method == "close":
+            r = self.close()
+            return r, None
 
         raise host.ProtocolError("Unknown method")

--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -208,8 +208,7 @@ class Loop:
             unchanged (default is None)
         """
 
-        info = LoopInfo()
-        fcntl.ioctl(self.fd, self.LOOP_GET_STATUS64, info)
+        info = self.get_status()
         if offset:
             info.lo_offset = offset
         if sizelimit:
@@ -225,6 +224,17 @@ class Loop:
             else:
                 info.lo_flags &= ~self.LO_FLAGS_PARTSCAN
         fcntl.ioctl(self.fd, self.LOOP_SET_STATUS64, info)
+
+    def get_status(self) -> LoopInfo:
+        """Get properties of the loopback device
+
+        Return a `LoopInfo` structure with the information of this
+        loopback device. See loop(4) for more information.
+        """
+
+        info = LoopInfo()
+        fcntl.ioctl(self.fd, self.LOOP_GET_STATUS64, info)
+        return info
 
     def set_direct_io(self, dio=True):
         """Set the direct-IO property on the loopback device

--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -43,6 +43,11 @@ class LoopInfo(ctypes.Structure):
         """Return if `LO_FLAGS_AUTOCLEAR` is set in `lo_flags`"""
         return bool(self.lo_flags & Loop.LO_FLAGS_AUTOCLEAR)
 
+    def is_bound_to(self, info: os.stat_result) -> bool:
+        """Return if the loop device is bound to the file `info`"""
+        return (self.lo_device == info.st_dev and
+                self.lo_inode == info.st_ino)
+
 
 class Loop:
     """Loopback device

--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -317,9 +317,12 @@ class LoopControl:
             or None to use /dev (default is None)
         """
 
-        if not dir_fd:
-            dir_fd = os.open("/dev", os.O_DIRECTORY)
-        self.fd = os.open("loop-control", os.O_RDWR, dir_fd=dir_fd)
+        with contextlib.ExitStack() as stack:
+            if not dir_fd:
+                dir_fd = os.open("/dev", os.O_DIRECTORY)
+                stack.callback(lambda: os.close(dir_fd))
+
+            self.fd = os.open("loop-control", os.O_RDWR, dir_fd=dir_fd)
 
     def __del__(self):
         self.close()

--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -38,6 +38,11 @@ class LoopInfo(ctypes.Structure):
         ('lo_init', ctypes.c_uint64 * 2)
     ]
 
+    @property
+    def autoclear(self) -> bool:
+        """Return if `LO_FLAGS_AUTOCLEAR` is set in `lo_flags`"""
+        return bool(self.lo_flags & Loop.LO_FLAGS_AUTOCLEAR)
+
 
 class Loop:
     """Loopback device

--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -180,6 +180,37 @@ class Loop:
 
         fcntl.ioctl(self.fd, self.LOOP_CHANGE_FD, fd)
 
+    def is_bound_to(self, fd: int) -> bool:
+        """Check if the loopback device is bound to `fd`
+
+        Checks if the loopback device is bound and, if so, whether the
+        backing file refers to the same file as `fd`. The latter is
+        done by comparing the device and inode information.
+
+        Parameters
+        ----------
+        fd : int
+            the file descriptor to check
+
+        Returns
+        -------
+        bool
+            True if the loopback device is bound to the file descriptor
+        """
+
+        try:
+            loop_info = self.get_status()
+        except OSError as err:
+
+            # raised if the loopback is bound at all
+            if err.errno == errno.ENXIO:
+                return False
+
+        file_info = os.fstat(fd)
+
+        # it is bound, check if it is bound by `fd`
+        return loop_info.is_bound_to(file_info)
+
     def set_status(self, offset=None, sizelimit=None, autoclear=None, partscan=None):
         """Set properties of the loopback device
 

--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -82,6 +82,7 @@ class LoopServer(api.BaseAPI):
     def _cleanup(self):
         for lo in self.devs:
             lo.close()
+        self.ctl.close()
 
 
 class LoopClient:

--- a/test/mod/test_loop.py
+++ b/test/mod/test_loop.py
@@ -4,7 +4,7 @@
 
 import contextlib
 import os
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, TemporaryFile
 
 import pytest
 
@@ -45,6 +45,16 @@ def test_basic(tempdir):
         info = lo.get_status()
         assert info.lo_inode == sb.st_ino
         assert info.lo_number == lo.minor
+
+        # check for `LoopInfo.is_bound_to` helper
+        assert info.is_bound_to(sb)
+
+        with TemporaryFile(dir=tempdir) as t:
+            t.write(b"")
+            t.flush()
+
+            st = os.fstat(t.fileno())
+            assert not info.is_bound_to(st)
 
         # check for autoclear flags setting and helpers
         assert info.autoclear

--- a/test/mod/test_loop.py
+++ b/test/mod/test_loop.py
@@ -37,6 +37,8 @@ def test_basic(tempdir):
         f.flush()
         lo = ctl.loop_for_fd(f.fileno(), autoclear=True)
 
+        assert lo.is_bound_to(f.fileno())
+
         sb = os.fstat(f.fileno())
 
         assert lo

--- a/test/mod/test_loop.py
+++ b/test/mod/test_loop.py
@@ -1,0 +1,66 @@
+#
+# Test for the loop.py
+#
+
+import contextlib
+import os
+
+
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from osbuild import loop
+
+from ..test import TestBase
+
+
+@pytest.fixture(name="tempdir")
+def tempdir_fixture():
+    with TemporaryDirectory(prefix="loop-") as tmp:
+        yield tmp
+
+
+@pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")
+def test_basic(tempdir):
+
+    path = os.path.join(tempdir, "test.img")
+    ctl = loop.LoopControl()
+
+    assert ctl
+
+    with pytest.raises(ValueError):
+        ctl.loop_for_fd(-1)
+
+    lo, f = None, None
+    try:
+        f = open(path, "wb+")
+        f.truncate(1024)
+        f.flush()
+        lo = ctl.loop_for_fd(f.fileno())
+
+        assert lo
+        assert lo.devname
+
+    finally:
+        if lo:
+            with contextlib.suppress(OSError):
+                lo.clear_fd()
+            lo.close()
+        if f:
+            f.close()
+
+        ctl.close()
+
+    # closing must be a no-op on a closed LoopControl
+    ctl.close()
+
+    # check we raise exceptions on methods that require
+    # an open LoopControl
+
+    for fn in (ctl.add, ctl.remove, ctl.get_unbound):
+        with pytest.raises(RuntimeError):
+            fn()
+
+    with pytest.raises(RuntimeError):
+        ctl.loop_for_fd(0)

--- a/test/mod/test_loop.py
+++ b/test/mod/test_loop.py
@@ -4,6 +4,8 @@
 
 import contextlib
 import os
+import time
+import threading
 from tempfile import TemporaryDirectory, TemporaryFile
 
 import pytest
@@ -87,3 +89,72 @@ def test_basic(tempdir):
 
     with pytest.raises(RuntimeError):
         ctl.loop_for_fd(0)
+
+
+@pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")
+def test_clear_fd_wait(tempdir):
+
+    path = os.path.join(tempdir, "test.img")
+    ctl = loop.LoopControl()
+
+    assert ctl
+
+    delay_time = 0.25
+
+    def close_loop(lo, barrier):
+        barrier.wait()
+        time.sleep(delay_time)
+        print("closing loop")
+        lo.close()
+
+    lo, lo2, f = None, None, None
+    try:
+        f = open(path, "wb+")
+        f.truncate(1024)
+        f.flush()
+        lo = ctl.loop_for_fd(f.fileno(), autoclear=False)
+        assert lo
+
+        # Increase reference count of the loop to > 1 thus
+        # preventing the kernel from immediately closing the
+        # device. Instead the kernel will set the autoclear
+        # attribute and return
+        lo2 = loop.Loop(lo.minor)
+        assert lo2
+
+        # as long as the second loop is alive, the kernel can
+        # not clear the fd and thus we will get a timeout
+        with pytest.raises(TimeoutError):
+            lo.clear_fd_wait(f.fileno(), 0.1, 0.01)
+
+        # start a thread and sync with a barrier, then close
+        # the loop device in the background thread while the
+        # main thread is waiting in `clear_fd_wait`. We wait
+        # four times the delay time of the thread to ensure
+        # we don't get a timeout.
+        barrier = threading.Barrier(2)
+        thread = threading.Thread(
+            target=close_loop,
+            args=(lo2, barrier)
+        )
+        barrier.reset()
+        thread.start()
+        barrier.wait()
+
+        lo.clear_fd_wait(f.fileno(), 4*delay_time, delay_time/10)
+
+        # no timeout exception has occurred and thus the device
+        # must not be be bound to the original file anymore
+        assert not lo.is_bound_to(f.fileno())
+
+    finally:
+        if lo2:
+            lo2.close()
+        if lo:
+            with contextlib.suppress(OSError):
+                lo.clear_fd()
+            lo.close()
+        if f:
+            f.close()
+
+        ctl.close()

--- a/test/mod/test_loop.py
+++ b/test/mod/test_loop.py
@@ -35,7 +35,7 @@ def test_basic(tempdir):
         f = open(path, "wb+")
         f.truncate(1024)
         f.flush()
-        lo = ctl.loop_for_fd(f.fileno())
+        lo = ctl.loop_for_fd(f.fileno(), autoclear=True)
 
         sb = os.fstat(f.fileno())
 
@@ -45,6 +45,13 @@ def test_basic(tempdir):
         info = lo.get_status()
         assert info.lo_inode == sb.st_ino
         assert info.lo_number == lo.minor
+
+        # check for autoclear flags setting and helpers
+        assert info.autoclear
+
+        lo.set_status(autoclear=False)
+        info = lo.get_status()
+        assert not info.autoclear
 
     finally:
         if lo:

--- a/test/mod/test_loop.py
+++ b/test/mod/test_loop.py
@@ -4,8 +4,6 @@
 
 import contextlib
 import os
-
-
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -39,8 +37,14 @@ def test_basic(tempdir):
         f.flush()
         lo = ctl.loop_for_fd(f.fileno())
 
+        sb = os.fstat(f.fileno())
+
         assert lo
         assert lo.devname
+
+        info = lo.get_status()
+        assert info.lo_inode == sb.st_ino
+        assert info.lo_number == lo.minor
 
     finally:
         if lo:

--- a/test/run/test_devices.py
+++ b/test/run/test_devices.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python3
+
+#
+# Runtime Tests for Device Host Services
+#
+
+import os
+import tempfile
+
+import pytest
+
+from osbuild import devices, host, loop, meta
+
+from ..test import TestBase
+
+
+@pytest.fixture(name="tmpdir")
+def tmpdir_fixture():
+    with tempfile.TemporaryDirectory(prefix="test-devices-") as tmp:
+        yield tmp
+
+
+@pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")
+def test_loopback_basic(tmpdir):
+    index = meta.Index(os.curdir)
+    info = index.get_module_info("Device", "org.osbuild.loopback")
+
+    tree = os.path.join(tmpdir, "tree")
+    os.makedirs(tree)
+
+    devpath = os.path.join(tmpdir, "dev")
+    os.makedirs(devpath)
+
+    size = 1024 * 1024
+    filename = os.path.join(tree, "image.img")
+    with open(filename, "wb") as f:
+        f.truncate(size)
+        sb = os.fstat(f.fileno())
+
+    testfile = os.path.join(tmpdir, "test.img")
+
+    options = {
+        "filename": "image.img",
+        "start": 0,
+        "size": size // 512  # size is in sectors / blocks
+    }
+
+    dev = devices.Device("loop", info, options)
+
+    with host.ServiceManager() as mgr:
+        reply = dev.open(mgr, devpath, tree)
+        assert reply
+        assert reply["path"]
+
+        node = reply["path"]
+        assert os.path.exists(os.path.join(devpath, node))
+
+        minor = reply["node"]["minor"]
+        lo = loop.Loop(minor)
+        li = lo.get_status()
+
+        assert li.lo_offset == 0
+        assert li.lo_sizelimit == size
+        assert li.lo_inode == sb.st_ino
+
+        with pytest.raises(OSError):
+            with open(testfile, "wb") as f:
+                f.truncate(1)
+                lo.set_fd(f.fileno())
+
+        lo.close()
+
+        uid = f"device/{dev.name}"
+        client = mgr.services[uid]
+
+        client.call("close", None)
+
+        lo = loop.Loop(minor)
+        with open(filename, "r") as f:
+            assert not lo.is_bound_to(f.fileno())


### PR DESCRIPTION
Add a `close` method so that we can properly release the underlying file descriptor for the `LoopControl` object. Use that in `devices/org.osbuild.loopback` but more importantly in `RemoteLoop`. The latter is instantiated on every `Stage.run` call and thus the leaks would accumulate over the run of `osbuild` (whereas `devices/org.osbuild.loopback` will release the fd once the process is terminated, which is after the stage has run).

Additionally, create a new `LoopControl.loop_for_fd` helper based on the `make_loop` method in `devices/org.osbuild.loopback`. This is so the code can be shared with other places that want to open loop devices and bind them to file descriptors.