### PR TITLE
stages/grub2.inst: add location to required properties

### DIFF
--- a/stages/org.osbuild.grub2.inst
+++ b/stages/org.osbuild.grub2.inst
@@ -99,7 +99,7 @@ SCHEMA = r"""
   }
 },
 "additionalProperties": false,
-"required": ["filename", "platform", "core", "prefix"],
+"required": ["filename", "platform", "location", "core", "prefix"],
 "properties": {
   "filename": {
     "type": "string",


### PR DESCRIPTION
The location property is required, otherwise the stage will fail due to
KeyError at line 261:

location = options["location"]

This commit adds the property to the list of required ones.