### PR TITLE
runners: add a runner for RHEL 8.6

### DIFF
--- a/runners/org.osbuild.rhel86
+++ b/runners/org.osbuild.rhel86
@@ -1,0 +1,1 @@
+org.osbuild.rhel82


### PR DESCRIPTION
Just a symlink to RHEL 8.2, no changes are required.