### PR TITLE
stages/grub2.inst: fix prefix for dos layouts

### DIFF
--- a/stages/org.osbuild.grub2.inst
+++ b/stages/org.osbuild.grub2.inst
@@ -251,7 +251,9 @@ def prefix_partition(options: Dict):
     number += 1
     path = path.lstrip("/")
 
-    prefix = f"(,{pt_label}{number})/{path}"
+    label = grub2_partition_id(pt_label)
+
+    prefix = f"(,{label}{number})/{path}"
     return prefix
 
 


### PR DESCRIPTION
When the partition layout is `dos` or `mbr`, the correct name for it in the prefix is `msdos`. The function to convert the option to the label already existed but was not used. Fix it by actually using said function.

Reported-by: Achilleas Koutsou <achilleas@koutsou.net>