### PR TITLE
devices/loopback: it is flush_buf not flushbuf

### DIFF
--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -123,7 +123,7 @@ class LoopbackService(devices.DeviceService):
             # seems to be required when clearing the fd of the
             # loop device (as of kernel 5.13.8) or otherwise
             # it leads to data loss.
-            self.lo.flushbuf()
+            self.lo.flush_buf()
 
             # clear the fd. Since it might not immediately be
             # cleared (due to a race with udev or some other


### PR DESCRIPTION
That ironically fix the underlying bug that `flush_buf` is trying to fix too, since now an exception is thrown and we are back to auto clear. The file fd is then closed when the process is terminated. Anyway, the right fix is to call the correct function.