### PR TITLE
 runners: add Fedora 36 runner

### DIFF
--- a/runners/org.osbuild.fedora36
+++ b/runners/org.osbuild.fedora36
@@ -1,0 +1,1 @@
+org.osbuild.fedora30


### PR DESCRIPTION
New `org.osbuild.fedora36` which is re-using the f30 runner. Needed since Fedora 36 was branched already.

Release Notes:
```markdown
  * `runners/org.osbuild.fedora36`: new runner for Fedora 36, reusing the existing f30 runner.
```