### PR TITLE
stages/lvm2.metadata: fix typo in regex

### DIFF
--- a/stages/org.osbuild.lvm2.metadata
+++ b/stages/org.osbuild.lvm2.metadata
@@ -48,7 +48,7 @@ SCHEMA_2 = r"""
     },
     "vg_name": {
       "type": "string",
-      "pattern": "[a-zA-Z09+_.][a-zA-Z0-9+_.-]*"
+      "pattern": "[a-zA-Z0-9+_.][a-zA-Z0-9+_.-]*"
     }
   }
 }


### PR DESCRIPTION
It is zero to nine, not zero and nine.
