### PR TITLE
stages/bootiso.mono: support for aarch64 tempates

### DIFF
--- a/stages/org.osbuild.bootiso.mono
+++ b/stages/org.osbuild.bootiso.mono
@@ -349,7 +349,16 @@ def main(inputs, root, options, workdir, loop_client):
 
     # input directories
     templatedir = os.path.join(LORAX_TEMPLATES, templates)
-    configdir = os.path.join(templatedir, "config_files", "x86")
+
+    # select the template based on the architecture, where
+    # we reuse the efi setting, since we only support efi
+    # on aarch64 this is good enough for now
+    if efi and "AA64" in efi["architectures"]:
+        arch = "aarch64"
+    else:
+        arch = "x86"
+
+    configdir = os.path.join(templatedir, "config_files", arch)
 
     # output directories
     imgdir = os.path.join(root, "images")


### PR DESCRIPTION
Use the aarch64 templates if the efi architecture was set to AA64.

NB: since we only support efi booting for aarch64 this should be good enough for aarch64 selection.