### PR TITLE
stages/kickstart: add schema for remote option

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -40,6 +40,10 @@ SCHEMA = """
       "ref": {
         "type": "string"
       },
+      "remote": {
+        "type": "string",
+        "description": "The remote to tie tie commit to"
+      },
       "gpg": {
         "type": "boolean",
         "default": true


### PR DESCRIPTION
The code of the `org.osbuild.kickstart` stage already supported adding the `--remote` option for `ostreesetup` via the `remote` option but it was not included in the schema.