### PR TITLE
stages/kickstart: quote ssh-key

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -182,7 +182,7 @@ def make_users(users: Dict) -> List[str]:
 
         key = opts.get("key")
         if key:
-            res.append(f"sshkey --username {name} {key}")
+            res.append(f'sshkey --username {name} "{key}"')
 
     return res
 


### PR DESCRIPTION
Surround the ssh key by quotes since it might contain spaces.