### PR TITLE
packit: Drop the COPR jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,31 +15,6 @@ actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
 
 jobs:
-- job: copr_build
-  trigger: pull_request
-  metadata:
-    targets:
-    - centos-stream-8-aarch64
-    - centos-stream-8-x86_64
-    - epel-8-aarch64
-    - epel-8-x86_64
-    - fedora-all-aarch64
-    - fedora-all-s390x
-    - fedora-all
-- job: copr_build
-  trigger: commit
-  metadata:
-    branch: main
-    owner: "@osbuild" # copr repo namespace
-    project: osbuild  # copr repo name so you can consume the builds
-    targets:
-    - centos-stream-8-aarch64
-    - centos-stream-8-x86_64
-    - epel-8-aarch64
-    - epel-8-x86_64
-    - fedora-all-aarch64
-    - fedora-all-s390x
-    - fedora-all
 - job: propose_downstream
   trigger: release
   metadata:


### PR DESCRIPTION
Along with composer I'm proposing we drop the copr steps in packit. We're already building the RPMs ourselves so this doesn't add any value but just wastes CO2.