### PR TITLE
stages/kickstart: set passwords with --iscrypted

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -156,7 +156,7 @@ def make_users(users: Dict) -> List[str]:
 
         password = opts.get("password")
         if password is not None:
-            arguments += ["--password", password or '""']
+            arguments += ["--password", password or '""', "--iscrypted"]
 
         shell = opts.get("shell")
         if shell:


### PR DESCRIPTION
The password is assumed to be encrypted so the `--iscrypted` option is required.