### PR TITLE
util/rhsm: Check if repositories is None before iterating

### DIFF
--- a/osbuild/util/rhsm.py
+++ b/osbuild/util/rhsm.py
@@ -93,13 +93,14 @@ class Subscriptions:
 
     def get_secrets(self, url):
         # Try to find a matching URL from redhat.repo file first
-        for parameters in self.repositories.values():
-            if parameters["matchurl"].match(url) is not None:
-                return {
-                    "ssl_ca_cert": parameters["sslcacert"],
-                    "ssl_client_key": parameters["sslclientkey"],
-                    "ssl_client_cert": parameters["sslclientcert"]
-                }
+        if self.repositories is not None:
+            for parameters in self.repositories.values():
+                if parameters["matchurl"].match(url) is not None:
+                    return {
+                        "ssl_ca_cert": parameters["sslcacert"],
+                        "ssl_client_key": parameters["sslclientkey"],
+                        "ssl_client_cert": parameters["sslclientcert"]
+                    }
 
         # In case there is no matching URL, try the fallback
         if self.secrets:


### PR DESCRIPTION
When `get_fallback_rhsm_secrets` was used, `Subscriptions.repositories`
was None, and `get_secrets` never returned the fallback secrets.

So check if `repositories` is None before
iterating over it, otherwise return the fallback secrets.