### PR TITLE
util/rhsm: Check if repositories is None before iterating

### DIFF
--- a/osbuild/util/rhsm.py
+++ b/osbuild/util/rhsm.py
@@ -93,13 +93,14 @@ class Subscriptions:
 
     def get_secrets(self, url):
         # Try to find a matching URL from redhat.repo file first
-        for parameters in self.repositories.values():
-            if parameters["matchurl"].match(url) is not None:
-                return {
-                    "ssl_ca_cert": parameters["sslcacert"],
-                    "ssl_client_key": parameters["sslclientkey"],
-                    "ssl_client_cert": parameters["sslclientcert"]
-                }
+        if self.repositories is not None:
+            for parameters in self.repositories.values():
+                if parameters["matchurl"].match(url) is not None:
+                    return {
+                        "ssl_ca_cert": parameters["sslcacert"],
+                        "ssl_client_key": parameters["sslclientkey"],
+                        "ssl_client_cert": parameters["sslclientcert"]
+                    }
 
         # In case there is no matching URL, try the fallback
         if self.secrets:

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -32,36 +32,6 @@ pipeline {
             failFast true
 
             parallel {
-                stage('Fedora 32') {
-                    agent { label "f32cloudbase && x86_64" }
-                    environment {
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                    }
-                    steps {
-                        sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
-                    }
-                }
-                stage('Fedora 33') {
-                    agent { label "f33cloudbase && x86_64" }
-                    environment {
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                    }
-                    steps {
-                        sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
-                    }
-                }
-                stage('Fedora 33 aarch64') {
-                    agent { label "f33cloudbase && aarch64 && aws" }
-                    environment {
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                    }
-                    steps {
-                        sh "schutzbot/ci_details.sh"
-                        sh "schutzbot/mockbuild.sh"
-                    }
-                }
                 stage('RHEL 8 CDN') {
                     agent { label "rhel8cloudbase && x86_64" }
                     environment {
@@ -122,38 +92,6 @@ pipeline {
             failFast false
 
             parallel {
-                stage('Fedora 32') {
-                    agent { label "f32cloudbase && x86_64 && psi" }
-                    environment {
-                        TEST_TYPE = "image"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        DISTRO_CODE = "fedora32"
-                    }
-                    steps {
-                        run_tests()
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora32-image')
-                        }
-                    }
-                }
-                stage('Fedora 33') {
-                    agent { label "f33cloudbase && x86_64 && psi" }
-                    environment {
-                        TEST_TYPE = "image"
-                        AWS_CREDS = credentials('aws-credentials-osbuildci')
-                        DISTRO_CODE = "fedora33"
-                    }
-                    steps {
-                        run_tests()
-                    }
-                    post {
-                        always {
-                            preserve_logs('fedora33-image')
-                        }
-                    }
-                }
                 stage('RHEL 8 CDN') {
                     agent { label "rhel8cloudbase && x86_64 && psi" }
                     environment {

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -4,8 +4,7 @@ set -euxo pipefail
 DNF_REPO_BASEURL=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com
 
 # The osbuild-composer commit to run reverse-dependency test against.
-# Currently: osbuild-composer 29
-OSBUILD_COMPOSER_COMMIT=bb235deb6279a0886c0324d61a2511485e6b44f8
+OSBUILD_COMPOSER_COMMIT=9d2aa19f0540abe3bf3b574febb57b68fd125c20
 
 # Get OS details.
 source /etc/os-release
@@ -32,7 +31,7 @@ priority=5
 
 [osbuild-composer]
 name=osbuild-composer ${OSBUILD_COMPOSER_COMMIT}
-baseurl=${DNF_REPO_BASEURL}/osbuild-composer/${ID}-${VERSION_ID}/${ARCH}/${OSBUILD_COMPOSER_COMMIT}
+baseurl=${DNF_REPO_BASEURL}/osbuild-composer/rhel-8-cdn/${ARCH}/${OSBUILD_COMPOSER_COMMIT}
 enabled=1
 gpgcheck=0
 # Give this a slightly lower priority, because we used to have osbuild in this repo as well.


### PR DESCRIPTION
When `get_fallback_rhsm_secrets` was used, `Subscriptions.repositories`
was None, and `get_secrets` never returned the fallback secrets.

So check if `repositories` is None before
iterating over it, otherwise return the fallback secrets.