### PR TITLE
packit: Propose PRs to all Fedoras

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -44,4 +44,4 @@ jobs:
   trigger: release
   metadata:
     dist_git_branches:
-      - fedora-rawhide
+      - fedora-all


### PR DESCRIPTION
Since we have made good experiences with packit and rawhide for the most recent releases I propose to extend it to all active Fedora releases.
(I proposed the same change to osbuild-composer: https://github.com/osbuild/osbuild-composer/pull/1756)