### PR TITLE
ostree.config: add `bootloader` config option

### DIFF
--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -5,6 +5,9 @@ Change OSTree configuration
 Change the configuration for an OSTree repository.
 Currently only the following values are supported:
   - `sysroot.readonly`
+  - `sysroot.bootloader`
+
+See `ostree.repo-config(5)` for more information.
 """
 
 import os
@@ -32,6 +35,11 @@ SCHEMA = """
         "additionalProperties": false,
         "description": "Options concerning the sysroot",
         "properties": {
+          "bootloader": {
+            "description": "Configure the bootloader that OSTree uses (use 'none' for BLS).",
+            "type": "string",
+            "enum": ["none", "auto", "grub2", "syslinux", "uboot", "zipl"]
+          },
           "readonly": {
             "description": "Read only sysroot and boot",
             "type": "boolean"

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -870,7 +870,8 @@
             "repo": "/ostree/repo",
             "config": {
               "sysroot": {
-                "readonly": true
+                "readonly": true,
+                "bootloader": "none"
               }
             }
           }

--- a/test/data/manifests/fedora-ostree-image.mpp.json
+++ b/test/data/manifests/fedora-ostree-image.mpp.json
@@ -282,7 +282,8 @@
             "repo": "/ostree/repo",
             "config": {
               "sysroot": {
-                "readonly": true
+                "readonly": true,
+                "bootloader": "none"
               }
             }
           }


### PR DESCRIPTION
Ability to set the bootloader backend that OSTree should use. NB: normally this should be set to `none` since in modern distros and bootloaders the BLS is used and the BLS snippets are generated on `none` but none of the of the specific bootloader tools are run, like `grub2-mkconfig` for grub.

Update the fedora image manifest to use that config setting.