### PR TITLE
Add support for defining variables from other variables or basic expression

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -555,7 +555,10 @@ class ManifestFile:
         if not variables:
             return
 
-        self.vars.update(variables)
+        for k, v in variables.items():
+            fakeroot = [v]
+            self._process_format(fakeroot)
+            self.vars[k] = fakeroot[0]
         self.substitute_vars(self.vars)
 
     def set_vars(self, args):

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -689,7 +689,8 @@ class ManifestFile:
                 format_string = node["mpp-format-int"]
 
             # pylint: disable=eval-used  # yolo this is fine!
-            res = eval(f'f\'\'\'{format_string}\'\'\'', local_vars)
+            # Note, we copy local_vars here to avoid eval modifying it
+            res = eval(f'f\'\'\'{format_string}\'\'\'', dict(local_vars))
 
             if res_type == "int":
                 return int(res)


### PR DESCRIPTION
Using this we can now define variables in the variable section using
basic expression that are evaluated as f-string.
For example, you can use the syntax:

```
"mpp-vars": {
   "rootfs_uuid": {"mpp-format-string": "{__import__('uuid').uuid1()}"},
   "bootfs_uuid": "156f0420-627b-4151-ae6f-fda298097515"
},
```

This will automatically call uuid.uuid1() for rootfs_uuid, thus allowing
to dynamically set the uuid for the rootfs variable.
This variable being able to be overridden via the -D argument of the
osbuild-mpp tool.

In addition, you can also define variable based on variables defined
above, for example:

```
"mpp-vars": {
   "rootfs_size": 4294967296,
   "homefs_size": {"mpp-format-string": "{rootfs_size}"}
},
```

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>