### PR TITLE
Add a mechanism to easily embed local files when preprocessing an mpp file

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -160,8 +160,10 @@ Example:
 
 
 import argparse
+import base64
 import collections
 import contextlib
+import hashlib
 import json
 import os
 import pathlib
@@ -509,6 +511,54 @@ class Image:
         return cls(size, table)
 
 
+class LocalFile:
+    def __init__(self, base64_content, sha256, sha512):
+        self.base64_content = base64_content
+        self.sha256 = sha256
+        self.sha512 = sha512
+
+    @property
+    def digest(self):
+        return f"sha256:{self.sha256}"
+
+    @classmethod
+    def from_dict(cls, js):
+        path = js["path"]
+        try:
+            with open(path, 'rb') as stream:
+                data = stream.read()
+        except:
+            print(f"Failed to read the local file: {path} in mpp-include-base64")
+            raise
+
+        base64_content = base64.b64encode(data).decode("utf-8")
+        sha256 = hashlib.sha256(data).hexdigest()
+        sha512 = hashlib.sha512(data).hexdigest()
+
+        # If the user wants to check that the file embedded is the expected one
+        if js.get("sha256"):
+            if sha256 != js.get("sha256"):
+                raise ValueError(
+                    "SHASUM 256 provided for %s (%s) does not correspond to the computed one (%s).",
+                    path, js.get("sha256"), sha256
+                )
+        elif js.get("sha512"):
+            if sha512 != js.get("sha512"):
+                raise ValueError(
+                    "SHASUM 512 provided for %s (%s) does not correspond to the computed one (%s).",
+                    path, js.get("sha512"), sha512
+                )
+
+        return cls(base64_content, sha256, sha512)
+
+    def to_dict(self, args=None) -> dict:
+        if args is None:
+            args = {}
+        data = {f"sha256:{self.sha256}": args}
+
+        return data
+
+
 class ManifestFile:
     @staticmethod
     def load(path):
@@ -672,7 +722,7 @@ class ManifestFile:
         def _is_format(node):
             if not isinstance(node, dict):
                 return False
-            for m in ("int", "string", "json"):
+            for m in ("int", "string", "json", "references"):
                 if f"mpp-format-{m}" in node:
                     return True
             return False
@@ -684,13 +734,21 @@ class ManifestFile:
             elif "mpp-format-json" in node:
                 res_type = "json"
                 format_string = node["mpp-format-json"]
+            elif "mpp-format-references" in node:
+                res_type = "references"
+                format_string = node["mpp-format-references"]
             else:
                 res_type = "int"
                 format_string = node["mpp-format-int"]
 
-            # pylint: disable=eval-used  # yolo this is fine!
-            # Note, we copy local_vars here to avoid eval modifying it
-            res = eval(f'f\'\'\'{format_string}\'\'\'', dict(local_vars))
+            if res_type == "references":
+                res = {}
+                for fstring in format_string:
+                    res.update(local_vars[fstring["id"]].to_dict(args=fstring.get("args")))
+            else:
+                # pylint: disable=eval-used  # yolo this is fine!
+                # Note, we copy local_vars here to avoid eval modifying it
+                res = eval(f'f\'\'\'{format_string}\'\'\'', dict(local_vars))
 
             if res_type == "int":
                 return int(res)
@@ -723,6 +781,24 @@ class ManifestFile:
 
         name = desc.get("id", "image")
         self.vars[name] = Image.from_dict(desc)
+
+    def process_local_files(self):
+        local_files = self.get_mpp_node(self.root, "include-base64")
+
+        if not local_files:
+            return
+
+        inline_files = element_enter(self.sources, "org.osbuild.inline", {})
+        self.inline_files = element_enter(inline_files, "items", {})
+
+        for local_file in local_files:
+            name = local_file["id"]
+            self.vars[name] = LocalFile.from_dict(local_file)
+
+            self.inline_files[self.vars[name].digest] = {
+                "encoding": "base64",
+                "data": self.vars[name].base64_content
+            }
 
 
 class ManifestFileV1(ManifestFile):
@@ -926,6 +1002,8 @@ def main():
     m.process_imports(args.searchdirs)
 
     m.process_partition()
+
+    m.process_local_files()
 
     # Override variables from the main of imported files
     if args.vars:


### PR DESCRIPTION
Basically, using the following structure:
```
"mpp-include-base64": [
    {"id": "README", "path": "README.md", "sha256": "301684a4b434fe51f287cf74360634b1800defec92744ce59400e4a6f36846d8"},
    {"id": "rhel8-rpi4-mpp", "path": "rhel8-rpi4.mpp.json"}
],
```
one can define a list of files that one wants included in the template.
This `id` contains the name given to the variable corresponding to this
file.
`path` contains a full path to the file one wants to embed, relative to
the template mpp file.
`sha256` or `sha512` are optional fields that can be used to ensure that
the file being embedded in the template is the expected on. If provided
these fields will be checked against the sha256/sha512 computed upon
reading the file.

You can then install the file using the following structure:
```
{
    "type": "org.osbuild.copy",
    "inputs": {
        "inlinefile": {
            "type": "org.osbuild.files",
            "origin": "org.osbuild.source",
            "references": {"mpp-format-references": [
                {"id": "README", "args": {"foo": "bar", "baz": "boum"}},
                {"id": "rhel8-rpi4-mpp"}
            ]}
        }
    },
    "options": {
        "paths": [
            {
                "from": { "mpp-format-string": "input://inlinefile/{foo.digest}"},
                "to": "tree:///usr/bin/start.sh"
            }
        ]
    }
}
```

Where `mpp-format-references` will generate the following structure
based on the `README` and `rhel8-rpi4-mpp` variables (defined by the
`id` in  `mpp-include-base64` above):
```
references": {
    "sha256:301684a4b434fe51f287cf74360634b1800defec92744ce59400e4a6f36846d8": {
      "foo": "bar",
      "baz": "boum"
    },
    "sha256:41d3afc0adb06d96397e082cb5192416adf80fd70ed767953c4b36ac7abc655a": {}
}
```

And `{ "mpp-format-string": "input://inlinefile/{foo.digest}"},` will
generate the actual content of the file as base64 as supported by osbuild
e.g.:
```
"paths": [
    {
        "from": "input://inlinefile/sha256:301684a4b434fe51f287cf74360634b1800defec92744ce59400e4a6f36846d8"
        "to": "tree:///usr/bin/start.sh"
    }
]
```

Finally, the code will automatically insert the "org.osbuild.inline"
sources for the file that are included.
This will result in a structure such as:
```
  "org.osbuild.inline": {
    "items": {
      "sha256:301684a4b434fe51f287cf74360634b1800defec92744ce59400e4a6f36846d8": {
        "encoding": "base64",
        "data": "VGhpcyBkaXJlY3RvcnkgY29udGFpbnMgc29tZSBzYW1wbGUgb3NidWlsZ...
      }
    }
  }
```

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>