### PR TITLE
Fix the assert as `.sort()`  returns None

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -748,7 +748,7 @@ class ManifestFileV1(ManifestFile):
         # We import `sources` from the manifest, as well as a pipeline description
         # from the `pipeline` entry. Make sure nothing else is in the manifest, so
         # we do not accidentally miss new features.
-        assert list(imp.root.keys()).sort() == ["pipeline", "sources"].sort()
+        assert sorted(imp.root) == sorted(["pipeline", "sources"])
 
         # Now with everything imported and verified, we can merge the pipeline back
         # into the original manifest. We take all URLs and merge them in the pinned


### PR DESCRIPTION
Since `.sort()` returns None, we were checking that None == None
which is not what we aimed to do.

Quick reproducer:
```
>>> assert [1,2,3].sort() == [2,3,4].sort()
>>> assert sorted([1,2,3]) == sorted([2,3,4])
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    assert sorted([1,2,3]) == sorted([2,3,4])
AssertionError
```

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>