### PR TITLE
RHEL 8.5 backports from main: subscription fallback, ostree.config bootloader option

### DIFF
--- a/osbuild/util/rhsm.py
+++ b/osbuild/util/rhsm.py
@@ -93,13 +93,14 @@ class Subscriptions:
 
     def get_secrets(self, url):
         # Try to find a matching URL from redhat.repo file first
-        for parameters in self.repositories.values():
-            if parameters["matchurl"].match(url) is not None:
-                return {
-                    "ssl_ca_cert": parameters["sslcacert"],
-                    "ssl_client_key": parameters["sslclientkey"],
-                    "ssl_client_cert": parameters["sslclientcert"]
-                }
+        if self.repositories is not None:
+            for parameters in self.repositories.values():
+                if parameters["matchurl"].match(url) is not None:
+                    return {
+                        "ssl_ca_cert": parameters["sslcacert"],
+                        "ssl_client_key": parameters["sslclientkey"],
+                        "ssl_client_cert": parameters["sslclientcert"]
+                    }
 
         # In case there is no matching URL, try the fallback
         if self.secrets:

--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -5,6 +5,9 @@ Change OSTree configuration
 Change the configuration for an OSTree repository.
 Currently only the following values are supported:
   - `sysroot.readonly`
+  - `sysroot.bootloader`
+
+See `ostree.repo-config(5)` for more information.
 """
 
 import os
@@ -32,6 +35,11 @@ SCHEMA = """
         "additionalProperties": false,
         "description": "Options concerning the sysroot",
         "properties": {
+          "bootloader": {
+            "description": "Configure the bootloader that OSTree uses (use 'none' for BLS).",
+            "type": "string",
+            "enum": ["none", "auto", "grub2", "syslinux", "uboot", "zipl"]
+          },
           "readonly": {
             "description": "Read only sysroot and boot",
             "type": "boolean"

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -870,7 +870,8 @@
             "repo": "/ostree/repo",
             "config": {
               "sysroot": {
-                "readonly": true
+                "readonly": true,
+                "bootloader": "none"
               }
             }
           }

--- a/test/data/manifests/fedora-ostree-image.mpp.json
+++ b/test/data/manifests/fedora-ostree-image.mpp.json
@@ -282,7 +282,8 @@
             "repo": "/ostree/repo",
             "config": {
               "sysroot": {
-                "readonly": true
+                "readonly": true,
+                "bootloader": "none"
               }
             }
           }


### PR DESCRIPTION
Fixed issues:
 - #795 
    https://bugzilla.redhat.com/show_bug.cgi?id=1985952
 - #806 
    https://bugzilla.redhat.com/show_bug.cgi?id=2004139