### PR TITLE
ci: trigger gitlab ci via workflow run event

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -1,35 +1,15 @@
 # inspired by rhinstaller/anaconda
 
 name: Trigger GitLab CI
-on: [push, pull_request_target]
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
 
 jobs:
-  pr-info:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Query author repository permissions
-        uses: octokit/request-action@v2.x
-        id: user_permission
-        with:
-          route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # restrict running of tests to users with admin or write permission for the repository
-      # see https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-repository-permissions-for-a-user
-      # store output if user is allowed in allowed_user job output so it has to be checked in downstream job
-      - name: Check if user does have correct permissions
-        if: contains('admin write', fromJson(steps.user_permission.outputs.data).permission)
-        id: check_user_perm
-        run: |
-          echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' allowed values: 'admin', 'write'"
-          echo "::set-output name=allowed_user::true"
-    outputs:
-      allowed_user: ${{ steps.check_user_perm.outputs.allowed_user }}
-
   trigger-gitlab:
-    needs: pr-info
-    if: needs.pr-info.outputs.allowed_user == 'true'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
       SCHUTZBOT_SSH_KEY: ${{ secrets.SCHUTZBOT_SSH_KEY }}


### PR DESCRIPTION
The `workflow_run` event is triggered either when a workflow was requested or complete (see `types`). We can use this event as a trigger for the gitlab ci conditioning on a successful workflow run of the main tests ("Tests" workflow). This will ensure that, with outside contributor protection turned o, no secrets are leaked via PRs from non-contributors, but also that gitlab ci is run for those PRs once they were manually allowed to run. The only downside is that now the gitlab ci will only run after the main workflow ("Tests) has completed and thus serializing both CI runs. OTOH gitlab CI is quite intense so maybe this is not so bad after all. If in the future we want to parallelize both CI runs we could have a third "precheck" condition with maybe the spell checker and the pylint tests that the main tests as well as the gitlab ci run depend on.