### PR TITLE
stages/qemu: fix 'compat' option

### DIFF
--- a/stages/org.osbuild.qemu
+++ b/stages/org.osbuild.qemu
@@ -126,7 +126,7 @@ SCHEMA_2 = r"""
 
 def qcow2_arguments(options):
     argv = ["-c"]
-    compat = options.get("qcow2_compat")
+    compat = options.get("compat")
 
     if compat:
         argv += ["-o", f"compat={compat}"]


### PR DESCRIPTION
The option got renamed to `compat` (and moved into the `qemu` object) when the stage was extracted from the `qemu` assembler; but the code, taken from the assembler, still used the old `qcow2_compat` name for the option. Fix this.