### PR TITLE
.github: Use the workflow_run event data in trigger-gitlab

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -14,12 +14,25 @@ jobs:
     env:
       SCHUTZBOT_SSH_KEY: ${{ secrets.SCHUTZBOT_SSH_KEY }}
     steps:
+      - name: Report status
+        uses: haya14busa/action-workflow_run-status@v1
+
       - name: Clone repository
         uses: actions/checkout@v2
         with:
-          # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+
+      # If the parent workflow belongs to a PR, create a new PR-# branch
+      - name: Checkout branch (PR)
+        if: ${{ github.event.workflow_run.pull_requests[0] != null }}
+        run: |
+          git checkout -b PR-${{ github.event.workflow_run.pull_requests[0].number }}
+
+      - name: Checkout branch (branch)
+        if: ${{ github.event.workflow_run.pull_requests[0] == null }}
+        run: |
+          git checkout ${{ github.event.workflow_run.head_branch }}
 
       - name: Push to gitlab
         run: |
@@ -29,7 +42,4 @@ jobs:
           touch ~/.ssh/known_hosts
           ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
           git remote add ci git@gitlab.com:osbuild/ci/osbuild.git
-          if [ ${{ github.event.pull_request.number }} ]; then
-            git checkout -b PR-${{ github.event.pull_request.number }}
-          fi
           git push -f ci


### PR DESCRIPTION
   This workflow doesn't have access to the original pull request event
    that resulted in this workflow being triggered.
    Simply use `head_sha` which will contain the PR sha if it was triggered
    by a PR's workflow, or the branch sha if it was triggered from a
    branch's workflow.
