### PR TITLE
.github: Write PR data to a file first in trigger-gitlab

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -36,7 +36,12 @@ jobs:
 
       - name: Checkout branch
         run: |
-          PR=$(echo '${{ steps.fetch_pulls.outputs.data }}' | jq -rc '.[] | select(.head.sha | contains("${{ github.event.workflow_run.head_sha }}")) | select(.state | contains("open"))' | jq -r .number)
+          PR_DATA=$(mktemp)
+          cat > "$PR_DATA" <<EOF
+          ${{ steps.fetch_pulls.outputs.data }}
+          EOF
+
+          PR=$(jq -rc '.[] | select(.head.sha | contains("${{ github.event.workflow_run.head_sha }}")) | select(.state | contains("open"))' "$PR_DATA" | jq -r .number)
           if [ ! -z "$PR" ]; then
             git checkout -b PR-$PR
           else


### PR DESCRIPTION
Using echo breaks if any PR body contains a `'` character.


---

Workflow run works as expected https://github.com/Gundersanne/osbuild/runs/3814374663 ; even if an open pr has `'`.