### PR TITLE
Transparent support for ostree deployments

### DIFF
--- a/mounts/org.osbuild.btrfs
+++ b/mounts/org.osbuild.btrfs
@@ -13,8 +13,23 @@ from typing import Dict
 from osbuild import mounts
 
 
-SCHEMA = """
-"additionalProperties": False
+SCHEMA_2 = """
+"additionalProperties": false,
+"required": ["name", "type", "source", "target"],
+"properties": {
+  "name": { "type": "string" },
+  "type": { "type": "string" },
+  "source": {
+    "type": "string"
+  },
+  "target": {
+    "type": "string"
+  },
+  "options": {
+    "type": "object",
+    "additionalProperties": true
+  }
+}
 """
 
 

--- a/mounts/org.osbuild.btrfs
+++ b/mounts/org.osbuild.btrfs
@@ -33,7 +33,7 @@ SCHEMA_2 = """
 """
 
 
-class BtrfsMount(mounts.MountService):
+class BtrfsMount(mounts.FileSystemMountService):
 
     def translate_options(self, _options: Dict):
         return ["-t", "btrfs"]

--- a/mounts/org.osbuild.ext4
+++ b/mounts/org.osbuild.ext4
@@ -33,7 +33,7 @@ SCHEMA_2 = """
 """
 
 
-class Ext4Mount(mounts.MountService):
+class Ext4Mount(mounts.FileSystemMountService):
 
     def translate_options(self, _options: Dict):
         return ["-t", "ext4"]

--- a/mounts/org.osbuild.ext4
+++ b/mounts/org.osbuild.ext4
@@ -13,8 +13,23 @@ from typing import Dict
 from osbuild import mounts
 
 
-SCHEMA = """
-"additionalProperties": false
+SCHEMA_2 = """
+"additionalProperties": false,
+"required": ["name", "type", "source", "target"],
+"properties": {
+  "name": { "type": "string" },
+  "type": { "type": "string" },
+  "source": {
+    "type": "string"
+  },
+  "target": {
+    "type": "string"
+  },
+  "options": {
+    "type": "object",
+    "additionalProperties": true
+  }
+}
 """
 
 

--- a/mounts/org.osbuild.fat
+++ b/mounts/org.osbuild.fat
@@ -33,7 +33,7 @@ SCHEMA_2 = """
 """
 
 
-class XfsMount(mounts.MountService):
+class XfsMount(mounts.FileSystemMountService):
 
     def translate_options(self, _options: Dict):
         return ["-t", "vfat"]

--- a/mounts/org.osbuild.fat
+++ b/mounts/org.osbuild.fat
@@ -13,8 +13,23 @@ from typing import Dict
 from osbuild import mounts
 
 
-SCHEMA = """
-"additionalProperties": false
+SCHEMA_2 = """
+"additionalProperties": false,
+"required": ["name", "type", "source", "target"],
+"properties": {
+  "name": { "type": "string" },
+  "type": { "type": "string" },
+  "source": {
+    "type": "string"
+  },
+  "target": {
+    "type": "string"
+  },
+  "options": {
+    "type": "object",
+    "additionalProperties": true
+  }
+}
 """
 
 

--- a/mounts/org.osbuild.noop
+++ b/mounts/org.osbuild.noop
@@ -15,8 +15,23 @@ from typing import Dict
 from osbuild import mounts
 
 
-SCHEMA = """
-"additionalProperties": false
+SCHEMA_2 = """
+"additionalProperties": false,
+"required": ["name", "type", "source", "target"],
+"properties": {
+  "name": { "type": "string" },
+  "type": { "type": "string" },
+  "source": {
+    "type": "string"
+  },
+  "target": {
+    "type": "string"
+  },
+  "options": {
+    "type": "object",
+    "additionalProperties": true
+  }
+}
 """
 
 

--- a/mounts/org.osbuild.noop
+++ b/mounts/org.osbuild.noop
@@ -37,7 +37,9 @@ SCHEMA_2 = """
 
 class NoOpMount(mounts.MountService):
 
-    def mount(self, _source: str, root: str, target: str, _options: Dict):
+    def mount(self, args: Dict):
+        root = args["root"]
+        target = args["target"]
 
         mountpoint = os.path.join(root, target.lstrip("/"))
 

--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -1,0 +1,122 @@
+#!/usr/bin/python3
+"""
+OSTree deployment mount service
+
+This mount service will setup all needed bind mounts so
+that a given `tree` will look like an active OSTree
+deployment, very much as OSTree does during early boot.
+
+More specifically it will:
+  - setup the sysroot bindmount to the deployment
+  - setup the shared var directory
+  - bind the boot directory into the deployment
+
+Host commands used: mount
+"""
+
+import os
+import sys
+import subprocess
+from typing import Dict
+
+from osbuild import mounts
+from osbuild.util import ostree
+
+
+SCHEMA_2 = """
+"additionalProperties": false,
+"required": ["name", "type"],
+"properties": {
+  "name": { "type": "string" },
+  "type": { "type": "string" },
+  "options": {
+    "type": "object",
+    "required": ["deployment"],
+    "properties": {
+      "deployment": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["osname", "ref"],
+        "properties": {
+          "osname": {
+            "description": "Name of the stateroot to be used in the deployment",
+            "type": "string"
+          },
+          "ref": {
+            "description": "OStree ref to create and use for deployment",
+            "type": "string"
+          },
+          "serial": {
+            "description": "The deployment serial (usually '0')",
+            "type": "number",
+            "default": 0
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class OSTreeDeploymentMount(mounts.MountService):
+
+    @staticmethod
+    def bind_mount(source, target):
+        subprocess.run([
+            "mount", "--bind", "--make-private", source, target,
+        ], check=True)
+
+    def mount(self, args: Dict):
+
+        tree = args["tree"]
+        options = args["options"]
+
+        deployment = options["deployment"]
+        osname = deployment["osname"]
+        ref = deployment["ref"]
+        serial = deployment.get("serial", 0)
+
+        root = ostree.deployment_path(tree, osname, ref, serial)
+
+        print(f"Deployment root at '{os.path.relpath(root, tree)}'")
+
+        var = os.path.join(tree, "ostree", "deploy", osname, "var")
+        boot = os.path.join(tree, "boot")
+
+        self.mountpoint = root
+        self.bind_mount(root, root)  # prepare to move it later
+
+        self.bind_mount(tree, os.path.join(root, "sysroot"))
+        self.bind_mount(var, os.path.join(root, "var"))
+        self.bind_mount(boot, os.path.join(root, "boot"))
+
+        subprocess.run([
+            "mount", "--move", root, tree,
+        ], check=True)
+
+        self.mountpoint = tree
+        self.check = True
+
+        return None
+
+    def umount(self):
+
+        if not self.mountpoint:
+            return
+
+        subprocess.run(["sync", "-f", self.mountpoint],
+                       check=self.check)
+
+        subprocess.run(["umount", "-R", self.mountpoint],
+                       check=self.check)
+        self.mountpoint = None
+
+
+def main():
+    service = OSTreeDeploymentMount.from_args(sys.argv[1:])
+    service.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/mounts/org.osbuild.xfs
+++ b/mounts/org.osbuild.xfs
@@ -13,8 +13,23 @@ from typing import Dict
 from osbuild import mounts
 
 
-SCHEMA = """
-"additionalProperties": false
+SCHEMA_2 = """
+"additionalProperties": false,
+"required": ["name", "type", "source", "target"],
+"properties": {
+  "name": { "type": "string" },
+  "type": { "type": "string" },
+  "source": {
+    "type": "string"
+  },
+  "target": {
+    "type": "string"
+  },
+  "options": {
+    "type": "object",
+    "additionalProperties": true
+  }
+}
 """
 
 

--- a/mounts/org.osbuild.xfs
+++ b/mounts/org.osbuild.xfs
@@ -33,7 +33,7 @@ SCHEMA_2 = """
 """
 
 
-class XfsMount(mounts.MountService):
+class XfsMount(mounts.FileSystemMountService):
 
     def translate_options(self, _options: Dict):
         return ["-t", "xfs"]

--- a/osbuild/devices.py
+++ b/osbuild/devices.py
@@ -15,8 +15,9 @@ support in osbuild itself is abstract.
 import abc
 import hashlib
 import json
+import os
 
-from typing import Dict
+from typing import Dict, Optional
 
 from osbuild import host
 
@@ -57,12 +58,20 @@ class DeviceManager:
         self.tree = tree
         self.devices = {}
 
+    def device_relpath(self, dev: Optional[Device]) -> Optional[str]:
+        if dev is None:
+            return None
+        return self.devices[dev.name]["path"]
+
+    def device_abspath(self, dev: Optional[Device]) -> Optional[str]:
+        relpath = self.device_relpath(dev)
+        if relpath is None:
+            return None
+        return os.path.join(self.devpath, relpath)
+
     def open(self, dev: Device) -> Dict:
 
-        if dev.parent:
-            parent = self.devices[dev.parent.name]["path"]
-        else:
-            parent = None
+        parent = self.device_relpath(dev.parent)
 
         args = {
             # global options

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -274,14 +274,16 @@ def load_mount(description: Dict, index: Index, stage: Stage):
     if name in stage.mounts:
         raise ValueError(f"Duplicated mount '{name}'")
 
-    source = description["source"]
-    target = description["target"]
+    source = description.get("source")
+    target = description.get("target")
 
     options = description.get("options", {})
 
-    device = stage.devices.get(source)
-    if not device:
-        raise ValueError(f"Unknown device '{source}' for mount '{name}'")
+    device = None
+    if source:
+        device = stage.devices.get(source)
+        if not device:
+            raise ValueError(f"Unknown device '{source}' for mount '{name}'")
 
     stage.add_mount(name, info, device, target, options)
 

--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -332,12 +332,18 @@ class ModuleInfo:
                 **opts,
             }
             schema["required"] = [type_id]
-        elif self.type in ("Device", "Mount"):
+        elif self.type in ("Device"):
             schema["additionalProperties"] = True
             opts = self._load_opts(version, "1")
             schema["properties"] = {
                 "type": {"enum": [self.name]},
                 "options": opts
+            }
+        elif self.type in ("Mount"):
+            opts = self._load_opts("2")
+            schema.update(opts)
+            schema["properties"]["type"] = {
+                "enum": [self.name],
             }
         else:
             opts = self._load_opts(version, "1")

--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -331,6 +331,10 @@ class ModuleInfo:
                 type_id: {"enum": [self.name]},
                 **opts,
             }
+            if "mounts" not in schema["properties"]:
+                schema["properties"]["mounts"] = {
+                    "type": "array"
+                }
             schema["required"] = [type_id]
         elif self.type in ("Device"):
             schema["additionalProperties"] = True

--- a/osbuild/mounts.py
+++ b/osbuild/mounts.py
@@ -35,8 +35,10 @@ class Mount:
     def calc_id(self):
         m = hashlib.sha256()
         m.update(json.dumps(self.info.name, sort_keys=True).encode())
-        m.update(json.dumps(self.device.id, sort_keys=True).encode())
-        m.update(json.dumps(self.target, sort_keys=True).encode())
+        if self.device:
+            m.update(json.dumps(self.device.id, sort_keys=True).encode())
+        if self.target:
+            m.update(json.dumps(self.target, sort_keys=True).encode())
         m.update(json.dumps(self.options, sort_keys=True).encode())
         return m.hexdigest()
 

--- a/osbuild/mounts.py
+++ b/osbuild/mounts.py
@@ -63,8 +63,10 @@ class MountManager:
 
         args = {
             "source": source,
-            "root": self.root,
             "target": mount.target,
+
+            "root": self.root,
+            "tree": self.devices.tree,
 
             "options": mount.options,
         }

--- a/osbuild/mounts.py
+++ b/osbuild/mounts.py
@@ -74,6 +74,11 @@ class MountManager:
         client = mgr.start(f"mount/{mount.name}", mount.info.path)
         path = client.call("mount", args)
 
+        if not path:
+            res = {}
+            self.mounts[mount.name] = res
+            return res
+
         if not path.startswith(self.root):
             raise RuntimeError(f"returned path '{path}' has wrong prefix")
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -12,7 +12,7 @@ from . import objectstore
 from . import remoteloop
 from .devices import Device, DeviceManager
 from .inputs import Input
-from .mounts import Mount
+from .mounts import Mount, MountManager
 from .sources import Source
 from .util import osrelease
 
@@ -164,10 +164,9 @@ class Stage:
             for name, dev in self.devices.items():
                 devices[name] = devmgr.open(dev)
 
+            mntmgr = MountManager(devmgr, mounts_tmpdir)
             for key, mount in self.mounts.items():
-                relpath = devices[mount.device.name]["path"]
-                abspath = os.path.join(build_root.dev, relpath)
-                data = mount.mount(mgr, abspath, mounts_tmpdir)
+                data = mntmgr.mount(mount)
                 mounts[key] = data
 
             self.prepare_arguments(args, args_path)

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -10,7 +10,7 @@ from . import buildroot
 from . import host
 from . import objectstore
 from . import remoteloop
-from .devices import Device
+from .devices import Device, DeviceManager
 from .inputs import Input
 from .mounts import Mount
 from .sources import Source
@@ -160,12 +160,9 @@ class Stage:
                 data = ip.map(mgr, storeapi, inputs_tmpdir)
                 inputs[key] = data
 
-            for key, dev in self.devices.items():
-                parent = None
-                if dev.parent:
-                    parent = devices[dev.parent.name]["path"]
-                reply = dev.open(mgr, build_root.dev, parent, tree)
-                devices[key] = reply
+            devmgr = DeviceManager(mgr, build_root.dev, tree)
+            for name, dev in self.devices.items():
+                devices[name] = devmgr.open(dev)
 
             for key, mount in self.mounts.items():
                 relpath = devices[mount.device.name]["path"]

--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -71,7 +71,7 @@
     "mount": {
       "title": "Mount point for a stage",
       "additionalProperties": false,
-      "required": ["name", "type", "source", "target"],
+      "required": ["name", "type"],
       "properties": {
         "name": { "type": "string" },
         "type": { "type": "string" },

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -919,13 +919,19 @@
         },
         {
           "type": "org.osbuild.fstab",
-          "options": {
-            "ostree": {
-              "deployment": {
-                "osname": "fedora",
-                "ref": "fedora/x86_64/osbuild"
+          "mounts": [
+            {
+              "type": "org.osbuild.ostree.deployment",
+              "name": "ostree.deployment",
+              "options": {
+                "deployment": {
+                  "osname": "fedora",
+                  "ref": "fedora/x86_64/osbuild"
+                }
               }
-            },
+            }
+          ],
+          "options": {
             "filesystems": [
               {
                 "label": "boot",

--- a/test/data/manifests/fedora-ostree-image.mpp.json
+++ b/test/data/manifests/fedora-ostree-image.mpp.json
@@ -331,13 +331,19 @@
         },
         {
           "type": "org.osbuild.fstab",
-          "options": {
-            "ostree": {
-              "deployment": {
-                "osname": "fedora",
-                "ref": "fedora/x86_64/osbuild"
+          "mounts": [
+            {
+              "type": "org.osbuild.ostree.deployment",
+              "name": "ostree.deployment",
+              "options": {
+                "deployment": {
+                  "osname": "fedora",
+                  "ref": "fedora/x86_64/osbuild"
+                }
               }
-            },
+            }
+          ],
+          "options": {
             "filesystems": [
               {
                 "label": "boot",

--- a/test/run/test_devices.py
+++ b/test/run/test_devices.py
@@ -48,7 +48,8 @@ def test_loopback_basic(tmpdir):
     dev = devices.Device("loop", info, None, options)
 
     with host.ServiceManager() as mgr:
-        reply = dev.open(mgr, devpath, None, tree)
+        devmgr = devices.DeviceManager(mgr, devpath, tree)
+        reply = devmgr.open(dev)
         assert reply
         assert reply["path"]
 


### PR DESCRIPTION
This PR introduces a new mount service that will set up bind mounts inside the tree very much as it is done by OSTree in early boot. This allows any stage to transparently work with OSTree deployments. As a pre-requirement the v2 schema was changed to give the individual stages more control over the `source` and `target` properties. Also the device and mount code was refactored to prepare this use case. See the individual commits for more details.