### PR TITLE
mpp: fix long options

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -909,7 +909,7 @@ def main():
         help="Path to DNF cache-directory to use",
     )
     parser.add_argument(
-        "-I,--import-dir",
+        "-I", "--import-dir",
         dest="searchdirs",
         default=[],
         action="append",
@@ -922,7 +922,7 @@ def main():
         help="Sort keys in generated json",
     )
     parser.add_argument(
-        "-D,--define",
+        "-D", "--define",
         default=[],
         dest="vars",
         action='append',


### PR DESCRIPTION
The correct way to specify long options is as separate arguments, not as one argument separated by comma.