### PR TITLE
Some more osbuild-mpp features

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -175,6 +175,7 @@ import tempfile
 import urllib.parse
 from typing import Dict, Optional
 
+import rpm
 import dnf
 import hawkey
 
@@ -941,6 +942,7 @@ def main():
     args = parser.parse_args(sys.argv[1:])
 
     defaults = {
+        "arch": rpm.expandMacro("%{_arch}")
     }
 
     # Override variables from the main of imported files


### PR DESCRIPTION
This adds mpp-eval, which is essentially mpp-format-* without the formating, and mpp-join that lets you join lists. The there are some improvements to how -D overrides work.

The end result of this is that we can simplify the automotive manifests and share manifests between arches.