### PR TITLE
trigger-gitlab: do not interpret the fetch_pulls outputs

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           PR_DATA=$(mktemp)
           # use uuid as a file terminator to avoid conflicts with data content
-          cat > "$PR_DATA" <<a21b3e7f-d5eb-44a3-8be0-c2412851d2e6
+          cat > "$PR_DATA" <<'a21b3e7f-d5eb-44a3-8be0-c2412851d2e6'
           ${{ steps.fetch_pulls.outputs.data }}
           a21b3e7f-d5eb-44a3-8be0-c2412851d2e6
 


### PR DESCRIPTION
Here documents are by default interpreted. Quoting the delimiter prevents
that.

See https://stackoverflow.com/questions/27920806/how-to-avoid-heredoc-expanding-variables