### PR TITLE
Support for on demand pipeline building

### DIFF
--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -201,11 +201,14 @@ def output(manifest: Manifest, res: Dict) -> Dict:
         # result but still need to to recurse
         current = res.get(pipeline.id, {})
         retval = {
-            "success": current.get("success", False)
+            "success": current.get("success", True)
         }
+
         if pipeline.build:
             build = manifest[pipeline.build]
             retval["build"] = result_for_pipeline(build)
+            retval["success"] = retval["build"]["success"]
+
         stages = current.get("stages")
         if stages:
             retval["stages"] = stages

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -73,7 +73,6 @@ def load_assembler(description: Dict, index: Index, manifest: Manifest):
 
     # Add a pipeline with one stage for our assembler
     pipeline = manifest.add_pipeline("assembler", runner, build)
-    pipeline.export = True
 
     info = index.get_module_info("Assembler", name)
 

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -405,7 +405,7 @@ def output(manifest: Manifest, res: Dict) -> Dict:
         # gather all the metadata
         for p in manifest.pipelines.values():
             data = {}
-            r = res[p.id]
+            r = res.get(p.id, {})
             for stage in r.get("stages", []):
                 md = stage.get("metadata")
                 if not md:

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -138,10 +138,6 @@ def osbuild_cli():
         print("Need --output-directory for --export")
         return 1
 
-    if not args.output_directory and not args.checkpoint:
-        print("No output directory or checkpoints specified, exited without building.")
-        return 0
-
     monitor_name = "NullMonitor" if args.json else "LogMonitor"
     monitor = osbuild.monitor.make(monitor_name, sys.stdout.fileno())
 

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -152,8 +152,7 @@ def osbuild_cli():
             r = manifest.build(
                 object_store,
                 monitor,
-                args.libdir,
-                output_directory=output_directory
+                args.libdir
             )
 
             if r["success"] and args.export:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -405,10 +405,10 @@ class Manifest:
 
         return list(map(lambda x: x.name, reversed(build.values())))
 
-    def build(self, store, monitor, libdir):
+    def build(self, store, pipelines, monitor, libdir):
         results = {"success": True}
 
-        for pl in self.pipelines.values():
+        for pl in map(self.get, pipelines):
             res = pl.run(store, monitor, libdir)
             results[pl.id] = res
             if not res["success"]:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -196,7 +196,6 @@ class Pipeline:
         self.runner = runner
         self.stages = []
         self.assembler = None
-        self.export = False
 
     @property
     def id(self):
@@ -298,7 +297,7 @@ class Pipeline:
 
         return results, build_tree, tree
 
-    def run(self, store, monitor, libdir, output_directory):
+    def run(self, store, monitor, libdir):
         results = {"success": True}
 
         monitor.begin(self)
@@ -315,10 +314,6 @@ class Pipeline:
 
             if not results["success"]:
                 return results
-
-        if self.export and obj:
-            if output_directory:
-                obj.export(output_directory)
 
         monitor.finish(results)
 
@@ -349,11 +344,11 @@ class Manifest:
             for source in self.sources:
                 source.download(mgr, store, libdir)
 
-    def build(self, store, monitor, libdir, output_directory):
+    def build(self, store, monitor, libdir):
         results = {"success": True}
 
         for pl in self.pipelines.values():
-            res = pl.run(store, monitor, libdir, output_directory)
+            res = pl.run(store, monitor, libdir)
             results[pl.id] = res
             if not res["success"]:
                 results["success"] = False

--- a/test/data/stages/first-boot/a.json
+++ b/test/data/stages/first-boot/a.json
@@ -1,4 +1,10 @@
 {
   "sources": {},
-  "pipeline": {}
+  "pipeline": {
+    "stages": [
+      {
+        "name": "org.osbuild.noop"
+      }
+    ]
+  }
 }

--- a/test/data/stages/first-boot/diff.json
+++ b/test/data/stages/first-boot/diff.json
@@ -11,12 +11,5 @@
     "/usr/lib/systemd/system/osbuild-first-boot.service"
   ],
   "deleted_files": [],
-  "differences": {
-    "/": {
-      "mode": [
-        16832,
-        16877
-      ]
-    }
-  }
+  "differences": {}
 }

--- a/test/data/stages/grub2/a.json
+++ b/test/data/stages/grub2/a.json
@@ -345,7 +345,11 @@
     {
       "name": "tree",
       "build": "name:build",
-      "stages": []
+      "stages": [
+        {
+          "type": "org.osbuild.noop"
+        }
+      ]
     }
   ],
   "sources": {

--- a/test/data/stages/grub2/a.mpp.json
+++ b/test/data/stages/grub2/a.mpp.json
@@ -11,7 +11,11 @@
     {
       "name": "tree",
       "build": "name:build",
-      "stages": []
+      "stages": [
+        {
+          "type": "org.osbuild.noop"
+        }
+      ]
     }
   ]
 }

--- a/test/data/stages/grub2/diff.json
+++ b/test/data/stages/grub2/diff.json
@@ -31,12 +31,5 @@
     "/etc/default/grub"
   ],
   "deleted_files": [],
-  "differences": {
-    "/": {
-      "mode": [
-        16832,
-        16877
-      ]
-    }
-  }
+  "differences": {}
 }

--- a/test/data/stages/gzip/a.json
+++ b/test/data/stages/gzip/a.json
@@ -345,7 +345,11 @@
     {
       "name": "tree",
       "build": "name:build",
-      "stages": []
+      "stages": [
+        {
+          "type": "org.osbuild.noop"
+        }
+      ]
     }
   ],
   "sources": {

--- a/test/data/stages/gzip/a.mpp.json
+++ b/test/data/stages/gzip/a.mpp.json
@@ -11,7 +11,11 @@
     {
       "name": "tree",
       "build": "name:build",
-      "stages": []
+      "stages": [
+        {
+          "type": "org.osbuild.noop"
+        }
+      ]
     }
   ]
 }

--- a/test/data/stages/gzip/diff.json
+++ b/test/data/stages/gzip/diff.json
@@ -3,12 +3,5 @@
     "/compressed.gz"
   ],
   "deleted_files": [],
-  "differences": {
-    "/": {
-      "mode": [
-        16832,
-        16877
-      ]
-    }
-  }
+  "differences": {}
 }

--- a/test/data/stages/nm.conf/a.json
+++ b/test/data/stages/nm.conf/a.json
@@ -270,7 +270,11 @@
         ]
       }
     },
-    "stages": []
+    "stages": [
+      {
+        "name": "org.osbuild.noop"
+      }
+    ]
   },
   "sources": {
     "org.osbuild.files": {

--- a/test/data/stages/nm.conf/a.mpp.json
+++ b/test/data/stages/nm.conf/a.mpp.json
@@ -6,6 +6,10 @@
       },
       "runner": "org.osbuild.fedora34"
     },
-    "stages": []
+    "stages": [
+      {
+        "name": "org.osbuild.noop"
+      }
+    ]
   }
 }

--- a/test/data/stages/nm.conf/diff.json
+++ b/test/data/stages/nm.conf/diff.json
@@ -7,12 +7,5 @@
     "/etc/NetworkManager/conf.d/99-unmanaged-devices.conf"
   ],
   "deleted_files": [],
-  "differences": {
-    "/": {
-      "mode": [
-        16832,
-        16877
-      ]
-    }
-  }
+  "differences": {}
 }

--- a/test/data/stages/nm.conn/a.json
+++ b/test/data/stages/nm.conn/a.json
@@ -270,7 +270,11 @@
         ]
       }
     },
-    "stages": []
+    "stages": [
+      {
+        "name": "org.osbuild.noop"
+      }
+    ]
   },
   "sources": {
     "org.osbuild.files": {

--- a/test/data/stages/nm.conn/a.mpp.json
+++ b/test/data/stages/nm.conn/a.mpp.json
@@ -6,6 +6,10 @@
       },
       "runner": "org.osbuild.fedora34"
     },
-    "stages": []
+    "stages": [
+      {
+        "name": "org.osbuild.noop"
+      }
+    ]
   }
 }

--- a/test/data/stages/nm.conn/diff.json
+++ b/test/data/stages/nm.conn/diff.json
@@ -11,12 +11,5 @@
     "/usr/lib/NetworkManager/system-connections/osbuild.nmconnection"
   ],
   "deleted_files": [],
-  "differences": {
-    "/": {
-      "mode": [
-        16832,
-        16877
-      ]
-    }
-  }
+  "differences": {}
 }

--- a/test/data/stages/rpm/a.json
+++ b/test/data/stages/rpm/a.json
@@ -1,4 +1,10 @@
 {
   "sources": {},
-  "pipeline": {}
+  "pipeline": {
+    "stages": [
+      {
+        "name": "org.osbuild.noop"
+      }
+    ]
+  }
 }

--- a/test/data/stages/rpm/diff.json
+++ b/test/data/stages/rpm/diff.json
@@ -269,12 +269,5 @@
     "/proc"
   ],
   "deleted_files": [],
-  "differences": {
-    "/": {
-      "mode": [
-        16832,
-        16877
-      ]
-    }
-  }
+  "differences": {}
 }

--- a/test/data/stages/untar/a.json
+++ b/test/data/stages/untar/a.json
@@ -345,7 +345,11 @@
     {
       "name": "tree",
       "build": "name:build",
-      "stages": []
+      "stages": [
+        {
+          "type": "org.osbuild.noop"
+        }
+      ]
     }
   ],
   "sources": {

--- a/test/data/stages/untar/a.mpp.json
+++ b/test/data/stages/untar/a.mpp.json
@@ -11,7 +11,11 @@
     {
       "name": "tree",
       "build": "name:build",
-      "stages": []
+      "stages": [
+        {
+          "type": "org.osbuild.noop"
+        }
+      ]
     }
   ]
 }

--- a/test/data/stages/untar/diff.json
+++ b/test/data/stages/untar/diff.json
@@ -7,12 +7,5 @@
     "/test/hello/world.txt"
   ],
   "deleted_files": [],
-  "differences": {
-    "/": {
-      "mode": [
-        16832,
-        16877
-      ]
-    }
-  }
+  "differences": {}
 }

--- a/test/data/stages/xz/a.json
+++ b/test/data/stages/xz/a.json
@@ -345,7 +345,11 @@
     {
       "name": "tree",
       "build": "name:build",
-      "stages": []
+      "stages": [
+        {
+          "type": "org.osbuild.noop"
+        }
+      ]
     }
   ],
   "sources": {

--- a/test/data/stages/xz/a.mpp.json
+++ b/test/data/stages/xz/a.mpp.json
@@ -11,7 +11,11 @@
     {
       "name": "tree",
       "build": "name:build",
-      "stages": []
+      "stages": [
+        {
+          "type": "org.osbuild.noop"
+        }
+      ]
     }
   ]
 }

--- a/test/data/stages/xz/diff.json
+++ b/test/data/stages/xz/diff.json
@@ -3,12 +3,5 @@
     "/compressed.xz"
   ],
   "deleted_files": [],
-  "differences": {
-    "/": {
-      "mode": [
-        16832,
-        16877
-      ]
-    }
-  }
+  "differences": {}
 }

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -82,7 +82,7 @@ class TestFormatV1(unittest.TestCase):
         libdir = os.path.abspath(os.curdir)
         store = ObjectStore(storedir)
 
-        res = manifest.build(store, monitor, libdir)
+        res = manifest.build(store, manifest.pipelines, monitor, libdir)
         return res
 
     def test_canonical(self):

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -81,10 +81,8 @@ class TestFormatV1(unittest.TestCase):
         monitor = NullMonitor(sys.stderr.fileno())
         libdir = os.path.abspath(os.curdir)
         store = ObjectStore(storedir)
-        outdir = pathlib.Path(tmpdir, "out")
-        outdir.mkdir()
 
-        res = manifest.build(store, monitor, libdir, outdir)
+        res = manifest.build(store, monitor, libdir)
         return res
 
     def test_canonical(self):

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -19,6 +19,7 @@ from .. import test
 
 class TapeMonitor(osbuild.monitor.BaseMonitor):
     """Record the usage of all called functions"""
+
     def __init__(self):
         super().__init__(sys.stderr.fileno())
         self.counter = defaultdict(int)
@@ -62,7 +63,6 @@ class TestMonitor(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             storedir = os.path.join(tmpdir, "store")
-            outputdir = os.path.join(tmpdir, "output")
 
             logfile = os.path.join(tmpdir, "log.txt")
 
@@ -70,8 +70,7 @@ class TestMonitor(unittest.TestCase):
                 monitor = LogMonitor(log.fileno())
                 res = pipeline.run(store,
                                    monitor,
-                                   libdir=os.path.abspath(os.curdir),
-                                   output_directory=outputdir)
+                                   libdir=os.path.abspath(os.curdir))
 
                 with open(logfile) as f:
                     log = f.read()
@@ -97,14 +96,12 @@ class TestMonitor(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             storedir = os.path.join(tmpdir, "store")
-            outputdir = os.path.join(tmpdir, "output")
 
             tape = TapeMonitor()
             with ObjectStore(storedir) as store:
                 res = pipeline.run(store,
                                    tape,
-                                   libdir=os.path.abspath(os.curdir),
-                                   output_directory=outputdir)
+                                   libdir=os.path.abspath(os.curdir))
 
         assert res
         self.assertEqual(tape.counter["begin"], 1)

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -17,6 +17,18 @@ from osbuild.pipeline import Manifest, detect_host_runner
 from .. import test
 
 
+def names(*lst):
+    return [x.name for x in lst]
+
+
+class MockStore:
+    def __init__(self) -> None:
+        self.have = set()
+
+    def contains(self, pipeline_id):
+        return pipeline_id in self.have
+
+
 class TestDescriptions(unittest.TestCase):
 
     @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
@@ -107,6 +119,137 @@ class TestDescriptions(unittest.TestCase):
         for i in [build, tree, assembler]:
             check = manifest[i.id]
             self.assertEqual(i.name, check.name)
+
+    # pylint: disable=too-many-statements
+    def test_on_demand(self):
+        index = osbuild.meta.Index(os.curdir)
+
+        manifest = Manifest()
+        noop = index.get_module_info("Stage", "org.osbuild.noop")
+        noip = index.get_module_info("Input", "org.osbuild.noop")
+
+        # the shared build pipeline
+        build = manifest.add_pipeline("build", None, None)
+        build.add_stage(noop, {"option": 1})
+
+        # a pipeline simulating some intermediate artefact
+        # that other pipeline need as dependency
+        dep = manifest.add_pipeline("dep",
+                                    "org.osbuild.linux",
+                                    build.id)
+
+        dep.add_stage(noop, {"option": 2})
+
+        # a pipeline that is not linked to the "main"
+        # assembler artefact and thus should normally
+        # not be built unless explicitly requested
+        # has an input that depends on `dep`
+        ul = manifest.add_pipeline("unlinked",
+                                   "org.osbuild.linux",
+                                   build.id)
+
+        stage = ul.add_stage(noop, {"option": 3})
+        ip = stage.add_input("dep", noip, "org.osbuild.pipeline")
+        ip.add_reference(dep.id)
+
+        # the main os root file system
+        rootfs = manifest.add_pipeline("rootfs",
+                                       "org.osbuild.inux",
+                                       build.id)
+        stage = rootfs.add_stage(noop, {"option": 4})
+
+        # the main raw image artefact, depending on "dep" and
+        # "rootfs"
+        image = manifest.add_pipeline("image",
+                                      "org.osbuild.inux",
+                                      build.id)
+
+        stage = image.add_stage(noop, {"option": 5})
+        ip = stage.add_input("dep", noip, "org.osbuild.pipeline")
+        ip.add_reference(dep.id)
+
+        stage = image.add_stage(noop, {"option": 6})
+
+        #  a stage using the rootfs as input (named 'image')
+        ip = stage.add_input("image", noip, "org.osbuild.pipeline")
+        ip.add_reference(rootfs.id)
+
+        # some compression of the image, like a qcow2
+        qcow2 = manifest.add_pipeline("qcow2",
+                                      "org.osbuild.inux",
+                                      build.id)
+        stage = qcow2.add_stage(noop, {"option": 7})
+        ip = stage.add_input("image", noip, "org.osbuild.pipeline")
+        ip.add_reference(image.id)
+
+        fmt = index.get_format_info("osbuild.formats.v2").module
+        self.assertIsNotNone(fmt)
+        print(json.dumps(fmt.describe(manifest), indent=2))
+
+        # The pipeline graph in the manifest with dependencies:
+        # ├─╼ build
+        # ├─╼ dep
+        # │ └ build
+        # ├─╼ unlinked
+        # │ ├ build
+        # │ └ dep
+        # ├─╼ rootfs
+        # │ └ build
+        # ├─╼ image
+        # │ ├ build
+        # │ ├ dep
+        # │ └ rootfs
+        # └─╼ qcow2
+        #   ├ build
+        #   └ image
+
+        store = MockStore()
+
+        # check an empty input leads to an empty list
+        res = manifest.depsolve(store, [])
+        assert res == []
+
+        # the build pipeline should resolve to just itself
+        res = manifest.depsolve(store, names(build))
+        assert res == names(build)
+
+        # if we build the 'unlinked' pipeline, we get it
+        # and its dependencies, dep and build
+        res = manifest.depsolve(store, names(ul))
+        assert res == names(build, dep, ul)
+
+        # building image with nothing in the store should
+        # result in all pipelines but 'unlinked'
+        res = manifest.depsolve(store, names(image))
+        assert res == names(build, rootfs, dep, image)
+
+        # if we have the 'dep' dependency in the store,
+        # we should be not be building that
+        store.have.add(dep.id)
+        res = manifest.depsolve(store, names(image))
+        assert res == names(build, rootfs, image)
+
+        # if we only have the build pipeline in the
+        # store we should not build that
+        store.have.clear()
+        store.have.add(build.id)
+        res = manifest.depsolve(store, names(image))
+        assert res == names(rootfs, dep, image)
+
+        # if we have the final artefact in the store,
+        # nothing should be built at all
+        store.have.clear()
+        store.have.add(image.id)
+        res = manifest.depsolve(store, names(image))
+        assert res == []
+
+        # we have a checkpoint of the stage in the image
+        # pipeline with the `dep` dependency, so that
+        # it effectively only depends on `rootfs`
+        store.have.clear()
+        store.have.add(image.stages[0].id)
+        res = manifest.depsolve(store, names(image))
+        assert res == names(build, rootfs, image)
 
     def check_moduleinfo(self, version):
         index = osbuild.meta.Index(os.curdir)

--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -41,9 +41,9 @@ class TestAssemblers(test.TestBase):
         assert treeid
 
         with tempfile.TemporaryDirectory(dir="/var/tmp") as output_dir:
-            osb.compile(data, output_dir=output_dir, checkpoints=[treeid], exports=["assembler"])
-            with osb.map_object(treeid) as tree:
-                yield tree, os.path.join(output_dir, "assembler", output_path)
+            osb.compile(data, output_dir=output_dir, exports=["assembler", "tree"])
+            tree = os.path.join(output_dir, "tree")
+            yield tree, os.path.join(output_dir, "assembler", output_path)
 
     def assertImageFile(self, filename, fmt, expected_size=None):
         info = json.loads(subprocess.check_output(["qemu-img", "info", "--output", "json", filename]))

--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -41,9 +41,9 @@ class TestAssemblers(test.TestBase):
         assert treeid
 
         with tempfile.TemporaryDirectory(dir="/var/tmp") as output_dir:
-            osb.compile(data, output_dir=output_dir, checkpoints=[treeid])
+            osb.compile(data, output_dir=output_dir, checkpoints=[treeid], exports=["assembler"])
             with osb.map_object(treeid) as tree:
-                yield tree, os.path.join(output_dir, output_path)
+                yield tree, os.path.join(output_dir, "assembler", output_path)
 
     def assertImageFile(self, filename, fmt, expected_size=None):
         info = json.loads(subprocess.check_output(["qemu-img", "info", "--output", "json", filename]))
@@ -118,9 +118,9 @@ class TestAssemblers(test.TestBase):
 
             data = json.dumps(manifest)
             with tempfile.TemporaryDirectory(dir="/var/tmp") as output_dir:
-                result = osb.compile(data, output_dir=output_dir)
-                compose_file = os.path.join(output_dir, "compose.json")
-                repo = os.path.join(output_dir, "repo")
+                result = osb.compile(data, output_dir=output_dir, exports=["assembler"])
+                compose_file = os.path.join(output_dir, "assembler", "compose.json")
+                repo = os.path.join(output_dir, "assembler", "repo")
 
                 with open(compose_file) as f:
                     compose = json.load(f)

--- a/test/run/test_boot.py
+++ b/test/run/test_boot.py
@@ -26,8 +26,8 @@ class TestBoot(test.TestBase):
 
         with self.osbuild as osb:
             with tempfile.TemporaryDirectory(dir="/var/tmp") as temp_dir:
-                osb.compile_file(manifest, output_dir=temp_dir)
-                qcow2 = os.path.join(temp_dir, "fedora-boot.qcow2")
+                osb.compile_file(manifest, output_dir=temp_dir, exports=["assembler"])
+                qcow2 = os.path.join(temp_dir, "assembler", "fedora-boot.qcow2")
                 output_file = os.path.join(temp_dir, "output")
 
                 subprocess.run(["qemu-system-x86_64",

--- a/test/run/test_noop.py
+++ b/test/run/test_noop.py
@@ -1,11 +1,13 @@
 #
 # Runtime Tests for No-op Pipelines
 #
+
 import json
 import tempfile
 import pytest
 
 from .. import test
+
 
 @pytest.fixture(name="jsondata", scope="module")
 def jsondata_fixture():
@@ -33,6 +35,7 @@ def jsondata_fixture():
         ]
     })
 
+
 @pytest.fixture(name="tmpdir", scope="module")
 def tmpdir_fixture():
     with tempfile.TemporaryDirectory() as tmp:
@@ -52,14 +55,18 @@ def osbuild_fixture():
 # Then run the entire thing again, to verify our own `osbuild` executor
 # tears things down properly and allows to be executed multiple times.
 #
+
+
 def test_noop(osb):
-    osb.compile("{}")
-    osb.compile("{}")
+    osb.compile("{}", checkpoints=[])
+    osb.compile("{}", checkpoints=[])
+
 
 def test_noop2(osb):
-    osb.compile("{}")
-    osb.compile("{}")
+    osb.compile("{}", checkpoints=[])
+    osb.compile("{}", checkpoints=[])
+
 
 @pytest.mark.skipif(not test.TestBase.can_bind_mount(), reason="root-only")
 def test_noop_v2(osb, tmpdir, jsondata):
-    osb.compile(jsondata, output_dir=tmpdir)
+    osb.compile(jsondata, output_dir=tmpdir, exports=["noop"])

--- a/test/test.py
+++ b/test/test.py
@@ -288,6 +288,9 @@ class OSBuild(contextlib.AbstractContextManager):
         Returns the build result as dictionary.
         """
 
+        if checkpoints is None and exports is None:
+            raise ValueError("Need `checkpoints` or `exports` argument")
+
         if output_dir is None:
             output_dir_context = tempfile.TemporaryDirectory(dir="/var/tmp")
         else:


### PR DESCRIPTION
Only build the minimal set of pipelines that we really need to build, i.e. the ones that were explicitly requested via `--export` or implicitly via `--checkpoint` and all the explicit and implicit dependencies of those taking into account which are not yet in the store. The check for `--output-directory` or `--checkpoints` was also removed thus enabling a download-only mode. Additionally, we check the validity of the arguments to `--export` before we are building anything, which improves the UX of osbuild. 

cc @alexlarsson 