### PR TITLE
ci: remove 8.5 nightly testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,8 +34,6 @@ RPM:
           - aws/rhel-8.4-ga-x86_64
           - aws/rhel-8.4-ga-aarch64
       - RUNNER:
-          - aws/rhel-8.5-nightly-x86_64
-          - aws/rhel-8.5-nightly-aarch64
           - aws/rhel-8.6-nightly-x86_64
           - aws/rhel-8.6-nightly-aarch64
           - aws/rhel-9.0-beta-nightly-x86_64
@@ -54,7 +52,7 @@ Testing:
           - aws/fedora-33-x86_64
           - aws/fedora-33-aarch64
           - aws/rhel-8.4-ga-x86_64
-          - aws/rhel-8.5-nightly-x86_64
+          - aws/rhel-8.6-nightly-x86_64
           - aws/rhel-9.0-beta-nightly-x86_64
         INTERNAL_NETWORK: "true"
 


### PR DESCRIPTION
It no longer makes sense because:

- we don't make any changes to 8.5
- we don't regenerate test manifests for 8.5
- osbuild-composer for 8.5 is in the rhel-8.5.0 branch

Also, the latest-8.5.0 symlink was removed, which broke the CI.