### PR TITLE
Do not bind-mount the `/boot` directory from the host into the build root

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -69,6 +69,7 @@ class BuildRoot(contextlib.AbstractContextManager):
         self._apis = []
         self.dev = None
         self.var = None
+        self.mount_boot = True
 
     @staticmethod
     def _mknod(path, name, mode, major, minor):
@@ -154,7 +155,11 @@ class BuildRoot(contextlib.AbstractContextManager):
         mounts = []
 
         # Import directories from the caller-provided root.
-        for p in ["boot", "usr"]:
+        imports = ["usr"]
+        if self.mount_boot:
+            imports.insert(0, "boot")
+
+        for p in imports:
             source = os.path.join(self._rootdir, p)
             if os.path.isdir(source) and not os.path.islink(source):
                 mounts += ["--ro-bind", source, os.path.join("/", p)]

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -108,6 +108,10 @@ class Stage:
             build_root = buildroot.BuildRoot(build_tree, runner, libdir, store.tmp)
             cm.enter_context(build_root)
 
+            # if we have a build root, then also bind-mount the boot
+            # directory from it, since it may contain efi binaries
+            build_root.mount_boot = bool(self.build)
+
             tmpdir = store.tempdir(prefix="buildroot-tmp-")
             tmpdir = cm.enter_context(tmpdir)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ ignored-classes=osbuild.loop.LoopInfo
 
 [pylint.DESIGN]
 max-attributes=10
+max-statements=75
 
 [pycodestyle]
 max-line-length = 120


### PR DESCRIPTION
Currently, we take to paths from the root file system supplied to the `BuildRoot` class: `/boot` and `/usr`. The reason for
mounting `/boot` is that grub2 and shim install efi binaries there and for certain images we want to copy the binaries from the build root and not install the respective packages.
However, if we build to build root itself, we probably don't want the mount the hosts' `/boot` since we don't want to copy anything from there. So never mount the build root from the host, i.e. only mount it if the stage has a build pipeline specified.