### PR TITLE
Let schutzbot do the post-release version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Upstream release
         uses: osbuild/release-action@main
         with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"


### PR DESCRIPTION
We need a privileged / admin user doing the post-release version bump as
this is a direct commit to main (i.e. without a PR) so switch to using
schutzbot with a scoped personal access token (only public_repo).