### PR TITLE
stages/lvm2.create: fix 'size' and add 'extents'

### DIFF
--- a/stages/org.osbuild.lvm2.create
+++ b/stages/org.osbuild.lvm2.create
@@ -41,16 +41,29 @@ SCHEMA_2 = r"""
       "items": {
         "description": "Logical volume",
         "type": "object",
-        "required": ["name", "size"],
+        "required": ["name"],
+        "oneOf": [
+          {
+            "required": ["size"]
+          }, {
+            "required": ["extents"]
+          }
+        ],
         "properties": {
           "name": {
             "description": "The logical volume name",
             "type": "string",
             "pattern": "[a-zA-Z09+_.][a-zA-Z0-9+_.-]*"
           },
+          "extents": {
+            "description": "The logical extents of the volume",
+            "type": "string",
+            "pattern": "[1-9][0-9]*(%(VG|PVS|FREE|ORIGIN))?"
+          },
           "size": {
             "description": "The size of the logical volume",
-            "type": "string"
+            "type": "string",
+            "pattern": "[1-9][0-9]*[bBsSkKmMgGtTpPeE]?"
           }
         }
       }
@@ -80,10 +93,14 @@ def main(devices, options):
     for volume in volumes:
         name = volume["name"]
         size = volume.get("size")
+        extents = volume.get("extents")
         cmd = ["lvcreate", "-an"]
 
+        if extents:
+            cmd += ["--extents", extents]
+
         if size:
-            cmd += ["-l", size]
+            cmd += ["--size", size]
 
         cmd += ["-n", name, vg_name]
 

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -1090,7 +1090,7 @@
             "volumes": [
               {
                 "name": "root",
-                "size": "100%FREE"
+                "extents": "100%FREE"
               }
             ]
           }

--- a/test/data/manifests/fedora-ostree-image.mpp.json
+++ b/test/data/manifests/fedora-ostree-image.mpp.json
@@ -488,7 +488,7 @@
             "volumes": [
               {
                 "name": "root",
-                "size": "100%FREE"
+                "extents": "100%FREE"
               }
             ]
           }


### PR DESCRIPTION
The `size` option was using `-l`, which in fact was `--extents`. Fix that to use `--size` and add a new option `extents` that will in fact call translate to `--extents` and this replace the current use of the `size` option.

Adapt the `fedora-ostree-image` test manifest to use `extents`.