### PR TITLE
New options for cloud-init: Azure datasource and reporting/logging

### DIFF
--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -24,6 +24,12 @@ import osbuild.api
 
 
 SCHEMA = r"""
+"definitions": {
+  "reporting_handlers": {
+    "type": "string",
+    "enum": ["log", "print", "webhook", "hyperv"]
+  }
+},
 "additionalProperties": false,
 "required": ["config", "filename"],
 "properties": {
@@ -53,6 +59,32 @@ SCHEMA = r"""
               "name": {
                 "type": "string",
                 "description": "username of the 'default' user."
+              }
+            }
+          }
+        }
+      },
+      "reporting": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Define reporting endpoints.",
+        "minProperties": 1,
+        "properties": {
+          "logging": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/reporting_handlers"
+              }
+            }
+          },
+          "telemetry": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/reporting_handlers"
               }
             }
           }

--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -57,6 +57,31 @@ SCHEMA = r"""
             }
           }
         }
+      },
+      "datasource_list": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": ["Azure"]
+        }
+      },
+      "datasource": {
+        "type": "object",
+        "description": "Sources of configuration data for cloud-init.",
+        "minProperties": 1,
+        "properties": {
+          "Azure": {
+            "type": "object",
+            "minProperties": 1,
+            "properties": {
+              "apply_network_config": {
+                "type": "boolean",
+                "description": "Whether to use network configuration described by Azure’s IMDS endpoint",
+                "default": true
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -152,7 +152,7 @@ def main(tree, options):
     config_files_dir = f"{tree}/etc/cloud/cloud.cfg.d"
 
     with open(f"{config_files_dir}/{filename}", "w") as f:
-        yaml.dump(config, f)
+        yaml.dump(config, f, default_flow_style=False)
 
     return 0
 

--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -114,6 +114,28 @@ SCHEMA = r"""
             }
           }
         }
+      },
+      "output": {
+        "type": "object",
+        "minProperties": 1,
+        "properties": {
+          "init": {
+            "description": "Redirect the output of the init stage",
+            "type": "string"
+          },
+          "config": {
+            "description": "Redirect the output of the config stage",
+            "type": "string"
+          },
+          "final": {
+            "description": "Redirect the output of the final stage",
+            "type": "string"
+          },
+          "all": {
+            "description": "Redirect the output of all stages",
+            "type": "string"
+          }
+        }
       }
     }
   }

--- a/test/data/stages/cloud-init/b.json
+++ b/test/data/stages/cloud-init/b.json
@@ -515,6 +515,49 @@
             }
           }
         }
+      },
+      {
+        "name": "org.osbuild.cloud-init",
+        "options": {
+          "filename": "10-azure-kfp.cfg",
+          "config": {
+            "reporting": {
+              "logging": {
+                "type": "log"
+              },
+              "telemetry": {
+                "type": "hyperv"
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "org.osbuild.cloud-init",
+        "options": {
+          "filename": "91-azure_datasource.cfg",
+          "config": {
+            "datasource_list": [
+              "Azure"
+            ],
+            "datasource": {
+              "Azure": {
+                "apply_network_config": false
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "org.osbuild.cloud-init",
+        "options": {
+          "filename": "06_logging_override.cfg",
+          "config": {
+            "output": {
+              "all": ">> /var/log/cloud-init-all.log"
+            }
+          }
+        }
       }
     ]
   },

--- a/test/data/stages/cloud-init/b.mpp.json
+++ b/test/data/stages/cloud-init/b.mpp.json
@@ -41,6 +41,47 @@
             }
           }
         }
+      },
+      {
+        "name": "org.osbuild.cloud-init",
+        "options": {
+          "filename": "10-azure-kfp.cfg",
+          "config": {
+            "reporting": {
+              "logging": {
+                "type": "log"
+              },
+              "telemetry": {
+                "type": "hyperv"
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "org.osbuild.cloud-init",
+        "options": {
+          "filename": "91-azure_datasource.cfg",
+          "config": {
+            "datasource_list": ["Azure"],
+            "datasource": {
+              "Azure": {
+                "apply_network_config": false
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "org.osbuild.cloud-init",
+        "options": {
+          "filename": "06_logging_override.cfg",
+          "config": {
+            "output": {
+              "all": ">> /var/log/cloud-init-all.log"
+            }
+          }
+        }
       }
     ]
   }

--- a/test/data/stages/cloud-init/diff.json
+++ b/test/data/stages/cloud-init/diff.json
@@ -1,6 +1,9 @@
 {
   "added_files": [
-    "/etc/cloud/cloud.cfg.d/00-default_user.cfg"
+    "/etc/cloud/cloud.cfg.d/00-default_user.cfg",
+    "/etc/cloud/cloud.cfg.d/06_logging_override.cfg",
+    "/etc/cloud/cloud.cfg.d/10-azure-kfp.cfg",
+    "/etc/cloud/cloud.cfg.d/91-azure_datasource.cfg"
   ],
   "deleted_files": [],
   "differences": {}


### PR DESCRIPTION
- Added support for configuring the Azure datasource.  Only options currently needed are defined.  More can be added later. Each defined datasource has to be listed in a top-level array in the config file.  This is added automatically.
- Added support for configuring reporting handlers.  It's likely that the names of the handlers can be arbitrary strings, but I couldn't confirm this, so I added the known names.