### PR TITLE
Support 'install' command in org.osbuild.modprobe stage

### DIFF
--- a/stages/org.osbuild.modprobe
+++ b/stages/org.osbuild.modprobe
@@ -9,6 +9,11 @@ Currently supported "command" objects are:
   - for 'blacklist' command
     - 'command' property value: "blacklist"
     - 'modulename' property value: a non-empty string with the name of a module
+  - for 'install' command
+    - 'command' property value: "install"
+    - 'modulename' property value: a non-empty string with the name of a module
+    - 'cmdline' property value: a non-empty string representing the command to
+      run instead of inserting the specified module.
 """
 
 
@@ -38,7 +43,7 @@ SCHEMA = r"""
           "additionalProperties": false,
           "type": "object",
           "description": "'blacklist' command",
-          "required": ["command","modulename"],
+          "required": ["command", "modulename"],
           "properties": {
             "command": {
               "type": "string",
@@ -49,6 +54,29 @@ SCHEMA = r"""
               "type": "string",
               "minLength": 1,
               "description": "name of the module to blacklist."
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "description": "'install' command",
+          "required": ["command", "modulename", "cmdline"],
+          "properties": {
+            "command": {
+              "type": "string",
+              "enum": ["install"],
+              "description": "modprobe command."
+            },
+            "modulename": {
+              "type": "string",
+              "minLength": 1,
+              "description": "name of the module to blacklis."
+            },
+            "cmdline": {
+              "type": "string",
+              "minLength": 1,
+              "description": "command to run instead of inserting the specified module as normal."
             }
           }
         }
@@ -69,6 +97,8 @@ def main(tree, options):
     for config_command in options["commands"]:
         if config_command["command"] == "blacklist":
             lines.append(f'{config_command["command"]} {config_command["modulename"]}\n')
+        elif config_command["command"] == "install":
+            lines.append(f'{config_command["command"]} {config_command["modulename"]} {config_command["cmdline"]}\n')
         else:
             raise ValueError()
 

--- a/test/data/stages/modprobe/b.json
+++ b/test/data/stages/modprobe/b.json
@@ -481,6 +481,19 @@
             }
           ]
         }
+      },
+      {
+        "name": "org.osbuild.modprobe",
+        "options": {
+          "filename": "firewalld-sysctls.conf",
+          "commands": [
+            {
+              "command": "install",
+              "modulename": "nf_conntrack",
+              "cmdline": "/usr/sbin/modprobe --ignore-install nf_conntrack $CMDLINE_OPTS && /usr/sbin/sysctl --quiet --pattern 'net[.]netfilter[.]nf_conntrack.*' --system"
+            }
+          ]
+        }
       }
     ]
   },

--- a/test/data/stages/modprobe/b.mpp.json
+++ b/test/data/stages/modprobe/b.mpp.json
@@ -56,6 +56,19 @@
             }
           ]
         }
+      },
+      {
+        "name": "org.osbuild.modprobe",
+        "options": {
+          "filename": "firewalld-sysctls.conf",
+          "commands": [
+            {
+              "command": "install",
+              "modulename": "nf_conntrack",
+              "cmdline": "/usr/sbin/modprobe --ignore-install nf_conntrack $CMDLINE_OPTS && /usr/sbin/sysctl --quiet --pattern 'net[.]netfilter[.]nf_conntrack.*' --system"
+            }
+          ]
+        }
       }
     ]
   }

--- a/test/data/stages/modprobe/diff.json
+++ b/test/data/stages/modprobe/diff.json
@@ -1,7 +1,8 @@
 {
   "added_files": [
     "/usr/lib/modprobe.d/disallow-modules.conf",
-    "/usr/lib/modprobe.d/disallow-additional-modules.conf"
+    "/usr/lib/modprobe.d/disallow-additional-modules.conf",
+    "/usr/lib/modprobe.d/firewalld-sysctls.conf"
   ],
   "deleted_files": [],
   "differences": {}


### PR DESCRIPTION
Add support for new 'install' command in the org.osbuild.modprobe stage.

Extend the unit test coverage to test the new command.

Signed-off-by: Tomas Hozza <thozza@redhat.com>