### PR TITLE
stages/yum.config: add a new stage to configure YUM langpacks plugin

### DIFF
--- a/stages/org.osbuild.yum.config
+++ b/stages/org.osbuild.yum.config
@@ -1,10 +1,12 @@
 #!/usr/bin/python3
 """
-Change YUM configuration.
+Configure yellowdog updater modified (YUM)
 
-The stage changes persistent YUM configuration on the filesystem.
+The stage currently supports configuring http_caching in YUM config and
+locales in langpacks plugin. If the config files don't exist, they
+are created.
 """
-
+import os
 import sys
 import iniparse
 
@@ -26,13 +28,71 @@ SCHEMA = r"""
         "description": "Determines how upstream HTTP caches are instructed to handle any HTTP downloads that YUM does."
       }
     }
+  },
+  "plugins": {
+    "additionalProperties": false,
+    "type": "object",
+    "description": "YUM plugins configuration",
+    "properties": {
+      "langpacks": {
+        "additionalProperties": false,
+        "type": "object",
+        "description": "'langpacks' YUM plugin configuration",
+        "minProperties": 1,
+        "properties": {
+          "locales": {
+            "type": "array",
+            "minItems": 1,
+            "description": "list of locales for YUM",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
   }
 }
 """
 
 
+def configure_plugins(tree, plugins_options):
+    for plugin, plugin_options in plugins_options.items():
+        plugin_conf_path = f"{tree}/etc/yum/pluginconf.d/{plugin}.conf"
+        plugin_conf = iniparse.SafeConfigParser()
+
+        try:
+            with open(plugin_conf_path, "r") as f:
+                plugin_conf.readfp(f)
+        except FileNotFoundError:
+            print(f"Warning: {plugin} configuration file '{plugin_conf_path}' does not exist, will create it.")
+
+        # ensure that the pluginconf directory exists
+        os.makedirs(f"{tree}/etc/yum/pluginconf.d/", exist_ok=True)
+
+        for option, value in plugin_options.items():
+            if option == "locales":
+                if not plugin_conf.has_section("main"):
+                    plugin_conf.add_section("main")
+
+                locales = ", ".join(value)
+
+                plugin_conf.set("main", "langpack_locales", locales)
+            else:
+                # schema does not allow any additional properties, but keeping this for completeness
+                print(f"Error: unknown property {option} specified for {plugin} plugin.")
+                return 1
+
+        with open(plugin_conf_path, "w") as f:
+            plugin_conf.write(f)
+
+    return 0
+
+
 def main(tree, options):
     config_options = options.get("config")
+    plugins_options = options.get("plugins", {})
+
     yum_config_path = f"{tree}/etc/yum.conf"
     yum_config = iniparse.SafeConfigParser()
 
@@ -52,6 +112,9 @@ def main(tree, options):
 
         with open(yum_config_path, "w") as f:
             yum_config.write(f)
+
+    if configure_plugins(tree, plugins_options):
+        return 1
 
     return 0
 

--- a/test/data/stages/yum.config/b.json
+++ b/test/data/stages/yum.config/b.json
@@ -498,6 +498,13 @@
         "options": {
           "config": {
             "http_caching": "packages"
+          },
+          "plugins": {
+            "langpacks": {
+              "locales": [
+                "en_US.UTF-8"
+              ]
+            }
           }
         }
       }

--- a/test/data/stages/yum.config/b.mpp.json
+++ b/test/data/stages/yum.config/b.mpp.json
@@ -34,6 +34,13 @@
         "options": {
           "config": {
             "http_caching": "packages"
+          },
+          "plugins": {
+            "langpacks": {
+              "locales": [
+                "en_US.UTF-8"
+              ]
+            }
           }
         }
       }

--- a/test/data/stages/yum.config/diff.json
+++ b/test/data/stages/yum.config/diff.json
@@ -1,6 +1,9 @@
 {
   "added_files": [
-    "/etc/yum.conf"
+    "/etc/yum.conf",
+    "/etc/yum",
+    "/etc/yum/pluginconf.d",
+    "/etc/yum/pluginconf.d/langpacks.conf"
   ],
   "deleted_files": [],
   "differences": {}


### PR DESCRIPTION
The new stage enables users to configure the langpacks plugin of YUM. Its
schema is derived from the rhsm stage and is designed to be flexible if
we need to add ability to configure more YUM plugins, or even YUM itself.