### PR TITLE
stages/selinux: ability to force an auto-relabel

### DIFF
--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -21,6 +21,7 @@ may not match the tree's policy.
 
 
 import os
+import pathlib
 import subprocess
 import sys
 
@@ -41,6 +42,11 @@ SCHEMA = """
     "items": {
       "type": "object"
     }
+  },
+  "force_autorelabel": {
+    "type": "boolean",
+    "description": "Do not use. Forces auto-relabelling on first boot.",
+    "default": false
   }
 }
 """
@@ -55,6 +61,10 @@ def main(tree, options):
     for path, label in labels.items():
         fullpath = os.path.join(tree, path.lstrip("/"))
         subprocess.run(["chcon", "-v", label, fullpath], check=True)
+
+    if options.get("force_autorelabel", False):
+        stamp = pathlib.Path(tree, ".autorelabel")
+        stamp.touch()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This should not be needed in any case but can be a sledgehammer for situations where we cannot properly label a file; it turns out such a scenario is if a label, lets call it `a1`, is is an alias to another label, lets call it `l1`. Setting `a1` will lead to `a1` being read back, and thus copying the label `a1` will result on the label `l1` being copied instead. Now if the target distribution does not have `l1` but `a1` we cannot set it and thus will end up with an unlabeled file.