### PR TITLE
formats/v2: fix describe for mount without source

### DIFF
--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -77,9 +77,11 @@ def describe(manifest: Manifest, *, with_id=False) -> Dict:
         desc = {
             "name": mnt.name,
             "type": mnt.info.name,
-            "source": mnt.device.name,
             "target": mnt.target
         }
+
+        if mnt.device:
+            desc["source"] = mnt.device.name
 
         if mnt.options:
             desc["options"] = mnt.options


### PR DESCRIPTION
Commit 5b1cd2b made `source` and `target` for mounts optional, but the corresponding code in `describe` still assumes that the device will always be present. Fix this so that source will only be used if it is set.