### PR TITLE
packit: enable copr builds for CS9 on main

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -41,6 +41,8 @@ jobs:
     targets:
     - centos-stream-8-aarch64
     - centos-stream-8-x86_64
+    - centos-stream-9-aarch64
+    - centos-stream-9-x86_64
     - epel-8-aarch64
     - epel-8-x86_64
     - fedora-all-aarch64


### PR DESCRIPTION
I forgot to enable CS9 builds on main previously, let's fix that.