### PR TITLE
Buildroot: mask `/proc/cmdline`

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -69,6 +69,7 @@ class BuildRoot(contextlib.AbstractContextManager):
         self._apis = []
         self.dev = None
         self.var = None
+        self.tmp = None
         self.mount_boot = True
 
     @staticmethod
@@ -101,8 +102,11 @@ class BuildRoot(contextlib.AbstractContextManager):
             self.dev = self._exitstack.enter_context(dev)
 
             os.makedirs(self._vardir, exist_ok=True)
-            var = tempfile.TemporaryDirectory(prefix="osbuild-var-", dir=self._vardir)
-            self.var = self._exitstack.enter_context(var)
+            tmp = tempfile.TemporaryDirectory(prefix="osbuild-tmp-", dir=self._vardir)
+            self.tmp = self._exitstack.enter_context(tmp)
+
+            self.var = os.path.join(self.tmp, "var")
+            os.makedirs(self.var, exist_ok=True)
 
             subprocess.run(["mount", "-t", "tmpfs", "-o", "nosuid", "none", self.dev], check=True)
             self._exitstack.callback(lambda: subprocess.run(["umount", "--lazy", self.dev], check=True))

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -145,3 +145,22 @@ def test_selinuxfs_ro(tempdir):
 
         r = root.run(cmd, monitor, readonly_binds=ro_binds)
         assert r.returncode == 0
+
+
+@pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")
+def test_proc_overrides(tempdir):
+    runner = detect_host_runner()
+    libdir = os.path.abspath(os.curdir)
+    var = pathlib.Path(tempdir, "var")
+    var.mkdir()
+
+    cmdline = "is-this-the-real-world"
+
+    monitor = NullMonitor(sys.stderr.fileno())
+    with BuildRoot("/", runner, libdir, var) as root:
+
+        root.proc.cmdline = cmdline
+
+        r = root.run(["cat", "/proc/cmdline"], monitor)
+        assert r.returncode == 0
+        assert cmdline in r.output.strip()


### PR DESCRIPTION
Since we bind `/proc` inside the container, we leak certain information that comes with it. One of this is the kernel command line. None of the decisions done by software running inside the container should depend on the kernel command line on the host, so overwrite the kernel command line by creating a temporary directory and mapping it inside the build- root. For now we default to a simple `root=/dev/osbuild` fake kernel command line.