### PR TITLE
spec: require python3-pyyaml for osbuild-tools

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -93,6 +93,7 @@ containers it uses to build OS artifacts.
 %package        tools
 Summary:        Extra tools and utilities
 Requires:       %{name} = %{version}-%{release}
+Requires:       python3-pyyaml
 
 %description    tools
 Contains additional tools and utilities for development of


### PR DESCRIPTION
osbuild-mpp has learned to read yaml files but with it gained a hard dependency on python3-pyyaml. Specify so in the spec file.