### PR TITLE
ci: make jobs interruptible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,12 +16,14 @@ init:
     - shell
   script:
     - schutzbot/update_github_status.sh start
+  interruptible: true
 
 RPM:
   stage: rpmbuild
   extends: .terraform
   script:
     - sh "schutzbot/mockbuild.sh"
+  interruptible: true
   parallel:
     matrix:
       - RUNNER:


### PR DESCRIPTION
This will cancel old running pipelines if a new one is created.

I want to just test it here because this seems to be more responsive then osbuild-composer repository.