### PR TITLE
stages/ostree.fillvar: fill the correct var

### DIFF
--- a/stages/org.osbuild.ostree.fillvar
+++ b/stages/org.osbuild.ostree.fillvar
@@ -111,9 +111,10 @@ def main(tree, options):
     serial = dep.get("serial", 0)
 
     deployment = ostree.deployment_path(tree, osname, ref, serial)
+    var = os.path.join(tree, "ostree", "deploy", osname, "var")
 
     with MountGuard() as mgr:
-        mgr.mount(f"{deployment}/var", f"{deployment}/var")
+        mgr.mount(var, f"{deployment}/var")
         populate_var(deployment)
 
 


### PR DESCRIPTION
The idea behind the stage is to provision `var` of the stateroot, i.e. the `var` the is shared amongst all deployments for a given os (indicated by `osname`, e.g. `fedora`, `centos`, ...). For `systemd-tmpfiles` to infer the correct paths, it needs to be run on the deployment. The `var` of the latter needs to be bind- mounted to the `var` of the stateroot, because it is shared. This was always the intention but not what the code did. Fix this by getting the `var` of the stateroot and bind it to the `var` of the deployment.

NB: In reality this never mattered since systemd-tmpfiles is also run during system startup.