### PR TITLE
stages/grub2.inst: Make grub-mkimage binary configurable

### DIFF
--- a/stages/org.osbuild.grub2.inst
+++ b/stages/org.osbuild.grub2.inst
@@ -70,6 +70,11 @@ SCHEMA = r"""
       "filesystem": {
         "type": "string",
         "enum": ["ext4", "xfs", "btrfs"]
+      },
+      "binary": {
+        "description": "grub-mkimage binary name",
+        "type": "string",
+        "default": "grub2-mkimage"
       }
     }
   },
@@ -231,7 +236,7 @@ def core_mkimage(platform: str, prefix: str, options: Dict,):
         raise ValueError(f"unknown boot filesystem type: '{fs_type}'")
 
     # now created the core image
-    subprocess.run(["grub2-mkimage",
+    subprocess.run([options.get("binary", "grub2-mkimage"),
                     "--verbose",
                     "--directory", f"/usr/lib/grub/{platform}",
                     "--prefix", prefix,


### PR DESCRIPTION
On Arch Linux grub-mkimage is provided by the `grub` package which is
grub2 and grub (1) no longer exists.