### PR TITLE
Small fix for `mounts/ostree.deployment` and an order check for `depsolve`

### DIFF
--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -61,6 +61,12 @@ SCHEMA_2 = """
 
 class OSTreeDeploymentMount(mounts.MountService):
 
+    def __init__(self, args):
+        super().__init__(args)
+
+        self.mountpoint = None
+        self.check = False
+
     @staticmethod
     def bind_mount(source, target):
         subprocess.run([

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -223,6 +223,15 @@ class TestDescriptions(unittest.TestCase):
         res = manifest.depsolve(store, names(image))
         assert res == names(build, rootfs, dep, image)
 
+        # ensure the order of inputs is preserved during
+        # the depsolving so that we build things in the
+        # same way they were requested
+        res = manifest.depsolve(store, names(ul, image))
+        assert res == names(build, dep, ul, rootfs, image)
+
+        res = manifest.depsolve(store, names(image, ul))
+        assert res == names(build, rootfs, dep, image, ul)
+
         # if we have the 'dep' dependency in the store,
         # we should be not be building that
         store.have.add(dep.id)


### PR DESCRIPTION
See the individual commits.