### PR TITLE
ci: initial mergify configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,62 @@
+queue_rules:
+  - name: default
+    conditions:
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - base=main
+      - check-success=📚 Documentation
+      - check-success=Schutzbot on GitLab
+      - check-success=Test Suite (test.mod)
+      - check-success=Test Suite (test.run.test_assemblers)
+      - check-success=Test Suite (test.run.test_boot)
+      - check-success=Test Suite (test.run.test_noop)
+      - check-success=Test Suite (test.run.test_sources)
+      - check-success=Test Suite (test.run.test_stages)
+      - check-success=Test Suite (test.src)
+      - check-success=Regenerate Test Data
+      - check-success=Spell check
+      - "check-success=LGTM analysis: Python"
+      - check-success=codecov/project
+      - "check-success~=rpm-build:.*"
+
+pull_request_rules:
+  - name: Automatic merge for Dependabot pull requests
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+      - title~=^Bump [^\s]+ from ([\d]+)\..+ to \1\.
+      - base=main
+      - check-success=📚 Documentation
+      - check-success=Schutzbot on GitLab
+      - check-success=Test Suite (test.mod)
+      - check-success=Test Suite (test.run.test_assemblers)
+      - check-success=Test Suite (test.run.test_boot)
+      - check-success=Test Suite (test.run.test_noop)
+      - check-success=Test Suite (test.run.test_sources)
+      - check-success=Test Suite (test.run.test_stages)
+      - check-success=Test Suite (test.src)
+      - check-success=Regenerate Test Data
+      - check-success=Spell check
+      - "check-success=LGTM analysis: Python"
+      - check-success=codecov/project
+      - "check-success~=rpm-build:.*"
+    actions:
+      queue:
+        name: default
+        method: rebase
+        update_method: rebase
+        rebase_fallback: none
+  - name: Automatic merge on green via label
+    conditions:
+      - base=main
+      - "check-success~=rpm-build:.*"
+      - "label=ci:automerge"
+    actions:
+      queue:
+        name: default
+        method: rebase
+        update_method: rebase
+        rebase_fallback: none
+        require_branch_protection: true
+      label:
+        remove:
+          - ci:automerge


### PR DESCRIPTION
Define a merge queue "default", with all current checks (minus the ostree one) are required to get out of.

Two rules to get into the queue:

1.  standard branch protection, plus packit, plus the `ci:automerge`
2. dependabot, does not require the standard branch protection since that implies reviews. Instead the checks are manually listed.