### PR TITLE
sshd.config stage: support PermitRootLogin option

### DIFF
--- a/stages/org.osbuild.sshd.config
+++ b/stages/org.osbuild.sshd.config
@@ -33,6 +33,18 @@ SCHEMA = """
       "ClientAliveInterval": {
         "description": "Number of seconds between keep-alive pings. 0 disables it.",
         "type": "integer"
+      },
+      "PermitRootLogin": {
+        "description": "Specifies whether root can log in using ssh.",
+        "oneOf": [
+          {
+            "enum": ["prohibit-password", "forced-commands-only"],
+            "type": "string"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
       }
     }
   }
@@ -51,6 +63,7 @@ def main(tree, options):
     password_auth = sshd_config.get("PasswordAuthentication")
     challenge_response_auth = sshd_config.get("ChallengeResponseAuthentication")
     client_alive_interval = sshd_config.get("ClientAliveInterval")
+    permit_root_login = sshd_config.get("PermitRootLogin")
     changes = {}
     if password_auth is not None:
         changes["passwordauthentication"] = {
@@ -66,6 +79,11 @@ def main(tree, options):
         changes["clientaliveinterval"] = {
             "key": "ClientAliveInterval",
             "value": client_alive_interval
+        }
+    if permit_root_login is not None:
+        changes["permitrootlogin"] = {
+            "key": "PermitRootLogin",
+            "value": bool_to_yes_no(permit_root_login) if isinstance(permit_root_login, bool) else permit_root_login
         }
 
     # For each of the configured options, find the first non-commented out instance

--- a/test/data/stages/sshd.config/a.json
+++ b/test/data/stages/sshd.config/a.json
@@ -455,9 +455,6 @@
             "sha256:0ebe43a9bef7ec2dc4cb98350fbde2e55dae886f905e2d9cea837da3fb613c87"
           ]
         }
-      },
-      {
-        "name": "org.osbuild.sshd.config"
       }
     ]
   },

--- a/test/data/stages/sshd.config/a.mpp.json
+++ b/test/data/stages/sshd.config/a.mpp.json
@@ -28,9 +28,6 @@
             ]
           }
         }
-      },
-      {
-        "name": "org.osbuild.sshd.config"
       }
     ]
   }

--- a/test/data/stages/sshd.config/b.json
+++ b/test/data/stages/sshd.config/b.json
@@ -462,7 +462,8 @@
           "config": {
             "PasswordAuthentication": false,
             "ChallengeResponseAuthentication": false,
-            "ClientAliveInterval": 180
+            "ClientAliveInterval": 180,
+            "PermitRootLogin": "forced-commands-only"
           }
         }
       },
@@ -472,7 +473,8 @@
           "config": {
             "PasswordAuthentication": false,
             "ChallengeResponseAuthentication": true,
-            "ClientAliveInterval": 200
+            "ClientAliveInterval": 200,
+            "PermitRootLogin": false
           }
         }
       }

--- a/test/data/stages/sshd.config/b.mpp.json
+++ b/test/data/stages/sshd.config/b.mpp.json
@@ -35,7 +35,8 @@
           "config": {
             "PasswordAuthentication": false,
             "ChallengeResponseAuthentication": false,
-            "ClientAliveInterval": 180
+            "ClientAliveInterval": 180,
+            "PermitRootLogin": "forced-commands-only"
           }
         }
       },
@@ -45,7 +46,8 @@
           "config": {
             "PasswordAuthentication": false,
             "ChallengeResponseAuthentication": true,
-            "ClientAliveInterval": 200
+            "ClientAliveInterval": 200,
+            "PermitRootLogin": false
           }
         }
       }

--- a/test/data/stages/sshd.config/diff.json
+++ b/test/data/stages/sshd.config/diff.json
@@ -5,25 +5,7 @@
     "/etc/ssh/sshd_config": {
       "content": [
         "sha256:1042f1b0e644ed40eef54614a3a8108b534f41beb2d210545a2bac5cbd8187b7",
-        "sha256:a995ff3d4c7c89987c210207d109a86815334f58bea30ccfea1c175fe8f12b76"
-      ]
-    },
-    "/etc/pki/ca-trust/extracted/java/cacerts": {
-      "content": [
-        null,
-        null
-      ]
-    },
-    "/var/cache/ldconfig/aux-cache": {
-      "content": [
-        null,
-        null
-      ]
-    },
-    "/var/lib/rpm/rpmdb.sqlite": {
-      "content": [
-        null,
-        null
+        "sha256:3c4833fc340eb78f5002a628dee13203eb0ca26fdb4394dc29a7d2f902f66723"
       ]
     }
   }


### PR DESCRIPTION
Add support for `PermitRootLogin` option in the
`org.osbuild.sshd.config` stage.

I kept the "yes" and "no" values for consistency with other stage
options. While it will make the implementation in osbuild-composer
harder, it won't be impossible as we already have a precedence for doing
it this way (e.g. in the `org.osbuild.pam.limits.conf`).

Modify the stage unit tests to check the new option.

Remove the empty `org.osbuild.sshd.config` stage from `a.mpp.json`
since it does not add any value and it actually made the `tree-diff`
tool provide a weird tree diff results.

Fix #910

Signed-off-by: Tomas Hozza <thozza@redhat.com>