### PR TITLE
[skip ci] ci: remove label _after_ pr is merged

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -82,6 +82,11 @@ pull_request_rules:
         update_method: rebase
         rebase_fallback: none
         require_branch_protection: false
+  - name: Remove label after merge or close
+    conditions:
+      - merged
+      - closed
+    actions:
       label:
         remove:
           - ci:automerge


### PR DESCRIPTION
Don't try to do it in the same action as otherwise the bot will refuse to actually add it to the queue.