### PR TITLE
build root: isolate container environment from the host and set `CONTAINER`

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -275,6 +275,7 @@ class BuildRoot(contextlib.AbstractContextManager):
 
         # Setup a new environment for the container.
         env = {
+            "container": "bwrap-osbuild",
             "LC_CTYPE": "C.UTF-8",
             "PATH": "/usr/sbin:/usr/bin",
             "PYTHONPATH": "/run/osbuild/lib",

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -264,9 +264,6 @@ class BuildRoot(contextlib.AbstractContextManager):
             "--chdir", "/",
             "--die-with-parent",
             "--new-session",
-            "--setenv", "PATH", "/usr/sbin:/usr/bin",
-            "--setenv", "PYTHONPATH", "/run/osbuild/lib",
-            "--setenv", "PYTHONUNBUFFERED", "1",
             "--unshare-ipc",
             "--unshare-pid",
             "--unshare-net"
@@ -276,8 +273,18 @@ class BuildRoot(contextlib.AbstractContextManager):
         cmd += ["--", f"/run/osbuild/lib/runners/{self._runner}"]
         cmd += argv
 
+        # Setup a new environment for the container.
+        env = {
+            "LC_CTYPE": "C.UTF-8",
+            "PATH": "/usr/sbin:/usr/bin",
+            "PYTHONPATH": "/run/osbuild/lib",
+            "PYTHONUNBUFFERED": "1",
+            "TERM": os.getenv("TERM", "dumb"),
+        }
+
         proc = subprocess.Popen(cmd,
                                 bufsize=0,
+                                env=env,
                                 stdin=subprocess.DEVNULL,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT,

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -214,6 +214,7 @@ def test_env_isolation(tempdir):
 
     allowed = [
         "_",      # added by `env` itself
+        "container",
         "LC_CTYPE",
         "PATH",
         "PWD",


### PR DESCRIPTION
Isolate the environment from the host to not leak any information. Set the `container` env variable to indicate we are running inside a container.