### PR TITLE
stages/users: Explicitly create a home directory

### DIFF
--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -94,6 +94,7 @@ def useradd(root, name, uid=None, gid=None, groups=None, description=None, home=
         arguments += ["--comment", description]
     if home:
         arguments += ["--home-dir", home]
+        arguments += ["--create-home"]
     if shell:
         arguments += ["--shell", shell]
     if password is not None:


### PR DESCRIPTION
On distributions such as Arch Linux the home directory is not created by
default.