### PR TITLE
[skip ci] ci: do not require label for rebase

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -29,3 +29,4 @@ jobs:
           MERGE_REMOVE_LABELS: "ci:automerge"
           MERGE_METHOD: "rebase"
           UPDATE_METHOD: "rebase"
+          UPDATE_LABELS: ""


### PR DESCRIPTION
Allow automerge to update the PR without any labels present.