### PR TITLE
release-action: Send notification to our Slack channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,3 +13,4 @@ jobs:
         uses: osbuild/release-action@main
         with:
           token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
+          slack_webhook_url: "${{ secrets.SLACK_WEBHOOK_URL }}"


### PR DESCRIPTION
Passing the webhook URL is necessary because GH composite actions don't
support handling secrets.
See also osbuild/release-action#3

[skip ci]