### PR TITLE
stages: allow using sysconfig stage multiple times.

### DIFF
--- a/stages/org.osbuild.sysconfig
+++ b/stages/org.osbuild.sysconfig
@@ -165,6 +165,9 @@ def bool_to_string(value):
 
 
 def configure_kernel(tree, kernel_options):
+    if not kernel_options:
+        return
+
     with open(f"{tree}/etc/sysconfig/kernel", 'w') as kernel_file:
         for option, value in kernel_options.items():
             if option == "update_default":
@@ -177,6 +180,9 @@ def configure_kernel(tree, kernel_options):
 
 
 def configure_network(tree, network_options):
+    if not network_options:
+        return
+
     with open(f"{tree}/etc/sysconfig/network", 'w') as network_file:
         for option, value in network_options.items():
             if option == "networking":


### PR DESCRIPTION
The sysconfig stage currently does not produce expected results when
used multiple times within the same pipeline. Specifically, the stage
always truncates respective configuration files for properties `kernel`
and `network`, if if these are not set in the stage options. Due to this
reason, the outcome of the image builds may depend on the order of
multiple occurrences of the sysconfig stage.

The following two pipeline snippets would produce different
configuration files content:

Configuration files are truncated:
```json
{
  "type": "org.osbuild.sysconfig",
  "options": {
    "kernel": {
      "update_default": true,
      "default_kernel": "kernel"
    },
    "network": {
      "networking": true,
      "no_zero_conf": true
    }
  }
},
{
  "type": "org.osbuild.sysconfig",
  "options": {
    "network-scripts": {
      "ifcfg": {
        "eth0": {
          "bootproto": "dhcp",
          "device": "eth0",
          "ipv6init": false,
          "onboot": true,
          "peerdns": true,
          "type": "Ethernet",
          "userctl": true
        }
      }
    }
  }
},
```

No configuration files are truncated:
```json
{
  "type": "org.osbuild.sysconfig",
  "options": {
    "network-scripts": {
      "ifcfg": {
        "eth0": {
          "bootproto": "dhcp",
          "device": "eth0",
          "ipv6init": false,
          "onboot": true,
          "peerdns": true,
          "type": "Ethernet",
          "userctl": true
        }
      }
    }
  }
},
{
  "type": "org.osbuild.sysconfig",
  "options": {
    "kernel": {
      "update_default": true,
      "default_kernel": "kernel"
    },
    "network": {
      "networking": true,
      "no_zero_conf": true
    }
  }
},
```

Change the stage to not touch respective configuration files if the
`kernel` and `network` properties are not set in the stage options.

Signed-off-by: Tomas Hozza <thozza@redhat.com>