### PR TITLE
`stages/grub2`: ability to not write kernel cmdline

### DIFF
--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -171,6 +171,11 @@ SCHEMA = """
     "type": "boolean",
     "default": true
   },
+  "write_cmdline": {
+    "description": "Include the kernel command line in `grubenv`",
+    "type": "boolean",
+    "default": true
+  },
   "ignition": {
     "description": "Include ignition support in the grub.cfg",
     "type": "boolean",
@@ -468,13 +473,14 @@ class GrubConfig:
         return data
 
 
-#pylint: disable=too-many-statements
+#pylint: disable=too-many-statements,too-many-branches
 def main(tree, options):
     root_fs = options.get("rootfs")
     boot_fs = options.get("bootfs")
     kernel_opts = options.get("kernel_opts", "")
     legacy = options.get("legacy", None)
     uefi = options.get("uefi", None)
+    write_cmdline = options.get("write_cmdline", True)
     write_defaults = options.get("write_defaults", True)
     ignition = options.get("ignition", False)
     saved_entry = options.get("saved_entry")
@@ -528,10 +534,10 @@ def main(tree, options):
 
     with open(grubenv, "w") as env:
         fs_type, fs_id = fs_spec_decode(root_fs)
-        data = (
-            "# GRUB Environment Block\n"
-            f"kernelopts=root={fs_type}={fs_id} {kernel_opts}\n"
-        )
+        data = "# GRUB Environment Block\n"
+
+        if write_cmdline:
+            data += f"kernelopts=root={fs_type}={fs_id} {kernel_opts}\n"
 
         if saved_entry:
             data += f"saved_entry={saved_entry}\n"

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -89,6 +89,16 @@ SCHEMA = """
   "required": ["rootfs"]
 }],
 "definitions": {
+  "uuid": {
+    "description": "Identify the file system by UUID",
+    "type": "string",
+    "oneOf": [
+      { "pattern": "^[0-9A-Za-z]{8}(-[0-9A-Za-z]{4}){3}-[0-9A-Za-z]{12}$",
+        "examples": ["9c6ae55b-cf88-45b8-84e8-64990759f39d"] },
+      { "pattern": "^[0-9A-Za-z]{4}-[0-9A-Za-z]{4}$",
+        "examples": ["6699-AFB5"] }
+    ]
+  },
   "filesystem": {
     "description": "Description of how to locate a file system",
     "type": "object",
@@ -102,16 +112,7 @@ SCHEMA = """
         "description": "Identify the file system by label",
         "type": "string"
       },
-      "uuid": {
-        "description": "Identify the file system by UUID",
-        "type": "string",
-        "oneOf": [
-          { "pattern": "^[0-9A-Za-z]{8}(-[0-9A-Za-z]{4}){3}-[0-9A-Za-z]{12}$",
-            "examples": ["9c6ae55b-cf88-45b8-84e8-64990759f39d"] },
-          { "pattern": "^[0-9A-Za-z]{4}-[0-9A-Za-z]{4}$",
-            "examples": ["6699-AFB5"] }
-        ]
-      }
+      "uuid": { "$ref": "#/definitions/uuid" }
     }
   },
   "terminal": {
@@ -125,26 +126,8 @@ SCHEMA = """
 "properties": {
   "rootfs": { "$ref": "#/definitions/filesystem" },
   "bootfs": { "$ref": "#/definitions/filesystem" },
-  "root_fs_uuid": {
-    "description": "UUID of the root filesystem image",
-    "type": "string",
-    "oneOf": [
-      { "pattern": "^[0-9A-Za-z]{8}(-[0-9A-Za-z]{4}){3}-[0-9A-Za-z]{12}$",
-        "examples": ["9c6ae55b-cf88-45b8-84e8-64990759f39d"] },
-      { "pattern": "^[0-9A-Za-z]{4}-[0-9A-Za-z]{4}$",
-        "examples": ["6699-AFB5"] }
-    ]
-  },
-  "boot_fs_uuid": {
-    "description": "UUID of the boot filesystem, if /boot is separated",
-    "type": "string",
-    "oneOf": [
-      { "pattern": "^[0-9A-Za-z]{8}(-[0-9A-Za-z]{4}){3}-[0-9A-Za-z]{12}$",
-        "examples": ["9c6ae55b-cf88-45b8-84e8-64990759f39d"] },
-      { "pattern": "^[0-9A-Za-z]{4}-[0-9A-Za-z]{4}$",
-        "examples": ["6699-AFB5"] }
-    ]
-  },
+  "root_fs_uuid": { "$ref": "#/definitions/uuid" },
+  "boot_fs_uuid": { "$ref": "#/definitions/uuid" },
   "kernel_opts": {
     "description": "Additional kernel boot options",
     "type": "string",

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -62,7 +62,6 @@ and reset the success indicator one.
 An implementation of the user space component for rpm-ostree is
 called `greenboot`.
 
-
 Support for ignition (https://github.com/coreos/ignition) can be turned
 on via the `ignition` option. If enabled, a 'ignition_firstboot' variable
 will be created, which is meant to be included in the kernel command line.

--- a/test/data/manifests/fedora-boot.json
+++ b/test/data/manifests/fedora-boot.json
@@ -681,9 +681,9 @@
         "name": "org.osbuild.grub2",
         "options": {
           "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
           "legacy": "i386-pc",
-          "saved_entry": "ffffffffffffffffffffffffffffffff-5.11.12-300.fc34.x86_64"
+          "saved_entry": "ffffffffffffffffffffffffffffffff-5.11.12-300.fc34.x86_64",
+          "write_cmdline": false
         }
       },
       {

--- a/test/data/manifests/fedora-boot.mpp.json
+++ b/test/data/manifests/fedora-boot.mpp.json
@@ -76,11 +76,11 @@
         "name": "org.osbuild.grub2",
         "options": {
           "root_fs_uuid": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
-          "kernel_opts": "ro biosdevname=0 net.ifnames=0",
           "legacy": "i386-pc",
           "saved_entry": {
             "mpp-format-string": "{'f'*32}-{rpms['stages']['kernel-core'].evra}"
-          }
+          },
+          "write_cmdline": false
         }
       },
       {

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -264,7 +264,7 @@ class TestDescriptions(unittest.TestCase):
         index = osbuild.meta.Index(os.curdir)
 
         modules = []
-        for klass in ("Assembler", "Input", "Source", "Stage"):
+        for klass in ("Assembler", "Device", "Input", "Mount", "Source", "Stage"):
             mods = index.list_modules_for_class(klass)
             modules += [(klass, module) for module in mods]
 


### PR DESCRIPTION
Currently we always write the kernel command line to the `grubenv` file, if only to include the root device. Starting with Fedora 33 and thus RHEL 9, the kernel command line included statically in the BLS snippets and the grubenv `kernelopts` variable not used. Instead one of the {/usr/lib,/etc}/kernel/cmdline files is read and the parameters in them used during the creation of the BLS snippets.
Therefore we add a new `write_cmdline` option that, if set to FALSE, will prevent us from writing the kernel command line.