### PR TITLE
Arch legacy grub compatibility

### DIFF
--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -380,7 +380,7 @@ class GrubConfig:
     def grubfs(self):
         """The filesystem containing the grub files,
 
-        This is  either a separate partition (self.bootfs if set) or
+        This is either a separate partition (self.bootfs if set) or
         the root file system (self.rootfs)
         """
         return self.bootfs or self.rootfs

--- a/stages/org.osbuild.grub2.legacy
+++ b/stages/org.osbuild.grub2.legacy
@@ -236,8 +236,8 @@ menuentry '${title}' --class red --class gnu-linux --class gnu --class os --unre
 	insmod all_video
 	set gfxpayload=keep
 	search --no-floppy --set=root ${search}
-	linux${loader} /vmlinuz-${kernel} ${cmdline}
-	initrd${loader} /initramfs-${kernel}.img
+	linux${loader} ${grub_home}vmlinuz-${kernel} ${cmdline}
+	initrd${loader} ${grub_home}initramfs-${kernel}.img
 }
 """
 
@@ -406,6 +406,7 @@ class GrubConfig:
             "cmdline": f"root={rootfs} {self.cmdline}",
             "search": search,
             "loader": loader,
+            "grub_home": self.grub_home
         }
 
         if self.serial:

--- a/stages/org.osbuild.grub2.legacy
+++ b/stages/org.osbuild.grub2.legacy
@@ -356,7 +356,7 @@ class GrubConfig:
     def grubfs(self):
         """The filesystem containing the grub files,
 
-        This is  either a separate partition (self.bootfs if set) or
+        This is either a separate partition (self.bootfs if set) or
         the root file system (self.rootfs)
         """
         return self.bootfs or self.rootfs

--- a/stages/org.osbuild.pacman
+++ b/stages/org.osbuild.pacman
@@ -85,18 +85,20 @@ def parse_input(inputs):
 def main(tree, inputs):
     pkgpath, packages = parse_input(inputs)
 
+    # The hook to generate kernel preset files requires /dev/stdin
+    # https://github.com/archlinux/svntogit-packages/blob/7f2711a77579a72414cef323bb5e914921177b38/linux/repos/core-i686/PKGBUILD#L114
     script = f"""
         set -e
         mkdir -p {tree}/dev {tree}/sys {tree}/proc
         mount -o bind /dev {tree}/dev
         mount -o bind /sys {tree}/sys
         mount -o bind /proc {tree}/proc
+        ln -s /proc/self/fd/0 /dev/stdin
     """
 
     machine_id_set_previously = os.path.exists(f"{tree}/etc/machine-id")
     if not machine_id_set_previously:
         # create a fake machine ID to improve reproducibility
-        print("creating a fake machine id")
         script += f"""
             mkdir -p {tree}/etc
             echo "ffffffffffffffffffffffffffffffff" > {tree}/etc/machine-id

--- a/test/data/manifests/arch/arch-build.json
+++ b/test/data/manifests/arch/arch-build.json
@@ -18,12 +18,12 @@
                 "sha256:c459054fdef5df9934e4a36dc295b347c59ed2eee3025a2c10e3e30cebbea51b": {},
                 "sha256:5133350a061b9e03ed411349b7bd2996b8d553d06a93b8b34d0176ababfb629d": {},
                 "sha256:0c63dbc82cc8e909c7225cee8c7399bcc0f4377f7877cda90dd0a3a3354dcc12": {},
-                "sha256:87fbc54f1011cbe1024428b48b9918e7e0dce5ba70c70f42efa7caa2a26403be": {},
+                "sha256:d10cc5b8e913314375e2596cc300eddf13700586b602c46c1b6138e33bac6ad7": {},
                 "sha256:964221d7e0c8888d833d8f235e210d931439e1591d73c54eff1b70ccef64a9d5": {},
                 "sha256:1e5a129b3d8ffbf054597ecfbcd04508085f863e22c702a1f709f5743d4ae682": {},
                 "sha256:2c2252246e73006fb8e17c955135897620a2a8f865ce100b905ba068672b81c8": {},
                 "sha256:c3aee4482695d19d9d8762fee429de51cbdc359bd1565e9ec52e9b46475e0360": {},
-                "sha256:4a2014ad6ff9c16beb044692216258aa668432550f3b619b1270d6dbb2f25872": {},
+                "sha256:f2868945d73874530a2745a305f9fa6fcd622388825576c155685e5acfa15f9a": {},
                 "sha256:44b400abf34e559e5c4cdd4d1cfe799795eef59780525d6d02d36a3f3152b249": {},
                 "sha256:2e87a6382bcffc364015f848217d0afdcffdaa5efab43d5ee1b4d80a9645c5b8": {},
                 "sha256:7076fc302df82ddfa249e99e35897271fb2a62a585e7ccb51896aac8d47b4775": {},
@@ -55,10 +55,10 @@
                 "sha256:40d550736a02da440f8764230317dbd6cff2bba87ca325999138ad8494d5f061": {},
                 "sha256:c2e1200e909a345f1eb01236529da5268b500448967d69d808630f19ca983613": {},
                 "sha256:54f2a81dfeccd21136753da917a3e031ff0f8fd7a1811971bda4a004b1d49f1a": {},
-                "sha256:24e9792946b726f5b24604fc3e1cdcfc6724950f7c7164679b59c6bcddd91e18": {},
+                "sha256:571986dc87f612d41b8e63eb606630d05685903f446c2ff1674bf11846e86985": {},
                 "sha256:313a359bf73dac82a1bb5c72a14754e84541b10751f2e4a00085a3c0a177cea8": {},
                 "sha256:994b1850653ff9bc03bd75f127e8c72d5fb2713a4028724f43cd09e3dcaec66c": {},
-                "sha256:56a67855e3dfc9fee076ecf48d1e61fd5586e8e00bfab6dcfed7c3081b63251f": {},
+                "sha256:75930e347a4d9ae2ffea42cb554cc1159174971bb77695b19a3ce92d8c36814f": {},
                 "sha256:1eab9a225fb40ce3cd661b4252eda36cb11a499ed883e7a5e3cb0403b45b8a0b": {},
                 "sha256:08d87979b2c1cc644d130f14325e10205a0b39e69b936523862e411f09f038dc": {},
                 "sha256:2fe1c9ef8d771e387503e8ee1ca8df2a4f0a077b7ae4aba2e59bfc415388d876": {},
@@ -76,29 +76,29 @@
                 "sha256:d7518d4dae1a383f91f74c872520e985c2cc7f92b6c7f477b47b365bc6d2463d": {},
                 "sha256:b71dcb2153d5165a4af3c90510d1431cc3902f766ffcc3db2e7060282fcb3f1c": {},
                 "sha256:da2b54539233f30f28b419c12bc2756eaf63454cc8ff19824c12a7bd4b329f7b": {},
-                "sha256:5a405d63d9cfd3fc05f70e4c284950d4c9fa1630d9a10312bc8c86ae7e01bf17": {},
+                "sha256:43595bb882c62cc363d8ba4798726af9647d745623536a9757ed4d87a45f408c": {},
                 "sha256:3f18a5902557c078b12fd20704b93db28718b9e4d8621e4dab1c468b22d7aaa4": {},
                 "sha256:33b906d6df9e467fea20516d6398c73ccf8a29ebe8dff3c837c8f296c09a347e": {},
                 "sha256:248a1e5aad3c5612139a8b41f9274c73a5fd520dd22457cdf554565b7a746a23": {},
                 "sha256:eb06c3eeb8138a204d2bf892fbce724e0bef148b0c36f892002e2809bc7ef83e": {},
                 "sha256:fe7723b62afea4cdf8530f0a0cff555831c4b3f54578d4a5943e23d0390e33d4": {},
                 "sha256:5095c3ccea91e860e27b86c714a83f146ac0c376250ae6f75acf8f101bdd36f8": {},
-                "sha256:811604b9603aaff62d735ca5ad4b5c6adaff784c9cae1a5aa9a4f9840c01ea85": {},
+                "sha256:9132c974b73688ac186254eb1e15dea53b2c498c8fb79b7546b9e49a6a260900": {},
                 "sha256:bdc37a7970eeea908da44513532e7ab5e801139a60b32eb9cea7267b27c6bad4": {},
                 "sha256:5f411b8854f6f56f0bb81418372f7bc6105203d508b9f0d8e85688a2658111c0": {},
                 "sha256:6f73778852be33880c5f749a77e66c3e0b7019c218de6483a9866dea78a68731": {},
                 "sha256:221100e6d11291d09afd06ef4c46758c26fbbf278c96029d61889b90ee05d451": {},
                 "sha256:5f3e2263c82ec153688f45648ed8ebb33b97634861f9ea18b117bb4ac385eb4f": {},
                 "sha256:791edb9d97f03193181b2dc82ed94c4414abf234ffa09b8f329da49f43c29156": {},
-                "sha256:cd697d7ecc784680bd32d2f81e401e6bcbf7ddac05fa0166bdcd2410cf473780": {},
-                "sha256:2a3f7b235b012cdbfcdffd319c4dc8bf0048915382c1919127234db9e27e6fe2": {},
+                "sha256:7909ea73e874c28ec2ea14d919973cd88a54dff762341a1c045c4604cf2cabf9": {},
+                "sha256:57106954e348e1e31b0e79c69891e9a829448778d9df4546ecf5cfcb078164c9": {},
                 "sha256:aef83f04f6c18e0d7cbff518fbc17ce011bccf7ce2761427c3615b2d0b340b55": {},
                 "sha256:7c7a5cc9f6321276414f68f6135a5ea38ee858a5e37cbfc0b196e4eca7622d3e": {},
                 "sha256:020a23a7be7fe69cc1605b9a8cbf3e7c2b6fd10ed06cf6480c4b06cbd4d6e47f": {},
                 "sha256:0e9de3ed449e4f061c34d640d5cd3cdf1232cb89b2da4be9ea5577bbfcbe834c": {},
                 "sha256:8d357ca0eb2c479d9dabad04087394c9df4764ed9672e01ee768aee42e1c320d": {},
                 "sha256:a16739c482654dc5c33e4d934c9d6f95e1949eb087f56f42fff4b1e579fba866": {},
-                "sha256:3b3d12a8b8e9543fe1e0946b88ab8b5e2c5ed1b864a77fb1bf805e0156a9965a": {},
+                "sha256:89a13b26fbda6da9bbc02eeca19d116223d21974f7065dfc97667a4d85e881c6": {},
                 "sha256:67dc2d5ab7e63b7dfd32e92535655da5763fe568bc47cb0318430784ab058bef": {},
                 "sha256:e738ef92d6bb9f33aeb83d5819f35fc61a87b7e4019fe5e9f1150f7b473503c2": {},
                 "sha256:70b76e351a4ab2477bf1d2351c7aca4a20e6aac697054aae5cc403144cc7e8fe": {},
@@ -110,7 +110,7 @@
                 "sha256:71ad81e43b03ec020e2b5d091ecae797c8ed49331283a0e6ba39d89024096254": {},
                 "sha256:53bdec110ccbc1bc69ca02a180e68830ec8cfbb8b81046330ad6b18ce11718b6": {},
                 "sha256:53d42ffb4f39c9beb3793413650526dac659349ad730c29ca431b3e5a7201cb1": {},
-                "sha256:6a73f37d35ec1a95ebb0038d34a2339a9c061c84775265899ee15577b17f0cec": {},
+                "sha256:ec0cc8b935f69f1e31ed69744e259607a033373692557fc932cd399826e2ce8b": {},
                 "sha256:1c88de0ce2a2a49c861ac5af18e08c05d2ed859dac0b7c9ce3a1a2a5749224bf": {},
                 "sha256:b945cde112bb54f750d4165fdb5d464cb455b79b1e8a8ac6aa0098d0129e6452": {},
                 "sha256:ed84350ddee5a6d5e22de22b53b262ed45b608a4ad2377f3d3402804e41c24ca": {},
@@ -126,7 +126,7 @@
                 "sha256:f2780887bd1dde0a615e2bbef3cc4b86d00e9d722b27c3515181c9de5c95a06a": {},
                 "sha256:5ce4b3101809d2c0ccb99a7269af25524f8a24a73ee87dee5c0dc08176b8d178": {},
                 "sha256:cbf77b00a044fd20f6af21ef18305c2fe9dc74e584d0f9330c28e6c229d4c251": {},
-                "sha256:bdfee3892d50a861e20b992da3926600ef00bf8028e3c124b3acf00455408b62": {},
+                "sha256:9bf7999cffd8fb564805ba731bcd9bd5d25fbb84be01b4521f18711984f2cd84": {},
                 "sha256:1ed0f340d97b2a34c6246313806e25d489c56a6e6f102ae307299f5593c3b7fe": {},
                 "sha256:95355372805a1819887d15da8ad1dccdc35f7ca9b9342b6765c47578d028e0ba": {},
                 "sha256:b13e1b3efbfa68902b7a43f7edbcbf8d773126557161aef133efb8302406c9d2": {},
@@ -141,7 +141,7 @@
                 "sha256:90b47a3058c600e0a4222d18166770caa9d215b4863e69f1500aad07bea126aa": {},
                 "sha256:3612fa2518e5fe5ec2d495daef10141971259990c9d3af3fdf35ab4e55eaadfb": {},
                 "sha256:2781904c33ab87e2f737bf329c115d375f9637dc09daaa369d0bd8c9390b1615": {},
-                "sha256:8bbb1ebd6d29e0374caf9c70a443428d7cea6bcb1f75b64f12b6601bdaf7f5f4": {},
+                "sha256:09a0f3d9ede07bd065881afd464e40cf03c84cdcd0a7d6619d2ca1b9d477e8de": {},
                 "sha256:1a7d285c338995e3e7361cbf63e13bb065f6d104eff255de08ca2ffb61e9b1eb": {},
                 "sha256:4fee095b88c80ebaf6a7d5a3a4c75783b8fbba8655721b352cf9196c0c71b138": {},
                 "sha256:0af4dc630bbe6fa873ff86198070c2a3ee77c457a5745da351de2e35aeea7c1a": {},
@@ -151,11 +151,11 @@
                 "sha256:87c3560bcb2246ef4316211f944a20016ef8db83749951e31456dd1bba857f8f": {},
                 "sha256:bf78700d2bfb743c72b4a6478b6743a11cec1136eb4e7acac12cbad47dabf3f6": {},
                 "sha256:f4a3728f9f968d43d81c50d4e667e4fe43313351aa674e9187debdc0c29bf83d": {},
-                "sha256:118732989aa6f31d99be9274930b221e86ce6fd84998e58e5e191b8e99afa225": {},
+                "sha256:f45a754682f8e929c38e83308c8038da55b8c1714077d8991b34cedafca4f131": {},
                 "sha256:613e6d9847f4575e2169bdcd5c2460dc7f618a59a4bb68c0d64ac960d4645a43": {},
-                "sha256:e5a3ad98e21099f6279daa2d72804c11d237de2ec1887584edffa4205c289789": {},
+                "sha256:549b1c4b555a97d05c1d7494c78fa54c4108a13dd504bc60db0336331d2bb612": {},
                 "sha256:006eb979188bf1fba178b2817f394c2e0aec3c2e6c64555fd62f11f30623225d": {},
-                "sha256:d455d045049f06f4af408fccf957537bc77fad6705f757fb65aa742610e1e59f": {},
+                "sha256:c24880c9f308e8155b25c8692fa6024764ba575b607584cb85f609e46ededb55": {},
                 "sha256:4c16bf7b44f2107ee89e8402423192cef9fb49005f94d06feeff49949706f3e9": {},
                 "sha256:bbbb5c3aa37529ca62c70e2332e1dacfaf0daed389e689ce5430d5c24b93edc7": {},
                 "sha256:aac3c9922bda89c694b51df187a8de7e2327a6d295149a856a82e47befa60cbd": {},
@@ -175,19 +175,19 @@
                 "sha256:41a03f13cac8bc2a79ff7efcd9e0ade82ffd2d02e15d0c260a7f5e04f2a4fd22": {},
                 "sha256:31e9732ee3bf1417faa53dbc6ee35e3a3a8c1f5bb19a6aaeda8c961dec99479e": {},
                 "sha256:a32fde4c51509f1e4b51b5518bf28eca1931088e4d7a826ed6defa12c7b6a862": {},
-                "sha256:3f5c832785a54fb5cd3808513d85a1bebda6cf13a202c351fcfa95f7b645d59e": {},
+                "sha256:e3b63ae201c63c3bebc30e9be3cea079f63a092fb7de4f285b5a1521eed35f32": {},
                 "sha256:8fefa22cb9f308e4fc2154a3811f31b823f7ba49de27a2c77ea7f7f5b7a82120": {},
                 "sha256:0b2447558a6e46c0b17af04314daf8a53ab3c7bf717889ada13e0fce095484c2": {},
                 "sha256:f7d8bfb69913929c756ecc472aab444629c9b29d532a77ef86e90b42bf32b59a": {},
                 "sha256:bdf0f800f3c781fd2689e2c1326518eb3bdf80c37ddc7b9e773e0149dbaa3237": {},
-                "sha256:cd3b129cf6ef2dc189573dfe1edb0184ceb04333bf39b2ee9903e28029dfa673": {},
-                "sha256:f60bf75c00b88ae7702bbfcd905ab8311e141ebacc4388fff5a05a5867708f4f": {},
+                "sha256:0d63801542a7f4ded5209351b271603b8bbb320051e76d9bc96f3bf534e5465e": {},
+                "sha256:07cd6052066a7235a96bc82cf2ba570a4d906734e402d70056a9b7733e67ad7c": {},
                 "sha256:f47d449cbefeb1a6476c80a2bc9aa795e6c07b89982151b237ffa41f7cf36812": {},
                 "sha256:3aa85ab3220d9545eab2a01be8d1c2f2aab5679e1eb9eb4a1e6be388b10f4a59": {},
                 "sha256:c0da14c0ce596b6c30f0aa9797324a5069db125136590b6f6e57feec2aa2bfc6": {},
                 "sha256:a03fd9f69459557bfc2cca083f28af08f281a435fa316690cf7213b8b1767980": {},
                 "sha256:1b31b2bd1cbb4740c26906578e42f52988c1f9861b1c92b97db5ddcbef1d3b06": {},
-                "sha256:0f1c8950a708f7fe37dd34fee2076fe58535e7372106d93a2ceb8518512c9c84": {},
+                "sha256:8717902d1fd93ee845fbc1ecac0fc7c6dc14b5e45d3cb879840ce82265230ada": {},
                 "sha256:bc023fe47374b6233a71e75aa8c7cac6905bc104e30b3ba8f8412aa9bcff9535": {},
                 "sha256:90a20e5190ffc879e2563c6f56645c36caf26c2f6a6e400d04b78927aecb70ac": {},
                 "sha256:afb816b7762c3a247973a99ab2f648dd7e30b4578cc872ac11458cd57b930b0d": {},
@@ -207,7 +207,7 @@
                 "sha256:0af4f9c189c81be1341da084b77e5df7f49a7ce5602016684936cddc9f141507": {},
                 "sha256:1b2dfa4cd3dcd3753f4daacab2e20e7bdc979063c7fa205f7ac23ea340c19958": {},
                 "sha256:b82b327f050133d80b9a9d84ba051609159c34fde25eb5bcdfa4aa4dc6eff95c": {},
-                "sha256:8d1c3f5a4c1ebd25083b24251aff5b93017fa2f30349b923c1a6cb0d8bbd2a3f": {},
+                "sha256:0064cc0aa1e908d2c0b377afc311cfc65b8291b2e4d80520bee7973cde66faa5": {},
                 "sha256:72037d28a7d14aa06aec74090a999f7f5dc19a4f0a2a580bf4ba7eab62ddd18d": {},
                 "sha256:8d561515a3b9ec065da830fbd1cf6414e995f28b19b9d3aeeba117478412e32f": {},
                 "sha256:80d5582d0200e81bdb578e6aefd162308d8e86dfc2681418f460cff67d287fc9": {},
@@ -219,7 +219,7 @@
                 "sha256:0cb975da99be41277a62bbc792c48ca176ba3a3d20e58c37653a3a63d48ec873": {},
                 "sha256:3634137d38bcd011ceb38daf7af6f2add4887372d8358652eda70fd756054a8b": {},
                 "sha256:84a9595136f2b42abf432abfc2f7f7580c755b22554afc3a7d589d9510ab2fe1": {},
-                "sha256:1e9a676c69bc15ca985dea6c8e40afad14275039dea07ae229c90ea8cd906daf": {},
+                "sha256:e0ce1c213118522d148f6c2eee052926eb15766422ab90e76ebbfb6a96bf35f3": {},
                 "sha256:3f7a056ceab6278903304300caa25436e6d966642c8ec5c0a46fe23a0c6765cb": {},
                 "sha256:433af2d0da97cd9cd5e6aec0c4fc86283e50133db4ec095ae982e4c4defea0a2": {},
                 "sha256:2d90eda9f3c75958109a676d19471e7b639f061c99eb7d48a323185f2148736f": {},
@@ -230,24 +230,33 @@
                 "sha256:13dbca24da8631f42c14183b183c3a49bb6173ca598222e3a0914a9fe50e8be2": {},
                 "sha256:f8ed162ed2b7db6a23245e94f895f77d2f64ad17c20f2bc69def56582c644a0d": {},
                 "sha256:1a2d31d5f15b02001a9906beb978f14e9e872fc5f789407b43b7917737dabf8d": {},
-                "sha256:003947ea9a853f0c93cbc2113ad767979e531bf9d9e278a026d21d6c087d4f54": {},
+                "sha256:5dae80e22587415df762932427ad6ad1a1108f638e74bcb39cbc03ef7216f8f7": {},
                 "sha256:f604b1d05f5610b24acbfe9d1cf48f751e0db7a1934ef71d0b2ba9bc47e72805": {},
                 "sha256:4634b60ae44f747d8133aeec22f8059428710a9cb096f575f008bba36664a16c": {},
                 "sha256:d90e1bc9d5f2469e9189e58152b5d1a0365191870ba70305bcd537981b64ec81": {},
                 "sha256:d93f131235822eabe12469333e675269abef2b7e2e8386c889150f935bf72dd7": {},
                 "sha256:48ee1afc8d7d9cbada8d889f1fa324345f7d12bdc0694633d7170627d40788b4": {},
-                "sha256:4d45e8710ba2150504f0c1e5fb04a16eff79e3a3ea49a7347e7e8fbba75d205c": {},
+                "sha256:0466ebde457bd9a6437425f5b694fbea2c2ee9c01d6a1c9d49e2654f78eb5b96": {},
                 "sha256:c09c854604da2b2b7fea13137336b41fe2354b3ace7ca503f439fe6bd9bc9b0d": {},
                 "sha256:65c8b82ff091ae56fafa2a7f3d26a0464417ef9f298107c631ae74531b176bce": {},
-                "sha256:891a7e077a839e599484dea11da6326729772df992d504d8d7b6ec36b041d565": {},
-                "sha256:6cd8aea5e9102c46249e5b6a0ab00feae5136676a05ef30e7811607122ef4814": {},
+                "sha256:767df3a10e752a56bbe7b67e5d82aa7c70dfa2839ecdc61da3b7d70062c4256b": {},
+                "sha256:021acfcf01588f69c0ecb9e44f39047f33cdb2bbdb83797fb30ed06d5720a7f5": {},
                 "sha256:2b0920bda7174b0510124966df68f8a71f767915da2b0a21e457086f35d0fa60": {},
                 "sha256:1954d740a0b0a9cd566632e80b009949819fe8f63e4389aa2c525a705b508a68": {},
                 "sha256:a16609b1d57febe7a7904bb5d5fda9b57c51d7cdf65345344b5ecbaf12633355": {},
-                "sha256:d6103ac87cba819b7e253e280db8e0357bfe5b2a8193881345aa620c46ed596f": {},
+                "sha256:0c6ca168436265b8e7e9b42f3455f80cffe4b8c1a06895e4267920430d59417d": {},
                 "sha256:6dde69d1fec57e16833e9a1135d04747b15f5ab23e04aaa47aca856225b69daf": {},
-                "sha256:72e7eb0bd33c040906aada11432ece3e66e55291482ed356d41b80242a6ee7cb": {},
-                "sha256:c76a126f166c4cb3060d4d0a960cf019618f9d1c07c0e952c5f30bfc4b2dbaf1": {}
+                "sha256:510ca3ac4f2828a7c4046a3ff3f0343ada7b4aec4c42f97a551448c988253ca5": {},
+                "sha256:c76a126f166c4cb3060d4d0a960cf019618f9d1c07c0e952c5f30bfc4b2dbaf1": {},
+                "sha256:f90038935d6ada0cb8f998fc4163fd11432d163db6dbb4749a90f3ec937ad543": {},
+                "sha256:cbb46471b64bd747d4433697d059a0fc093886b9b6585a20e1453b27722a52ae": {},
+                "sha256:f085ba2dbbd1b9540735643937dfddc286cc52bffcb06058a3bd5fc1a2fc435e": {},
+                "sha256:a78c70a769ee27192c8bbc181a0de0e68bc210312e414bc010e65a3d04f93c61": {},
+                "sha256:83225cf0cc706cb6078a3cf6673ac234d0ac4f5712339a30276cb74c1d49e0e4": {},
+                "sha256:9bd2a88104c6fd8ce62c669076746dca38b05e8d33f545cb38e7f6658d1ae3df": {},
+                "sha256:53b6bbe7a539cf395a3cba1e8d589b0acd160a45ed8024e5aa0414301947b18f": {},
+                "sha256:eca12ceaef774299ed7022de9b00dd7ce379186da4c223cf357fc157a9064da6": {},
+                "sha256:7fe0a44158460b1cdb1fb1abd28163116903d6900f6ab68ef48413de807a24c6": {}
               }
             }
           },
@@ -270,14 +279,14 @@
               "origin": "org.osbuild.source",
               "references": {
                 "sha256:0c63dbc82cc8e909c7225cee8c7399bcc0f4377f7877cda90dd0a3a3354dcc12": {},
-                "sha256:87fbc54f1011cbe1024428b48b9918e7e0dce5ba70c70f42efa7caa2a26403be": {},
+                "sha256:d10cc5b8e913314375e2596cc300eddf13700586b602c46c1b6138e33bac6ad7": {},
                 "sha256:c459054fdef5df9934e4a36dc295b347c59ed2eee3025a2c10e3e30cebbea51b": {},
                 "sha256:5133350a061b9e03ed411349b7bd2996b8d553d06a93b8b34d0176ababfb629d": {},
                 "sha256:964221d7e0c8888d833d8f235e210d931439e1591d73c54eff1b70ccef64a9d5": {},
                 "sha256:1e5a129b3d8ffbf054597ecfbcd04508085f863e22c702a1f709f5743d4ae682": {},
                 "sha256:2c2252246e73006fb8e17c955135897620a2a8f865ce100b905ba068672b81c8": {},
                 "sha256:c3aee4482695d19d9d8762fee429de51cbdc359bd1565e9ec52e9b46475e0360": {},
-                "sha256:4a2014ad6ff9c16beb044692216258aa668432550f3b619b1270d6dbb2f25872": {},
+                "sha256:f2868945d73874530a2745a305f9fa6fcd622388825576c155685e5acfa15f9a": {},
                 "sha256:44b400abf34e559e5c4cdd4d1cfe799795eef59780525d6d02d36a3f3152b249": {},
                 "sha256:2e87a6382bcffc364015f848217d0afdcffdaa5efab43d5ee1b4d80a9645c5b8": {},
                 "sha256:2ec675610224ffd3de19ab566e40af1e7059dc453e5763aadf679c3567e83922": {},
@@ -313,7 +322,7 @@
                 "sha256:40d550736a02da440f8764230317dbd6cff2bba87ca325999138ad8494d5f061": {},
                 "sha256:634206f58e35e2c71c174bb5563f1a8af8ef17d99b2951aee71eba600cbcbb07": {},
                 "sha256:0414f4baa43aef409b235184e6079ee0dac8e692912e1da61a8ae264c7606670": {},
-                "sha256:24e9792946b726f5b24604fc3e1cdcfc6724950f7c7164679b59c6bcddd91e18": {},
+                "sha256:571986dc87f612d41b8e63eb606630d05685903f446c2ff1674bf11846e86985": {},
                 "sha256:781b41d3f73573e0d85701153d885f1fedf3760c69f5cb64cfb4a8e7dfed2454": {},
                 "sha256:498ead5a5f6d41790d1e40e490bf4b1841af615bace81a5b643ae550f9342a2c": {},
                 "sha256:afb816b7762c3a247973a99ab2f648dd7e30b4578cc872ac11458cd57b930b0d": {},
@@ -337,7 +346,7 @@
                 "sha256:7973be9a51a478cb713d63fed608d478762a807a98191d1358dd7e6da3a08a55": {},
                 "sha256:313a359bf73dac82a1bb5c72a14754e84541b10751f2e4a00085a3c0a177cea8": {},
                 "sha256:994b1850653ff9bc03bd75f127e8c72d5fb2713a4028724f43cd09e3dcaec66c": {},
-                "sha256:56a67855e3dfc9fee076ecf48d1e61fd5586e8e00bfab6dcfed7c3081b63251f": {},
+                "sha256:75930e347a4d9ae2ffea42cb554cc1159174971bb77695b19a3ce92d8c36814f": {},
                 "sha256:1eab9a225fb40ce3cd661b4252eda36cb11a499ed883e7a5e3cb0403b45b8a0b": {},
                 "sha256:08d87979b2c1cc644d130f14325e10205a0b39e69b936523862e411f09f038dc": {},
                 "sha256:00ceae518c3f0f640c5574572dc3f5bce783d085e230a09697a41a0e0f51a815": {},
@@ -352,13 +361,13 @@
                 "sha256:d7518d4dae1a383f91f74c872520e985c2cc7f92b6c7f477b47b365bc6d2463d": {},
                 "sha256:b71dcb2153d5165a4af3c90510d1431cc3902f766ffcc3db2e7060282fcb3f1c": {},
                 "sha256:da2b54539233f30f28b419c12bc2756eaf63454cc8ff19824c12a7bd4b329f7b": {},
-                "sha256:5a405d63d9cfd3fc05f70e4c284950d4c9fa1630d9a10312bc8c86ae7e01bf17": {},
+                "sha256:43595bb882c62cc363d8ba4798726af9647d745623536a9757ed4d87a45f408c": {},
                 "sha256:3f18a5902557c078b12fd20704b93db28718b9e4d8621e4dab1c468b22d7aaa4": {},
                 "sha256:33b906d6df9e467fea20516d6398c73ccf8a29ebe8dff3c837c8f296c09a347e": {},
                 "sha256:248a1e5aad3c5612139a8b41f9274c73a5fd520dd22457cdf554565b7a746a23": {},
                 "sha256:eb06c3eeb8138a204d2bf892fbce724e0bef148b0c36f892002e2809bc7ef83e": {},
                 "sha256:fe7723b62afea4cdf8530f0a0cff555831c4b3f54578d4a5943e23d0390e33d4": {},
-                "sha256:d455d045049f06f4af408fccf957537bc77fad6705f757fb65aa742610e1e59f": {},
+                "sha256:c24880c9f308e8155b25c8692fa6024764ba575b607584cb85f609e46ededb55": {},
                 "sha256:4c16bf7b44f2107ee89e8402423192cef9fb49005f94d06feeff49949706f3e9": {},
                 "sha256:bbbb5c3aa37529ca62c70e2332e1dacfaf0daed389e689ce5430d5c24b93edc7": {},
                 "sha256:aac3c9922bda89c694b51df187a8de7e2327a6d295149a856a82e47befa60cbd": {},
@@ -373,20 +382,18 @@
                 "sha256:2ee2cd3e2cf3e925d299bed02528fc1efa56558b48c3038de5c4df7e49d248e0": {},
                 "sha256:2e5d571d455f2543ade57b4b865f247b0b738c5b6f95dacce53aef87e9e868ed": {},
                 "sha256:0af4dc630bbe6fa873ff86198070c2a3ee77c457a5745da351de2e35aeea7c1a": {},
-                "sha256:3f5c832785a54fb5cd3808513d85a1bebda6cf13a202c351fcfa95f7b645d59e": {},
-                "sha256:f9e32e71816598b97397ae68ad721485be2b02038c5193fb44820cf1b82ff268": {},
+                "sha256:e3b63ae201c63c3bebc30e9be3cea079f63a092fb7de4f285b5a1521eed35f32": {},
+                "sha256:eaf50eadacdb9012850224440e4f1466183eb0d61ab0ad6712b97a16ca2ea3ef": {},
                 "sha256:206a0268f894355714aad6fb6a232c7db0448bab4deb89c91b056eba2e9f04bf": {},
                 "sha256:11a13594f20004865c6e774317f261ec6c00b2425ba2ee2480ea90e62ec1c514": {},
                 "sha256:d5fae32d2fd8de6e53e4aaeddbf14d4cbec35920a38f2407bb764ad27e223778": {},
                 "sha256:5095c3ccea91e860e27b86c714a83f146ac0c376250ae6f75acf8f101bdd36f8": {},
-                "sha256:811604b9603aaff62d735ca5ad4b5c6adaff784c9cae1a5aa9a4f9840c01ea85": {},
+                "sha256:9132c974b73688ac186254eb1e15dea53b2c498c8fb79b7546b9e49a6a260900": {},
                 "sha256:bdc37a7970eeea908da44513532e7ab5e801139a60b32eb9cea7267b27c6bad4": {},
-                "sha256:65d5fc8721bf90bf5d91bc40ffe83476e5266460685cb18aa393a793a4a6ad8f": {},
-                "sha256:b8007485c7f664d1241f39cec0acda1c39fcafc153980c5abda8c2ceb1e6c316": {},
-                "sha256:cc7194d905f2768add4cd80594128a310efd50a5883f48185993394bdc41c5c8": {},
+                "sha256:9bd2a88104c6fd8ce62c669076746dca38b05e8d33f545cb38e7f6658d1ae3df": {},
                 "sha256:53b6bbe7a539cf395a3cba1e8d589b0acd160a45ed8024e5aa0414301947b18f": {},
-                "sha256:6cc25d86e6571e71984814be73e38c997aec6be95fde201ac34650cdd8d60864": {},
-                "sha256:060b55b66dbaab5184732d5dbb5fa60d0574b21cd9ea72eee6f9b523f58927a3": {},
+                "sha256:7fe0a44158460b1cdb1fb1abd28163116903d6900f6ab68ef48413de807a24c6": {},
+                "sha256:76fd3bd0062a2317ba1d4c566fa016c3af42468f5d7c148f2d9863bcee1143bf": {},
                 "sha256:f085ba2dbbd1b9540735643937dfddc286cc52bffcb06058a3bd5fc1a2fc435e": {},
                 "sha256:f32dd4b6c9e5138f6eee84b585f1ca4dabcd6717c59a468e9c8f87b294b76a49": {},
                 "sha256:fdf7a13b06d1a4473fb2667a234e265790f63a33d12773de9352cc28edcf894a": {},
@@ -396,6 +403,75 @@
             }
           },
           "options": {}
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+              "arch": {
+                "password": "$6$.Pkz378k0geWPWsH$IhFEP1WmQUEkmfMLbf14C./LUYJqsKBVXsNZ2mrOAcKY4wjMN8e/r8TwQmqpm/xPIpfPq1l0PpKD7YQyVHvuD/",
+                "home": "/home/arch"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2.legacy",
+          "options": {
+            "architecture": "x64",
+            "rootfs": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+            },
+            "bios": "i386-pc",
+            "entries": [
+              {
+                "id": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "default": true,
+                "product": {
+                  "name": "Arch Linux",
+                  "version": "latest",
+                  "nick": "Arch"
+                },
+                "kernel": "linux"
+              }
+            ],
+            "config": {
+              "cmdline": "ro crashkernel=auto console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 scsi_mod.use_blk_mq=y enforcing=0",
+              "distributor": "$(sed 's, release .*$,,g' /etc/system-release)",
+              "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
+              "terminal_input": [
+                "serial",
+                "console"
+              ],
+              "terminal_output": [
+                "serial",
+                "console"
+              ]
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkinitcpio"
         }
       ]
     },
@@ -419,6 +495,160 @@
           }
         }
       ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "options": {
+            "label": "gpt",
+            "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+            "partitions": [
+              {
+                "bootable": true,
+                "size": 2048,
+                "start": 2048,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "size": 204800,
+                "start": 4096,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "size": 20762524,
+                "start": 208896,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+              }
+            ]
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "options": {
+            "volid": "7B7795E7"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 204800
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "options": {
+            "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+            "label": "root"
+          },
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 208896,
+                "size": 20762524
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "root-tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:os"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://root-tree/",
+                "to": "mount://root/"
+              }
+            ]
+          },
+          "devices": {
+            "efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 4096,
+                "size": 204800
+              }
+            },
+            "root": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 208896,
+                "size": 20762524
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "root",
+              "target": "/"
+            },
+            {
+              "name": "efi",
+              "type": "org.osbuild.fat",
+              "source": "efi",
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.grub2.inst",
+          "options": {
+            "filename": "disk.img",
+            "platform": "i386-pc",
+            "location": 2048,
+            "core": {
+              "type": "mkimage",
+              "partlabel": "gpt",
+              "filesystem": "xfs",
+              "binary": "grub-mkimage"
+            },
+            "prefix": {
+              "type": "partition",
+              "partlabel": "gpt",
+              "number": 2,
+              "path": "/boot/grub2"
+            }
+          }
+        }
+      ]
     }
   ],
   "sources": {
@@ -429,35 +659,33 @@
         "sha256:433af2d0da97cd9cd5e6aec0c4fc86283e50133db4ec095ae982e4c4defea0a2": "https://archive.archlinux.org/repos/2021/11/24/community/os/x86_64/libnfs-4.0.0-4-x86_64.pkg.tar.zst",
         "sha256:2d90eda9f3c75958109a676d19471e7b639f061c99eb7d48a323185f2148736f": "https://archive.archlinux.org/repos/2021/11/24/community/os/x86_64/libslirp-4.6.1-1-x86_64.pkg.tar.zst",
         "sha256:a16609b1d57febe7a7904bb5d5fda9b57c51d7cdf65345344b5ecbaf12633355": "https://archive.archlinux.org/repos/2021/11/24/community/os/x86_64/liburcu-0.13.0-1-x86_64.pkg.tar.zst",
-        "sha256:4d45e8710ba2150504f0c1e5fb04a16eff79e3a3ea49a7347e7e8fbba75d205c": "https://archive.archlinux.org/repos/2021/11/24/community/os/x86_64/usbredir-0.12.0-1-x86_64.pkg.tar.zst",
+        "sha256:0466ebde457bd9a6437425f5b694fbea2c2ee9c01d6a1c9d49e2654f78eb5b96": "https://archive.archlinux.org/repos/2021/11/24/community/os/x86_64/usbredir-0.11.0-1-x86_64.pkg.tar.zst",
         "sha256:2e87a6382bcffc364015f848217d0afdcffdaa5efab43d5ee1b4d80a9645c5b8": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/acl-2.3.1-1-x86_64.pkg.tar.zst",
         "sha256:eb06c3eeb8138a204d2bf892fbce724e0bef148b0c36f892002e2809bc7ef83e": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/archlinux-keyring-20211028-1-any.pkg.tar.zst",
         "sha256:aac3c9922bda89c694b51df187a8de7e2327a6d295149a856a82e47befa60cbd": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/argon2-20190702-3-x86_64.pkg.tar.zst",
         "sha256:44b400abf34e559e5c4cdd4d1cfe799795eef59780525d6d02d36a3f3152b249": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/attr-2.5.1-1-x86_64.pkg.tar.zst",
         "sha256:e998fed21337bdfc9c30d79329ec5ae68de80edf7620472b1b2e144bcef5a545": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/audit-3.0.6-2-x86_64.pkg.tar.zst",
         "sha256:d5fae32d2fd8de6e53e4aaeddbf14d4cbec35920a38f2407bb764ad27e223778": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/base-2-2-any.pkg.tar.xz",
-        "sha256:4a2014ad6ff9c16beb044692216258aa668432550f3b619b1270d6dbb2f25872": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/bash-5.1.012-1-x86_64.pkg.tar.zst",
-        "sha256:cc7194d905f2768add4cd80594128a310efd50a5883f48185993394bdc41c5c8": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/binutils-2.36.1-3-x86_64.pkg.tar.zst",
+        "sha256:f2868945d73874530a2745a305f9fa6fcd622388825576c155685e5acfa15f9a": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/bash-5.1.008-1-x86_64.pkg.tar.zst",
         "sha256:08d87979b2c1cc644d130f14325e10205a0b39e69b936523862e411f09f038dc": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/brotli-1.0.9-4-x86_64.pkg.tar.zst",
-        "sha256:811604b9603aaff62d735ca5ad4b5c6adaff784c9cae1a5aa9a4f9840c01ea85": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/btrfs-progs-5.15.1-1-x86_64.pkg.tar.zst",
+        "sha256:9132c974b73688ac186254eb1e15dea53b2c498c8fb79b7546b9e49a6a260900": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/btrfs-progs-5.15-1-x86_64.pkg.tar.zst",
         "sha256:7076fc302df82ddfa249e99e35897271fb2a62a585e7ccb51896aac8d47b4775": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/bzip2-1.0.8-4-x86_64.pkg.tar.zst",
         "sha256:1eab9a225fb40ce3cd661b4252eda36cb11a499ed883e7a5e3cb0403b45b8a0b": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/ca-certificates-20210603-1-any.pkg.tar.zst",
-        "sha256:56a67855e3dfc9fee076ecf48d1e61fd5586e8e00bfab6dcfed7c3081b63251f": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/ca-certificates-mozilla-3.73-1-x86_64.pkg.tar.zst",
+        "sha256:75930e347a4d9ae2ffea42cb554cc1159174971bb77695b19a3ce92d8c36814f": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/ca-certificates-mozilla-3.72-2-x86_64.pkg.tar.zst",
         "sha256:994b1850653ff9bc03bd75f127e8c72d5fb2713a4028724f43cd09e3dcaec66c": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/ca-certificates-utils-20210603-1-any.pkg.tar.zst",
         "sha256:b2e09e3f2d22242eab7e4467fecc8c32d1f831040e82f7b5c6686df198e71f68": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/coreutils-9.0-2-x86_64.pkg.tar.zst",
         "sha256:b8502af5c066b6026f5548b384ceb5627b391815bd79413f020ba7c2455f62f4": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/cryptsetup-2.4.2-1-x86_64.pkg.tar.zst",
         "sha256:1151e42688e808ceeefd86e1d05e36fffa0f6659a1de9fe641de47bf0e2b971e": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/curl-7.80.0-1-x86_64.pkg.tar.zst",
         "sha256:80d5582d0200e81bdb578e6aefd162308d8e86dfc2681418f460cff67d287fc9": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/db-5.3.28-5-x86_64.pkg.tar.xz",
         "sha256:1ed0f340d97b2a34c6246313806e25d489c56a6e6f102ae307299f5593c3b7fe": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/dbus-1.12.20-1-x86_64.pkg.tar.zst",
-        "sha256:d455d045049f06f4af408fccf957537bc77fad6705f757fb65aa742610e1e59f": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/device-mapper-2.03.14-2-x86_64.pkg.tar.zst",
+        "sha256:c24880c9f308e8155b25c8692fa6024764ba575b607584cb85f609e46ededb55": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/device-mapper-2.03.14-1-x86_64.pkg.tar.zst",
         "sha256:53b6bbe7a539cf395a3cba1e8d589b0acd160a45ed8024e5aa0414301947b18f": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/diffutils-3.8-1-x86_64.pkg.tar.zst",
         "sha256:fdf7a13b06d1a4473fb2667a234e265790f63a33d12773de9352cc28edcf894a": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/dnssec-anchors-20190629-3-any.pkg.tar.zst",
         "sha256:bdc37a7970eeea908da44513532e7ab5e801139a60b32eb9cea7267b27c6bad4": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/dosfstools-4.2-1-x86_64.pkg.tar.zst",
         "sha256:aa06d0db4fddde2098433d5b12f32be8a3e16d3366ec3448c14e9d8ef93e7857": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/e2fsprogs-1.46.4-1-x86_64.pkg.tar.zst",
-        "sha256:b8007485c7f664d1241f39cec0acda1c39fcafc153980c5abda8c2ceb1e6c316": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/elfutils-0.186-1-x86_64.pkg.tar.zst",
         "sha256:2a9a652c9d19dbb6e2797e99b5335065cbc180c4a39990a87388fdb2c9e67b5b": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/expat-2.4.1-1-x86_64.pkg.tar.zst",
         "sha256:41a03f13cac8bc2a79ff7efcd9e0ade82ffd2d02e15d0c260a7f5e04f2a4fd22": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/file-5.41-1-x86_64.pkg.tar.zst",
-        "sha256:87fbc54f1011cbe1024428b48b9918e7e0dce5ba70c70f42efa7caa2a26403be": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/filesystem-2021.12.07-1-x86_64.pkg.tar.zst",
+        "sha256:d10cc5b8e913314375e2596cc300eddf13700586b602c46c1b6138e33bac6ad7": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/filesystem-2021.11.11-1-x86_64.pkg.tar.zst",
         "sha256:f792aa0e12750e18bf10b1f36b7506ee4b662942960ce7575b63e1e3eefa01ff": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/findutils-4.8.0-1-x86_64.pkg.tar.zst",
         "sha256:83225cf0cc706cb6078a3cf6673ac234d0ac4f5712339a30276cb74c1d49e0e4": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/gawk-5.1.1-1-x86_64.pkg.tar.zst",
         "sha256:1e5a129b3d8ffbf054597ecfbcd04508085f863e22c702a1f709f5743d4ae682": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/gcc-libs-11.1.0-1-x86_64.pkg.tar.zst",
@@ -520,18 +748,18 @@
         "sha256:1b31b2bd1cbb4740c26906578e42f52988c1f9861b1c92b97db5ddcbef1d3b06": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/libusb-1.0.24-2-x86_64.pkg.tar.zst",
         "sha256:cd3a36213c829e2f1c85258da265a199fc5a913c9bd27fc81182fccfbb93038c": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/libxcrypt-4.4.26-1-x86_64.pkg.tar.zst",
         "sha256:c7fd87086fe885d73d7ae712577c4b94d86633055b9887735b6fedce1e3c6080": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/licenses-20200427-1-any.pkg.tar.zst",
-        "sha256:060b55b66dbaab5184732d5dbb5fa60d0574b21cd9ea72eee6f9b523f58927a3": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/linux-5.15.7.arch1-1-x86_64.pkg.tar.zst",
+        "sha256:76fd3bd0062a2317ba1d4c566fa016c3af42468f5d7c148f2d9863bcee1143bf": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/linux-5.15.4.arch1-1-x86_64.pkg.tar.zst",
         "sha256:c459054fdef5df9934e4a36dc295b347c59ed2eee3025a2c10e3e30cebbea51b": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/linux-api-headers-5.12.3-1-any.pkg.tar.zst",
         "sha256:634206f58e35e2c71c174bb5563f1a8af8ef17d99b2951aee71eba600cbcbb07": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/lz4-1:1.9.3-2-x86_64.pkg.tar.zst",
         "sha256:5095c3ccea91e860e27b86c714a83f146ac0c376250ae6f75acf8f101bdd36f8": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/lzo-2.10-3-x86_64.pkg.tar.xz",
-        "sha256:6cc25d86e6571e71984814be73e38c997aec6be95fde201ac34650cdd8d60864": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/mkinitcpio-31-2-any.pkg.tar.zst",
-        "sha256:65d5fc8721bf90bf5d91bc40ffe83476e5266460685cb18aa393a793a4a6ad8f": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/mkinitcpio-busybox-1.34.1-1-x86_64.pkg.tar.zst",
+        "sha256:7fe0a44158460b1cdb1fb1abd28163116903d6900f6ab68ef48413de807a24c6": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/mkinitcpio-30-2-any.pkg.tar.zst",
+        "sha256:9bd2a88104c6fd8ce62c669076746dca38b05e8d33f545cb38e7f6658d1ae3df": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/mkinitcpio-busybox-1.33.1-1-x86_64.pkg.tar.zst",
         "sha256:a78c70a769ee27192c8bbc181a0de0e68bc210312e414bc010e65a3d04f93c61": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/mpfr-4.1.0.p13-1-x86_64.pkg.tar.zst",
         "sha256:2c2252246e73006fb8e17c955135897620a2a8f865ce100b905ba068672b81c8": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/ncurses-6.3-1-x86_64.pkg.tar.zst",
         "sha256:b71dcb2153d5165a4af3c90510d1431cc3902f766ffcc3db2e7060282fcb3f1c": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/nettle-3.7.3-1-x86_64.pkg.tar.zst",
         "sha256:2113782a20de5cdcac82f060ab917982a38fad26bd6c3fbc0f6187d1b918931a": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/npth-1.6-3-x86_64.pkg.tar.zst",
         "sha256:84a9595136f2b42abf432abfc2f7f7580c755b22554afc3a7d589d9510ab2fe1": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/nspr-4.32-1-x86_64.pkg.tar.zst",
-        "sha256:1e9a676c69bc15ca985dea6c8e40afad14275039dea07ae229c90ea8cd906daf": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/nss-3.73-1-x86_64.pkg.tar.zst",
+        "sha256:e0ce1c213118522d148f6c2eee052926eb15766422ab90e76ebbfb6a96bf35f3": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/nss-3.72-2-x86_64.pkg.tar.zst",
         "sha256:33f19546bb24b810279d70fa5da2a0561706a3c34f03264e9b0acc9f7add5e51": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/openssh-8.8p1-1-x86_64.pkg.tar.zst",
         "sha256:4d8eb6a330cbe00e4b7c36f6d59f0245c3cec46ae2dce1ed675f1cb11327fa40": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/openssl-1.1.1.l-1-x86_64.pkg.tar.zst",
         "sha256:313a359bf73dac82a1bb5c72a14754e84541b10751f2e4a00085a3c0a177cea8": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/p11-kit-0.24.0-2-x86_64.pkg.tar.zst",
@@ -546,19 +774,19 @@
         "sha256:4c16bf7b44f2107ee89e8402423192cef9fb49005f94d06feeff49949706f3e9": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/popt-1.18-1-x86_64.pkg.tar.zst",
         "sha256:781b41d3f73573e0d85701153d885f1fedf3760c69f5cb64cfb4a8e7dfed2454": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/procps-ng-3.3.17-1-x86_64.pkg.tar.zst",
         "sha256:680ab02725c4588553e1abb3471fb817ef7d82bb9b347a684575b32b03c751e4": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/psmisc-23.4-1-x86_64.pkg.tar.zst",
-        "sha256:72e7eb0bd33c040906aada11432ece3e66e55291482ed356d41b80242a6ee7cb": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/python-3.9.9-1-x86_64.pkg.tar.zst",
+        "sha256:510ca3ac4f2828a7c4046a3ff3f0343ada7b4aec4c42f97a551448c988253ca5": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/python-3.9.7-2-x86_64.pkg.tar.zst",
         "sha256:c3aee4482695d19d9d8762fee429de51cbdc359bd1565e9ec52e9b46475e0360": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/readline-8.1.001-1-x86_64.pkg.tar.zst",
         "sha256:498ead5a5f6d41790d1e40e490bf4b1841af615bace81a5b643ae550f9342a2c": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/sed-4.8-1-x86_64.pkg.tar.zst",
         "sha256:ded49dd52e9bae67da83d564b2d5d146e052fe942ebd9c78aaa0356b689f32a2": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/shadow-4.8.1-4-x86_64.pkg.tar.zst",
-        "sha256:5a405d63d9cfd3fc05f70e4c284950d4c9fa1630d9a10312bc8c86ae7e01bf17": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/sqlite-3.37.0-1-x86_64.pkg.tar.zst",
-        "sha256:3f5c832785a54fb5cd3808513d85a1bebda6cf13a202c351fcfa95f7b645d59e": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/systemd-249.7-2-x86_64.pkg.tar.zst",
-        "sha256:24e9792946b726f5b24604fc3e1cdcfc6724950f7c7164679b59c6bcddd91e18": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/systemd-libs-249.7-2-x86_64.pkg.tar.zst",
-        "sha256:f9e32e71816598b97397ae68ad721485be2b02038c5193fb44820cf1b82ff268": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/systemd-sysvcompat-249.7-2-x86_64.pkg.tar.zst",
+        "sha256:43595bb882c62cc363d8ba4798726af9647d745623536a9757ed4d87a45f408c": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/sqlite-3.36.0-1-x86_64.pkg.tar.zst",
+        "sha256:e3b63ae201c63c3bebc30e9be3cea079f63a092fb7de4f285b5a1521eed35f32": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/systemd-249.7-1-x86_64.pkg.tar.zst",
+        "sha256:571986dc87f612d41b8e63eb606630d05685903f446c2ff1674bf11846e86985": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/systemd-libs-249.7-1-x86_64.pkg.tar.zst",
+        "sha256:eaf50eadacdb9012850224440e4f1466183eb0d61ab0ad6712b97a16ca2ea3ef": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/systemd-sysvcompat-249.7-1-x86_64.pkg.tar.zst",
         "sha256:afb816b7762c3a247973a99ab2f648dd7e30b4578cc872ac11458cd57b930b0d": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/tar-1.34-1-x86_64.pkg.tar.zst",
         "sha256:5133350a061b9e03ed411349b7bd2996b8d553d06a93b8b34d0176ababfb629d": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/tzdata-2021e-1-x86_64.pkg.tar.zst",
         "sha256:31e9732ee3bf1417faa53dbc6ee35e3a3a8c1f5bb19a6aaeda8c961dec99479e": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/util-linux-2.37.2-1-x86_64.pkg.tar.zst",
         "sha256:f77a4871f0589a9819210c50cc616251e7ea666fd52ac1907e5339242fe7fcc3": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/util-linux-libs-2.37.2-1-x86_64.pkg.tar.zst",
-        "sha256:d6103ac87cba819b7e253e280db8e0357bfe5b2a8193881345aa620c46ed596f": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/xfsprogs-5.14.2-1-x86_64.pkg.tar.zst",
+        "sha256:0c6ca168436265b8e7e9b42f3455f80cffe4b8c1a06895e4267920430d59417d": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/xfsprogs-5.14.0-1-x86_64.pkg.tar.zst",
         "sha256:9ea509219aeb99c033caa5ce6cfa93d1ca8d83adec069015c0c126fa035056b8": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/xz-5.2.5-2-x86_64.pkg.tar.zst",
         "sha256:43a17987d348e0b395cb6e28d2ece65fb3b5a0fe433714762780d18c0451c149": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/zlib-1:1.2.11-4-x86_64.pkg.tar.xz",
         "sha256:0414f4baa43aef409b235184e6079ee0dac8e692912e1da61a8ae264c7606670": "https://archive.archlinux.org/repos/2021/11/24/core/os/x86_64/zstd-1.5.0-1-x86_64.pkg.tar.zst",
@@ -572,24 +800,24 @@
         "sha256:b945cde112bb54f750d4165fdb5d464cb455b79b1e8a8ac6aa0098d0129e6452": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/atk-2.36.0-1-x86_64.pkg.tar.zst",
         "sha256:a03fd9f69459557bfc2cca083f28af08f281a435fa316690cf7213b8b1767980": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/avahi-0.8+22+gfd482a7-1-x86_64.pkg.tar.zst",
         "sha256:67f5d3ff76c56581b36820789efe5a068c142de0e353ab98fdf19d81ec90ce7d": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/cairo-1.17.4-5-x86_64.pkg.tar.zst",
-        "sha256:e5a3ad98e21099f6279daa2d72804c11d237de2ec1887584edffa4205c289789": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/cantarell-fonts-1:0.303.1-1-any.pkg.tar.zst",
+        "sha256:549b1c4b555a97d05c1d7494c78fa54c4108a13dd504bc60db0336331d2bb612": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/cantarell-fonts-1:0.303-1-any.pkg.tar.zst",
         "sha256:d1c8b81e5bbb18900d35508ce6e9887a6ce0635ee46e83049c1eb5282f6fb450": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/celt-0.11.3-4-x86_64.pkg.tar.zst",
         "sha256:0e8d215fa662e360eeda534ab12d28b1456bbd0c2f032b6dcdfef0ba7f4a07b9": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/dconf-0.40.0-1-x86_64.pkg.tar.zst",
         "sha256:3612fa2518e5fe5ec2d495daef10141971259990c9d3af3fdf35ab4e55eaadfb": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/desktop-file-utils-0.26-1-x86_64.pkg.tar.zst",
         "sha256:375dfbbcc1dfd260c2f7ee9ee1b737d4c83c0e4f03151b0d69c02c194e34c8e1": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/flac-1.3.3-3-x86_64.pkg.tar.zst",
         "sha256:aef83f04f6c18e0d7cbff518fbc17ce011bccf7ce2761427c3615b2d0b340b55": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/fontconfig-2:2.13.94-1-x86_64.pkg.tar.zst",
-        "sha256:2a3f7b235b012cdbfcdffd319c4dc8bf0048915382c1919127234db9e27e6fe2": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/freetype2-2.11.1-1-x86_64.pkg.tar.zst",
+        "sha256:57106954e348e1e31b0e79c69891e9a829448778d9df4546ecf5cfcb078164c9": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/freetype2-2.11.0-4-x86_64.pkg.tar.zst",
         "sha256:cbf77b00a044fd20f6af21ef18305c2fe9dc74e584d0f9330c28e6c229d4c251": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/fribidi-1.0.11-1-x86_64.pkg.tar.zst",
         "sha256:c75bd25583f2a417705c68f02b211f4b039387a841a54ec38420b0e29e8fac3e": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/fuse-common-3.10.5-1-x86_64.pkg.tar.zst",
         "sha256:cece5fd1b08d5f653674836f02ef872cd481ea02fb18a3488ccf0ab031efbfe4": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/fuse3-3.10.5-1-x86_64.pkg.tar.zst",
         "sha256:1c88de0ce2a2a49c861ac5af18e08c05d2ed859dac0b7c9ce3a1a2a5749224bf": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/gdk-pixbuf2-2.42.6-2-x86_64.pkg.tar.zst",
         "sha256:f604b1d05f5610b24acbfe9d1cf48f751e0db7a1934ef71d0b2ba9bc47e72805": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/giflib-5.2.1-2-x86_64.pkg.tar.zst",
-        "sha256:cd3b129cf6ef2dc189573dfe1edb0184ceb04333bf39b2ee9903e28029dfa673": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/glib-networking-1:2.70.1-1-x86_64.pkg.tar.zst",
+        "sha256:0d63801542a7f4ded5209351b271603b8bbb320051e76d9bc96f3bf534e5465e": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/glib-networking-1:2.70.0-1-x86_64.pkg.tar.zst",
         "sha256:791edb9d97f03193181b2dc82ed94c4414abf234ffa09b8f329da49f43c29156": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/graphite-1:1.3.14-1-x86_64.pkg.tar.zst",
         "sha256:bdf0f800f3c781fd2689e2c1326518eb3bdf80c37ddc7b9e773e0149dbaa3237": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/gsettings-desktop-schemas-41.0-1-any.pkg.tar.zst",
         "sha256:3c577afb51a5284c6407e1b581ece4fdfda8810af1639ab52c64930947c39496": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/gtk-update-icon-cache-1:4.4.1-1-x86_64.pkg.tar.zst",
         "sha256:8d561515a3b9ec065da830fbd1cf6414e995f28b19b9d3aeeba117478412e32f": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/gtk3-1:3.24.30+90+g20be04f7ac-1-x86_64.pkg.tar.zst",
-        "sha256:cd697d7ecc784680bd32d2f81e401e6bcbf7ddac05fa0166bdcd2410cf473780": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/harfbuzz-3.1.2-1-x86_64.pkg.tar.zst",
+        "sha256:7909ea73e874c28ec2ea14d919973cd88a54dff762341a1c045c4604cf2cabf9": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/harfbuzz-3.1.1-2-x86_64.pkg.tar.zst",
         "sha256:175667a8bda94fb632c8532e522388004b578f0d3b81a8b0b72b510f550ef309": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/hicolor-icon-theme-0.17-2-any.pkg.tar.zst",
         "sha256:0af4f9c189c81be1341da084b77e5df7f49a7ce5602016684936cddc9f141507": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/iso-codes-4.8.0-1-any.pkg.tar.zst",
         "sha256:2377a74508e28066c1f3798e79d23261408f18197b01aa70d58417c6bc8eaf80": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/jack2-1.9.19-2-x86_64.pkg.tar.zst",
@@ -602,10 +830,10 @@
         "sha256:1b2dfa4cd3dcd3753f4daacab2e20e7bdc979063c7fa205f7ac23ea340c19958": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libcloudproviders-0.3.1-2-x86_64.pkg.tar.zst",
         "sha256:8fefa22cb9f308e4fc2154a3811f31b823f7ba49de27a2c77ea7f7f5b7a82120": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libcolord-1.4.5-4-x86_64.pkg.tar.zst",
         "sha256:f90038935d6ada0cb8f998fc4163fd11432d163db6dbb4749a90f3ec937ad543": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libcroco-0.6.13-2-x86_64.pkg.tar.zst",
-        "sha256:0f1c8950a708f7fe37dd34fee2076fe58535e7372106d93a2ceb8518512c9c84": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libcups-1:2.4.0-4-x86_64.pkg.tar.zst",
+        "sha256:8717902d1fd93ee845fbc1ecac0fc7c6dc14b5e45d3cb879840ce82265230ada": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libcups-1:2.3.3op2-4-x86_64.pkg.tar.zst",
         "sha256:3aa85ab3220d9545eab2a01be8d1c2f2aab5679e1eb9eb4a1e6be388b10f4a59": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libdaemon-0.14-5-x86_64.pkg.tar.zst",
         "sha256:8ecf4dd70a18869a506ae9e027d6c16aab99bb1d8028f6fa7c56ee7ea9399709": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libdatrie-0.2.13-1-x86_64.pkg.tar.zst",
-        "sha256:8bbb1ebd6d29e0374caf9c70a443428d7cea6bcb1f75b64f12b6601bdaf7f5f4": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libdrm-2.4.109-1-x86_64.pkg.tar.zst",
+        "sha256:09a0f3d9ede07bd065881afd464e40cf03c84cdcd0a7d6619d2ca1b9d477e8de": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libdrm-2.4.108-1-x86_64.pkg.tar.zst",
         "sha256:551695a8f7ec2ea6778ffd32c8a88403db33406b187657a2af5b856b13b7ad43": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libepoxy-1.5.9-1-x86_64.pkg.tar.zst",
         "sha256:f4a3728f9f968d43d81c50d4e667e4fe43313351aa674e9187debdc0c29bf83d": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libglvnd-1.3.4-1-x86_64.pkg.tar.zst",
         "sha256:f8ed162ed2b7db6a23245e94f895f77d2f64ad17c20f2bc69def56582c644a0d": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libibus-1.5.25-3-x86_64.pkg.tar.zst",
@@ -621,8 +849,8 @@
         "sha256:55d603c27b9f8975b435c71d9ba26342a0fa0e3d1bd0086e0f6023d4074b47c9": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libsamplerate-0.2.2-1-x86_64.pkg.tar.zst",
         "sha256:06f29c87b27a5ea8fcefe8d1ee14189eb965e94fda58faa4fbe1f6ffd04e27f0": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libsm-1.2.3-2-x86_64.pkg.tar.zst",
         "sha256:2f069652b1acdf9c7bef371209916dfb7b450e620cb034eadd7a92388cc95950": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libsndfile-1.0.31-1-x86_64.pkg.tar.zst",
-        "sha256:f60bf75c00b88ae7702bbfcd905ab8311e141ebacc4388fff5a05a5867708f4f": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libsoup-2.74.2-1-x86_64.pkg.tar.zst",
-        "sha256:8d1c3f5a4c1ebd25083b24251aff5b93017fa2f30349b923c1a6cb0d8bbd2a3f": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libsoup3-3.0.3-1-x86_64.pkg.tar.zst",
+        "sha256:07cd6052066a7235a96bc82cf2ba570a4d906734e402d70056a9b7733e67ad7c": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libsoup-2.74.1-1-x86_64.pkg.tar.zst",
+        "sha256:0064cc0aa1e908d2c0b377afc311cfc65b8291b2e4d80520bee7973cde66faa5": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libsoup3-3.0.2-1-x86_64.pkg.tar.zst",
         "sha256:b2892c9f4f515fd07029a2e3226faa61b5a3e695a9abe9f9a3f46e442a7d8aab": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libssh-0.9.6-1-x86_64.pkg.tar.zst",
         "sha256:b82b327f050133d80b9a9d84ba051609159c34fde25eb5bcdfa4aa4dc6eff95c": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libstemmer-2.2.0-1-x86_64.pkg.tar.zst",
         "sha256:f2780887bd1dde0a615e2bbef3cc4b86d00e9d722b27c3515181c9de5c95a06a": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libthai-0.1.28-2-x86_64.pkg.tar.zst",
@@ -631,7 +859,7 @@
         "sha256:c32048690ca1aaa68fdd2f913e19fa668a482603e4a7d0b2bab7b1bb90e623e8": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/liburing-2.1-1-x86_64.pkg.tar.zst",
         "sha256:90a20e5190ffc879e2563c6f56645c36caf26c2f6a6e400d04b78927aecb70ac": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libvorbis-1.3.7-2-x86_64.pkg.tar.zst",
         "sha256:4634b60ae44f747d8133aeec22f8059428710a9cb096f575f008bba36664a16c": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libwebp-1.2.1-2-x86_64.pkg.tar.zst",
-        "sha256:3b3d12a8b8e9543fe1e0946b88ab8b5e2c5ed1b864a77fb1bf805e0156a9965a": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libx11-1.7.3.1-1-x86_64.pkg.tar.zst",
+        "sha256:89a13b26fbda6da9bbc02eeca19d116223d21974f7065dfc97667a4d85e881c6": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libx11-1.7.2-1-x86_64.pkg.tar.zst",
         "sha256:0e9de3ed449e4f061c34d640d5cd3cdf1232cb89b2da4be9ea5577bbfcbe834c": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libxau-1.0.9-3-x86_64.pkg.tar.zst",
         "sha256:8d357ca0eb2c479d9dabad04087394c9df4764ed9672e01ee768aee42e1c320d": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libxcb-1.14-1-x86_64.pkg.tar.zst",
         "sha256:171f5026e4d7ac0aa9634e5fa02bd1d9308935116e46145237bd9a2f004452bb": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/libxcomposite-0.4.5-3-x86_64.pkg.tar.zst",
@@ -656,15 +884,15 @@
         "sha256:b6cc60cc396f43778de021e2122def071c92a2c3f8b890aecbab38b9ea978102": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/ndctl-71.1-1-x86_64.pkg.tar.zst",
         "sha256:30c4a0308215abe803a4fbe8a0dbdf91792dd8e2e685b6c185f298040c4b1015": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/numactl-2.0.14-1-x86_64.pkg.tar.zst",
         "sha256:7099aa4d859ac2d48537f68ba63c9b8fad7d8d6cc7358967f94e161f20ece7a6": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/opus-1.3.1-2-x86_64.pkg.tar.zst",
-        "sha256:bdfee3892d50a861e20b992da3926600ef00bf8028e3c124b3acf00455408b62": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/pango-1:1.50.0-3-x86_64.pkg.tar.zst",
+        "sha256:9bf7999cffd8fb564805ba731bcd9bd5d25fbb84be01b4521f18711984f2cd84": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/pango-1:1.48.10-1-x86_64.pkg.tar.zst",
         "sha256:70b76e351a4ab2477bf1d2351c7aca4a20e6aac697054aae5cc403144cc7e8fe": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/pixman-0.40.0-1-x86_64.pkg.tar.zst",
         "sha256:c76a126f166c4cb3060d4d0a960cf019618f9d1c07c0e952c5f30bfc4b2dbaf1": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/pyalpm-0.10.6-1-x86_64.pkg.tar.zst",
         "sha256:2b0920bda7174b0510124966df68f8a71f767915da2b0a21e457086f35d0fa60": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/qemu-6.1.0-5-x86_64.pkg.tar.zst",
         "sha256:f47d449cbefeb1a6476c80a2bc9aa795e6c07b89982151b237ffa41f7cf36812": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/rest-0.8.1-3-x86_64.pkg.tar.zst",
-        "sha256:003947ea9a853f0c93cbc2113ad767979e531bf9d9e278a026d21d6c087d4f54": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/sdl2-2.0.18-1-x86_64.pkg.tar.zst",
+        "sha256:5dae80e22587415df762932427ad6ad1a1108f638e74bcb39cbc03ef7216f8f7": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/sdl2-2.0.16-4-x86_64.pkg.tar.zst",
         "sha256:d90e1bc9d5f2469e9189e58152b5d1a0365191870ba70305bcd537981b64ec81": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/sdl2_image-2.0.5-2-x86_64.pkg.tar.zst",
         "sha256:13dbca24da8631f42c14183b183c3a49bb6173ca598222e3a0914a9fe50e8be2": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/seabios-1.14.0-1-any.pkg.tar.zst",
-        "sha256:6a73f37d35ec1a95ebb0038d34a2339a9c061c84775265899ee15577b17f0cec": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/shared-mime-info-2.0+115+gd74a913-1-x86_64.pkg.tar.zst",
+        "sha256:ec0cc8b935f69f1e31ed69744e259607a033373692557fc932cd399826e2ce8b": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/shared-mime-info-2.0+57+gc1d1c70-1-x86_64.pkg.tar.zst",
         "sha256:d93f131235822eabe12469333e675269abef2b7e2e8386c889150f935bf72dd7": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/snappy-1.1.9-2-x86_64.pkg.tar.zst",
         "sha256:8177488d66b41d7f0258608fd4002282f878a3eb5ece4fed28d10f2f4ce7f35a": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/sound-theme-freedesktop-0.8-4-any.pkg.tar.zst",
         "sha256:e8a7381025dd80e898119b980b741d3ecbea41ac2b870abc0e930fbd7d046c6d": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/speex-1.2.0-3-x86_64.pkg.tar.zst",
@@ -674,9 +902,9 @@
         "sha256:72037d28a7d14aa06aec74090a999f7f5dc19a4f0a2a580bf4ba7eab62ddd18d": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/tracker3-3.2.1-2-x86_64.pkg.tar.zst",
         "sha256:65c8b82ff091ae56fafa2a7f3d26a0464417ef9f298107c631ae74531b176bce": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/vde2-2.3.2-16-x86_64.pkg.tar.zst",
         "sha256:c09c854604da2b2b7fea13137336b41fe2354b3ace7ca503f439fe6bd9bc9b0d": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/virglrenderer-0.9.1-1-x86_64.pkg.tar.zst",
-        "sha256:891a7e077a839e599484dea11da6326729772df992d504d8d7b6ec36b041d565": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/vte-common-0.66.2-1-x86_64.pkg.tar.zst",
-        "sha256:6cd8aea5e9102c46249e5b6a0ab00feae5136676a05ef30e7811607122ef4814": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/vte3-0.66.2-1-x86_64.pkg.tar.zst",
-        "sha256:118732989aa6f31d99be9274930b221e86ce6fd84998e58e5e191b8e99afa225": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/vulkan-icd-loader-1.2.202-1-x86_64.pkg.tar.zst",
+        "sha256:767df3a10e752a56bbe7b67e5d82aa7c70dfa2839ecdc61da3b7d70062c4256b": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/vte-common-0.66.1-2-x86_64.pkg.tar.zst",
+        "sha256:021acfcf01588f69c0ecb9e44f39047f33cdb2bbdb83797fb30ed06d5720a7f5": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/vte3-0.66.1-2-x86_64.pkg.tar.zst",
+        "sha256:f45a754682f8e929c38e83308c8038da55b8c1714077d8991b34cedafca4f131": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/vulkan-icd-loader-1.2.194-1-x86_64.pkg.tar.zst",
         "sha256:1648c6b14e9302596e1ea030be56bd5113758ae7b912fac2916f31d5df2288c0": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/wayland-1.19.0-2-x86_64.pkg.tar.zst",
         "sha256:7c7a5cc9f6321276414f68f6135a5ea38ee858a5e37cbfc0b196e4eca7622d3e": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/xcb-proto-1.14.1-3-any.pkg.tar.zst",
         "sha256:ba6b6ca9288b06873794141d398e0fb99c6c80159395562603e34cab6946fb45": "https://archive.archlinux.org/repos/2021/11/24/extra/os/x86_64/xkeyboard-config-2.34-1-any.pkg.tar.zst",

--- a/test/data/manifests/arch/arch-build.mpp.json
+++ b/test/data/manifests/arch/arch-build.mpp.json
@@ -44,6 +44,7 @@
                   "xz",
                   "python",
                   "pyalpm",
+                  "grub",
                   "mkinitcpio"
                 ]
               }
@@ -93,6 +94,7 @@
                   "e2fsprogs",
                   "systemd",
                   "linux",
+                  "mkinitcpio",
                   "tar",
                   "grub",
                   "openssh"
@@ -101,6 +103,72 @@
             }
           },
           "options": {}
+        },
+        {
+          "type": "org.osbuild.users",
+          "options": {
+            "users": {
+            "arch": {
+              "password": "$6$.Pkz378k0geWPWsH$IhFEP1WmQUEkmfMLbf14C./LUYJqsKBVXsNZ2mrOAcKY4wjMN8e/r8TwQmqpm/xPIpfPq1l0PpKD7YQyVHvuD/",
+              "home": "/home/arch"
+            }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.fstab",
+          "options": {
+            "filesystems": [
+              {
+                "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                "vfs_type": "xfs",
+                "path": "/",
+                "options": "defaults"
+              },
+              {
+                "uuid": "7B77-95E7",
+                "vfs_type": "vfat",
+                "path": "/boot/efi",
+                "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                "passno": 2
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.grub2.legacy",
+          "options": {
+            "architecture": "x64",
+            "rootfs": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+            },
+            "bios": "i386-pc",
+            "entries": [
+              {
+                "id": "76a22bf4-f153-4541-b6c7-0332c0dfaeac",
+                "default": true,
+                "product": {
+                  "name": "Arch Linux",
+                  "version": "latest",
+                  "nick": "Arch"
+                },
+                "kernel": "linux"
+              }
+            ],
+            "config": {
+              "cmdline": "ro crashkernel=auto console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 scsi_mod.use_blk_mq=y enforcing=0",
+              "distributor": "$(sed 's, release .*$,,g' /etc/system-release)",
+              "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
+              "terminal_input": [
+                "serial",
+                "console"
+              ],
+              "terminal_output": [
+                "serial",
+                "console"
+              ]
+            }
+          }
         },
         {
           "type": "org.osbuild.mkinitcpio"
@@ -126,6 +194,160 @@
             }
           }
         }
+      ]
+    },
+    {
+      "name": "image",
+      "build": "name:build",
+      "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "disk.img",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+                },
+                {
+                  "size": 204800,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 20762524,
+                  "start": 208896,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 4096,
+                  "size": 204800
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.xfs",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 208896,
+                  "size": 20762524
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 4096,
+                  "size": 204800
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "disk.img",
+                  "start": 208896,
+                  "size": 20762524
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.xfs",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "efi",
+                "type": "org.osbuild.fat",
+                "source": "efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "disk.img",
+              "platform": "i386-pc",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "gpt",
+                "filesystem": "xfs",
+                "binary": "grub-mkimage"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "gpt",
+                "number": 2,
+                "path": "/boot/grub2"
+              }
+            }
+          }
       ]
     }
   ]


### PR DESCRIPTION
This is the final piece for generating a successful booting Arch Linux VM. Arch Linux can't use the normal grub stage as the the open bootloader specification patches are not merged upstream yet.