### PR TITLE
stages/users: Create old home directory before running usermod

### DIFF
--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -113,6 +113,7 @@ def usermod(root, name, gid=None, groups=None, description=None, home=None, shel
         arguments += ["--comment", description]
     if home:
         arguments += ["--home", home]
+        arguments += ["--move-home"]
     if shell:
         arguments += ["--shell", shell]
     if password is not None:

--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -156,6 +156,11 @@ def main(tree, options):
             if uid is not None:
                 print(f"Error: can't set uid of existing user '{name}'")
                 return 1
+            # create and chown existing home directory in case it doesn't exist
+            # this happens in ostree deployments with existing users
+            _, _, old_uid, old_gid, _, old_home, _ = passwd
+            os.makedirs(old_home, 0o700, exist_ok=True)
+            os.chown(old_home, int(old_uid), int(old_gid))
             usermod(tree, name, gid, groups, description, home, shell, password)
         else:
             useradd(tree, name, uid, gid, groups, description, home, shell, password)

--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -73,7 +73,11 @@ SCHEMA = """
 
 
 def getpwnam(root, name):
-    """Similar to pwd.getpwnam, but takes a @root parameter"""
+    """Similar to pwd.getpwnam, but takes a @root parameter
+
+    The returned values are:
+    login name, encrypted password, uid, gid, name or comment, home directory, user command interpreter (shell)
+    """
     with open(f"{root}/etc/passwd") as f:
         for line in f:
             passwd = line.split(":")


### PR DESCRIPTION
When building ostree upgrade commits (commits with a parent), we inherit the passwd and group files from the parent commit.  While users might exist in the parent and specified again in the new commit, the home directory wont exist in the tree.

Before running `usermod`, create the old home directory (and chown it), so that
1. potentially running `usermod --home <newhome> --move-home` doesn't fail (<oldhome> not found),
2. the new ssh key can be created in the home directory of an existing ostree user.