### PR TITLE
osbuild: Add a new progress mode for --json output

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -187,10 +187,9 @@ def osbuild_cli():
         return 130
 
     if args.json:
-        if args.json_mode == "batch":
-            r = fmt.output(manifest, r)
-            json.dump(r, sys.stdout)
-            sys.stdout.write("\n")
+        monitor.log("dump manifest")
+        monitor.dump_json(fmt.output(manifest, r))
+        monitor.log("manifest dumped")
     else:
         if r["success"]:
             for name, pl in manifest.pipelines.items():

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -76,6 +76,10 @@ def parse_arguments(sys_argv):
                         help="object to export, can be passed multiple times")
     parser.add_argument("--json", action="store_true",
                         help="output results in JSON format")
+    parser.add_argument("--json-mode", metavar="MODE", type=str, default="batch",
+                        help=("output mode for JSON format; "
+                              "'batch' (default if unspecified) mode prints all the results when the build ends "
+                              "'progress' prints status updates while building with each line being a JSON object"))
     parser.add_argument("--output-directory", metavar="DIRECTORY", type=os.path.abspath,
                         help="directory where result objects are stored")
     parser.add_argument("--inspect", action="store_true",
@@ -144,10 +148,18 @@ def osbuild_cli():
         print("Need --output-directory for --export")
         return 1
 
-    monitor_name = args.monitor
-    if not monitor_name:
-        monitor_name = "NullMonitor" if args.json else "LogMonitor"
-    monitor = osbuild.monitor.make(monitor_name, args.monitor_fd)
+    outfd = sys.stdout.fileno()
+    if args.json:
+        if args.json_mode == "progress":
+            monitor = osbuild.monitor.JSONProgressMonitor(outfd, manifest)
+            monitor.log("start", origin="org.osbuild.main")
+        elif args.json_mode == "batch":
+            monitor = osbuild.monitor.NullMonitor(outfd)
+        else:
+            print(f"unknown json mode {args.json_mode}")
+            return 1
+    else:
+        monitor = osbuild.monitor.LogMonitor(outfd)
 
     try:
         with ObjectStore(args.store) as object_store:
@@ -175,9 +187,10 @@ def osbuild_cli():
         return 130
 
     if args.json:
-        r = fmt.output(manifest, r)
-        json.dump(r, sys.stdout)
-        sys.stdout.write("\n")
+        if args.json_mode == "batch":
+            r = fmt.output(manifest, r)
+            json.dump(r, sys.stdout)
+            sys.stdout.write("\n")
     else:
         if r["success"]:
             for name, pl in manifest.pipelines.items():

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -210,7 +210,7 @@ class BaseMonitor(abc.ABC):
     def result(self, result: osbuild.pipeline.BuildResult):
         """Called when a module is done with its result"""
 
-    def log(self, message: str):
+    def log(self, message: str, origin: str = None):
         """Called for all module log outputs"""
 
 
@@ -263,7 +263,7 @@ class LogMonitor(BaseMonitor):
 
         self.timer_start = time.time()
 
-    def log(self, message):
+    def log(self, message, origin: str = None):
         self.out.write(message)
 
 

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -219,11 +219,11 @@ class NullMonitor(BaseMonitor):
 
 
 class LogMonitor(BaseMonitor):
-    """Monitor that follows show the log output of modules
+    """Monitor that follows the log output of modules
 
     This monitor will print a header with `name: id` followed
     by the options for each module as it is being built. The
-    full log messages of the modules will be print as soon as
+    full log messages of the modules will be printed as soon as
     they become available.
     The constructor argument `fd` is a file descriptor, where
     the log will get written to. If `fd`  is a `TTY`, escape

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -267,6 +267,43 @@ class LogMonitor(BaseMonitor):
         self.out.write(message)
 
 
+class JSONProgressMonitor(BaseMonitor):
+    """Monitor that prints the log output of modules wrapped in a JSON object with context and progress metadata"""
+
+    def __init__(self, fd: int, manifest: osbuild.Manifest):
+        super().__init__(fd)
+        self._ctx_ids = set()
+        self._progress = Progress("pipelines", len(manifest.pipelines))
+        self._context = Context(origin="org.osbuild")
+
+    def result(self, result):
+        pass
+
+    def begin(self, pipeline: osbuild.Pipeline):
+        self._context.pipeline(pipeline)
+        self._progress.sub_progress(Progress("stages", len(pipeline.stages)))
+        self._progress.incr()
+
+    def stage(self, stage: osbuild.Stage):
+        self._context.stage(stage)
+        self._progress.incr(depth=1)
+
+    def assembler(self, assembler):
+        self.module(assembler)
+
+    def module(self, module):
+        self.stage(module)
+
+    def log(self, message, origin: str = None):
+        oo = self._context.origin
+        if origin is not None:
+            self._context.origin = origin
+        line = LogLine(message=message, context=self._context, progress=self._progress)
+        json.dump(line.as_dict(), self.out)
+        self.out.write("\n")
+        self._context.origin = oo
+
+
 def make(name, fd):
     module = sys.modules[__name__]
     monitor = getattr(module, name, None)

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -275,11 +275,21 @@ class LogMonitor(BaseMonitor):
 class JSONProgressMonitor(BaseMonitor):
     """Monitor that prints the log output of modules wrapped in a JSON object with context and progress metadata"""
 
-    def __init__(self, fd: int, manifest: osbuild.Manifest):
+    def __init__(self, fd: int):
         super().__init__(fd)
         self._ctx_ids = set()
-        self._progress = Progress("pipelines", len(manifest.pipelines))
+        self._manifest = None
         self._context = Context(origin="org.osbuild")
+        self._progress = Progress("pipelines", 0)
+
+    @property
+    def manifest(self):
+        return self._manifest
+
+    @manifest.setter
+    def manifest(self, manifest: osbuild.Manifest):
+        self._manifest = manifest
+        self._progress = Progress("pipelines", len(self._manifest.pipelines))
 
     def result(self, result):
         pass

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -9,6 +9,7 @@ are called on the monitor object at certain events. Consult the
 """
 
 import abc
+import hashlib
 import json
 import os
 import sys
@@ -21,6 +22,143 @@ import osbuild
 
 RESET = "\033[0m"
 BOLD = "\033[1m"
+
+
+class Context:
+    """Context for a single log line. Automatically calculates hash/id when read."""
+    def __init__(self, origin: str = None, pipeline: osbuild.Pipeline = None, stage: osbuild.Stage = None):
+        self._origin = origin
+        self._pipeline_name = pipeline.name if pipeline else None
+        self._pipeline_id = pipeline.id if pipeline else None
+        self._stage_name = stage.name if stage else None
+        self._stage_id = stage.id if stage else None
+        self._id = None
+        self._id_history = set()
+
+    @property
+    def origin(self):
+        return self._origin
+
+    @origin.setter
+    def origin(self, origin: str):
+        self._id = None
+        self._origin = origin
+
+    @property
+    def pipeline_name(self):
+        return self._pipeline_name
+
+    @property
+    def pipeline_id(self):
+        return self._pipeline_id
+
+    def pipeline(self, pipeline: osbuild.Pipeline):
+        self._id = None
+        self._pipeline_name = pipeline.name
+        self._pipeline_id = pipeline.id
+
+    @property
+    def stage_name(self):
+        return self._stage_name
+
+    @property
+    def stage_id(self):
+        return self._stage_id
+
+    def stage(self, stage: osbuild.Stage):
+        self._id = None
+        self._stage_name = stage.name
+        self._stage_id = stage.id
+
+    @property
+    def id(self):
+        if self._id is None:
+            self._id = hashlib.sha256(json.dumps(self._dict()).encode()).hexdigest()
+        return self._id
+
+    def _dict(self):
+        return {
+            "origin": self._origin,
+            "pipeline": {
+                "name": self._pipeline_name,
+                "id": self._pipeline_id,
+                "stage": {
+                    "name": self._stage_name,
+                    "id": self._stage_id,
+                },
+            },
+        }
+
+    def as_dict(self):
+        d = self._dict()
+        ctxid = self.id
+        if ctxid in self._id_history:
+            return {"id": self.id}
+        d["id"] = self.id
+        self._id_history.add(self.id)
+        return d
+
+
+class Progress:
+    def __init__(self, name: str, total: int, unit: str = None):
+        self.name = name
+        self.total = total
+        self.unit = unit
+        self.done = None
+        self._sub_progress = None
+
+    def incr(self, depth=0):
+        if depth > 0:
+            self._sub_progress.incr(depth-1)
+        else:
+            if self.done is None:
+                self.done = 0
+            else:
+                self.done += 1
+            if self._sub_progress:
+                self._sub_progress.reset()
+
+    def reset(self):
+        self.done = None
+        if self._sub_progress:
+            self._sub_progress.reset()
+
+    def sub_progress(self, prog: "Progress"):
+        self._sub_progress = prog
+
+    def as_dict(self):
+        d = {
+            "name": self.name,
+            "total": self.total,
+            "done": self.done,
+            "unit": self.unit,
+        }
+        if self._sub_progress:
+            d["progress"] = self._sub_progress.as_dict()
+        return d
+
+
+class LogLine:
+    """A single JSON serializable log line
+
+    Create a single log line with a given message, error message, context, and progress objects.
+    All arguments are optional. A timestamp is added to the dictionary when calling the 'as_dict()' method.
+    """
+    def __init__(self, *, message: str = None, error: str = None,
+                 context: Context = None, progress: Progress = None):
+        self.message = message
+        self.error = error
+        self.context = context
+        self.progress = progress
+
+    def as_dict(self):
+        return {
+            "message": self.message,
+            "error": self.error,
+            "context": self.context.as_dict(),
+            "progress": self.progress.as_dict(),
+            "timestamp": time.time(),
+        }
 
 
 class TextWriter:

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -213,6 +213,11 @@ class BaseMonitor(abc.ABC):
     def log(self, message: str, origin: str = None):
         """Called for all module log outputs"""
 
+    def dump_json(self, json_object):
+        """Called to output any json object on self.out"""
+        json.dump(json_object, self.out)
+        self.out.write("\n")
+
 
 class NullMonitor(BaseMonitor):
     """Monitor class that does not report anything"""
@@ -302,7 +307,6 @@ class JSONProgressMonitor(BaseMonitor):
         json.dump(line.as_dict(), self.out)
         self.out.write("\n")
         self._context.origin = oo
-
 
 def make(name, fd):
     module = sys.modules[__name__]

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -3,6 +3,7 @@
 #
 
 import io
+import json
 import os
 import sys
 import tempfile
@@ -12,6 +13,7 @@ from collections import defaultdict
 import osbuild
 import osbuild.meta
 from osbuild.monitor import LogMonitor
+from osbuild.monitor import JSONProgressMonitor, Context, Progress, LogLine
 from osbuild.objectstore import ObjectStore
 from osbuild.pipeline import detect_host_runner
 from .. import test
@@ -43,7 +45,7 @@ class TapeMonitor(osbuild.monitor.BaseMonitor):
         self.counter["result"] += 1
         self.results.add(result.id)
 
-    def log(self, message: str):
+    def log(self, message: str, origin: str = None):
         self.counter["log"] += 1
         self.logger.write(message)
 
@@ -112,3 +114,124 @@ class TestMonitor(unittest.TestCase):
         self.assertIn(pipeline.stages[0].id, tape.stages)
         self.assertIn("isthisthereallife", tape.output)
         self.assertIn("isthisjustfantasy", tape.output)
+
+
+def test_context():
+    pipeline = osbuild.Pipeline(name="test-pipeline")
+    index = osbuild.meta.Index(os.curdir)
+    info = index.get_module_info("Stage", "org.osbuild.noop")
+    stage = osbuild.Stage(info, {}, None, None, {})
+    ctx = Context("org.osbuild.test", pipeline, stage)
+    assert ctx.id == "e6305b7e8ccbc39ec88415ea955b89149faf6f51fb6c89831658068bc6850411"
+
+    ctx_dict = ctx.as_dict()
+    # should be a full dict
+    assert "origin" in ctx_dict
+    assert ctx_dict["id"] == "e6305b7e8ccbc39ec88415ea955b89149faf6f51fb6c89831658068bc6850411"
+    assert "pipeline" in ctx_dict
+    assert ctx_dict["pipeline"]["name"] == "test-pipeline"
+    assert ctx_dict["pipeline"]["stage"]["name"] == "org.osbuild.noop"
+
+    ctx_dict = ctx.as_dict()
+    # should only have id
+    assert ctx_dict["id"] == "e6305b7e8ccbc39ec88415ea955b89149faf6f51fb6c89831658068bc6850411"
+    assert len(ctx_dict) == 1
+
+    ctx.origin = "org.osbuild.test-2"
+    ctx_dict = ctx.as_dict()
+    # should be a full dict again
+    assert "origin" in ctx_dict
+    assert "pipeline" in ctx_dict
+    assert ctx_dict["pipeline"]["name"] == "test-pipeline"
+    assert ctx_dict["pipeline"]["stage"]["name"] == "org.osbuild.noop"
+
+    ctx.origin = "org.osbuild.test"
+    ctx_dict = ctx.as_dict()
+    # should only have id again (old context ID)
+    assert ctx_dict["id"] == "e6305b7e8ccbc39ec88415ea955b89149faf6f51fb6c89831658068bc6850411"
+    assert len(ctx_dict) == 1
+
+
+def test_progress():
+    prog = Progress("test", total=12, unit="tests")
+    subprog = Progress("test-sub1", total=3)
+    prog.sub_progress(subprog)
+    assert prog.done is None  # starts with None until the first incr()
+    prog.incr()
+
+    prog.incr(depth=1)
+    progdict = prog.as_dict()
+    assert progdict["done"] == 0
+    assert progdict["progress"]["done"] == 0
+
+    prog.incr(depth=1)
+    progdict = prog.as_dict()
+    assert progdict["done"] == 0
+    assert progdict["progress"]["done"] == 1
+
+    prog.incr()
+    progdict = prog.as_dict()
+    assert progdict["done"] == 1
+    assert progdict["progress"]["done"] is None, "sub-progress did not reset"
+
+
+def test_json_progress_monitor():
+    index = osbuild.meta.Index(os.curdir)
+    info = index.get_module_info("Stage", "org.osbuild.noop")
+
+    manifest = osbuild.Manifest()
+    pl1 = manifest.add_pipeline("test-pipeline-first", "", "")
+    first_stage = pl1.add_stage(info, {})
+    pl1.add_stage(info, {})
+
+    pl2 = manifest.add_pipeline("test-pipeline-second", "", "")
+    pl2.add_stage(info, {})
+    pl2.add_stage(info, {})
+    manifest.add_pipeline(pl2, "", "")
+
+    with tempfile.TemporaryFile() as tf:
+        mon = JSONProgressMonitor(tf.fileno(), manifest)
+        mon.log("test-message-1")
+        mon.log("test-message-2", origin="test.origin.override")
+        mon.begin(manifest.pipelines["test-pipeline-first"])
+        mon.log("pipeline 1 message 1")
+        mon.stage(first_stage)
+        mon.log("pipeline 1 message 2")
+        mon.log("pipeline 1 finished", origin="org.osbuild")
+        mon.begin(manifest.pipelines["test-pipeline-second"])
+        mon.log("pipeline 2 starting", origin="org.osbuild")
+        mon.log("pipeline 2 message 2")
+
+        tf.seek(0)
+        log = tf.read().decode().strip().split("\n")
+
+        assert len(log) == 7
+        logitem = json.loads(log[0])
+        assert logitem["message"] == "test-message-1"
+        assert logitem["context"]["origin"] == "org.osbuild"
+
+        logitem = json.loads(log[1])
+        assert logitem["message"] == "test-message-2"
+        assert logitem["context"]["origin"] == "test.origin.override"
+
+        logitem = json.loads(log[2])
+        assert logitem["message"] == "pipeline 1 message 1"
+        assert logitem["context"]["origin"] == "org.osbuild"
+        assert logitem["context"]["pipeline"]["name"] == "test-pipeline-first"
+        assert logitem["context"]["pipeline"]["stage"]["name"] is None
+
+        logitem = json.loads(log[3])
+        assert logitem["message"] == "pipeline 1 message 2"
+        assert logitem["context"]["origin"] == "org.osbuild"
+        assert logitem["context"]["pipeline"]["name"] == "test-pipeline-first"
+        assert logitem["context"]["pipeline"]["stage"]["name"] == "org.osbuild.noop"
+
+        logitem = json.loads(log[4])
+        assert logitem["message"] == "pipeline 1 finished"
+        assert "origin" not in logitem["context"]
+        assert len(logitem["context"]) == 1
+
+        logitem = json.loads(log[5])
+        assert logitem["message"] == "pipeline 2 starting"
+        assert logitem["context"]["origin"] == "org.osbuild"
+        assert logitem["context"]["pipeline"]["name"] == "test-pipeline-second"


### PR DESCRIPTION
Progress mode for json output lets osbuild send log messages and progression information on the go instead of stacking all of this information for the final json status.

A more detailed discussion here : https://github.com/osbuild/osbuild/discussions/957