### PR TITLE
Make source gathering subprocesses able to give feedback

### DIFF
--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -10,6 +10,7 @@ to fetch resources.
 from typing import Dict
 from osbuild.meta import Index, ValidationResult
 from ..pipeline import Manifest, Pipeline, detect_host_runner
+from ..sources import SourceError
 
 
 VERSION = "1"
@@ -285,3 +286,30 @@ def validate(manifest: Dict, index: Index) -> ValidationResult:
         result.merge(res, path=["sources", name])
 
     return result
+
+
+GENERIC_ID = 0
+GENERIC_CODE = "EXCEPTION"
+SOURCE_ERROR_ID = 1000
+
+
+def format_error(error: Exception):
+    id_ = GENERIC_ID
+    code = GENERIC_CODE
+    reason = str(error)
+    details = ""
+
+    if isinstance(error, SourceError):
+        id_ = SOURCE_ERROR_ID + error.kind.value
+        code = error.kind.name
+        details = {"source": error.source}
+
+    return {
+        "type": "error",
+        "error": {
+                "id": id_,
+                "code": code,
+                "reason": reason,
+                "details": details
+        }
+    }

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -7,6 +7,7 @@ from osbuild.meta import Index, ModuleInfo, ValidationResult
 from ..inputs import Input
 from ..pipeline import Manifest, Pipeline, Stage, detect_host_runner
 from ..sources import Source
+from ..sources import SourceError
 
 
 VERSION = "2"
@@ -500,3 +501,30 @@ def validate(manifest: Dict, index: Index) -> ValidationResult:
         validate_pipeline(pipeline, path=["pipelines", i])
 
     return result
+
+
+GENERIC_ID = 0
+GENERIC_CODE = "EXCEPTION"
+SOURCE_ERROR_ID = 1000
+
+
+def format_error(error: Exception):
+    id_ = GENERIC_ID
+    code = GENERIC_CODE
+    reason = str(error)
+    details = ""
+
+    if isinstance(error, SourceError):
+        id_ = SOURCE_ERROR_ID + error.kind.value
+        code = error.kind.name
+        details = {"source": error.source}
+
+    return {
+        "type": "error",
+        "error": {
+                "id": id_,
+                "code": code,
+                "reason": reason,
+                "details": details
+        }
+    }

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -168,6 +168,16 @@ def osbuild_cli():
             if r["success"] and exports:
                 for pid in exports:
                     export(pid, output_directory, object_store, manifest)
+    # pylint: disable=broad-except
+    except Exception as e:
+        if args.json:
+            r = fmt.format_error(e)
+            json.dump(r, sys.stdout)
+            sys.stdout.write("\n")
+        else:
+            print()
+            print(f"{RESET}{BOLD}{RED}Failed{RESET}")
+        return 1
 
     except KeyboardInterrupt:
         print()

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -17,10 +17,9 @@ import os
 import subprocess
 import sys
 
-from osbuild import sources
-
 from osbuild.util.checksum import verify_file
 from osbuild.util.rhsm import Subscriptions
+from osbuild.sources import SourceService, SourceError, SourceErrorKind
 
 
 SCHEMA = """
@@ -80,7 +79,101 @@ SCHEMA = """
 """
 
 
-class CurlSource(sources.SourceService):
+CURL_CODE_MAP = {
+    # networking errors
+    5: ("Couldn't resolve proxy", SourceErrorKind.DOWNLOAD),
+    6: ("Couldn't resolve host", SourceErrorKind.DOWNLOAD),
+    7: ("Failed to connect to host", SourceErrorKind.DOWNLOAD),
+    8: ("Unknown FTP server response", SourceErrorKind.DOWNLOAD),
+    10: ("FTP accept failed", SourceErrorKind.DOWNLOAD),
+    11: ("FTP weird PASS reply", SourceErrorKind.DOWNLOAD),
+    12: ("FTP Timeout", SourceErrorKind.DOWNLOAD),
+    13: ("Unknown response to FTP PASV command", SourceErrorKind.DOWNLOAD),
+    14: ("Unknown FTP 227 format", SourceErrorKind.DOWNLOAD),
+    15: ("FTP cannot get host", SourceErrorKind.DOWNLOAD),
+    16: ("HTTP/2 error", SourceErrorKind.DOWNLOAD),
+    17: ("FTP could not set binary", SourceErrorKind.DOWNLOAD),
+    18: ("Partial file. Only a part of the file was transferred", SourceErrorKind.DOWNLOAD),
+    19: ("FTP could not download/access the given file", SourceErrorKind.DOWNLOAD),
+    22: ("HTTP page not retrieved", SourceErrorKind.DOWNLOAD),
+    25: ("Upload failed", SourceErrorKind.DOWNLOAD),
+    26: ("Read error", SourceErrorKind.DOWNLOAD),
+    28: ("Operation timeout", SourceErrorKind.DOWNLOAD),
+    30: ("FTP PORT failed", SourceErrorKind.DOWNLOAD),
+    31: ("FTP could not use REST", SourceErrorKind.DOWNLOAD),
+    33: ("HTTP range error", SourceErrorKind.DOWNLOAD),
+    34: ("HTTP post error", SourceErrorKind.DOWNLOAD),
+    36: ("Bad download resume", SourceErrorKind.DOWNLOAD),
+    45: ("A specified outgoing network interface could not be used", SourceErrorKind.DOWNLOAD),
+    47: ("Too many redirects.", SourceErrorKind.DOWNLOAD),
+    52: ("The server did not reply anything", SourceErrorKind.DOWNLOAD),
+    55: ("Failed sending network data", SourceErrorKind.DOWNLOAD),
+    56: ("Failure in receiving network data", SourceErrorKind.DOWNLOAD),
+    60: ("Unrecognized transfer encoding", SourceErrorKind.DOWNLOAD),
+    85: ("RTSP: mismatch of CSeq numbers", SourceErrorKind.DOWNLOAD),
+    86: ("RTSP: mismatch of Session Identifiers", SourceErrorKind.DOWNLOAD),
+    89: ("No connection available, the session will be queued", SourceErrorKind.DOWNLOAD),
+    92: ("Stream error in HTTP/2 framing layer", SourceErrorKind.DOWNLOAD),
+    96: ("QUIC connection error", SourceErrorKind.DOWNLOAD),
+    # credentials errors
+    9: ("FTP access denied", SourceErrorKind.DOWNLOAD),
+    66: ("failed to log in", SourceErrorKind.DOWNLOAD),
+    68: ("Permission problem on TFTP server", SourceErrorKind.DOWNLOAD),
+    94: ("Authentication error", SourceErrorKind.DOWNLOAD),
+    # Security errors
+    35: ("A TLS/SSL connect error", SourceErrorKind.DOWNLOAD),
+    51: ("The server's SSL/TLS certificate or SSH fingerprint failed verification", SourceErrorKind.DOWNLOAD),
+    53: ("SSL crypto engine not found", SourceErrorKind.DOWNLOAD),
+    54: ("Cannot set SSL crypto engine as default", SourceErrorKind.DOWNLOAD),
+    58: ("Couldn't use the specified SSL cipher", SourceErrorKind.DOWNLOAD),
+    59: ("Peer certificate cannot be authenticated with known CA certificates", SourceErrorKind.DOWNLOAD),
+    63: ("Requested FTP SSL level failed", SourceErrorKind.DOWNLOAD),
+    65: ("Failed to initialize SSL Engine", SourceErrorKind.DOWNLOAD),
+    76: ("Problem with reading the SSL CA cert", SourceErrorKind.DOWNLOAD),
+    79: ("Failed to shut down the SSL connection", SourceErrorKind.DOWNLOAD),
+    82: ("Could not load CRL file, missing or wrong format", SourceErrorKind.DOWNLOAD),
+    83: ("TLS certificate issuer check failed", SourceErrorKind.DOWNLOAD),
+    84: ("The FTP PRET command failed", SourceErrorKind.DOWNLOAD),
+    90: ("SSL public key does not matched pinned public key", SourceErrorKind.DOWNLOAD),
+    91: ("Invalid SSL certificate status", SourceErrorKind.DOWNLOAD),
+    # User input errors
+    1: ("Unsupported protocol", SourceErrorKind.BAD_INPUT),
+    3: ("URL malformed", SourceErrorKind.BAD_INPUT),
+    21: ("Quote error", SourceErrorKind.BAD_INPUT),
+    48: ("Unknown option specified to libcurl", SourceErrorKind.BAD_INPUT),
+    49: ("Malformed telnet option", SourceErrorKind.BAD_INPUT),
+    67: ("File not found on TFTP server", SourceErrorKind.BAD_INPUT),
+    77: ("The resource referenced in the URL does not exist", SourceErrorKind.BAD_INPUT),
+    # Storage errors
+    23: ("Curl could not write data to a local filesystem.", SourceErrorKind.STORAGE),
+    37: ("Couldn't read the given file when using the FILE:// ", SourceErrorKind.STORAGE),
+    69: ("Out of disk space on TFTP server", SourceErrorKind.STORAGE),
+    # Internal errors
+    2: ("Failed to initialize", SourceErrorKind.FAILED),
+    4: ("A feature or option that was needed to perform the desired request", SourceErrorKind.FAILED),
+    27: ("Out of memory. A memory allocation request failed", SourceErrorKind.FAILED),
+    38: ("LDAP cannot bind", SourceErrorKind.FAILED),
+    39: ("LDAP search failed", SourceErrorKind.FAILED),
+    42: ("Aborted by callback. An application told libcurl to abort the operation", SourceErrorKind.FAILED),
+    43: ("Bad function argument. A function was called with a bad parameter", SourceErrorKind.FAILED),
+    61: ("Invalid LDAP URL", SourceErrorKind.FAILED),
+    62: ("Maximum file size exceeded", SourceErrorKind.FAILED),
+    64: ("Sending the data requires a rewind that failed", SourceErrorKind.FAILED),
+    70: ("Illegal TFTP operation", SourceErrorKind.FAILED),
+    71: ("Unknown TFTP transfer ID", SourceErrorKind.FAILED),
+    72: ("File already exists (TFTP)", SourceErrorKind.FAILED),
+    73: ("No such user (TFTP)", SourceErrorKind.FAILED),
+    74: ("Character conversion failed", SourceErrorKind.FAILED),
+    75: ("Character conversion functions required", SourceErrorKind.FAILED),
+    78: ("An unspecified error occurred during the SSH session", SourceErrorKind.FAILED),
+    87: ("Unable to parse FTP file list", SourceErrorKind.FAILED),
+    88: ("FTP chunk callback reported error", SourceErrorKind.FAILED),
+    93: ("An API function was called from inside a callback", SourceErrorKind.FAILED),
+    95: ("HTTP/3 layer error", SourceErrorKind.FAILED)
+}
+
+
+class CurlSource(SourceService):
 
     content_type = "org.osbuild.files"
     max_workers = 4
@@ -129,19 +222,22 @@ class CurlSource(sources.SourceService):
             # url must follow options
             curl_command.append(url)
 
-            curl = subprocess.run(curl_command, encoding="utf-8", cwd=self.tmpdir, check=False)
-            return_code = curl.returncode
+            return_code = subprocess.run(curl_command, encoding="utf-8", cwd=self.tmpdir, check=False).returncode
             if return_code == 0:
                 break
         else:
-            raise RuntimeError(f"curl: error downloading {url}: error code {return_code}")
+            message, kind = CURL_CODE_MAP.get(return_code, [SourceErrorKind.FAILED.name, SourceErrorKind.FAILED])
+            return self.signal_error(SourceError(kind=kind,
+                                                 message=message,
+                                                 source=str(url)))
 
         if not verify_file(f"{self.tmpdir}/{checksum}", checksum):
-            raise RuntimeError(f"checksum mismatch: {checksum} {url}")
+            return self.signal_error(SourceError(kind=SourceErrorKind.CHECKSUM,
+                                                 message=SourceErrorKind.CHECKSUM.name,
+                                                 source=str(url)))
 
-        # The checksum has been verified, move the file into place. in case we race
-        # another download of the same file, we simply ignore the error as their
-        # contents are guaranteed to be  the same.
+        # The checksum has been verified, move the file into place. In case we race another download of the same file,
+        # we simply ignore the error as their contents are guaranteed to be  the same.
         try:
             os.rename(f"{self.tmpdir}/{checksum}", f"{self.cache}/{checksum}")
         except FileExistsError:

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -16,7 +16,6 @@ up the download.
 import os
 import subprocess
 import sys
-import tempfile
 
 from osbuild import sources
 
@@ -106,49 +105,47 @@ class CurlSource(sources.SourceService):
     def fetch_one(self, checksum, desc):
         secrets = desc.get("secrets")
         url = desc.get("url")
-        # Download to a temporary sub cache until we have verified the checksum. Use a
-        # subdirectory, so we avoid copying across block devices.
-        with tempfile.TemporaryDirectory(prefix="osbuild-unverified-file-", dir=self.cache) as tmpdir:
-            # some mirrors are sometimes broken. retry manually, because we could be
-            # redirected to a different, working, one on retry.
-            return_code = 0
-            for _ in range(10):
-                curl_command = [
-                    "curl",
-                    "--silent",
-                    "--speed-limit", "1000",
-                    "--connect-timeout", "30",
-                    "--fail",
-                    "--location",
-                    "--output", checksum,
-                ]
-                if secrets:
-                    if secrets.get('ssl_ca_cert'):
-                        curl_command.extend(["--cacert", secrets.get('ssl_ca_cert')])
-                    if secrets.get('ssl_client_cert'):
-                        curl_command.extend(["--cert", secrets.get('ssl_client_cert')])
-                    if secrets.get('ssl_client_key'):
-                        curl_command.extend(["--key", secrets.get('ssl_client_key')])
-                # url must follow options
-                curl_command.append(url)
+        # Download to a temporary sub cache until we have verified the checksum. Use a subdirectory, so we avoid copying
+        # across block devices. some mirrors are sometimes broken. retry manually, because we could be redirected to a
+        # different, working, one on retry.
+        return_code = 0
+        for _ in range(10):
+            curl_command = [
+                "curl",
+                "--silent",
+                "--speed-limit", "1000",
+                "--connect-timeout", "30",
+                "--fail",
+                "--location",
+                "--output", checksum,
+            ]
+            if secrets:
+                if secrets.get('ssl_ca_cert'):
+                    curl_command.extend(["--cacert", secrets.get('ssl_ca_cert')])
+                if secrets.get('ssl_client_cert'):
+                    curl_command.extend(["--cert", secrets.get('ssl_client_cert')])
+                if secrets.get('ssl_client_key'):
+                    curl_command.extend(["--key", secrets.get('ssl_client_key')])
+            # url must follow options
+            curl_command.append(url)
 
-                curl = subprocess.run(curl_command, encoding="utf-8", cwd=tmpdir, check=False)
-                return_code = curl.returncode
-                if return_code == 0:
-                    break
-            else:
-                raise RuntimeError(f"curl: error downloading {url}: error code {return_code}")
+            curl = subprocess.run(curl_command, encoding="utf-8", cwd=self.tmpdir, check=False)
+            return_code = curl.returncode
+            if return_code == 0:
+                break
+        else:
+            raise RuntimeError(f"curl: error downloading {url}: error code {return_code}")
 
-            if not verify_file(f"{tmpdir}/{checksum}", checksum):
-                raise RuntimeError(f"checksum mismatch: {checksum} {url}")
+        if not verify_file(f"{self.tmpdir}/{checksum}", checksum):
+            raise RuntimeError(f"checksum mismatch: {checksum} {url}")
 
-            # The checksum has been verified, move the file into place. in case we race
-            # another download of the same file, we simply ignore the error as their
-            # contents are guaranteed to be  the same.
-            try:
-                os.rename(f"{tmpdir}/{checksum}", f"{self.cache}/{checksum}")
-            except FileExistsError:
-                pass
+        # The checksum has been verified, move the file into place. in case we race
+        # another download of the same file, we simply ignore the error as their
+        # contents are guaranteed to be  the same.
+        try:
+            os.rename(f"{self.tmpdir}/{checksum}", f"{self.cache}/{checksum}")
+        except FileExistsError:
+            pass
 
 
 def main():

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -16,8 +16,8 @@ import contextlib
 import os
 import sys
 
-from osbuild import sources
 from osbuild.util.checksum import verify_file
+from osbuild.sources import SourceService, SourceError, SourceErrorKind
 
 
 SCHEMA = """
@@ -53,7 +53,7 @@ SCHEMA = """
 """
 
 
-class InlineSource(sources.SourceService):
+class InlineSource(SourceService):
 
     content_type = "org.osbuild.files"
 
@@ -69,7 +69,11 @@ class InlineSource(sources.SourceService):
             f.write(data)
 
         if not verify_file(floating, checksum):
-            raise RuntimeError(f"Checksum mismatch for {format(checksum)}")
+            self.signal_error(
+                SourceError(kind=SourceErrorKind.CHECKSUM,
+                            message=f"Checksum mismatch for {checksum}",
+                            source=str(checksum)))
+            return
 
         with contextlib.suppress(FileExistsError):
             os.rename(floating, target)

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -61,9 +61,6 @@ class InlineSource(sources.SourceService):
         target = os.path.join(self.cache, checksum)
         floating = os.path.join(self.tmpdir, checksum)
 
-        if os.path.isfile(target):
-            return
-
         data = base64.b64decode(desc["data"])
 
         # Write the bits to disk and then verify the checksum

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -63,9 +63,8 @@ class InlineSource(sources.SourceService):
 
         data = base64.b64decode(desc["data"])
 
-        # Write the bits to disk and then verify the checksum
-        # This ensures that 1) the data is ok and that 2) we
-        # wrote them correctly as well
+        # Write the bits to disk and then verify the checksum This ensures that 1) the data is ok and that 2) we wrote
+        # them correctly as well
         with open(floating, "wb") as f:
             f.write(data)
 

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -94,22 +94,17 @@ class OSTreeSource(sources.SourceService):
         if not gpg:
             verify_args = ["--no-gpg-verify"]
 
-        ostree("remote", "add",
-               uid, url,
-               *verify_args,
-               repo=self.repo)
+        ostree("remote", "add", uid, url, *verify_args, repo=self.repo)
 
         for key in gpg:
-            ostree("remote", "gpg-import", "--stdin", uid,
-                   repo=self.repo, _input=key)
+            ostree("remote", "gpg-import", "--stdin", uid, repo=self.repo, _input=key)
 
         # Transfer the commit: remote → cache
         print(f"pulling {commit}", file=sys.stderr)
         ostree("pull", uid, commit, repo=self.repo)
 
         # Remove the temporary remotes again
-        ostree("remote", "delete", uid,
-               repo=self.repo)
+        ostree("remote", "delete", uid, repo=self.repo)
 
     def setup(self, args):
         super().setup(args)
@@ -117,9 +112,8 @@ class OSTreeSource(sources.SourceService):
         self.repo = os.path.join(self.cache, "repo")
         ostree("init", mode="archive", repo=self.repo)
 
-        # Make sure the cache repository uses locks to protect the metadata during
-        # shared access. This is the default since `2018.5`, but lets document this
-        # explicitly here.
+        # Make sure the cache repository uses locks to protect the metadata during shared access. This is the default
+        # since `2018.5`, but lets document this explicitly here.
         ostree("config", "set", "repo.locking", "true", repo=self.repo)
 
     # pylint: disable=[no-self-use]

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -10,10 +10,11 @@ gpg keys are provided via `gpgkeys`.
 import os
 import sys
 import subprocess
+from subprocess import CalledProcessError
 import uuid
 from osbuild.util.ostree import show
 
-from osbuild import sources
+from osbuild.sources import SourceService, SourceError, SourceErrorKind
 
 
 SCHEMA = """
@@ -75,7 +76,7 @@ def ostree(*args, _input=None, **kwargs):
                    check=True)
 
 
-class OSTreeSource(sources.SourceService):
+class OSTreeSource(SourceService):
 
     content_type = "org.osbuild.ostree"
 
@@ -90,21 +91,32 @@ class OSTreeSource(sources.SourceService):
         gpg = remote.get("gpgkeys", [])
         uid = str(uuid.uuid4())
 
-        verify_args = []
-        if not gpg:
-            verify_args = ["--no-gpg-verify"]
+        error_kind = SourceErrorKind.FAILED
+        try:
+            verify_args = []
+            if not gpg:
+                verify_args = ["--no-gpg-verify"]
 
-        ostree("remote", "add", uid, url, *verify_args, repo=self.repo)
+            error_kind = SourceErrorKind.BAD_INPUT
 
-        for key in gpg:
-            ostree("remote", "gpg-import", "--stdin", uid, repo=self.repo, _input=key)
+            ostree("remote", "add", uid, url, *verify_args, repo=self.repo)
 
-        # Transfer the commit: remote → cache
-        print(f"pulling {commit}", file=sys.stderr)
-        ostree("pull", uid, commit, repo=self.repo)
+            for key in gpg:
+                ostree("remote", "gpg-import", "--stdin", uid, repo=self.repo, _input=key)
 
-        # Remove the temporary remotes again
-        ostree("remote", "delete", uid, repo=self.repo)
+            error_kind = SourceErrorKind.DOWNLOAD
+
+            # Transfer the commit: remote → cache
+            print(f"pulling {commit}", file=sys.stderr)
+            ostree("pull", uid, commit, repo=self.repo)
+
+            # Remove the temporary remotes again
+            ostree("remote", "delete", uid, repo=self.repo)
+
+            error_kind = SourceErrorKind.FAILED
+
+        except CalledProcessError as e:
+            self.signal_error(SourceError(error_kind, str(e), f"{commit}@{url} {remote}"))
 
     def setup(self, args):
         super().setup(args)

--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -10,9 +10,10 @@ import sys
 import subprocess
 import tempfile
 import hashlib
+from subprocess import CalledProcessError
 
-from osbuild import sources
 from osbuild.util import ctx
+from osbuild.sources import SourceService, SourceError, SourceErrorKind
 
 SCHEMA = """
 "additionalProperties": false,
@@ -64,7 +65,7 @@ SCHEMA = """
 """
 
 
-class SkopeoSource(sources.SourceService):
+class SkopeoSource(SourceService):
 
     content_type = "org.osbuild.containers"
 
@@ -75,10 +76,9 @@ class SkopeoSource(sources.SourceService):
         digest = image["digest"]
         tls_verify = image.get("tls-verify", True)
 
+        source = f"docker://{imagename}@{digest}"
         with tempfile.TemporaryDirectory(prefix="tmp-download-", dir=self.cache) as tmpdir:
             archive_path = os.path.join(tmpdir, "container-image.tar")
-
-            source = f"docker://{imagename}@{digest}"
 
             # We use the docker format, not oci, because that is the
             # default return image type of real world registries,
@@ -95,25 +95,32 @@ class SkopeoSource(sources.SourceService):
             if not tls_verify:
                 extra_args.append("--src-tls-verify=false")
 
-            subprocess.run(["skopeo", "copy"] + extra_args + [source, destination],
-                           encoding="utf-8",
-                           check=True)
+            error_kind = SourceErrorKind.FAILED
+            try:
+                error_kind = SourceErrorKind.DOWNLOAD
+                subprocess.run(["skopeo", "copy"] + extra_args + [source, destination],
+                               encoding="utf-8",
+                               check=True)
 
-            # Verify that the digest supplied downloaded the correct container image id.
-            # The image id is the digest of the config, but skopeo can' currently
-            # get the config id, only the full config, so we checksum it ourselves.
-            res = subprocess.run(["skopeo", "inspect", "--raw", "--config", destination],
-                                 capture_output=True,
-                                 check=True)
-            downloaded_id = "sha256:" + hashlib.sha256(res.stdout).hexdigest()
-            if downloaded_id != image_id:
-                raise RuntimeError(
-                    f"Downloaded image {imagename}@{digest} has a id of {downloaded_id}, but expected {image_id}")
+                # Verify that the digest supplied downloaded the correct container image id.
+                # The image id is the digest of the config, but skopeo can' currently
+                # get the config id, only the full config, so we checksum it ourselves.
+                res = subprocess.run(["skopeo", "inspect", "--raw", "--config", destination],
+                                     capture_output=True,
+                                     check=True)
+                downloaded_id = "sha256:" + hashlib.sha256(res.stdout).hexdigest()
+                error_kind = SourceErrorKind.FAILED
+                if downloaded_id != image_id:
+                    raise RuntimeError(
+                        f"Downloaded image {imagename}@{digest} has a id of {downloaded_id}, but expected {image_id}")
 
-            # Atomically move download dir into place on successful download
-            os.chmod(tmpdir, 0o755)
-            with ctx.suppress_oserror(errno.ENOTEMPTY, errno.EEXIST):
-                os.rename(tmpdir, f"{self.cache}/{image_id}")
+                # Atomically move download dir into place on successful download
+                os.chmod(tmpdir, 0o755)
+                with ctx.suppress_oserror(errno.ENOTEMPTY, errno.EEXIST):
+                    os.rename(tmpdir, f"{self.cache}/{image_id}")
+
+            except (CalledProcessError, RuntimeError) as e:
+                self.signal_error(SourceError(error_kind, str(e), source))
 
 
 def main():

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -99,7 +99,7 @@ def check_case(source, case, store, libdir):
     with host.ServiceManager() as mgr:
         expects = case["expects"]
         if expects == "error":
-            with pytest.raises(host.RemoteError):
+            with pytest.raises(osbuild.sources.SourceError):
                 source.download(mgr, store, libdir)
         elif expects == "success":
             source.download(mgr, store, libdir)


### PR DESCRIPTION
This PR introduces a way for the programs in charge of downloading or decoding data mandatory for the manifest building to be able to report the status of each download/decoding.

Originally this PR was aiming only at fixing some issues with curl, but I decided to extend it to inline and ostree since they could suffer from the same kind of issues.