### PR TITLE
Initial work on more reproducible builds

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -169,7 +169,7 @@ class BuildRoot(contextlib.AbstractContextManager):
         if self._exitstack:
             self._exitstack.enter_context(api)
 
-    def run(self, argv, monitor, timeout=None, binds=None, readonly_binds=None):
+    def run(self, argv, monitor, timeout=None, binds=None, readonly_binds=None, extra_env=None):
         """Runs a command in the buildroot.
 
         Takes the command and arguments, as well as bind mounts to mirror
@@ -282,6 +282,8 @@ class BuildRoot(contextlib.AbstractContextManager):
             "PYTHONUNBUFFERED": "1",
             "TERM": os.getenv("TERM", "dumb"),
         }
+        if extra_env:
+            env.update(extra_env)
 
         proc = subprocess.Popen(cmd,
                                 bufsize=0,

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -318,12 +318,13 @@ def load_pipeline(description: Dict, index: Index, manifest: Manifest, source_re
     name = description["name"]
     build = description.get("build")
     runner = description.get("runner")
+    source_epoch = description.get("source-epoch")
 
     if build and build.startswith("name:"):
         target = resolve_ref(build, manifest)
         build = target
 
-    pl = manifest.add_pipeline(name, runner, build)
+    pl = manifest.add_pipeline(name, runner, build, source_epoch)
 
     for desc in description.get("stages", []):
         load_stage(desc, index, pl, manifest, source_refs)

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -96,10 +96,12 @@ class Stage:
 
     def prepare_arguments(self, args, location):
         args["options"] = self.options
-        args["meta"] = {
+        args["meta"] = meta = {
             "id": self.id,
-            "source-epoch": self.source_epoch
         }
+
+        if self.source_epoch is not None:
+            meta["source-epoch"] = self.source_epoch
 
         # Root relative paths: since paths are different on the
         # host and in the container they need to be mapped to

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -97,7 +97,8 @@ class Stage:
     def prepare_arguments(self, args, location):
         args["options"] = self.options
         args["meta"] = {
-            "id": self.id
+            "id": self.id,
+            "source-epoch": self.source_epoch
         }
 
         # Root relative paths: since paths are different on the

--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -104,6 +104,7 @@
         "name": { "type:": "string" },
         "build": { "type": "string" },
         "runner": { "type": "string" },
+        "source-epoch": { "type": "integer" },
         "stages": { "$ref": "#/definitions/stages" }
       }
     },

--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -209,10 +209,16 @@ def blobs_add_layer(blobs: str, tree: str):
 
     command = [
         "tar",
+        # Sort for better reproduceability
+        "--sort=name",
         "--no-selinux",
         "--acls",
         "--xattrs",
         "--xattrs-include=" + XATTRS_WANT,
+        # Enforce standard format
+        "--format=posix",
+        # Drop atime and ctime for better reproduceability
+        "--pax-option", "delete=atime,delete=ctime",
         "-cf", layer_file,
         "-C", tree,
     ] + os.listdir(tree)
@@ -339,11 +345,22 @@ def main(inputs, output_dir, options, meta):
 
         create_oci_dir(inputs, workdir, options, create_time)
 
+        # This sorts by name and removes various metadata to make
+        # the tarfile reproducible
         command = [
             "tar",
             "--remove-files",
+            "--sort=name",
             "--no-selinux",
             "--no-xattrs",
+            "--no-acls",
+            "--owner=0",
+            "--group=0",
+            "--numeric-owner",
+            "--mode=go=rX,u+rw,a-s",
+            "--format=posix",
+            f"--mtime=@{int(create_time.timestamp())}",
+            "--pax-option", "delete=atime,delete=ctime",
             "-cf", os.path.join(output_dir, filename),
             f"--directory={workdir}",
         ] + os.listdir(workdir)

--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -38,6 +38,7 @@ podman[3] with `podman pull oci-archive:<archive>`.
 
 
 import datetime
+import time
 import json
 import os
 import subprocess
@@ -262,13 +263,13 @@ def config_from_options(options):
     return config
 
 
-def create_oci_dir(inputs, output_dir, options):
+def create_oci_dir(inputs, output_dir, options, create_time):
     architecture = options["architecture"]
 
-    now = datetime.datetime.utcnow().isoformat() + "Z"
+    created = create_time.isoformat() + "Z"
 
     config = {
-        "created": now,
+        "created": created,
         "architecture": architecture,
         "os": "linux",
         "config": config_from_options(options["config"]),
@@ -305,7 +306,7 @@ def create_oci_dir(inputs, output_dir, options):
         manifest["layers"].append(info)
         config["rootfs"]["diff_ids"] = [digest]
         config["history"].append({
-            "created": now,
+            "created": created,
             "created_by": f"/bin/sh -c #(nop) osbuild input '{ip}'"
         })
 
@@ -327,14 +328,16 @@ def create_oci_dir(inputs, output_dir, options):
         json.dump({"imageLayoutVersion": "1.0.0"}, f)
 
 
-def main(inputs, output_dir, options):
+def main(inputs, output_dir, options, meta):
     filename = options["filename"]
 
+    source_time = int(meta.get("source-epoch", time.time()))
+    create_time = datetime.datetime.fromtimestamp(source_time, datetime.timezone.utc)
     with tempfile.TemporaryDirectory(dir=output_dir) as tmpdir:
         workdir = os.path.join(tmpdir, "output")
         os.makedirs(workdir)
 
-        create_oci_dir(inputs, workdir, options)
+        create_oci_dir(inputs, workdir, options, create_time)
 
         command = [
             "tar",
@@ -353,5 +356,5 @@ def main(inputs, output_dir, options):
 
 if __name__ == '__main__':
     args = osbuild.api.arguments()
-    r = main(args["inputs"], args["tree"], args["options"])
+    r = main(args["inputs"], args["tree"], args["options"], args["meta"])
     sys.exit(r)

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -35,7 +35,7 @@ class TestDescriptions(unittest.TestCase):
     def test_stage_run(self):
         index = osbuild.meta.Index(os.curdir)
         info = index.get_module_info("Stage", "org.osbuild.noop")
-        stage = osbuild.Stage(info, {}, None, None, {})
+        stage = osbuild.Stage(info, {}, None, None, {}, None)
 
         with tempfile.TemporaryDirectory() as tmpdir:
 


### PR DESCRIPTION
This adds a source-epoch option on the pipeline, which if set is passed down as `SOURCE_DATE_EPOCH` in the buildroot environment, as per the spec at:

      https://reproducible-builds.org/docs/source-date-epoch/

In addition it passes the epoch to the stages, and there are some inital code in the oci-archive stage to use it to override the creation time of the container config file.

There are also some general changes to the tar creation in the oci-archive stage in order to make the tarfiles more reproducible.

One of my goals with this is to be able to create an oci-archive from a pipeline and then end up with an identical oci config file and uncompressed layer tarball, because then that will imply that the installed container image will get the same id. However, this currently requires more work, because the pipeline will not be identical in two runs. For example, lots of stages create files or directories with the current time as the mtime. So, there is more work to do here.