### PR TITLE
Fix executable test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
         - "test.mod"
         - "test.run.test_assemblers"
         - "test.run.test_boot"
+        - "test.run.test_executable"
         - "test.run.test_noop"
         - "test.run.test_sources"
         - "test.run.test_stages"

--- a/test/run/test_executable.py
+++ b/test/run/test_executable.py
@@ -17,7 +17,7 @@ class TestExecutable(unittest.TestCase):
         invalid = json.dumps({"foo": 42})
 
         with self.osbuild as osb, self.assertRaises(subprocess.CalledProcessError) as e:
-            osb.compile(invalid, check=True)
+            osb.compile(invalid, checkpoints=[], check=True)
 
         self.assertEqual(e.exception.returncode, 2)
 


### PR DESCRIPTION
During the rework done in commit "use and require explicit exports" with commit id https://github.com/osbuild/osbuild/commit/7ae4a7e7858f1ffd1936711966048e76bc9e0b75, the test got overlooked. Add an empty list of checkpoints to the `obs.compile` invocation as to actually trigger the osbuild invocation.

Also actually run the test in ci.