### PR TITLE
stages/sfdisk: support changing GPT partition attribute bits

### DIFF
--- a/stages/org.osbuild.sfdisk
+++ b/stages/org.osbuild.sfdisk
@@ -66,6 +66,17 @@ SCHEMA_2 = r"""
           "uuid": {
             "description": "UUID of the partition (GPT)",
             "type": "string"
+          },
+          "attrs": {
+            "description": "Attributes of the partition (GPT)",
+            "type": "array",
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 63
+            }
           }
         }
       }
@@ -82,7 +93,8 @@ class Partition:
                  size: int = None,
                  bootable: bool = False,
                  name: str = None,
-                 uuid: str = None):
+                 uuid: str = None,
+                 attrs: int = None):
         self.type = pttype
         self.start = start
         self.size = size
@@ -90,6 +102,7 @@ class Partition:
         self.name = name
         self.uuid = uuid
         self.index = None
+        self.attrs = attrs
 
     @property
     def start_in_bytes(self):
@@ -135,9 +148,13 @@ class PartitionTable:
         command = f"label: {self.label}\nlabel-id: {self.uuid}"
         for partition in self.partitions:
             fields = []
-            for field in ["start", "size", "type", "name", "uuid"]:
+            for field in ["start", "size", "type", "name", "uuid", "attrs"]:
                 value = getattr(partition, field)
                 if value:
+                    if field == "attrs":
+                        # make a list into a comma-separated string
+                        attr_list = [str(element) for element in value]
+                        value = ",".join(attr_list)
                     fields += [f'{field}="{value}"']
             if partition.bootable:
                 fields += ["bootable"]
@@ -169,6 +186,7 @@ class PartitionTable:
             part.size = disk_parts[i]["size"]
             part.type = disk_parts[i].get("type")
             part.name = disk_parts[i].get("name")
+            part.attrs = disk_parts[i].get("attrs")
 
 
 def partition_from_json(js) -> Partition:
@@ -177,7 +195,8 @@ def partition_from_json(js) -> Partition:
                   size=js.get("size"),
                   bootable=js.get("bootable"),
                   name=js.get("name"),
-                  uuid=js.get("uuid"))
+                  uuid=js.get("uuid"),
+                  attrs=js.get("attrs"))
     return p
 
 


### PR DESCRIPTION
The GPT attribute field is a 64-bit field that contains two subfields. The higher field is interpreted only in the context of the partition ID, while the lower field is common to all partition IDs. sfdisk supports to change this fields, and also a osbuild user might be interested on change these bits. This patchset adds support to change these bits in the sfdisk stage. 

The meaning of these bits (from Wikipedia) :

- 0 Platform required (required by the computer to function properly, OEM partition for example, disk partitioning utilities must preserve the partition as is)
- 1 EFI firmware should ignore the content of the partition and not try to read from it
- 2 Legacy BIOS bootable (equivalent to active flag (typically bit 7 set) at offset +0h in partition entries of the MBR partition table)
- 3–47 Reserved for future use
- 48–63 Defined and used by the individual partition type

