### PR TITLE
stages/oci-archive: fix creation time format

### DIFF
--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -272,7 +272,7 @@ def config_from_options(options):
 def create_oci_dir(inputs, output_dir, options, create_time):
     architecture = options["architecture"]
 
-    created = create_time.isoformat() + "Z"
+    created = create_time.isoformat()
 
     config = {
         "created": created,


### PR DESCRIPTION
According to OCI image specification the `created` property needs to be in the format describe in RFC 3339, section 5.6 "Internet Date / Time Format". The suffix is the "time-offset" which is either "Z" or "time-numoffset". Before commit 25b5679[2] we the datetime object, created via `utcnow` did not have timezone information so "Z" was manually appended. This was changed with commit 25b5679 and now the timezone information was indeed included, which also meant that `isoformat` now included the offset, i.e. `+00:00`. But the `Z` was still appended and the result was `+00:00Z`, something that is not standard compliant. Fix this by removing the extra `Z`.

[1] https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
[2] 25b567990bcc1ac2cf1a6e5804499126f9434f89