### PR TITLE
util/udev: fix path for udev device inhibitor

### DIFF
--- a/osbuild/util/udev.py
+++ b/osbuild/util/udev.py
@@ -53,7 +53,7 @@ class UdevInhibitor:
     @classmethod
     def for_device(cls, major: int, minor: int, lockdir=LOCKDIR):
         """Inhibit a device given its major and minor number"""
-        path = pathlib.Path(lockdir, f"device-{major}-{minor}")
+        path = pathlib.Path(lockdir, f"device-{major}:{minor}")
         ib = cls(path)
         ib.inhibit()
         return ib


### PR DESCRIPTION
The udev inhibitor rules are checking for `device-$major:$minor` but we created them with `f"device-{major}-{minor}"`. So they did indeed not actually work. Fix that.