### PR TITLE
Extend firewall stage to set the default zone

### DIFF
--- a/stages/org.osbuild.firewall
+++ b/stages/org.osbuild.firewall
@@ -59,6 +59,10 @@ SCHEMA = """
       "type": "string",
       "description": "Service name (from /{lib,etc}/firewalld/services/*.xml)"
     }
+  },
+  "default_zone": {
+    "description": "Set default zone for connections and interfaces where no zone has been selected.",
+    "type": "string"
   }
 }
 """
@@ -72,7 +76,14 @@ def main(tree, options):
     enabled_services = options.get("enabled_services", [])
     disabled_services = options.get("disabled_services", [])
 
+    default_zone = options.get("default_zone", "")
+
     # firewall-offline-cmd does not implement --root option so we must chroot it
+    if default_zone:
+        subprocess.run(["chroot", tree, "firewall-offline-cmd", f"--set-default-zone={default_zone}"], check=True)
+
+    # The options below are "lokkit" compatibility options and can not be used
+    # with other options.
     subprocess.run(["chroot",
                     tree,
                     "firewall-offline-cmd"] +

--- a/test/data/stages/firewall/b.json
+++ b/test/data/stages/firewall/b.json
@@ -488,7 +488,8 @@
           ],
           "disabled_services": [
             "telnet"
-          ]
+          ],
+          "default_zone": "trusted"
         }
       }
     ]

--- a/test/data/stages/firewall/b.mpp.json
+++ b/test/data/stages/firewall/b.mpp.json
@@ -42,7 +42,8 @@
           ],
           "disabled_services": [
             "telnet"
-          ]
+          ],
+          "default_zone": "trusted"
         }
       }
     ]

--- a/test/data/stages/firewall/diff.json
+++ b/test/data/stages/firewall/diff.json
@@ -1,8 +1,11 @@
 {
   "added_files": [
-    "/etc/firewalld/zones/public.xml",
-    "/etc/firewalld/zones/public.xml.old"
+    "/etc/firewalld/firewalld.conf.old",
+    "/etc/firewalld/zones/trusted.xml",
+    "/etc/firewalld/zones/trusted.xml.old"
   ],
   "deleted_files": [],
-  "differences": {}
+  "differences": {
+    "/etc/firewalld/firewalld.conf": {"mode": [41471, 33152]}
+  }
 }


### PR DESCRIPTION
Extend the firewall stage to allow setting the default firewall zone.
Modify the stage unit test accordingly.

This is needed for the GCE image.

TODO:

- [x] need to manually verify the filesystem tree modified by the stage.

Signed-off-by: Tomas Hozza <thozza@redhat.com>