### PR TITLE
LVM2: separate stderr, stdout

### DIFF
--- a/devices/org.osbuild.lvm2.lv
+++ b/devices/org.osbuild.lvm2.lv
@@ -67,12 +67,12 @@ class LVService(devices.DeviceService):
         ]
         res = subprocess.run(cmd,
                              check=False,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT,
+                             stdout=subprocess.DEVNULL,
+                             stderr=subprocess.PIPE,
                              encoding="UTF-8")
 
         if res.returncode != 0:
-            data = res.stdout.strip()
+            data = res.stderr.strip()
             msg = f"Failed to set LV device ({fullname}) status: {data}"
             raise RuntimeError(msg)
 
@@ -90,7 +90,7 @@ class LVService(devices.DeviceService):
             res = subprocess.run(cmd,
                                  check=False,
                                  stdout=subprocess.PIPE,
-                                 stderr=subprocess.STDOUT,
+                                 stderr=subprocess.PIPE,
                                  encoding="UTF-8")
 
             if res.returncode == 5:
@@ -101,7 +101,7 @@ class LVService(devices.DeviceService):
                 continue
 
             if res.returncode != 0:
-                json.dump({"error": res.stdout.strip()}, sys.stdout)
+                json.dump({"error": res.stderr.strip()}, sys.stdout)
                 return 1
 
             vg_name = res.stdout.strip()
@@ -125,11 +125,11 @@ class LVService(devices.DeviceService):
         res = subprocess.run(cmd,
                              check=False,
                              stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT,
+                             stderr=subprocess.PIPE,
                              encoding="UTF-8")
 
         if res.returncode != 0:
-            raise RuntimeError(res.stdout.strip())
+            raise RuntimeError(res.stderr.strip())
 
         data = res.stdout.strip()
         devnum = list(map(int, data.split(";")))

--- a/test/mod/test_util_lvm2.py
+++ b/test/mod/test_util_lvm2.py
@@ -81,13 +81,13 @@ def list_vgs():
     res = subprocess.run(cmd,
                          check=False,
                          stdout=subprocess.PIPE,
-                         stderr=subprocess.STDOUT,
+                         stderr=subprocess.PIPE,
                          encoding="UTF-8")
 
     data = res.stdout.strip()
 
     if res.returncode != 0:
-        msg = f"vgs: {data}"
+        msg = f"vgs: {res.stderr.strip()}"
         raise RuntimeError(msg)
 
     data = json.loads(data)


### PR DESCRIPTION
In all invocations of `subprocess.run` stderr and stdout were both combined in a shared pipe, but lvm sometimes spits out notices and informational messages on stderr and thus potentially interfering with the data we are interested in on stdout. Separate the two.