### PR TITLE
stages/firewall: fix fail when setting only the default zone

### DIFF
--- a/stages/org.osbuild.firewall
+++ b/stages/org.osbuild.firewall
@@ -84,13 +84,14 @@ def main(tree, options):
 
     # The options below are "lokkit" compatibility options and can not be used
     # with other options.
-    subprocess.run(["chroot",
-                    tree,
-                    "firewall-offline-cmd"] +
-                   list(map(lambda x: f"--port={x}", ports)) +
-                   list(map(lambda x: f"--service={x}", enabled_services)) +
-                   list(map(lambda x: f"--remove-service={x}", disabled_services)),
-                   check=True)
+    if ports or enabled_services or disabled_services:
+        subprocess.run(["chroot",
+                        tree,
+                        "firewall-offline-cmd"] +
+                      list(map(lambda x: f"--port={x}", ports)) +
+                      list(map(lambda x: f"--service={x}", enabled_services)) +
+                      list(map(lambda x: f"--remove-service={x}", disabled_services)),
+                      check=True)
 
     return 0
 

--- a/test/data/stages/firewall/b.json
+++ b/test/data/stages/firewall/b.json
@@ -478,6 +478,12 @@
       {
         "name": "org.osbuild.firewall",
         "options": {
+          "default_zone": "trusted"
+        }
+      },
+      {
+        "name": "org.osbuild.firewall",
+        "options": {
           "ports": [
             "53:tcp",
             "88:udp"
@@ -488,8 +494,7 @@
           ],
           "disabled_services": [
             "telnet"
-          ],
-          "default_zone": "trusted"
+          ]
         }
       }
     ]

--- a/test/data/stages/firewall/b.mpp.json
+++ b/test/data/stages/firewall/b.mpp.json
@@ -32,6 +32,12 @@
       {
         "name": "org.osbuild.firewall",
         "options": {
+          "default_zone": "trusted"
+        }
+      },
+      {
+        "name": "org.osbuild.firewall",
+        "options": {
           "ports": [
             "53:tcp",
             "88:udp"
@@ -42,8 +48,7 @@
           ],
           "disabled_services": [
             "telnet"
-          ],
-          "default_zone": "trusted"
+          ]
         }
       }
     ]


### PR DESCRIPTION
When the firewall stage is provided with stage options, which set only
the default firewall zone, the `firewall-offline-cmd` command is
executed unconditionally without any parameters. This is because in this
case `ports`, `enabled_services` and `disabled_services` are all an
empty lists. This results in a failure with the following error message:

`Opening of '/etc/sysconfig/system-config-firewall' failed, exiting.`

Make sure that the second invocation of `firewall-offline-cmd` happens
conditionally, only when at least one of the `ports`, `enabled_services`
or `disabled_services` is a non-empty list.

Adjust the stage test to cover this scenario.

Signed-off-by: Tomas Hozza <thozza@redhat.com>