### PR TITLE
stages: fix ostree config stage

### DIFF
--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -63,13 +63,13 @@ def ostree(*args, _input=None, **kwargs):
 
 def main(tree, options):
     repo = os.path.join(tree, options["repo"].lstrip("/"))
-    config = options["config"]
+    sysroot_options = options["config"]["sysroot"]
 
-    for group, items in config.items():
-        for key, value in items.items():
-            name = f"{group}.{key}"
-            ostree("config", "set", name, str(value),
-                   repo=repo)
+    ostree("config", "set", "sysroot.bootloader", sysroot_options["bootloader"],
+          repo=repo)
+
+    ostree("config", "set", "sysroot.readonly", str(sysroot_options["readonly"]).lower(),
+          repo=repo)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently we're using `str(value)` on a boolean which yields `True` or
`False` - turns out ostree reads these values case sensitive and despite
setting `True|False`, it doesn't just work.

From jlebon on slack:

> the syntax is readonly=true . it's case sensitive

Fix the above and also just remove the loop as, while it's handy, we'll
have to differentiate between options' values anyway and it's just two
options we support today.

This is what we have on a deployed Rhel for edge system:

```
[admin@localhost ~]$ cat /sysroot/ostree/repo/config 
[core]
repo_version=1
mode=bare

[sysroot]
readonly=True
bootloader=none

[remote "rhel-edge"]
url=http://192.168.178.43:8090/repo/
gpg-verify=false
```

I also think we need to set `rw` at kernel command line too at this point - see also https://fedoraproject.org/wiki/Changes/Silverblue_Kinoite_readonly_sysroot

There's some sort of a migration story to implement also here:

- set/upgrade deployments to `rw` first
- switch `sysroot.readonly=true` at a later stage

@gicmo ptal

Signed-off-by: Antonio Murdaca <runcom@linux.com>