### PR TITLE
Packit: build SRPMs in Copr

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,6 +13,7 @@ copy_upstream_release_description: true
 
 upstream_tag_template: v{version}
 
+srpm_build_deps: []
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
 


### PR DESCRIPTION
Add srpm_build_deps key to the Packit configuration to specify the needed dependencies for SRPM build
and indicate to build SRPM in Copr.

If you are interested in the transition to building SRPMs in Copr, you can read more about it [here](https://packit.dev/posts/copr-srpms/).