### PR TITLE
stages/selinux: directly call setfilecon

### DIFF
--- a/osbuild/util/selinux.py
+++ b/osbuild/util/selinux.py
@@ -5,6 +5,9 @@ import subprocess
 
 from typing import Dict, TextIO
 
+# Extended attribute name for SELinux labels
+XATTR_NAME_SELINUX = b"security.selinux"
+
 
 def parse_config(config_file: TextIO):
     """Parse an SELinux configuration file"""
@@ -51,6 +54,6 @@ def setfiles(spec_file: str, root: str, *paths):
 
 def getfilecon(path: str) -> str:
     """Get the security context associated with `path`"""
-    label = os.getxattr(path, b"security.selinux",
+    label = os.getxattr(path, XATTR_NAME_SELINUX,
                         follow_symlinks=False)
     return label.decode().strip('\n\0')

--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -26,6 +26,7 @@ import subprocess
 import sys
 
 import osbuild.api
+from osbuild.util import selinux
 
 
 SCHEMA = """
@@ -60,7 +61,7 @@ def main(tree, options):
 
     for path, label in labels.items():
         fullpath = os.path.join(tree, path.lstrip("/"))
-        subprocess.run(["chcon", "-v", label, fullpath], check=True)
+        selinux.setfilecon(fullpath, label)
 
     if options.get("force_autorelabel", False):
         stamp = pathlib.Path(tree, ".autorelabel")

--- a/test/mod/test_util_selinux.py
+++ b/test/mod/test_util_selinux.py
@@ -3,40 +3,37 @@
 #
 
 import io
-import unittest
 
 from osbuild.util import selinux
 
 
-class TestObjectStore(unittest.TestCase):
+def test_selinux_config():
+    f = io.StringIO()
+    cfg = selinux.parse_config(f)
+    assert cfg is not None
+    policy = selinux.config_get_policy(cfg)
+    assert policy is None
 
-    def test_selinux_config(self):
-        f = io.StringIO()
-        cfg = selinux.parse_config(f)
-        self.assertIsNotNone(cfg)
-        policy = selinux.config_get_policy(cfg)
-        self.assertIsNone(policy)
+    example_good = """
+    # This file controls the state of SELinux on the system.
+    # SELINUX= can take one of these three values:
+    #     enforcing - SELinux security policy is enforced.
+    #     permissive - SELinux prints warnings instead of enforcing.
+    #     disabled - No SELinux policy is loaded.
+    SELINUX=enforcing
+    # SELINUXTYPE= can take one of these three values:
+    #     targeted - Targeted processes are protected,
+    #     minimum - Modification of targeted policy.
+    #     mls - Multi Level Security protection.
+    SELINUXTYPE=targeted
+    """
 
-        example_good = """
-        # This file controls the state of SELinux on the system.
-        # SELINUX= can take one of these three values:
-        #     enforcing - SELinux security policy is enforced.
-        #     permissive - SELinux prints warnings instead of enforcing.
-        #     disabled - No SELinux policy is loaded.
-        SELINUX=enforcing
-        # SELINUXTYPE= can take one of these three values:
-        #     targeted - Targeted processes are protected,
-        #     minimum - Modification of targeted policy.
-        #     mls - Multi Level Security protection.
-        SELINUXTYPE=targeted
-        """
+    f = io.StringIO(example_good)
+    cfg = selinux.parse_config(f)
+    assert 'SELINUX' in cfg
+    assert 'SELINUXTYPE' in cfg
+    assert cfg['SELINUX'] == 'enforcing'
+    assert cfg['SELINUXTYPE'] == 'targeted'
 
-        f = io.StringIO(example_good)
-        cfg = selinux.parse_config(f)
-        self.assertIn('SELINUX', cfg)
-        self.assertIn('SELINUXTYPE', cfg)
-        self.assertEqual(cfg['SELINUX'], 'enforcing')
-        self.assertEqual(cfg['SELINUXTYPE'], 'targeted')
-
-        policy = selinux.config_get_policy(cfg)
-        self.assertEqual(policy, 'targeted')
+    policy = selinux.config_get_policy(cfg)
+    assert policy == 'targeted'


### PR DESCRIPTION
Instead of using `chcon`, directly call `selinux.setfilecon`. On systems without SELinux support, i.e. coreutils was built without `<selinux.h>` present, `chcon` will return `ENOTSUP` for all selinux related calls like `setfilecon` even if the selinux libraries are later installed. Therefore we directly call the library function which should ensure that we don't error out as long as the library is present.  The only other thing `chcon` is doing besides a cal to the `setfilecon` method is to convert the context string to a `contex_t` and back to validate it. This should not be needed since the kernel will do this for us. On system without SELinux support `context_new` will also not validate the context.