### PR TITLE
Enable scheduled upstream releases

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,24 @@
+# This action creates a release every second Wednesday
+name: "Create and push release tag"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 13 * * 3"
+
+jobs:
+  tag-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Even or odd week
+        run: if [ `expr \`date +\%s\` / 86400 \% 2` -eq 0 ]; then echo "WEEK=odd" >> $GITHUB_ENV; else echo "WEEK=even" >> $GITHUB_ENV; fi
+        shell: bash
+
+      - name: Upstream tag
+        uses: osbuild/release-action@create-tag
+        if: ${{ env.WEEK == 'even' || github.event_name != 'schedule' }}
+        with:
+          token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
+          username: "imagebuilder-bot"
+          email: "imagebuilder-bots+imagebuilder-bot@redhat.com"


### PR DESCRIPTION
Instead of a human pushing a tag with the release notes let a bot do the
work.
The bot is part of our composite action in osbuild/release-action on the
create-tag branch. It calculates the next subsequent release version and
creates a tag based on pull request titles associated with the changes
since the last release.
Finally the tag is pushed to the repository.

Unfortunately GH Actions don't allow for reliably fortnightly schedules,
so we do an additional check that determines if this is an even or an
odd week. This will help with correctly scheduling alternating osbuild
and osbuild-composer releases.

For reference, we do exactly the same for osbuild-composer already:
https://github.com/osbuild/osbuild-composer/blob/main/.github/workflows/create-tag.yml

Here's the actual successful scheduled run of the pipeline:
https://github.com/osbuild/osbuild-composer/runs/5661954973?check_suite_focus=true