### PR TITLE
sources: refactor the SourceService class

### DIFF
--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -54,6 +54,10 @@ class SourceService(host.Service):
     def download(self, items, cache, options):
         pass
 
+    def setup(self, cache, content_type):
+        self.cache = os.path.join(cache, content_type)
+        os.makedirs(self.cache, exist_ok=True)
+
     def dispatch(self, method: str, args, fds):
         if method == "download":
             with os.fdopen(fds.steal(0)) as f:

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -55,6 +55,7 @@ class SourceService(host.Service):
         super().__init__(*args, **kwargs)
         self.cache = None
         self.options = None
+        self.tmpdir = None
 
     @abc.abstractmethod
     def download(self, items):
@@ -80,6 +81,7 @@ class SourceService(host.Service):
     def dispatch(self, method: str, args, fds):
         if method == "download":
             self.setup(args)
-            return self.download(SourceService.load_items(fds)), None
+            with tempfile.TemporaryDirectory(prefix=".unverified-", dir=self.cache) as self.tmpdir:
+                return self.download(SourceService.load_items(fds)), None
 
         raise host.ProtocolError("Unknown method")

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -3,6 +3,7 @@ import contextlib
 import os
 import json
 import tempfile
+from abc import abstractmethod
 
 from . import host
 from .objectstore import ObjectStore
@@ -54,12 +55,19 @@ class SourceService(host.Service):
     def download(self, items, cache, options):
         pass
 
-    def setup(self, cache, content_type):
-        self.cache = os.path.join(cache, content_type)
+    @property
+    @classmethod
+    @abstractmethod
+    def content_type(cls):
+        """The content type of the source."""
+
+    def setup(self, args):
+        self.cache = os.path.join(args["cache"], self.content_type)
         os.makedirs(self.cache, exist_ok=True)
 
     def dispatch(self, method: str, args, fds):
         if method == "download":
+            self.setup(args)
             with os.fdopen(fds.steal(0)) as f:
                 items = json.load(f)
 

--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -129,6 +129,24 @@ def rev_parse(repo: PathLike, ref: str) -> str:
     return msg
 
 
+def show(repo: PathLike, checksum: str) -> str:
+    """Show the metada of an OSTree object pointed by `checksum` in the repository at `repo`"""
+
+    repo = os.fspath(repo)
+
+    r = subprocess.run(["ostree", "show", f"--repo={repo}", checksum],
+                       encoding="utf-8",
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT,
+                       check=False)
+
+    msg = r.stdout.strip()
+    if r.returncode != 0:
+        raise RuntimeError(msg)
+
+    return msg
+
+
 def deployment_path(root: PathLike, osname: str, ref: str, serial: int):
     """Return the path to a deployment given the parameters"""
 

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -166,10 +166,8 @@ def download(items, cache):
 class CurlSource(sources.SourceService):
 
     def download(self, items, cache, _options):
-        cache = os.path.join(cache, "org.osbuild.files")
-        os.makedirs(cache, exist_ok=True)
-
-        download(items, cache)
+        self.setup(cache, "org.osbuild.files")
+        download(items, self.cache)
 
 
 def main():

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -13,8 +13,6 @@ up the download.
 """
 
 
-import concurrent.futures
-import itertools
 import os
 import subprocess
 import sys
@@ -83,92 +81,74 @@ SCHEMA = """
 """
 
 
-def fetch(url, checksum, directory):
-    secrets = url.get("secrets")
-    url_path = url.get("url")
-    # Download to a temporary directory until we have verified the checksum. Use a
-    # subdirectory, so we avoid copying across block devices.
-    with tempfile.TemporaryDirectory(prefix="osbuild-unverified-file-", dir=directory) as tmpdir:
-        # some mirrors are sometimes broken. retry manually, because we could be
-        # redirected to a different, working, one on retry.
-        return_code = 0
-        for _ in range(10):
-            curl_command = [
-                "curl",
-                "--silent",
-                "--speed-limit", "1000",
-                "--connect-timeout", "30",
-                "--fail",
-                "--location",
-                "--output", checksum,
-            ]
-            if secrets:
-                if secrets.get('ssl_ca_cert'):
-                    curl_command.extend(["--cacert", secrets.get('ssl_ca_cert')])
-                if secrets.get('ssl_client_cert'):
-                    curl_command.extend(["--cert", secrets.get('ssl_client_cert')])
-                if secrets.get('ssl_client_key'):
-                    curl_command.extend(["--key", secrets.get('ssl_client_key')])
-            # url must follow options
-            curl_command.append(url_path)
-
-            curl = subprocess.run(curl_command, encoding="utf-8", cwd=tmpdir, check=False)
-            return_code = curl.returncode
-            if return_code == 0:
-                break
-        else:
-            raise RuntimeError(f"curl: error downloading {url}: error code {return_code}")
-
-        if not verify_file(f"{tmpdir}/{checksum}", checksum):
-            raise RuntimeError(f"checksum mismatch: {checksum} {url}")
-
-        # The checksum has been verified, move the file into place. in case we race
-        # another download of the same file, we simply ignore the error as their
-        # contents are guaranteed to be  the same.
-        try:
-            os.rename(f"{tmpdir}/{checksum}", f"{directory}/{checksum}")
-        except FileExistsError:
-            pass
-
-
-def download(items, cache):
-    with concurrent.futures.ProcessPoolExecutor(max_workers=4) as executor:
-        requested_urls = []
-        requested_checksums = []
-        subscriptions = None
-
-        for (checksum, url) in items.items():
-
-            # Invariant: all files in @directory must be named after their (verified) checksum.
-            # Check this before secrets so that if everything is pre-downloaded we don't need secrets
-            if os.path.isfile(f"{cache}/{checksum}"):
-                continue
-
-            if not isinstance(url, dict):
-                url = {"url": url}
-
-            # check if url needs rhsm secrets
-            if url.get("secrets", {}).get("name") == "org.osbuild.rhsm":
-                # rhsm secrets only need to be retrieved once and can then be reused
-                if subscriptions is None:
-                    subscriptions = Subscriptions.from_host_system()
-                url["secrets"] = subscriptions.get_secrets(url.get("url"))
-
-            requested_urls.append(url)
-            requested_checksums.append(checksum)
-
-        results = executor.map(fetch, requested_urls, requested_checksums, itertools.repeat(cache))
-
-        for _ in results:
-            pass
-
-
 class CurlSource(sources.SourceService):
 
     content_type = "org.osbuild.files"
+    max_workers = 4
 
-    def download(self, items):
-        download(items, self.cache)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.subscriptions = None
+
+    def transform(self, checksum, desc):
+        url = desc
+        if not isinstance(url, dict):
+            url = {"url": url}
+
+        # check if url needs rhsm secrets
+        if url.get("secrets", {}).get("name") == "org.osbuild.rhsm":
+            # rhsm secrets only need to be retrieved once and can then be reused
+            if self.subscriptions is None:
+                self.subscriptions = Subscriptions.from_host_system()
+            url["secrets"] = self.subscriptions.get_secrets(url.get("url"))
+        return checksum, url
+
+    def fetch_one(self, checksum, desc):
+        secrets = desc.get("secrets")
+        url = desc.get("url")
+        # Download to a temporary sub cache until we have verified the checksum. Use a
+        # subdirectory, so we avoid copying across block devices.
+        with tempfile.TemporaryDirectory(prefix="osbuild-unverified-file-", dir=self.cache) as tmpdir:
+            # some mirrors are sometimes broken. retry manually, because we could be
+            # redirected to a different, working, one on retry.
+            return_code = 0
+            for _ in range(10):
+                curl_command = [
+                    "curl",
+                    "--silent",
+                    "--speed-limit", "1000",
+                    "--connect-timeout", "30",
+                    "--fail",
+                    "--location",
+                    "--output", checksum,
+                ]
+                if secrets:
+                    if secrets.get('ssl_ca_cert'):
+                        curl_command.extend(["--cacert", secrets.get('ssl_ca_cert')])
+                    if secrets.get('ssl_client_cert'):
+                        curl_command.extend(["--cert", secrets.get('ssl_client_cert')])
+                    if secrets.get('ssl_client_key'):
+                        curl_command.extend(["--key", secrets.get('ssl_client_key')])
+                # url must follow options
+                curl_command.append(url)
+
+                curl = subprocess.run(curl_command, encoding="utf-8", cwd=tmpdir, check=False)
+                return_code = curl.returncode
+                if return_code == 0:
+                    break
+            else:
+                raise RuntimeError(f"curl: error downloading {url}: error code {return_code}")
+
+            if not verify_file(f"{tmpdir}/{checksum}", checksum):
+                raise RuntimeError(f"checksum mismatch: {checksum} {url}")
+
+            # The checksum has been verified, move the file into place. in case we race
+            # another download of the same file, we simply ignore the error as their
+            # contents are guaranteed to be  the same.
+            try:
+                os.rename(f"{tmpdir}/{checksum}", f"{self.cache}/{checksum}")
+            except FileExistsError:
+                pass
 
 
 def main():

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -165,8 +165,9 @@ def download(items, cache):
 
 class CurlSource(sources.SourceService):
 
-    def download(self, items, cache, _options):
-        self.setup(cache, "org.osbuild.files")
+    content_type = "org.osbuild.files"
+
+    def download(self, items, _cache, _options):
         download(items, self.cache)
 
 

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -167,7 +167,7 @@ class CurlSource(sources.SourceService):
 
     content_type = "org.osbuild.files"
 
-    def download(self, items, _cache, _options):
+    def download(self, items):
         download(items, self.cache)
 
 

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -15,9 +15,6 @@ import base64
 import contextlib
 import os
 import sys
-import tempfile
-
-from typing import Dict
 
 from osbuild import sources
 from osbuild.util.checksum import verify_file
@@ -56,15 +53,18 @@ SCHEMA = """
 """
 
 
-def process(items: Dict, cache: str, tmpdir):
-    for checksum, item in items.items():
-        target = os.path.join(cache, checksum)
-        floating = os.path.join(tmpdir, checksum)
+class InlineSource(sources.SourceService):
+
+    content_type = "org.osbuild.files"
+
+    def fetch_one(self, checksum, desc):
+        target = os.path.join(self.cache, checksum)
+        floating = os.path.join(self.tmpdir, checksum)
 
         if os.path.isfile(target):
             return
 
-        data = base64.b64decode(item["data"])
+        data = base64.b64decode(desc["data"])
 
         # Write the bits to disk and then verify the checksum
         # This ensures that 1) the data is ok and that 2) we
@@ -73,18 +73,10 @@ def process(items: Dict, cache: str, tmpdir):
             f.write(data)
 
         if not verify_file(floating, checksum):
-            raise RuntimeError("Checksum mismatch for {}".format(checksum))
+            raise RuntimeError(f"Checksum mismatch for {format(checksum)}")
 
         with contextlib.suppress(FileExistsError):
             os.rename(floating, target)
-
-
-class InlineSource(sources.SourceService):
-
-    content_type = "org.osbuild.files"
-
-    def download(self, items):
-        process(items, self.cache, self.tmpdir)
 
 
 def main():

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -82,11 +82,9 @@ def process(items: Dict, cache: str, tmpdir):
 class InlineSource(sources.SourceService):
 
     def download(self, items, cache, _options):
-        cache = os.path.join(cache, "org.osbuild.files")
-        os.makedirs(cache, exist_ok=True)
-
+        self.setup(cache, "org.osbuild.files")
         with tempfile.TemporaryDirectory(prefix=".unverified-", dir=cache) as tmpdir:
-            process(items, cache, tmpdir)
+            process(items, self.cache, tmpdir)
 
 
 def main():

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -84,8 +84,7 @@ class InlineSource(sources.SourceService):
     content_type = "org.osbuild.files"
 
     def download(self, items):
-        with tempfile.TemporaryDirectory(prefix=".unverified-", dir=self.cache) as tmpdir:
-            process(items, self.cache, tmpdir)
+        process(items, self.cache, self.tmpdir)
 
 
 def main():

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -81,9 +81,10 @@ def process(items: Dict, cache: str, tmpdir):
 
 class InlineSource(sources.SourceService):
 
-    def download(self, items, cache, _options):
-        self.setup(cache, "org.osbuild.files")
-        with tempfile.TemporaryDirectory(prefix=".unverified-", dir=cache) as tmpdir:
+    content_type = "org.osbuild.files"
+
+    def download(self, items, _cache, _options):
+        with tempfile.TemporaryDirectory(prefix=".unverified-", dir=self.cache) as tmpdir:
             process(items, self.cache, tmpdir)
 
 

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -83,7 +83,7 @@ class InlineSource(sources.SourceService):
 
     content_type = "org.osbuild.files"
 
-    def download(self, items, _cache, _options):
+    def download(self, items):
         with tempfile.TemporaryDirectory(prefix=".unverified-", dir=self.cache) as tmpdir:
             process(items, self.cache, tmpdir)
 

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -114,8 +114,9 @@ def download(items, cache):
 
 class OSTreeSource(sources.SourceService):
 
-    def download(self, items, cache, _options):
-        self.setup(cache, "org.osbuild.ostree")
+    content_type = "org.osbuild.ostree"
+
+    def download(self, items, _cache, _options):
 
         download(items, self.cache)
 

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -116,7 +116,7 @@ class OSTreeSource(sources.SourceService):
 
     content_type = "org.osbuild.ostree"
 
-    def download(self, items, _cache, _options):
+    def download(self, items):
 
         download(items, self.cache)
 

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -11,6 +11,7 @@ import os
 import sys
 import subprocess
 import uuid
+from osbuild.util.ostree import show
 
 from osbuild import sources
 
@@ -122,8 +123,12 @@ class OSTreeSource(sources.SourceService):
         ostree("config", "set", "repo.locking", "true", repo=self.repo)
 
     # pylint: disable=[no-self-use]
-    def exists(self, _checksum, _item):
-        return False
+    def exists(self, checksum, _desc):
+        try:
+            show(self.repo, checksum)
+        except RuntimeError:
+            return False
+        return True
 
 
 def main():

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -74,18 +74,17 @@ def ostree(*args, _input=None, **kwargs):
                    check=True)
 
 
-def download(items, cache):
-    # Prepare the cache and the output repo
-    repo_cache = os.path.join(cache, "repo")
-    ostree("init", mode="archive", repo=repo_cache)
+class OSTreeSource(sources.SourceService):
 
-    # Make sure the cache repository uses locks to protect the metadata during
-    # shared access. This is the default since `2018.5`, but lets document this
-    # explicitly here.
-    ostree("config", "set", "repo.locking", "true", repo=repo_cache)
+    content_type = "org.osbuild.ostree"
 
-    for commit, item in items.items():
-        remote = item["remote"]
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.repo = None
+
+    def fetch_one(self, checksum, desc):
+        commit = checksum
+        remote = desc["remote"]
         url = remote["url"]
         gpg = remote.get("gpgkeys", [])
         uid = str(uuid.uuid4())
@@ -97,28 +96,34 @@ def download(items, cache):
         ostree("remote", "add",
                uid, url,
                *verify_args,
-               repo=repo_cache)
+               repo=self.repo)
 
         for key in gpg:
             ostree("remote", "gpg-import", "--stdin", uid,
-                   repo=repo_cache, _input=key)
+                   repo=self.repo, _input=key)
 
         # Transfer the commit: remote → cache
         print(f"pulling {commit}", file=sys.stderr)
-        ostree("pull", uid, commit, repo=repo_cache)
+        ostree("pull", uid, commit, repo=self.repo)
 
         # Remove the temporary remotes again
         ostree("remote", "delete", uid,
-               repo=repo_cache)
+               repo=self.repo)
 
+    def setup(self, args):
+        super().setup(args)
+        # Prepare the cache and the output repo
+        self.repo = os.path.join(self.cache, "repo")
+        ostree("init", mode="archive", repo=self.repo)
 
-class OSTreeSource(sources.SourceService):
+        # Make sure the cache repository uses locks to protect the metadata during
+        # shared access. This is the default since `2018.5`, but lets document this
+        # explicitly here.
+        ostree("config", "set", "repo.locking", "true", repo=self.repo)
 
-    content_type = "org.osbuild.ostree"
-
-    def download(self, items):
-
-        download(items, self.cache)
+    # pylint: disable=[no-self-use]
+    def exists(self, _checksum, _item):
+        return False
 
 
 def main():

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -115,10 +115,9 @@ def download(items, cache):
 class OSTreeSource(sources.SourceService):
 
     def download(self, items, cache, _options):
-        cache = os.path.join(cache, "org.osbuild.ostree")
-        os.makedirs(cache, exist_ok=True)
+        self.setup(cache, "org.osbuild.ostree")
 
-        download(items, cache)
+        download(items, self.cache)
 
 
 def main():

--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -118,8 +118,9 @@ def download(items, cache):
 
 class SkopeoSource(sources.SourceService):
 
-    def download(self, items, cache, _options):
-        self.setup(cache, "org.osbuild.containers")
+    content_type = "org.osbuild.containers"
+
+    def download(self, items, _cache, _options):
 
         download(items, self.cache)
 

--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -120,7 +120,7 @@ class SkopeoSource(sources.SourceService):
 
     content_type = "org.osbuild.containers"
 
-    def download(self, items, _cache, _options):
+    def download(self, items):
 
         download(items, self.cache)
 

--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -64,18 +64,18 @@ SCHEMA = """
 """
 
 
-def download(items, cache):
-    for image_id, item in items.items():
-        image = item["image"]
+class SkopeoSource(sources.SourceService):
+
+    content_type = "org.osbuild.containers"
+
+    def fetch_one(self, checksum, desc):
+        image_id = checksum
+        image = desc["image"]
         imagename = image["name"]
         digest = image["digest"]
         tls_verify = image.get("tls-verify", True)
 
-        path = f"{cache}/{image_id}"
-        if os.path.isdir(path):
-            continue
-
-        with tempfile.TemporaryDirectory(prefix="tmp-download-", dir=cache) as tmpdir:
+        with tempfile.TemporaryDirectory(prefix="tmp-download-", dir=self.cache) as tmpdir:
             archive_path = os.path.join(tmpdir, "container-image.tar")
 
             source = f"docker://{imagename}@{digest}"
@@ -113,16 +113,7 @@ def download(items, cache):
             # Atomically move download dir into place on successful download
             os.chmod(tmpdir, 0o755)
             with ctx.suppress_oserror(errno.ENOTEMPTY, errno.EEXIST):
-                os.rename(tmpdir, path)
-
-
-class SkopeoSource(sources.SourceService):
-
-    content_type = "org.osbuild.containers"
-
-    def download(self, items):
-
-        download(items, self.cache)
+                os.rename(tmpdir, f"{self.cache}/{image_id}")
 
 
 def main():

--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -119,10 +119,9 @@ def download(items, cache):
 class SkopeoSource(sources.SourceService):
 
     def download(self, items, cache, _options):
-        cache = os.path.join(cache, "org.osbuild.containers")
-        os.makedirs(cache, exist_ok=True)
+        self.setup(cache, "org.osbuild.containers")
 
-        download(items, cache)
+        download(items, self.cache)
 
 
 def main():

--- a/test/mod/test_util_ostree.py
+++ b/test/mod/test_util_ostree.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import tempfile
 import unittest
+import pytest
 
 from osbuild.util import ostree
 
@@ -22,7 +23,7 @@ def run(*args, check=True, encoding="utf-8", **kwargs):
     return res
 
 
-class TestObjectStore(unittest.TestCase):
+class TestObjectStore(test.TestBase):
 
     # pylint: disable=no-self-use
     @unittest.skipUnless(test.TestBase.have_rpm_ostree(), "rpm-ostree missing")
@@ -87,6 +88,13 @@ class TestObjectStore(unittest.TestCase):
 
         for p, v in params.items():
             self.assertEqual(v, js[p])
+
+    @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
+    def test_show_commit(self):
+        repo_path = os.path.join(self.locate_test_data(), "sources/org.osbuild.ostree/data/repo")
+        ostree.show(repo_path, "d6243b0d0ca3dc2aaef2e0eb3e9f1f4836512c2921007f124b285f7c466464d8")
+        with pytest.raises(RuntimeError):
+            ostree.show(repo_path, "f000000000000000000000000DEADBEEF000000000000000000000000000000f")
 
 
 class TestPasswdLike(unittest.TestCase):


### PR DESCRIPTION
This refactor integrate the download method into `SourceService` in order to simplify the code base on all the sub downloading programs. The API now requires each downloading program to define a method named `fetch_one`. The objective of this method is to execute the proper downloading of a single element.

The generalization process has let us define a better workflow to perform the downloading. The workdfow is:

Setup -> Filter -> Prepare -> Download.

* Setup initializes the cache
* Filter checks if elements are already in it
* Prepare amends the input data to include things like subscriptions
* Download calls fetch_one for each element.

The overloading class in the sub program has the ability of customizing each step of the workflow.
To customize the filtering it can overload the `exits` method. Which is done by the `ostree` program.
To customize the preparation step, it can overload the `transform` method. Which is done by the `curl` program.

The downloading can be run either in sequence or in parallel. Choosing one or the other is done by the changing of a class parameter `max_workers`


```mermaid
classDiagram
    direction TB
    class SourceService{
        +content_type
        +max_workers = 1
        +fetch_one(checsum, desc)
        +exists(chechsum, desc)
        +transform(checsum, desc)
        -download(items)
        +dispatch()
        +setup()
    }
    <<abstract>> SourceService

    SourceService <|-- CurlSource
    class CurlSource{
        +content_type = "org.osbuild.files" 
        +max_workers = 4
        +fetch_one(checsum, desc)
        +transform(checsum, desc)
    }

    SourceService <|-- InlineSource
    class InlineSource{
        +content_type = "org.osbuild.files"
        +fetch_one(checsum, desc)
    }

    SourceService <|-- OstreeSource
    class OstreeSource{
        +content_type = "org.osbuild.ostree"
        +fetch_one(checsum, desc)
        +setup()
        +exists(chechsum, desc)
    }

    SourceService <|-- SkopeoSource
    class SkopeoSource{
        +content_type = "org.osbuild.containers"
        +fetch_one(checsum, desc)
    }
```