### PR TITLE
Pin rpmrepo snapshots for CI runners + use them in mockbuild + ci improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,10 +5,17 @@ stages:
   - finish
 
 .terraform:
+  before_script:
+    - schutzbot/ci_details.sh > ci-details-before-run
   after_script:
+    - schutzbot/ci_details.sh > ci-details-after-run
     - schutzbot/update_github_status.sh update
   tags:
     - terraform
+  artifacts:
+    paths:
+      - ci-details-before-run
+      - ci-details-after-run
 
 init:
   stage: init

--- a/Schutzfile
+++ b/Schutzfile
@@ -1,0 +1,324 @@
+{
+  "fedora-34": {
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/fedora.repo",
+        "x86_64": [
+          {
+            "title": "fedora",
+            "name": "fedora",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "fedora",
+            "name": "fedora",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-20210512"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-modular.repo",
+        "x86_64": [
+          {
+            "title": "fedora-modular",
+            "name": "fedora-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-modular-20210512"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "fedora-modular",
+            "name": "fedora-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-fedora-modular-20210512"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates.repo",
+        "x86_64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-20220330"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-20220330"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates-modular.repo",
+        "x86_64": [
+          {
+            "title": "updates-modular",
+            "name": "updates-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-updates-released-modular-20220330"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates-modular",
+            "name": "updates-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-aarch64-updates-released-modular-20220330"
+          }
+        ]
+      }
+    ]
+  },
+  "fedora-35": {
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/fedora.repo",
+        "x86_64": [
+          {
+            "title": "fedora",
+            "name": "fedora",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "fedora",
+            "name": "fedora",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-modular.repo",
+        "x86_64": [
+          {
+            "title": "fedora-modular",
+            "name": "fedora-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-modular-20220106"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "fedora-modular",
+            "name": "fedora-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-modular-20220106"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates.repo",
+        "x86_64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220330"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220330"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates-modular.repo",
+        "x86_64": [
+          {
+            "title": "updates-modular",
+            "name": "updates-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-modular-20220330"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates-modular",
+            "name": "updates-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-modular-20220330"
+          }
+        ]
+      }
+    ]
+  },
+  "rhel-8.6": {
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/rhel8internal.repo",
+        "x86_64": [
+          {
+            "title": "RHEL-8-RPMREPO-NIGHTLY-BaseOS",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220301"
+          },
+          {
+            "title": "RHEL-8-RPMREPO-NIGHTLY-AppStream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220301"
+          },
+          {
+            "title": "RHEL-8-RPMREPO-NIGHTLY-CRB",
+            "name": "crb",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-crb-n8.6-20220301"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "RHEL-8-RPMREPO-NIGHTLY-BaseOS",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.6-20220301"
+          },
+          {
+            "title": "RHEL-8-RPMREPO-NIGHTLY-AppStream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220301"
+          },
+          {
+            "title": "RHEL-8-RPMREPO-NIGHTLY-CRB",
+            "name": "crb",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-crb-n8.6-20220301"
+          }
+        ]
+      }
+    ]
+  },
+  "rhel-9.0": {
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/rhel9internal.repo",
+        "x86_64": [
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-BaseOS",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220301"
+          },
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-AppStream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220301"
+          },
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-CRB",
+            "name": "crb",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-crb-n9.0-20220301"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-BaseOS",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.0-20220301"
+          },
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-AppStream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220301"
+          },
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-CRB",
+            "name": "crb",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-crb-n9.0-20220301"
+          }
+        ]
+      }
+    ]
+  },
+  "centos-stream-9": {
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/centos.repo",
+        "x86_64": [
+          {
+            "title": "baseos",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20220330"
+          },
+          {
+            "title": "appstream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20220330"
+          },
+          {
+            "title": "crb",
+            "name": "crb",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-crb-20220330"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "baseos",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20220330"
+          },
+          {
+            "title": "appstream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-appstream-20220330"
+          },
+          {
+            "title": "crb",
+            "name": "crb",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-crb-20220330"
+          }
+        ]
+      }
+    ]
+  },
+  "centos-stream-8": {
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/CentOS-Stream-BaseOS.repo",
+        "x86_64": [
+          {
+            "title": "baseos",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-baseos-20220322"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "baseos",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-baseos-20220322"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/CentOS-Stream-AppStream.repo",
+        "x86_64": [
+          {
+            "title": "appstream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220322"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "appstream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220322"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/CentOS-Stream-PowerTools.repo",
+        "x86_64": [
+          {
+            "title": "powertools",
+            "name": "powertools",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-powertools-20220330"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "powertools",
+            "name": "powertoosl",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-powertools-20220330"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/schutzbot/ci_details.sh
+++ b/schutzbot/ci_details.sh
@@ -8,6 +8,9 @@ CPUS=$(nproc)
 MEM=$(free -m | grep -oP '\d+' | head -n 1)
 DISK=$(df --output=size -h / | sed '1d;s/[^0-9]//g')
 HOSTNAME=$(uname -n)
+USER=$(whoami)
+ARCH=$(uname -m)
+KERNEL=$(uname -r)
 
 echo -e "\033[0;36m"
 cat << EOF
@@ -16,16 +19,24 @@ CI MACHINE SPECS
 ------------------------------------------------------------------------------
 
      Hostname: ${HOSTNAME}
+         User: ${USER}
    Primary IP: ${PRIMARY_IP}
   External IP: ${EXTERNAL_IP}
   Reverse DNS: ${PTR}
          CPUs: ${CPUS}
           RAM: ${MEM} GB
          DISK: ${DISK} GB
+         ARCH: ${ARCH}
+       KERNEL: ${KERNEL}
 
 ------------------------------------------------------------------------------
 EOF
 echo -e "\033[0m"
+
+echo "List of system repositories:"
+yum repolist -v
+
+echo "------------------------------------------------------------------------------"
 
 echo "List of installed packages:"
 rpm -qa | sort

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -37,8 +37,7 @@ function template_override {
 }
 
 # Get OS and architecture details.
-source /etc/os-release
-ARCH=$(uname -m)
+source tools/set-env-variables.sh
 
 # Register RHEL if we are provided with a registration script and intend to do that.
 REGISTER="${REGISTER:-'false'}"

--- a/tools/set-env-variables.sh
+++ b/tools/set-env-variables.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# don't error on unused ARCH and DISTRO_CODE variables
+# shellcheck disable=SC2034
+
+source /etc/os-release
+ARCH=$(uname -m)
+DISTRO_CODE="${DISTRO_CODE:-${ID}-${VERSION_ID//./}}"


### PR DESCRIPTION
Adding Schutzfile to enable system repo pinning and using them in mockbuild.
Adding `set-env-variables.sh` script
Updating `ci-details.sh` and running it in CI.