### PR TITLE
workflows/trigger-gitlab: run Gitlab CI in new image-builder project

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
-      SCHUTZBOT_SSH_KEY: ${{ secrets.SCHUTZBOT_SSH_KEY }}
+      IMAGEBUILDER_BOT_GITLAB_SSH_KEY: ${{ secrets.IMAGEBUILDER_BOT_GITLAB_SSH_KEY }}
     steps:
       - name: Report status
         uses: haya14busa/action-workflow_run-status@v1
@@ -52,9 +52,9 @@ jobs:
       - name: Push to gitlab
         run: |
           mkdir -p ~/.ssh
-          echo "${SCHUTZBOT_SSH_KEY}" > ~/.ssh/id_rsa
+          echo "${IMAGEBUILDER_BOT_GITLAB_SSH_KEY}" > ~/.ssh/id_rsa
           chmod 400 ~/.ssh/id_rsa
           touch ~/.ssh/known_hosts
           ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
-          git remote add ci git@gitlab.com:osbuild/ci/osbuild.git
+          git remote add ci git@gitlab.com:redhat/services/products/image-builder/ci/osbuild.git
           git push -f ci


### PR DESCRIPTION
We have a new project in Gitlab
https://gitlab.com/redhat/services/products/image-builder/ci/osbuild
and we want to run the CI there instead.