### PR TITLE
Support specifying multiple devices in all mkfs versions (like xfs)

### DIFF
--- a/stages/org.osbuild.mkfs.btrfs
+++ b/stages/org.osbuild.mkfs.btrfs
@@ -18,7 +18,7 @@ import osbuild.api
 SCHEMA_2 = r"""
 "devices": {
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["device"],
   "properties": {
     "device": {

--- a/stages/org.osbuild.mkfs.ext4
+++ b/stages/org.osbuild.mkfs.ext4
@@ -18,7 +18,7 @@ import osbuild.api
 SCHEMA_2 = r"""
 "devices": {
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["device"],
   "properties": {
     "device": {

--- a/stages/org.osbuild.mkfs.fat
+++ b/stages/org.osbuild.mkfs.fat
@@ -18,7 +18,7 @@ import osbuild.api
 SCHEMA_2 = r"""
 "devices": {
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["device"],
   "properties": {
     "device": {


### PR DESCRIPTION
mkfs.xfs already has `additionalProperties: true` for the devices
section, as this is necessary for example when creating lvm2 setups.
This should be possible for other filesystem types too.