### PR TITLE
buildroot: don't explicitly add `CAP_MAC_ADMIN`

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -265,7 +265,6 @@ class BuildRoot(contextlib.AbstractContextManager):
 
         cmd = [
             "bwrap",
-            "--cap-add", "CAP_MAC_ADMIN",
             "--chdir", "/",
             "--die-with-parent",
             "--new-session",


### PR DESCRIPTION
This is a left-over from the time when `systemd-nspawn` was used, which only retained a limited set of capabilities which did not include `CAP_MAC_ADMIN`[1]. Bubblewrap, on the other hand, retains all currently capabilities if the process is run as root[2].

[1] see e.g. [src/nspawn/nspawn.c#L147](https://github.com/systemd/systemd/blob/c52950c292be639aec38f9a5db1681005203c2cd/src/nspawn/nspawn.c#L147) of commit c52950c
[2] see commit [abc56644566a6095bb72a5bf70fcee7dd90e9447](https://github.com/containers/bubblewrap/commit/abc56644566a6095bb72a5bf70fcee7dd90e9447)