### PR TITLE
org.osbuild.luks2.format: Support dm-integrity

### DIFF
--- a/stages/org.osbuild.luks2.format
+++ b/stages/org.osbuild.luks2.format
@@ -115,6 +115,9 @@ SCHEMA_2 = r"""
     "sector-size": {
       "description": "Sector size to use",
       "type": "integer"
+    },
+    "integrity": {
+      "enum": ["hmac-sha256"]
     }
   }
 }
@@ -128,6 +131,7 @@ def main(devices, options):
     pbkdf = options["pbkdf"]
     cipher = options.get("cipher")
     label = options.get("label")
+    integrity = options.get("integrity")
     subsystem = options.get("subsystem", "")
     sector_size = options.get("sector-size")
     path = os.path.join("/dev", device["path"])
@@ -149,6 +153,9 @@ def main(devices, options):
 
     if sector_size:
         command += ["--sector-size", str(sector_size)]
+
+    if integrity:
+        command += ["--integrity", integrity]
 
     # password base key derivation function parameters
     command += [


### PR DESCRIPTION
I've been looking at:
  https://archive.fosdem.org/2018/schedule/event/cryptsetup/attachments/slides/2506/export/events/attachments/cryptsetup/slides/2506/fosdem18_cryptsetup_aead.pdf

And it seems if you want integrity checking, dm-crypt is not enough,
but should be combined with dm-integrity. This allows this by using
the --integrity option with cryptsetup.

It should be noted that the slides above mention that this is marked
experimental in the docs because the existing algorithms usable for
this is a bit slow. Something to be aware of if you want to use this.