### PR TITLE
Re-enable pylint warning W0201 (attribute-defined-outside-init)

### DIFF
--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -353,6 +353,7 @@ class Loop:
             unchanged (default is None)
         """
 
+        #  pylint: disable=attribute-defined-outside-init
         info = self.get_status()
         if offset:
             info.lo_offset = offset

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -91,6 +91,11 @@ class LogMonitor(BaseMonitor):
     the log will get written to. If `fd`  is a `TTY`, escape
     sequences will be used to highlight sections of the log.
     """
+
+    def __init__(self, fd: int):
+        super().__init__(fd)
+        self.timer_start = 0
+
     def result(self, result):
         duration = int(time.time() - self.timer_start)
         self.out.write(f"\n⏱  Duration: {duration}s\n")

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -25,6 +25,7 @@ BOLD = "\033[1m"
 
 class TextWriter:
     """Helper class for writing text to file descriptors"""
+
     def __init__(self, fd: int):
         self.fd = fd
         self.isatty = os.isatty(fd)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pylint.MASTER]
-disable=missing-docstring,too-few-public-methods,invalid-name,duplicate-code,superfluous-parens,too-many-locals,attribute-defined-outside-init,too-many-arguments,consider-using-with,consider-using-from-import
+disable=missing-docstring,too-few-public-methods,invalid-name,duplicate-code,superfluous-parens,too-many-locals,too-many-arguments,consider-using-with,consider-using-from-import
 
 [pylint.TYPECHECK]
 ignored-classes=osbuild.loop.LoopInfo

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -27,6 +27,7 @@ class TapeMonitor(osbuild.monitor.BaseMonitor):
         self.asm = None
         self.results = set()
         self.logger = io.StringIO()
+        self.output = None
 
     def begin(self, pipeline: osbuild.Pipeline):
         self.counter["begin"] += 1


### PR DESCRIPTION
This was disabled globally due to `LoopInfo` and its dynamic attributes and thus some actual issues found their way into the code base. Fix those and silence the `LoopInfo` false positive locally; then re-enable the warning globally.