### PR TITLE
packit: Enable Koji build integration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,7 +17,6 @@ srpm_build_deps: []
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
 
-create_pr: false
 jobs:
 - job: copr_build
   trigger: pull_request
@@ -52,6 +51,11 @@ jobs:
     - fedora-all
 - job: propose_downstream
   trigger: release
+  metadata:
+    dist_git_branches:
+      - fedora-all
+- job: koji_build
+  trigger: commit
   metadata:
     dist_git_branches:
       - fedora-all


### PR DESCRIPTION
Packit has recently added integration for running builds on Koji. This job is triggered each time a spec-file change is detected in a new commit in dist-git.
For the time being, this change can be merged and can co-exist with our [fedora-bot](https://github.com/osbuild/fedora-bot) implementation.
Once the same change is merged into the koji-osbuild and osbuild repos as well we can drop it from fedora-bot and update our documentation.

Also drop the `create_pr` option, which was removed by Packit.

As soon as the https://github.com/packit/packit-service/issues/1413 is fixed, I would like to also enable the bodhi integration. In the meantime it will just create issues in our GitHub project and ping us a lot on every upstream release so I consciously left it out.

Related PR for composer: https://github.com/osbuild/osbuild-composer/pull/2626