### PR TITLE
meta: show stage name when schema is missing

### DIFF
--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -232,7 +232,13 @@ class Schema:
             return res
 
         if not self.data:
-            res.fail("missing schema information")
+            msg = "could not find schema information"
+
+            if self.name:
+                msg += f" for '{self.name}'"
+
+            res.fail(msg)
+
             return res
 
         try:


### PR DESCRIPTION
Show the stage name (if one is set) when failing the stage in the
validator. This closes #1007, example output:

```
€ python3 -m osbuild supakeen-os.json
supakeen-os.json has errors:

pipelines[0].stages[0]
  could not find schema information for 'org.osbuild.rpmb'

  .pipelines[0].stages[0].inputs.packages:
    could not find schema information for 'org.osbuild.filesz'
```