### PR TITLE
sources: curl max_workers 2 * num_cpus

### DIFF
--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -84,7 +84,7 @@ SCHEMA = """
 class CurlSource(sources.SourceService):
 
     content_type = "org.osbuild.files"
-    max_workers = 4
+    max_workers = 2 * os.cpu_count()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
This changes the curl source to use the number of cpus times two for its thread count. A conservative number but a commonly used default.

Tiny benchmark on my system (with 8 logical cores, so 16 workers):

```
user@desktopa osbuild € rm -rf .osbuild && time osbuild samples/fedora-container.json
...
osbuild samples/fedora-container.json  47.03s user 3.09s system 41% cpu 2:01.47 total
user@desktopa osbuild € rm -rf .osbuild && time osbuild samples/fedora-container.json
...
osbuild samples/fedora-container.json  42.64s user 2.35s system 147% cpu 30.569 total
```

There's room for discussion on the multiplier, I went with two because while the curl processes are waiting a bunch for network I/O the fork+exec (or posix_spawn) actions are still CPU intensive and happen a lot.