### PR TITLE
stages/udev.rules: use correct separator

### DIFF
--- a/stages/org.osbuild.udev.rules
+++ b/stages/org.osbuild.udev.rules
@@ -288,7 +288,7 @@ def make_rule(data: dict):
 
 
 def write_rule(f, rule: list):
-    data = " ".join(make_rule(rule))
+    data = ", ".join(make_rule(rule))
     f.write(data + "\n")
 
 


### PR DESCRIPTION
The key-value-operator expressions should separated by comma not space. Fix this.