### PR TITLE
fmt: separate manifest validation from result fmt

### DIFF
--- a/osbuild/formats/json.py
+++ b/osbuild/formats/json.py
@@ -1,0 +1,136 @@
+"""Legacy JSON formatting for output
+
+Will output mostly json
+"""
+import json
+import sys
+from typing import Dict
+from ..pipeline import Manifest
+
+FORMAT_KIND = ["OUT"]
+VERSION = "json"
+COMPATIBLE_RESULT_FORMATS = None
+
+#pylint: disable=too-many-branches
+
+
+def output_v2(manifest: Manifest, res: Dict) -> Dict:
+    """Convert a result into the v2 format"""
+
+    if not res["success"]:
+        last = list(res.keys())[-1]
+        failed = res[last]["stages"][-1]
+
+        result = {
+            "type": "error",
+            "success": False,
+            "error": {
+                "type": "org.osbuild.error.stage",
+                "details": {
+                    "stage": {
+                        "id": failed["id"],
+                        "type": failed["name"],
+                        "output": failed["output"],
+                        "error": failed["error"]
+                    }
+                }
+            }
+        }
+    else:
+        result = {
+            "type": "result",
+            "success": True,
+            "metadata": {}
+        }
+
+        # gather all the metadata
+        for p in manifest.pipelines.values():
+            data = {}
+            r = res.get(p.id, {})
+            for stage in r.get("stages", []):
+                md = stage.get("metadata")
+                if not md:
+                    continue
+                name = stage["name"]
+                val = data.setdefault(name, {})
+                val.update(md)
+
+            if data:
+                result["metadata"][p.name] = data
+
+    # generate the log
+    result["log"] = {}
+    for p in manifest.pipelines.values():
+        r = res.get(p.id, {})
+        log = []
+
+        for stage in r.get("stages", []):
+            data = {
+                "id": stage["id"],
+                "type": stage["name"],
+                "output": stage["output"]
+            }
+            if not stage["success"]:
+                data["success"] = stage["success"]
+                if stage["error"]:
+                    data["error"] = stage["error"]
+
+            log.append(data)
+
+        if log:
+            result["log"][p.name] = log
+
+    return result
+
+
+def output_v1(manifest: Manifest, res: Dict) -> Dict:
+    """Convert a result into the v1 format"""
+
+    def result_for_pipeline(pipeline):
+        # The pipeline might not have been built one of its
+        # dependencies, i.e. its build pipeline, failed to
+        # build. We thus need to be tolerant of a missing
+        # result but still need to to recurse
+        current = res.get(pipeline.id, {})
+        retval = {
+            "success": current.get("success", True)
+        }
+
+        if pipeline.build:
+            build = manifest[pipeline.build]
+            retval["build"] = result_for_pipeline(build)
+            retval["success"] = retval["build"]["success"]
+
+        stages = current.get("stages")
+        if stages:
+            retval["stages"] = stages
+        return retval
+
+    result = result_for_pipeline(manifest["tree"])
+
+    assembler = manifest.get("assembler")
+    if not assembler:
+        return result
+
+    current = res.get(assembler.id)
+    # if there was an error before getting to the assembler
+    # pipeline, there might not be a result present
+    if not current:
+        return result
+
+    result["assembler"] = current["stages"][0]
+    if not result["assembler"]["success"]:
+        result["success"] = False
+
+    return result
+
+
+def output(manifest: Manifest, res: Dict, version: str) -> Dict:
+    if version == "1":
+        return output_v1(manifest, res)
+    return output_v2(manifest, res)
+
+
+def print_result(manifest: Manifest, res: Dict, version: str = "2") -> Dict:
+    json.dump(output(manifest, res, version), sys.stdout)
+    sys.stdout.write("\n")

--- a/osbuild/formats/text.py
+++ b/osbuild/formats/text.py
@@ -1,0 +1,28 @@
+"""Text formatting for output
+
+Will output mostly text
+"""
+from typing import Dict
+from ..pipeline import Manifest
+
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+
+FORMAT_KIND = ["OUT"]
+VERSION = "text"
+COMPATIBLE_RESULT_FORMATS = None
+
+
+def print_text_error(error: str):
+    print(f"{RESET}{BOLD}{RED}{error}{RESET}")
+
+
+def print_result(manifest: Manifest, res: Dict, _info) -> Dict:
+    if res["success"]:
+        for name, pl in manifest.pipelines.items():
+            print(f"{name + ':': <10}\t{pl.id}")
+    print()
+    print_text_error("failed")

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -160,7 +160,6 @@ class TestFormatV1(unittest.TestCase):
         self.assertEqual(pl.runner, runner)
         check_stage(have, want)
 
-
     def test_describe(self):
         index = osbuild.meta.Index(os.curdir)
 
@@ -412,9 +411,9 @@ class TestFormatV1(unittest.TestCase):
         self.assertEqual(res.valid, False)
         self.assertEqual(len(res), 2)
         lst = res[".pipeline.stages[0].options"]
-        self.assertEqual(len(lst), 1)  #  missing rootfs
+        self.assertEqual(len(lst), 1)  # missing rootfs
         lst = res[".pipeline.stages[0].options.uefi"]
-        self.assertEqual(len(lst), 1)  #  missing "osname"
+        self.assertEqual(len(lst), 1)  # missing "osname"
 
         assembler_check = {
             "pipeline": {
@@ -431,6 +430,6 @@ class TestFormatV1(unittest.TestCase):
         self.assertEqual(res.valid, False)
         self.assertEqual(len(res), 2)
         lst = res[".pipeline.assembler.options"]
-        self.assertEqual(len(lst), 1)  #  missing "filename"
+        self.assertEqual(len(lst), 1)  # missing "filename"
         lst = res[".pipeline.assembler.options.compression"]
-        self.assertEqual(len(lst), 1)  #  wrong compression method
+        self.assertEqual(len(lst), 1)  # wrong compression method

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -202,6 +202,8 @@ class TestFormatV1(unittest.TestCase):
                 ]
             }
         }
+        info = index.detect_format_info({"version": "1"})
+        rslt_fmt = index.get_result_fmt(info, "json", "1")
 
         manifest = fmt.load(description, index)
         self.assertIsNotNone(manifest)
@@ -210,7 +212,16 @@ class TestFormatV1(unittest.TestCase):
             res = self.build_manifest(manifest, tmpdir)
 
         self.assertIsNotNone(res)
-        result = fmt.output(manifest, res)
+
+        # test formatting to V2 output
+        result = rslt_fmt.output(manifest, res, "2")
+        self.assertIsNotNone(result)
+        self.assertIn("success", result)
+        self.assertFalse(result["success"])
+        self.assertNotIn("stages", result)
+
+        # test formatting to V1 output
+        result = rslt_fmt.output(manifest, res, info.version)
         self.assertIsNotNone(result)
         self.assertIn("success", result)
         self.assertFalse(result["success"])
@@ -248,7 +259,7 @@ class TestFormatV1(unittest.TestCase):
             res = self.build_manifest(manifest, tmpdir)
 
         self.assertIsNotNone(res)
-        result = fmt.output(manifest, res)
+        result = rslt_fmt.output(manifest, res, info.version)
         self.assertIsNotNone(result)
         self.assertIn("success", result)
         self.assertFalse(result["success"])
@@ -278,7 +289,7 @@ class TestFormatV1(unittest.TestCase):
             res = self.build_manifest(manifest, tmpdir)
 
         self.assertIsNotNone(res)
-        result = fmt.output(manifest, res)
+        result = rslt_fmt.output(manifest, res, info.version)
         self.assertIsNotNone(result)
 
         self.assertIn("assembler", result)
@@ -310,7 +321,7 @@ class TestFormatV1(unittest.TestCase):
             res = self.build_manifest(manifest, tmpdir)
 
         self.assertIsNotNone(res)
-        result = fmt.output(manifest, res)
+        result = rslt_fmt.output(manifest, res, info.version)
         self.assertIsNotNone(result)
 
         self.assertIn("stages", result)


### PR DESCRIPTION
Osbuild is now able to produce a result formatting independent of the
manifest version. Concretely, a user can ask for the build of a v1
manifest but with a v2 manifest output and vice versa. If no parameters
are given or `auto` is selected, then the behaviour is legacy.