### PR TITLE
store: various code cleanups

### DIFF
--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -187,16 +187,6 @@ class Object:
         if self._writer:
             raise ValueError("Write operation is ongoing")
 
-    @contextlib.contextmanager
-    def _open(self):
-        """Open the directory and return the file descriptor"""
-        with self.read() as path:
-            fd = os.open(path, os.O_DIRECTORY)
-            try:
-                yield fd
-            finally:
-                os.close(fd)
-
     def tempdir(self, suffix=None):
         workdir = self._workdir.name
         if suffix:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -299,13 +299,16 @@ class Pipeline:
         # Not in the store yet, need to actually build it, but maybe
         # an intermediate checkpoint exists: Find the last stage that
         # already exists in the store and use that as the base.
-        tree = object_store.new()
+        tree = None
         todo = collections.deque()
         for stage in reversed(self.stages):
-            if object_store.contains(stage.id):
-                tree.base = stage.id
+            tree = object_store.get(stage.id)
+            if tree:
                 break
             todo.append(stage)  # append right side of the deque
+
+        if not tree:
+            tree = object_store.new()
 
         # If two run() calls race each-other, two trees will get built
         # and it is nondeterministic which of them will end up

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -348,10 +348,10 @@ class Pipeline:
 
         monitor.begin(self)
 
-        results = self.build_stages(store, monitor, libdir, stage_timeout)
-
-        if not results["success"]:
-            return results
+        results = self.build_stages(store,
+                                    monitor,
+                                    libdir,
+                                    stage_timeout)
 
         monitor.finish(results)
 

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -81,31 +81,6 @@ class TestObjectStore(unittest.TestCase):
             self.assertEqual(len(os.listdir(object_store.tmp)), 0)
 
     # pylint: disable=no-self-use
-    def test_duplicate(self):
-        with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
-            object_store = objectstore.ObjectStore(tmp)
-            with object_store.new() as tree:
-                with tree.write() as path:
-                    p = Path(path, "A")
-                    p.touch()
-                object_store.commit(tree, "a")
-
-            with object_store.new() as tree:
-                with tree.write() as path:
-                    shutil.copy2(f"{object_store.refs}/a/A",
-                                 os.path.join(path, "A"))
-                object_store.commit(tree, "b")
-
-            assert os.path.exists(f"{object_store.refs}/a")
-            assert os.path.exists(f"{object_store.refs}/a/A")
-            assert os.path.exists(f"{object_store.refs}/b/A")
-
-            assert len(os.listdir(object_store.refs)) == 2
-            assert len(os.listdir(object_store.objects)) == 2
-            assert len(os.listdir(f"{object_store.refs}/a/")) == 1
-            assert len(os.listdir(f"{object_store.refs}/b/")) == 1
-
-    # pylint: disable=no-self-use
     def test_object_base(self):
         # operate with a clean object store
         with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:


### PR DESCRIPTION
Cleanup some left over dead code and simplify areas that had to be more complicated when we still had recursive pipelines.
See the individual commits for details.