### PR TITLE
tests: handle `-` in the sfdisk version test

### DIFF
--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -33,6 +33,10 @@ def have_sfdisk_with_json():
 
     data = r.stdout.strip()
     vstr = data.split(" ")[-1]
+
+    if "-" in vstr:
+        vstr = vstr.split("-")[0]
+
     ver = list(map(int, vstr.split(".")))
     return ver[0] >= 2 and ver[1] >= 27
 


### PR DESCRIPTION
When a `-` is in the version (meaning a version such as: `2.38-rc1`), take only the part before the dash.

This closes #1036.