### PR TITLE
main: add a --version argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,3 +301,4 @@ bump-version:
 	sed -i "s|Version:\(\s*\)$(VERSION)|Version:\1$(NEXT_VERSION)|" osbuild.spec
 	sed -i "s|Release:\(\s*\)[[:digit:]]\+|Release:\11|" osbuild.spec
 	sed -i "s|version=\"$(VERSION)\"|version=\"$(NEXT_VERSION)\"|" setup.py
+	sed -i "s|__version__ = \"$(VERSION)\"|__version__ = \"$(NEXT_VERSION)\"|" osbuild/__init__.py

--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -11,8 +11,11 @@ independent of osbuild but used across the osbuild codebase.
 from .pipeline import Manifest, Pipeline, Stage
 
 
+__version__ = "60"
+
 __all__ = [
     "Manifest",
     "Pipeline",
     "Stage",
+    "__version__",
 ]

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -61,7 +61,8 @@ def export(name_or_id, output_directory, store, manifest):
 
 
 def parse_arguments(sys_argv):
-    parser = argparse.ArgumentParser(description="Build operating system images")
+    parser = argparse.ArgumentParser(prog="osbuild",
+                                     description="Build operating system images")
 
     parser.add_argument("manifest_path", metavar="MANIFEST",
                         help="json file containing the manifest that should be built, or a '-' to read from stdin")
@@ -86,6 +87,9 @@ def parse_arguments(sys_argv):
                         help="File descriptor to be used for the monitor")
     parser.add_argument("--stage-timeout", type=int, default=None,
                         help="set the maximal time (in seconds) each stage is allowed to run")
+    parser.add_argument("--version", action="version",
+                        help="return the version of osbuild",
+                        version="%(prog)s " + osbuild.__version__)
 
     return parser.parse_args(sys_argv[1:])
 


### PR DESCRIPTION
Add `__version__` to `__init__.py` and an argument to show it.

This closes #992 by adding a `--version` argument.

```
user@desktopa osbuild € python3 -m osbuild --version
osbuild 58
```

and

```
user@desktopa osbuild € python3 -m osbuild          
usage: osbuild [-h] [--store DIRECTORY] [-l DIRECTORY] [--checkpoint ID]
               [--export ID] [--json] [--output-directory DIRECTORY]
               [--inspect] [--monitor NAME] [--monitor-fd FD]
               [--stage-timeout STAGE_TIMEOUT] [--version]
               MANIFEST
osbuild: error: the following arguments are required: MANIFEST
```