### PR TITLE
ci: Adjust release schedule timer

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -4,7 +4,7 @@ name: "Create and push release tag"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 13 * * 3"
+    - cron: "0 8 * * 3"
 
 jobs:
   tag-and-push:


### PR DESCRIPTION
Adjust the timer for our automated releases to trigger the workflow at 8 UTC. This corresponds to 10am in most of our team's timezone and to the reminder event in our team calendar.

See the corresponding PR for osbuild-composer: https://github.com/osbuild/osbuild-composer/pull/2744