### PR TITLE
stages/qemu: expose vpc options

### DIFF
--- a/stages/org.osbuild.qemu
+++ b/stages/org.osbuild.qemu
@@ -79,6 +79,17 @@ SCHEMA_2 = r"""
         "description": "The type of the format, here 'vpc'",
         "type": "string",
         "enum": ["vpc"]
+      },
+      "force_size": {
+        "description": "Force disk size calculation to use the actual size specified, rather than using the nearest CHS-based calculation",
+        "type": "boolean",
+        "default": true
+      },
+      "subformat": {
+        "description": "Type of virtual hard disk format",
+        "type": "string",
+        "default": "fixed",
+        "enum": ["fixed", "dynamic"]
       }
     }
   },
@@ -146,6 +157,16 @@ def vmdk_arguments(options):
     return argv
 
 
+def vpc_arguments(options):
+    subformat = options.get("subformat", "fixed")
+    opts = [f"subformat={subformat}"]
+
+    if options.get("force_size", True):
+        opts += ["force_size"]
+
+    return ["-o", ",".join(opts)]
+
+
 def parse_input(inputs):
     image = inputs["image"]
     files = image["data"]["files"]
@@ -167,7 +188,7 @@ def main(inputs, output, options):
         "qcow2": qcow2_arguments,
         "vdi": [],
         "vmdk": vmdk_arguments,
-        "vpc": ["-o", "subformat=fixed,force_size"],
+        "vpc": vpc_arguments,
         "vhdx": []
     }
 

--- a/test/data/stages/qemu/checks.json
+++ b/test/data/stages/qemu/checks.json
@@ -27,7 +27,12 @@
     }
   },
   "image.vpc": {
-    "format": "raw"
+    "format": "raw",
+    "virtual-size": 104858112
+  },
+  "image-no-force-size.vpc": {
+    "format": "raw",
+    "virtual-size": 104866304
   },
   "image.vhdx": {
     "format": "vhdx"

--- a/test/data/stages/qemu/qemu.json
+++ b/test/data/stages/qemu/qemu.json
@@ -523,6 +523,33 @@
       ]
     },
     {
+      "name": "image-no-force-size.vpc",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "image.raw"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image-no-force-size.vpc",
+            "format": {
+              "type": "vpc",
+              "force_size": false
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "image.vhdx",
       "build": "name:build",
       "stages": [

--- a/test/data/stages/qemu/qemu.mpp.json
+++ b/test/data/stages/qemu/qemu.mpp.json
@@ -180,6 +180,33 @@
       ]
     },
     {
+      "name": "image-no-force-size.vpc",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "image.raw"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image-no-force-size.vpc",
+            "format": {
+              "type": "vpc",
+              "force_size": false
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "image.vhdx",
       "build": "name:build",
       "stages": [


### PR DESCRIPTION
Currently we hard code the vpc options `subformat=fixed` and `force_size`, which are needed to generate valid azure images with newer versions of qemu. But for other use cases or other versions of qemu these options might not be wanted or valid.
Expose all the options but with defaults corresponding to the old behavior.