### PR TITLE
stages/mkfs.fat: pass `-I` command line option

### DIFF
--- a/stages/org.osbuild.mkfs.fat
+++ b/stages/org.osbuild.mkfs.fat
@@ -5,6 +5,10 @@ Construct an FAT file-system via mkfs.fat(8)
 Construct a FAT file-system with the given options at the device
 specified via `device`.
 
+NB: `mkfs.fat` is called via `-I` to ignore existing partitions
+on the device. This should also prevent the situation where
+the partition table information on a (loop-)device is outdated.
+
 Buildhost commands used: `mkfs.fat`.
 """
 
@@ -64,7 +68,7 @@ def main(devices, options):
     if fatsize:
         opts = ["-F", str(fatsize)]
 
-    subprocess.run(["mkfs.fat", "-i", volid] + opts + [device],
+    subprocess.run(["mkfs.fat", "-I", "-i", volid] + opts + [device],
                    encoding='utf-8', check=True)
 
 


### PR DESCRIPTION
The option will force `mkfs.fat` to ignore existing partitions on the target device. The check is done via the corresponding device node in sysfs, i.e. the contents of the `partition` attribute in `/sys/dev/block/<major>:<minor>`. In certain situations this info can be stale. Passing `-I` will work-around these situations.