### PR TITLE
test: manifests testing on each PR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,6 +100,38 @@ SonarQube:
     INTERNAL_NETWORK: "true"
     GIT_DEPTH: 0
 
+Manifests:
+  stage: test
+  extends: .terraform
+  script:
+    - schutzbot/deploy.sh
+    - schutzbot/manifest_tests.sh
+  artifacts:
+    when: always
+    paths:
+      - manifest-db/generated-image-infos/
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/fedora-35-x86_64
+          - aws/fedora-35-aarch64
+          - aws/fedora-36-x86_64
+          - aws/fedora-36-aarch64
+          - aws/centos-stream-8-x86_64
+          - aws/centos-stream-8-aarch64
+          - aws/centos-stream-9-x86_64
+          - aws/centos-stream-9-aarch64
+      - RUNNER:
+          - aws/rhel-8.6-ga-x86_64
+          - aws/rhel-8.6-ga-aarch64
+          - aws/rhel-9.0-ga-x86_64
+          - aws/rhel-9.0-ga-aarch64
+          - aws/rhel-8.7-nightly-x86_64
+          - aws/rhel-8.7-nightly-aarch64
+          - aws/rhel-9.1-nightly-x86_64
+          - aws/rhel-9.1-nightly-aarch64
+        INTERNAL_NETWORK: "true"
+
 finish:
   stage: finish
   tags:

--- a/Schutzfile
+++ b/Schutzfile
@@ -1,4 +1,11 @@
 {
+  "global": {
+    "dependencies": {
+      "manifest-db": {
+        "commit": "a5df7345e7f30d7915cb78624e748c44aeefd8f7"
+      }
+    }
+  },
   "fedora-35": {
     "repos": [
       {
@@ -184,7 +191,7 @@
       }
     ]
   },
-"rhel-8.7": {
+  "rhel-8.7": {
     "repos": [
       {
         "file": "/etc/yum.repos.d/rhel8internal.repo",

--- a/schutzbot/manifest_tests.sh
+++ b/schutzbot/manifest_tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euxo pipefail
+# Get OS details.
+source /etc/os-release
+ARCH=$(uname -m)
+DISTRO_CODE="${DISTRO_CODE:-${ID}-${VERSION_ID//./}}"
+
+# get manifest-db at the version specified for this arch+distro
+MANIFEST_DB_COMMIT=$(cat Schutzfile | jq -r '.global.dependencies."manifest-db".commit')
+MANIFEST_DB_REPO="https://github.com/osbuild/manifest-db"
+git clone "$MANIFEST_DB_REPO" manifest-db
+cd manifest-db
+git checkout "$MANIFEST_DB_COMMIT"
+
+# update selinux labels for the image-info tool
+OSBUILD_LABEL=$(matchpathcon -n /usr/bin/osbuild)
+chcon $OSBUILD_LABEL tools/image-info
+
+# run the tests from the manifest-db for this arch+distro
+echo "Running the osbuild-image-test for arch $ARCH and ditribution $DISTRO_CODE"
+sudo tools/osbuild-image-test --arch=$ARCH --distro=$DISTRO_CODE --image-info-path=tools/image-info


### PR DESCRIPTION
On each PR test that osbuild don't break the image generation by testing against the manifest-db that the produced image-infos are still the same as the one stored.

This paves the way to replace the old `image_test` imported from `composer` https://github.com/osbuild/osbuild-composer/blob/main/test/cases/image_tests.sh. It will have for advantages:
* to have up to date image-infos and manifests
* to don't rely on diff to diff image-infos
* to don't run on Openstack anymore on the CI.