### PR TITLE
inputs: introduce new input manager class

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -11,7 +11,7 @@ from . import host
 from . import objectstore
 from . import remoteloop
 from .devices import Device, DeviceManager
-from .inputs import Input
+from .inputs import Input, InputManager
 from .mounts import Mount, MountManager
 from .sources import Source
 from .util import osrelease
@@ -203,8 +203,9 @@ class Stage:
             mgr = host.ServiceManager(monitor=monitor)
             cm.enter_context(mgr)
 
+            ipmgr = InputManager(mgr, storeapi, inputs_tmpdir)
             for key, ip in self.inputs.items():
-                data = ip.map(mgr, storeapi, inputs_tmpdir)
+                data = ipmgr.map(ip)
                 inputs[key] = data
 
             devmgr = DeviceManager(mgr, build_root.dev, tree)


### PR DESCRIPTION
Introduce a new class to manage inputs, `InputManger` and move the code to map inputs from the `Input` here. The main insight of why the logic should be place here is that certain information is needed to map inputs, independently of specific type: the path to the input directory, `root`, the store API, `storeapi` and the service managerinstance to start the actual service. Instead of passing all this information again and again to the `Input` class, we now have a specialized (service) manager class for inputs that has all the needed information all the time.