### PR TITLE
ci: push tags to gitlab

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -58,3 +58,4 @@ jobs:
           ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
           git remote add ci git@gitlab.com:redhat/services/products/image-builder/ci/osbuild.git
           git push -f ci
+          git push -f --tags ci


### PR DESCRIPTION
Tags are missing from GitLab (I pushed them once manually) while they should really be there to be a full mirror.