### PR TITLE
`stages/dnf.config`: ability to configure rpm transaction flags

### DIFF
--- a/stages/org.osbuild.dnf.config
+++ b/stages/org.osbuild.dnf.config
@@ -33,10 +33,14 @@ SCHEMA = r"""
     }
   },
   "config_main": {
-    "ip_resolve": {
-      "type": "string",
-      "enum": ["4", "IPv4", "6", "IPv6"],
-      "description": "Determines how DNF resolves host names."
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "ip_resolve": {
+        "type": "string",
+        "enum": ["4", "IPv4", "6", "IPv6"],
+        "description": "Determines how DNF resolves host names."
+      }
     }
   }
 },

--- a/stages/org.osbuild.dnf.config
+++ b/stages/org.osbuild.dnf.config
@@ -75,7 +75,7 @@ def configure_variable(tree, name, value):
     """
     vars_directory = "/etc/dnf/vars"
 
-    with open(f"{tree}{vars_directory}/{name}", "w") as f:
+    with open(f"{tree}{vars_directory}/{name}", "w", encoding="utf-8") as f:
         f.write(value + "\n")
 
 
@@ -102,16 +102,16 @@ def make_dnf_config(tree, config_options):
     dnf_config = iniparse.SafeConfigParser()
 
     try:
-        with open(dnf_config_path, "r") as f:
+        with open(dnf_config_path, "r", encoding="utf-8") as f:
             dnf_config.readfp(f)
     except FileNotFoundError:
         print(f"Warning: DNF configuration file '{dnf_config_path}' does not exist, will create it.")
         os.makedirs(f"{tree}/etc/dnf", exist_ok=True)
 
-    for section, items  in config_options.items():
+    for section, items in config_options.items():
         make_section(dnf_config, section, items)
 
-    with open(dnf_config_path, "w") as f:
+    with open(dnf_config_path, "w",  encoding="utf-8") as f:
         os.fchmod(f.fileno(), 0o644)
         dnf_config.write(f)
 

--- a/stages/org.osbuild.dnf.config
+++ b/stages/org.osbuild.dnf.config
@@ -2,8 +2,12 @@
 """
 Change DNF configuration.
 
-The stage changes persistent DNF configuration on the filesystem. Currently,
-only DNF variables can be defined.
+The stage changes persistent DNF configuration on the filesystem.
+
+Allows defining dnf variables via the `variables` option and
+specific configuration options via the `config` option. The
+latter will be saved in `/etc/dnf/dnf.conf`. See `dnf.conf(5)`
+for details about the configuration options.
 """
 
 import os

--- a/stages/org.osbuild.dnf.config
+++ b/stages/org.osbuild.dnf.config
@@ -40,6 +40,25 @@ SCHEMA = r"""
         "type": "string",
         "enum": ["4", "IPv4", "6", "IPv6"],
         "description": "Determines how DNF resolves host names."
+      },
+      "tsflags": {
+        "type": "array",
+        "description": "Extra flags for the RPM transaction.",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+          "type": "string",
+          "enum": [
+            "noscripts",
+            "test",
+            "notriggers",
+            "nodocs",
+            "justdb",
+            "nocontexts",
+            "nocaps",
+            "nocrypto"
+          ]
+        }
       }
     }
   }
@@ -84,6 +103,10 @@ def configure_variable(tree, name, value):
 
 
 def make_value(value):
+    if isinstance(value, list):
+        val = ", ".join(value)
+        return val
+
     val = str(value)
     return val
 

--- a/test/data/stages/dnf.config/b.json
+++ b/test/data/stages/dnf.config/b.json
@@ -503,7 +503,10 @@
           ],
           "config": {
             "main": {
-              "ip_resolve": "4"
+              "ip_resolve": "4",
+              "tsflags": [
+                "nodocs"
+              ]
             }
           }
         }

--- a/test/data/stages/dnf.config/b.mpp.json
+++ b/test/data/stages/dnf.config/b.mpp.json
@@ -40,7 +40,10 @@
           ],
           "config": {
             "main": {
-              "ip_resolve": "4"
+              "ip_resolve": "4",
+              "tsflags": [
+                "nodocs"
+              ]
             }
           }
         }

--- a/test/data/stages/dnf.config/diff.json
+++ b/test/data/stages/dnf.config/diff.json
@@ -7,7 +7,7 @@
     "/etc/dnf/dnf.conf": {
       "content": [
         "sha256:c517559154f0de26716dd6464fbf524aeebf965cb8cf89ebde69e51355633878",
-        "sha256:86795d352e3107dfb5257a9a4466fdc93668ec0776def8f62e211560f6fabeac"
+        "sha256:1469ad98fc3bb8c2d88d5bdb81eb5f91c48107a5ecabcafd5025b03d9d215325"
       ]
     }
   }


### PR DESCRIPTION
Add support for specifying rpm transaction flags via the `tsflags` options. See `dnf.conf(5)` for more details.