### PR TITLE
git: ignore common virtual env locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ cov-int/
 
 /docs/osbuild.1
 /docs/osbuild-manifest.5
+
+venv
+.venv


### PR DESCRIPTION
Super minor, I often use virtual environments during testing, this puts them on the ignore list.