### PR TITLE
osbuild: fix current partial type annotations

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,3 +56,15 @@ jobs:
         with:
           ignore_words_list: msdos, pullrequest
           skip: ./.git,coverity,rpmbuild,samples
+
+  mypy:
+    name: "Mypy check"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+      - name: Check files with mypy
+        run: |
+          sudo apt install python3-pip -y
+          sudo pip install mypy types-pyyaml jsonschema mako
+          mypy osbuild

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+
+[mypy-jsonschema.*]
+ignore_missing_imports = True
+
+[mypy-mako.*]
+ignore_missing_imports = True

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -28,7 +28,7 @@ import struct
 import subprocess
 import sys
 import tempfile
-from typing import List, BinaryIO
+from typing import List, BinaryIO, Optional
 
 import osbuild.api
 import osbuild.remoteloop as remoteloop
@@ -285,14 +285,14 @@ class PartitionTable:
         parts_fs = filter(lambda p: p.filesystem is not None, self.partitions)
         return sorted(parts_fs, key=mountpoint_len)
 
-    def partition_containing_root(self) -> Partition:
+    def partition_containing_root(self) -> Optional[Partition]:
         """Return the partition containing the root filesystem"""
         for p in self.partitions:
             if p.mountpoint and p.mountpoint == "/":
                 return p
         return None
 
-    def partition_containing_boot(self) -> Partition:
+    def partition_containing_boot(self) -> Optional[Partition]:
         """Return the partition containing /boot"""
         for p in self.partitions_with_filesystems():
             if p.mountpoint == "/boot":
@@ -300,7 +300,7 @@ class PartitionTable:
         # fallback to the root partition
         return self.partition_containing_root()
 
-    def find_prep_partition(self) -> Partition:
+    def find_prep_partition(self) -> Optional[Partition]:
         """Find the PReP partition'"""
         if self.label == "dos":
             prep_type = "41"
@@ -312,7 +312,7 @@ class PartitionTable:
                 return part
         return None
 
-    def find_bios_boot_partition(self) -> Partition:
+    def find_bios_boot_partition(self) -> Optional[Partition]:
         """Find the BIOS-boot Partition"""
         bb_type = "21686148-6449-6E6F-744E-656564454649"
         for part in self.partitions:
@@ -465,7 +465,7 @@ def grub2_write_core_bios_boot(core_f: BinaryIO,
                                pt: PartitionTable):
     """Write the core to the bios boot partition"""
     bb = pt.find_bios_boot_partition()
-    if bb is None:
+    if not bb:
         raise ValueError("BIOS-boot partition missing")
     core_size = os.fstat(core_f.fileno()).st_size
     if bb.size_in_bytes < core_size:
@@ -480,6 +480,10 @@ def grub2_write_core_bios_boot(core_f: BinaryIO,
     # the "sector start parameter" ("size .long 2, 0"):
     # 0x200 - GRUB_BOOT_MACHINE_LIST_SIZE (12) = 0x1F4 = 500
     image_f.seek(bb.start_in_bytes + 500)
+
+    if not bb.start:
+        raise ValueError("BIOS-boot partition start missing")
+
     image_f.write(struct.pack("<Q", bb.start + 1))
 
     return bb.start
@@ -499,6 +503,7 @@ def grub2_partition_id(pt: PartitionTable):
     return label2grub[pt.label]
 
 
+#pylint: disable=too-many-branches
 def install_grub2(image: str, pt: PartitionTable, options):
     """Install grub2 to image"""
     platform = options.get("platform", "i386-pc")
@@ -517,6 +522,9 @@ def install_grub2(image: str, pt: PartitionTable, options):
 
     # find the partition containing /boot/grub2
     boot_part = pt.partition_containing_boot()
+
+    if not boot_part:
+        raise RuntimeError("Failed to find boot_part")
 
     # modules: access the disk and read the partition table:
     # on x86 'biosdisk' is used to access the disk, on ppc64le
@@ -544,6 +552,9 @@ def install_grub2(image: str, pt: PartitionTable, options):
         raise ValueError(f"unknown boot filesystem type: '{fs_type}'")
 
     # identify the partition containing boot for grub2
+    if boot_part.index is None:
+        raise RuntimeError("No boot_part index")
+
     partid = grub2_partition_id(pt) + str(boot_part.index + 1)
     print(f"grub2 prefix {partid}")
 
@@ -610,6 +621,10 @@ def install_zipl(root: str, device: str, pt: PartitionTable):
     """Install the bootloader on s390x via zipl"""
     kernel, initrd, kopts = find_kernel(root)
     part_with_boot = pt.partition_containing_boot()
+
+    if not part_with_boot:
+        raise RuntimeError("Could not find part_with_boot")
+
     subprocess.run(["/usr/sbin/zipl",
                     "--verbose",
                     "--target", f"{root}/boot",

--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -22,7 +22,7 @@ import errno
 import os
 import sys
 
-from typing import Dict
+from typing import Dict, Optional
 
 from osbuild import devices
 from osbuild import loop
@@ -63,8 +63,6 @@ class LoopbackService(devices.DeviceService):
 
     def __init__(self, args: argparse.Namespace):
         super().__init__(args)
-        self.fd = None
-        self.lo = None
         self.ctl = loop.LoopControl()
 
     @staticmethod

--- a/devices/org.osbuild.luks2
+++ b/devices/org.osbuild.luks2
@@ -20,7 +20,7 @@ import subprocess
 import sys
 import uuid
 
-from typing import Dict
+from typing import Dict, Optional
 
 from osbuild import devices
 from osbuild.util.udev import UdevInhibitor
@@ -44,7 +44,7 @@ class CryptDeviceService(devices.DeviceService):
 
     def __init__(self, args: argparse.Namespace):
         super().__init__(args)
-        self.devname = None
+        self.devname: Optional[str] = None
         self.lock = None
         self.check = False
 

--- a/devices/org.osbuild.lvm2.lv
+++ b/devices/org.osbuild.lvm2.lv
@@ -35,7 +35,7 @@ import subprocess
 import sys
 import time
 
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 
 from osbuild import devices
 
@@ -108,7 +108,7 @@ class LVService(devices.DeviceService):
             msg = f"Failed to set LV device ({fullname}) status: {data}"
             raise RuntimeError(msg)
 
-    def volume_group_for_device(self, device: str) -> str:
+    def volume_group_for_device(self, device: str) -> Union[int, str]:
         # Find the volume group that belongs to the device specified via `parent`
         vg_name = None
         count = 0
@@ -193,13 +193,13 @@ class LVService(devices.DeviceService):
 
         # Now that we have the volume group, find the major and minor
         # device numbers for the logical volume
-        major, minor = self.device_for_logical_volume(vg, lv)
+        major, minor = self.device_for_logical_volume(vg, lv)  # type: ignore
 
         # Create the device node for the LV in the build root's /dev
-        devname = os.path.join(vg, lv)
+        devname = os.path.join(vg, lv)  # type: ignore
         fullpath = os.path.join(devpath, devname)
 
-        os.makedirs(os.path.join(devpath, vg), exist_ok=True)
+        os.makedirs(os.path.join(devpath, vg), exist_ok=True)  # type: ignore
         os.mknod(fullpath, 0o666 | stat.S_IFBLK, os.makedev(major, minor))
 
         data = {

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -75,7 +75,8 @@ class BaseAPI(abc.ABC):
         msg, fds, _ = sock.recv()
         if msg is None:
             # Peer closed the connection
-            self.event_loop.remove_reader(sock)
+            if self.event_loop:
+                self.event_loop.remove_reader(sock)
             return
         self._message(msg, fds, sock)
         fds.close()

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -16,8 +16,9 @@ import subprocess
 import tempfile
 import time
 
-from typing import Optional
+from typing import Optional, Set
 
+from osbuild.api import BaseAPI
 from osbuild.util import linux
 
 
@@ -57,7 +58,7 @@ class ProcOverrides:
 
     def __init__(self, path) -> None:
         self.path = path
-        self.overrides = set()
+        self.overrides: Set["str"] = set()
 
     @property
     def cmdline(self) -> str:
@@ -167,7 +168,7 @@ class BuildRoot(contextlib.AbstractContextManager):
         self._exitstack.close()
         self._exitstack = None
 
-    def register_api(self, api: "BaseAPI"):
+    def register_api(self, api: BaseAPI):
         """Register an API endpoint.
 
         The context of the API endpoint will be bound to the context of

--- a/osbuild/devices.py
+++ b/osbuild/devices.py
@@ -17,7 +17,7 @@ import hashlib
 import json
 import os
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 from osbuild import host
 
@@ -52,11 +52,11 @@ class DeviceManager:
     Uses a `host.ServiceManager` to open `Device` instances.
     """
 
-    def __init__(self, mgr: host.ServiceManager, devpath: str, tree: str) -> Dict:
+    def __init__(self, mgr: host.ServiceManager, devpath: str, tree: str) -> None:
         self.service_manager = mgr
         self.devpath = devpath
         self.tree = tree
-        self.devices = {}
+        self.devices: Dict[str, Dict[str, Any]] = {}
 
     def device_relpath(self, dev: Optional[Device]) -> Optional[str]:
         if dev is None:

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -7,7 +7,7 @@ the created tree into an artefact. The pipeline can have any
 number of nested build pipelines. A sources section is used
 to fetch resources.
 """
-from typing import Dict
+from typing import Dict, Any
 from osbuild.meta import Index, ValidationResult
 from ..pipeline import BuildResult, Manifest, Pipeline, detect_host_runner
 
@@ -15,9 +15,9 @@ from ..pipeline import BuildResult, Manifest, Pipeline, detect_host_runner
 VERSION = "1"
 
 
-def describe(manifest: Manifest, *, with_id=False) -> Dict:
+def describe(manifest: Manifest, *, with_id=False) -> Dict[str, Any]:
     """Create the manifest description for the pipeline"""
-    def describe_stage(stage):
+    def describe_stage(stage) -> Dict[str, Any]:
         description = {"name": stage.name}
         if stage.options:
             description["options"] = stage.options
@@ -25,8 +25,8 @@ def describe(manifest: Manifest, *, with_id=False) -> Dict:
             description["id"] = stage.id
         return description
 
-    def describe_pipeline(pipeline: Pipeline) -> Dict:
-        description = {}
+    def describe_pipeline(pipeline: Pipeline) -> Dict[str, Any]:
+        description: Dict[str, Any] = {}
         if pipeline.build:
             build = manifest[pipeline.build]
             description["build"] = {

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -2,7 +2,7 @@
 
 Second, and current, version of the manifest description
 """
-from typing import Dict
+from typing import Dict, Any
 from osbuild.meta import Index, ModuleInfo, ValidationResult
 from ..inputs import Input
 from ..pipeline import Manifest, Pipeline, Stage, detect_host_runner
@@ -120,7 +120,7 @@ def describe(manifest: Manifest, *, with_id=False) -> Dict:
         return desc
 
     def describe_pipeline(p: Pipeline):
-        desc = {
+        desc: Dict[str, Any] = {
             "name": p.name
         }
 
@@ -158,7 +158,7 @@ def describe(manifest: Manifest, *, with_id=False) -> Dict:
         for source in manifest.sources
     }
 
-    description = {
+    description: Dict[str, Any] = {
         "version": VERSION,
         "pipelines": pipelines
     }
@@ -384,6 +384,8 @@ def load(description: Dict, index: Index) -> Manifest:
 def output(manifest: Manifest, res: Dict) -> Dict:
     """Convert a result into the v2 format"""
 
+    result: Dict[str, Any] = {}
+
     if not res["success"]:
         last = list(res.keys())[-1]
         failed = res[last]["stages"][-1]
@@ -412,7 +414,7 @@ def output(manifest: Manifest, res: Dict) -> Dict:
 
         # gather all the metadata
         for p in manifest.pipelines.values():
-            data = {}
+            data: Dict[str, Any] = {}
             r = res.get(p.id, {})
             for stage in r.get("stages", []):
                 md = stage.metadata

--- a/osbuild/inputs.py
+++ b/osbuild/inputs.py
@@ -21,7 +21,7 @@ import hashlib
 import json
 import os
 
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Any
 
 from osbuild import host
 from osbuild.util.types import PathLike
@@ -37,7 +37,7 @@ class Input:
         self.name = name
         self.info = info
         self.origin = origin
-        self.refs = {}
+        self.refs: Dict[str, Dict[str, Any]] = {}
         self.options = options or {}
         self.id = self.calc_id()
 
@@ -60,11 +60,11 @@ class Input:
 
 
 class InputManager:
-    def __init__(self, mgr: host.ServiceManager, storeapi: StoreServer, root: PathLike) -> Dict:
+    def __init__(self, mgr: host.ServiceManager, storeapi: StoreServer, root: PathLike) -> None:
         self.service_manager = mgr
         self.storeapi = storeapi
         self.root = root
-        self.inputs = {}
+        self.inputs: Dict[str, Input] = {}
 
     def map(self, ip: Input) -> Tuple[str, Dict]:
 

--- a/osbuild/util/jsoncomm.py
+++ b/osbuild/util/jsoncomm.py
@@ -127,13 +127,20 @@ class Socket(contextlib.AbstractContextManager):
     @blocking.setter
     def blocking(self, value: bool):
         """Set the blocking mode of the socket."""
-        self._socket.setblocking(value)
+        if self._socket:
+            self._socket.setblocking(value)
+        else:
+            raise RuntimeError("Tried to set blocking mode without socket.")
 
     def accept(self) -> Optional["Socket"]:
         """Accept a new connection on the socket.
 
         See python's `socket.accept` for more information.
         """
+
+        if not self._socket:
+            raise RuntimeError("Tried to accept without socket.")
+
         # Since, in the kernel, for AF_UNIX, new connection requests,
         # i.e. clients connecting, are directly put on the receive
         # queue of the listener socket, accept here *should* always
@@ -150,6 +157,9 @@ class Socket(contextlib.AbstractContextManager):
 
         See python's `socket.listen` for details.
         """
+
+        if not self._socket:
+            raise RuntimeError("Tried to listen without socket.")
 
         # `Socket.listen` accepts an `int` or no argument, but not `None`
         args = [backlog] if backlog is not None else []
@@ -385,6 +395,9 @@ class Socket(contextlib.AbstractContextManager):
         TypeError
             If the payload cannot be serialized, a type error is raised.
         """
+
+        if not self._socket:
+            raise RuntimeError("Tried to send without socket.")
 
         serialized = json.dumps(payload).encode()
         cmsg = []

--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -141,25 +141,25 @@ class LibCap:
         get_bound = lib.cap_get_bound
         get_bound.argtypes = (self.cap_value_t,)
         get_bound.restype = ctypes.c_int
-        get_bound.errcheck = self._check_result
+        get_bound.errcheck = self._check_result  # type: ignore
         self._get_bound = get_bound
 
         from_name = lib.cap_from_name
         from_name.argtypes = (ctypes.c_char_p, ctypes.POINTER(self.cap_value_t),)
         from_name.restype = ctypes.c_int
-        from_name.errcheck = self._check_result
+        from_name.errcheck = self._check_result  # type: ignore
         self._from_name = from_name
 
         to_name = lib.cap_to_name
         to_name.argtypes = (ctypes.c_int,)
         to_name.restype = ctypes.POINTER(ctypes.c_char)
-        to_name.errcheck = self._check_result
+        to_name.errcheck = self._check_result  # type: ignore
         self._to_name = to_name
 
         free = lib.cap_free
         free.argtypes = (ctypes.c_void_p,)
         free.restype = ctypes.c_int
-        free.errcheck = self._check_result
+        free.errcheck = self._check_result  # type: ignore
         self._free = free
 
     @staticmethod
@@ -210,6 +210,10 @@ class LibCap:
         """Translate from the capability's integer value to the its symbolic name"""
         raw = self._to_name(value)
         val = ctypes.cast(raw, ctypes.c_char_p).value
+
+        if val is None:
+            raise RuntimeError("Failed to cast.")
+
         res = str(val, encoding="utf-8")
         self._free(raw)
         return res.upper()

--- a/osbuild/util/lorax.py
+++ b/osbuild/util/lorax.py
@@ -16,6 +16,8 @@ import shlex
 import shutil
 import subprocess
 
+from typing import Dict, Any
+
 import mako.template
 
 
@@ -44,7 +46,7 @@ def rglob(pathname, *, fatal=False):
 class Script:
 
     # all built-in commands in a name to method map
-    commands = {}
+    commands: Dict[str, Any] = {}
 
     # helper decorator to register builtin methods
     class command:

--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 import typing
 
-from typing import List
+from typing import List, Any
 
 from .types import PathLike
 
@@ -116,6 +116,9 @@ def rev_parse(repo: PathLike, ref: str) -> str:
 
     repo = os.fspath(repo)
 
+    if isinstance(repo, bytes):
+        repo = repo.decode("utf8")
+
     r = subprocess.run(["ostree", "rev-parse", ref, f"--repo={repo}"],
                        encoding="utf-8",
                        stdout=subprocess.PIPE,
@@ -133,6 +136,9 @@ def show(repo: PathLike, checksum: str) -> str:
     """Show the metada of an OSTree object pointed by `checksum` in the repository at `repo`"""
 
     repo = os.fspath(repo)
+
+    if isinstance(repo, bytes):
+        repo = repo.decode("utf8")
 
     r = subprocess.run(["ostree", "show", f"--repo={repo}", checksum],
                        encoding="utf-8",
@@ -216,7 +222,7 @@ class SubIdsDB:
     """
 
     def __init__(self) -> None:
-        self.db = collections.OrderedDict()
+        self.db: collections.OrderedDict[str, Any] = collections.OrderedDict()
 
     def read(self, fp) -> int:
         idx = 0

--- a/osbuild/util/path.py
+++ b/osbuild/util/path.py
@@ -1,10 +1,7 @@
 """Path handling utility functions"""
-import os.path
+import os
 
-from .types import PathLike
-
-
-def in_tree(path: PathLike, tree: PathLike, must_exist=False) -> bool:
+def in_tree(path: str, tree: str, must_exist: bool = False) -> bool:
     """Return whether the canonical location of 'path' is under 'tree'.
     If 'must_exist' is True, the file must also exist for the check to succeed.
     """

--- a/osbuild/util/types.py
+++ b/osbuild/util/types.py
@@ -2,10 +2,5 @@
 # Define some useful typing abbreviations
 #
 
-import os
-
-from typing import Union
-
-
 #: Represents a file system path. See also `os.fspath`.
-PathLike = Union[str, bytes, os.PathLike]
+PathLike = str

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -89,7 +89,8 @@ SCHEMA = """
 class CurlSource(sources.SourceService):
 
     content_type = "org.osbuild.files"
-    max_workers = 2 * os.cpu_count()
+
+    max_workers = 2 * (os.cpu_count() or 1)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stages/org.osbuild.sfdisk
+++ b/stages/org.osbuild.sfdisk
@@ -7,6 +7,7 @@ import json
 import subprocess
 import sys
 
+from typing import Optional
 
 import osbuild.api
 
@@ -122,7 +123,7 @@ class PartitionTable:
     def __getitem__(self, key) -> Partition:
         return self.partitions[key]
 
-    def find_prep_partition(self) -> Partition:
+    def find_prep_partition(self) -> Optional[Partition]:
         """Find the PReP partition'"""
         if self.label == "dos":
             prep_type = "41"
@@ -134,7 +135,7 @@ class PartitionTable:
                 return part
         return None
 
-    def find_bios_boot_partition(self) -> Partition:
+    def find_bios_boot_partition(self) -> Optional[Partition]:
         """Find the BIOS-boot Partition"""
         bb_type = "21686148-6449-6E6F-744E-656564454649"
         for part in self.partitions:

--- a/stages/org.osbuild.sgdisk
+++ b/stages/org.osbuild.sgdisk
@@ -95,7 +95,7 @@ class Partition:
         self.size = size
         self.name = name
         self.uuid = uuid
-        self.attrs = set(attrs or [])
+        self.attrs = set([attrs] if attrs else [])
 
         if bootable:
             self.attrs.add(2)

--- a/stages/org.osbuild.udev.rules
+++ b/stages/org.osbuild.udev.rules
@@ -18,6 +18,8 @@ and the possible keys for the `OPTIONS` assignment are not checked.
 import os
 import sys
 
+from typing import Dict
+
 import osbuild.api
 
 
@@ -259,7 +261,7 @@ SCHEMA = r"""
 """
 
 
-def make_key(data: dict):
+def make_key(data: Dict):
     key = data["key"]
 
     if isinstance(key, str):
@@ -274,12 +276,12 @@ def make_key(data: dict):
     return res
 
 
-def make_value(data: dict):
+def make_value(data: Dict):
     val = data["val"]
     return '"' + val.replace('"', r'\"') + '"'
 
 
-def make_rule(data: dict):
+def make_rule(data: Dict):
     for item in data:
         res = make_key(item)
         res += item["op"]
@@ -287,7 +289,7 @@ def make_rule(data: dict):
         yield res
 
 
-def write_rule(f, rule: list):
+def write_rule(f, rule: Dict):
     data = ", ".join(make_rule(rule))
     f.write(data + "\n")
 


### PR DESCRIPTION
`osbuild` currently has incomplete type annotations. This PR first fixes them where necessary and will then expand to enable `--strict` for `mypy`.