### PR TITLE
osbuild: share terminal formats between files

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -15,12 +15,7 @@ import osbuild
 import osbuild.meta
 import osbuild.monitor
 from osbuild.objectstore import ObjectStore
-
-
-RESET = "\033[0m"
-BOLD = "\033[1m"
-RED = "\033[31m"
-GREEN = "\033[32m"
+from osbuild.util.term import fmt as vt
 
 
 def parse_manifest(path):
@@ -37,17 +32,17 @@ def show_validation(result, name):
     if name == "-":
         name = "<stdin>"
 
-    print(f"{BOLD}{name}{RESET} ", end='')
+    print(f"{vt.bold}{name}{vt.reset} ", end='')
 
     if result:
-        print(f"is {BOLD}{GREEN}valid{RESET}")
+        print(f"is {vt.bold}{vt.green}valid{vt.reset}")
         return
 
-    print(f"has {BOLD}{RED}errors{RESET}:")
+    print(f"has {vt.bold}{vt.red}errors{vt.reset}:")
     print("")
 
     for error in result:
-        print(f"{BOLD}{error.id}{RESET}:")
+        print(f"{vt.bold}{error.id}{vt.reset}:")
         print(f"  {error.message}\n")
 
 
@@ -124,16 +119,16 @@ def osbuild_cli():
     unresolved = [e for e in exports if e not in manifest]
     if unresolved:
         for name in unresolved:
-            print(f"Export {BOLD}{name}{RESET} not found!")
-        print(f"{RESET}{BOLD}{RED}Failed{RESET}")
+            print(f"Export {vt.bold}{name}{vt.reset} not found!")
+        print(f"{vt.reset}{vt.bold}{vt.red}Failed{vt.reset}")
         return 1
 
     if args.checkpoint:
         missed = manifest.mark_checkpoints(args.checkpoint)
         if missed:
             for checkpoint in missed:
-                print(f"Checkpoint {BOLD}{checkpoint}{RESET} not found!")
-            print(f"{RESET}{BOLD}{RED}Failed{RESET}")
+                print(f"Checkpoint {vt.bold}{checkpoint}{vt.reset} not found!")
+            print(f"{vt.reset}{vt.bold}{vt.red}Failed{vt.reset}")
             return 1
 
     if args.inspect:
@@ -175,7 +170,7 @@ def osbuild_cli():
 
     except KeyboardInterrupt:
         print()
-        print(f"{RESET}{BOLD}{RED}Aborted{RESET}")
+        print(f"{vt.reset}{vt.bold}{vt.red}Aborted{vt.reset}")
         return 130
 
     if args.json:
@@ -188,6 +183,6 @@ def osbuild_cli():
                 print(f"{name + ':': <10}\t{pl.id}")
         else:
             print()
-            print(f"{RESET}{BOLD}{RED}Failed{RESET}")
+            print(f"{vt.reset}{vt.bold}{vt.red}Failed{vt.reset}")
 
     return 0 if r["success"] else 1

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -17,10 +17,7 @@ import time
 from typing import Dict
 
 import osbuild
-
-
-RESET = "\033[0m"
-BOLD = "\033[1m"
+from osbuild.util.term import fmt as vt
 
 
 class TextWriter:
@@ -36,7 +33,7 @@ class TextWriter:
             return
 
         if clear:
-            self.write(RESET)
+            self.write(vt.reset)
 
         self.write(text)
 
@@ -102,18 +99,18 @@ class LogMonitor(BaseMonitor):
         self.out.write(f"\n⏱  Duration: {duration}s\n")
 
     def begin(self, pipeline):
-        self.out.term(BOLD, clear=True)
+        self.out.term(vt.bold, clear=True)
         self.out.write(f"Pipeline {pipeline.name}: {pipeline.id}")
-        self.out.term(RESET)
+        self.out.term(vt.reset)
         self.out.write("\n")
 
     def stage(self, stage):
         self.module(stage)
 
     def assembler(self, assembler):
-        self.out.term(BOLD, clear=True)
+        self.out.term(vt.bold, clear=True)
         self.out.write("Assembler ")
-        self.out.term(RESET)
+        self.out.term(vt.reset)
 
         self.module(assembler)
 
@@ -121,9 +118,9 @@ class LogMonitor(BaseMonitor):
         options = module.options or {}
         title = f"{module.name}: {module.id}"
 
-        self.out.term(BOLD, clear=True)
+        self.out.term(vt.bold, clear=True)
         self.out.write(title)
-        self.out.term(RESET)
+        self.out.term(vt.reset)
         self.out.write(" ")
 
         json.dump(options, self.out, indent=2)

--- a/osbuild/util/term.py
+++ b/osbuild/util/term.py
@@ -1,0 +1,32 @@
+"""Wrapper module for output formatting."""
+
+import sys
+
+from typing import Dict
+
+
+class VT:
+    """Video terminal output, disables formatting when stdout is not a tty."""
+
+    isatty: bool
+
+    escape_sequences: Dict[str, str] = {
+        "reset": "\033[0m",
+
+        "bold": "\033[1m",
+
+        "red": "\033[31m",
+        "green": "\033[32m",
+    }
+
+    def __init__(self) -> None:
+        self.isatty = sys.stdout.isatty()
+
+    def __getattr__(self, name: str) -> str:
+        if not self.isatty:
+            return ""
+
+        return self.escape_sequences[name]
+
+
+fmt = VT()


### PR DESCRIPTION
Terminal escape sequences for formatting were defined multiple times. This is a prelude to more extensive (prettier) formatting.