### PR TITLE
stages/skopeo: use extra intermediate download dir

### DIFF
--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -76,7 +76,10 @@ class SkopeoSource(sources.SourceService):
         tls_verify = image.get("tls-verify", True)
 
         with tempfile.TemporaryDirectory(prefix="tmp-download-", dir=self.cache) as tmpdir:
-            archive_path = os.path.join(tmpdir, "container-image.tar")
+            archive_dir = os.path.join(tmpdir, "container-archive")
+            os.makedirs(archive_dir)
+            os.chmod(archive_dir, 0o755)
+            archive_path = os.path.join(archive_dir, "container-image.tar")
 
             source = f"docker://{imagename}@{digest}"
 
@@ -109,9 +112,8 @@ class SkopeoSource(sources.SourceService):
                     f"Downloaded image {imagename}@{digest} has a id of {downloaded_id}, but expected {image_id}")
 
             # Atomically move download dir into place on successful download
-            os.chmod(tmpdir, 0o755)
             with ctx.suppress_oserror(errno.ENOTEMPTY, errno.EEXIST):
-                os.rename(tmpdir, f"{self.cache}/{image_id}")
+                os.rename(archive_dir, f"{self.cache}/{image_id}")
 
 
 def main():


### PR DESCRIPTION
Instead of downloading the image directly to the temporary directory and then moving that temporary directory into the cache use one more intermediate directory and move that into the cache. The reason is that on Python 3.6 removing the temporary directory itself will make Python crash like this:

```
Python 3.6.8 (default, Sep  9 2021, 07:49:02)
[GCC 8.5.0 20210514 (Red Hat 8.5.0-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tempfile
>>> with tempfile.TemporaryDirectory(prefix="tmp-download-") as tmpdir:
...     import os
...     os.rename(tmpdir, "/tmp/foo")

Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "/usr/lib64/python3.6/tempfile.py", line 809, in __exit__
    self.cleanup()
  File "/usr/lib64/python3.6/tempfile.py", line 813, in cleanup
    _shutil.rmtree(self.name)
  File "/usr/lib64/python3.6/shutil.py", line 477, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/usr/lib64/python3.6/shutil.py", line 475, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmp-download-adl86mwa'
```