### PR TITLE
`stages/container.storage.conf`: fix `filename` property lookup

### DIFF
--- a/stages/org.osbuild.containers.storage.conf
+++ b/stages/org.osbuild.containers.storage.conf
@@ -149,7 +149,7 @@ def write_comment(f, comment: list):
 
 
 def main(tree, options):
-    location = options.get("location", DEFAULT_LOCATION)
+    location = options.get("filename", DEFAULT_LOCATION)
     config = options["config"]
     comment = options.get("comment", [])
 

--- a/stages/org.osbuild.containers.storage.conf
+++ b/stages/org.osbuild.containers.storage.conf
@@ -79,7 +79,11 @@ SCHEMA = r"""
   "filename": {
     "type": "string",
     "description": "location of the configuration file.",
-    "default": "/etc/containers/storage.conf"
+    "default": "/etc/containers/storage.conf",
+    "enum": [
+      "/etc/containers/storage.conf",
+      "/usr/share/containers/storage.conf"
+    ]
   },
   "comment": {
     "type": "array",


### PR DESCRIPTION
The schema said `filename` but we were accessing `location`. Also restrict the value of it to the two locations that the storage.conf file will be looked for.