### PR TITLE
stages/containers.storage.conf: support pytoml

### DIFF
--- a/stages/org.osbuild.containers.storage.conf
+++ b/stages/org.osbuild.containers.storage.conf
@@ -12,7 +12,11 @@ import os
 import sys
 from typing import Dict
 
-import toml
+try:
+    import toml
+except ModuleNotFoundError:
+    import pytoml as toml
+
 
 import osbuild.api
 


### PR DESCRIPTION
RHEL 8 only has the old pytoml library, so we need to support that as well. Try falling back if importing `toml` fails.