### PR TITLE
Add greenboot configuration management via osbuild

### DIFF
--- a/stages/org.osbuild.greenboot.conf
+++ b/stages/org.osbuild.greenboot.conf
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+"""
+update greenboot configuration in /etc/greenboot/greenbot.conf
+"""
+
+import sys
+from configparser import RawConfigParser
+import osbuild.api
+
+SCHEMA_2 = r"""
+"required": ["config"],
+"additionalProperties": false,
+"properties": {
+    "config": {
+      "type": "object",
+      "properties": {
+        "max_boot_attempt": {
+          "type": "int",
+          "description": "The maximum number of boot attempts before rollback",
+          "default": 3
+        },
+        "watchdog_check": {
+          "type": "boolean",
+          "description": "Validation for the presence of real time clock",
+          "default": true
+        },
+        "watchdog_grace_period": {
+          "type": "int",
+          "description": "This variable is the number of hours after an upgrade that we consider the new deployment as culprit of reboot",
+          "default": 24
+        },
+        "service_monitor": {
+          "type": "string",
+          "description": "Validates the status of the services before boot-complete.target is reached",
+          "default": "sshd NetworkManager"
+        }
+      }
+    }
+  }
+"""
+
+def main(tree, options):
+  config_file = f"{tree}/etc/greenboot/greenboot.conf"
+  config = options.get("config",{})
+  if not config:
+    return 0
+  max_boot_attempt=config.get("max_boot_attempt",3)
+  watchdog_check=config.get("watchdog_check",True)
+  watchdog_grace_period=config.get("watchdog_grace_period",24)
+  service_monitor=config.get("service_monitor","sshd NetworkManager")
+  s = "top" #section to add to conf file for configparser to work correctly
+  
+  try:
+    with open(config_file) as f:
+      file_content = "[{}]\n".format(s) + f.read() #aaded the leading section name to conf
+  except:
+    return 0
+  
+  config_object = RawConfigParser()
+  config_object.read_string(file_content)
+  config = config_object[s]
+  
+  config_object.set(s,"GREENBOOT_MAX_BOOT_ATTEMPTS",max_boot_attempt)
+  config_object.set(s,"GREENBOOT_WATCHDOG_CHECK_ENABLED",watchdog_check)
+  config_object.set(s,"GREENBOOT_WATCHDOG_GRACE_PERIOD",watchdog_grace_period)
+  config_object.set(s,"GREENBOOT_MONITOR_SERVICES","\"{}\"".format(service_monitor))
+
+  updated_config = '\n'.join(['='.join(item) for item in config_object.items(s)])
+  with open(config_file, 'w') as f:   
+    f.write(updated_config)
+
+  return 0
+
+if __name__ == "__main__":
+    args = osbuild.api.arguments()
+    sys.exit(main(args["tree"], args["options"]))


### PR DESCRIPTION
The script will update /etc/greenboot/greenboot.conf if user passes
the parameter in the config.
All the other configs will be set to default.