### PR TITLE
Use flake8 to lint pep8

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,3 +86,15 @@ jobs:
           sudo apt install python3-pip -y
           sudo pip install mypy types-pyyaml jsonschema mako
           mypy osbuild
+
+  flake8:
+    name: "flake8 check"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+      - name: Check files with flake8
+        run: |
+          sudo apt install python3-pip -y
+          sudo pip install flake8
+          flake8 osbuild

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -195,7 +195,7 @@ def sort_devices(devices: Dict) -> Dict:
             desc = devices[name]
 
             parent = desc.get("parent")
-            if parent and not parent in result:
+            if parent and parent not in result:
                 # if the parent is not in the `result` list, it must
                 # be in `todo`; otherwise it is missing
                 if parent not in todo:
@@ -380,7 +380,7 @@ def load(description: Dict, index: Index) -> Manifest:
     return manifest
 
 
-#pylint: disable=too-many-branches
+# pylint: disable=too-many-branches
 def output(manifest: Manifest, res: Dict) -> Dict:
     """Convert a result into the v2 format"""
 

--- a/osbuild/host.py
+++ b/osbuild/host.py
@@ -272,7 +272,7 @@ class Service(abc.ABC):
                 # an exception in `sock.send` later.
                 self._check_fds(reply_fds)
 
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 reply_fds = self._close_all(reply_fds)
                 _, val, tb = sys.exc_info()
                 reply = self.protocol.encode_exception(val, tb)

--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -584,7 +584,7 @@ class LoopControl:
             if callable(setup):
                 try:
                     setup(lo)
-                except:
+                except Exception:
                     lo.close()
                     raise
 

--- a/osbuild/util/jsoncomm.py
+++ b/osbuild/util/jsoncomm.py
@@ -57,7 +57,7 @@ class FdSet:
         self._fds = array.array("i")
 
     @classmethod
-    def from_list(cls, l: list):
+    def from_list(cls, L: list):
         """Create new Set from List
 
         This creates a new file-descriptor set initialized to the same entries
@@ -66,7 +66,7 @@ class FdSet:
         """
 
         fds = array.array("i")
-        fds.fromlist(l)
+        fds.fromlist(L)
         return cls(rawfds=fds)
 
     def __len__(self):
@@ -216,7 +216,7 @@ class Socket(contextlib.AbstractContextManager):
             # default destination for send operations.
             if connect_to is not None:
                 sock.connect(os.fspath(connect_to))
-        except:
+        except Exception:
             if sock is not None:
                 sock.close()
             raise
@@ -255,7 +255,7 @@ class Socket(contextlib.AbstractContextManager):
             sock.bind(os.fspath(bind_to))
             unlink = os.open(os.path.join(".", path[0]), os.O_CLOEXEC | os.O_PATH)
             sock.setblocking(False)
-        except:
+        except Exception:
             if unlink is not None:
                 os.close(unlink)
             if sock is not None:

--- a/osbuild/util/lvm2.py
+++ b/osbuild/util/lvm2.py
@@ -359,8 +359,8 @@ class MDAHeader(Header):
         for loc in self.raw_locns:
             loc.write(fr)
 
-        l = fr.tell()
-        fr.write(b"\0" * (self.HEADER_SIZE - l))
+        L = fr.tell()
+        fr.write(b"\0" * (self.HEADER_SIZE - L))
 
         raw = fr.getvalue()
 
@@ -542,7 +542,7 @@ class Disk:
 
         try:
             self._init_headers()
-        except:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             self.fp.close()
             raise
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ max-statements=75
 
 [pycodestyle]
 max-line-length = 120
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
`flake8` is a pretty opinionated checker, but it is configurable. It runs much faster than say pylint does and doesn't disagree with it.

This PR includes changes due to running flake8 and adds a GitHub action to run this on every PR.

Note: this could be a *replacement* for pylint.