### PR TITLE
osbuild: pylint version fixes

### DIFF
--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -178,7 +178,7 @@ class PasswdLike:
 
     def __init__(self):
         """Initialize an empty PasswdLike object"""
-        self.db = dict()
+        self.db = {}
 
     @classmethod
     def from_file(cls, path: PathLike, allow_missing_file: bool = False):

--- a/osbuild/util/rhsm.py
+++ b/osbuild/util/rhsm.py
@@ -79,7 +79,7 @@ class Subscriptions:
         parser = configparser.ConfigParser()
         parser.read_file(fp)
 
-        repositories = dict()
+        repositories = {}
         for section in parser.sections():
             current = {
                 "matchurl": cls._process_baseurl(parser.get(section, "baseurl"))

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -207,7 +207,7 @@ class TestDescriptions(unittest.TestCase):
 
         # check an empty input leads to an empty list
         res = manifest.depsolve(store, [])
-        assert res == []
+        assert not res
 
         # the build pipeline should resolve to just itself
         res = manifest.depsolve(store, names(build))
@@ -250,7 +250,7 @@ class TestDescriptions(unittest.TestCase):
         store.have.clear()
         store.have.add(image.id)
         res = manifest.depsolve(store, names(image))
-        assert res == []
+        assert not res
 
         # we have a checkpoint of the stage in the image
         # pipeline with the `dep` dependency, so that


### PR DESCRIPTION
If you have a newer pylint version than the one in the GHCI container you get various new warnings. This PR disables one (`unspecified-encoding`) and fixes two others.

The `unspecified-encoding` can stay at the "default" (locale encoding), if we were actually using various encodings then I'd agree with the warning.