### PR TITLE
Add new properties to ostree.remotes stage: gpgkeypath and contenturl

### DIFF
--- a/stages/org.osbuild.ostree.remotes
+++ b/stages/org.osbuild.ostree.remotes
@@ -48,6 +48,13 @@ SCHEMA = """
             "description": "GPG keys for the remote to verify commits",
             "type": "string"
           }
+        },
+        "gpgkeypaths": {
+          "type": "array",
+          "items": {
+            "description": "Path to ASCII-armored GPG key or directory containing ASCII-armored GPG keys to import",
+            "type": "string"
+          }
         }
       }
     }
@@ -77,9 +84,14 @@ def main(tree, options):
         url = remote["url"]
         branches = remote.get("branches", [])
         gpgkeys = remote.get("gpgkeys", [])
+        gpgkeypaths = remote.get("gpgkeypaths", [])
 
         extra_args = []
-        if not gpgkeys:
+        if gpgkeypaths:
+            paths = ",".join(gpgkeypaths)
+            extra_args.append(f"--set=gpgkeypath={paths}")
+            extra_args.append("--set=gpg-verify=true")
+        elif not gpgkeys:
             extra_args += ["--no-gpg-verify"]
 
         ostree("remote", "add",

--- a/stages/org.osbuild.ostree.remotes
+++ b/stages/org.osbuild.ostree.remotes
@@ -32,7 +32,11 @@ SCHEMA = """
           "type": "string"
         },
         "url": {
-          "description": "URL of the remote",
+          "description": "URL for accessing metadata and content for the remote",
+          "type": "string"
+        },
+        "contenturl": {
+          "description": "URL for accessing content. When set, url is used only for metadata. Supports 'mirrorlist=' prefix",
           "type": "string"
         },
         "branches": {
@@ -85,6 +89,7 @@ def main(tree, options):
         branches = remote.get("branches", [])
         gpgkeys = remote.get("gpgkeys", [])
         gpgkeypaths = remote.get("gpgkeypaths", [])
+        contenturl = remote.get("contenturl")
 
         extra_args = []
         if gpgkeypaths:
@@ -93,6 +98,9 @@ def main(tree, options):
             extra_args.append("--set=gpg-verify=true")
         elif not gpgkeys:
             extra_args += ["--no-gpg-verify"]
+
+        if contenturl:
+            extra_args.append(f"--set=contenturl={contenturl}")
 
         ostree("remote", "add",
                "--if-not-exists",


### PR DESCRIPTION
Adding new options tot he ostree.remotes stage.  These will be used in the Fedora IoT raw image to set up the ostree remote to match the official image [0] 

- `gpgkeypath`: import keys from a file on disk or a directory containing multiple keys
- `contenturl`: when specified, is used for content while the `url` is used for metadata only.  Supports `mirrorlist` URLs.

[0] https://pagure.io/fedora-kickstarts/blob/6bdafa15043b2fb27ee9a112136c2b246e535247/f/fedora-iot.ks