### PR TITLE
pipeline: include mounts in stage checksum

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -88,6 +88,9 @@ class Stage:
         if self.inputs:
             data = {n: i.id for n, i in self.inputs.items()}
             m.update(json.dumps(data, sort_keys=True).encode())
+        if self.mounts:
+            data = [m.id for m in self.mounts.values()]
+            m.update(json.dumps(data).encode())
         return m.hexdigest()
 
     @property


### PR DESCRIPTION
When calculating the checksum of the stage, the mount options were not included. This was maybe deliberate, because if the mounts of a stage change, it is very likely that previous stages change too. But the introduction of non-device mounts, like ostree.deployment, have changed the setting, since the content of the tree will be different if that mount is applied or not. And even for the device based mounts it will change the tree if e.g. a device is mounted at at different path but otherwise is formatted with the very same options. In the worst case we miss a few cache hits due to changes in the mount setup that don't lead to tree changes, but that will rarely happen in practice.