### PR TITLE
packit: Enable Bodhi updates workflow

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -59,3 +59,7 @@ jobs:
   metadata:
     dist_git_branches:
       - fedora-all
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - fedora-stable # rawhide updates are created automatically


### PR DESCRIPTION
This enables Bodhi updates created by packit (see https://packit.dev/docs/configuration/#bodhi_update).

It is preferable at this time to switch to packit because fedora-bot got blocked by authentication changes to Bodhi, so we need to manually publish all updates (until the auth method in Bodhi is fixed). See https://github.com/osbuild/fedora-bot/issues/41

We've been trialing this packit workflow in osbuild-composer for a while already successfully (https://github.com/osbuild/osbuild-composer/blob/main/.packit.yaml#L22).