### PR TITLE
org.osbuild.oci-archive: Support setting Entrypoint

### DIFF
--- a/assemblers/org.osbuild.oci-archive
+++ b/assemblers/org.osbuild.oci-archive
@@ -58,6 +58,12 @@ SCHEMA = """
           "type": "string"
         }
       },
+      "Entrypoint": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
       "Env": {
         "type": "array",
         "default": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
@@ -181,7 +187,7 @@ def config_from_options(options):
         "Cmd": command
     }
 
-    for name in ["User", "Labels", "StopSignal", "WorkingDir"]:
+    for name in ["Entrypoint", "User", "Labels", "StopSignal", "WorkingDir"]:
         item = options.get(name)
         if item:
             config[name] = item

--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -76,6 +76,12 @@ SCHEMA_2 = r"""
             "type": "string"
           }
         },
+        "Entrypoint": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "Env": {
           "type": "array",
           "default": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
@@ -255,7 +261,7 @@ def config_from_options(options):
         "Cmd": command
     }
 
-    for name in ["User", "Labels", "StopSignal", "WorkingDir"]:
+    for name in ["Entrypoint", "User", "Labels", "StopSignal", "WorkingDir"]:
         item = options.get(name)
         if item:
             config[name] = item


### PR DESCRIPTION
This allows setting Entrypoint (as well as Cmd) in the oci image,
as per the spec:

  https://github.com/opencontainers/image-spec/blob/main/config.md

Note: These two are not equivalent, the Cmd part is replaced by the
argument on the `docker run` commandline, whereas the entrypoint is
kept from the config, so it is important to expose both of these.