### PR TITLE
test/src: improve file enumeration

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,9 +40,9 @@ jobs:
     - name: "Clone Repository"
       uses: actions/checkout@v2
     - name: "Regenerate Test Data"
-      uses: osbuild/containers/src/actions/privdocker@e4de123f43b95e99dfe8eed0bd5a1cd58db50715
+      uses: osbuild/containers/src/actions/privdocker@1e349b1c69884f9f38f7afa567869b975104828c
       with:
-        image: ghcr.io/osbuild/osbuild-ci:latest-202202021637
+        image: ghcr.io/osbuild/osbuild-ci:latest-202209070757
         run: |
           make test-data
           git diff --exit-code -- ./test/data
@@ -64,9 +64,9 @@ jobs:
     - name: "Clone Repository"
       uses: actions/checkout@v2
     - name: "Run Tests"
-      uses: osbuild/containers/src/actions/privdocker@e4de123f43b95e99dfe8eed0bd5a1cd58db50715
+      uses: osbuild/containers/src/actions/privdocker@1e349b1c69884f9f38f7afa567869b975104828c
       with:
-        image: ghcr.io/osbuild/osbuild-ci:latest-202208041541
+        image: ghcr.io/osbuild/osbuild-ci:latest-202209070757
         run: |
           git config --global --add safe.directory /osb/workdir
           python3 -m pytest \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,9 @@ jobs:
       with:
            fetch-depth: 2  # codecov requires this (https://github.com/codecov/codecov-action/issues/190)
     - name: "Run Tests"
-      uses: osbuild/containers/src/actions/privdocker@e4de123f43b95e99dfe8eed0bd5a1cd58db50715
+      uses: osbuild/containers/src/actions/privdocker@1e349b1c69884f9f38f7afa567869b975104828c
       with:
-        image: ghcr.io/osbuild/osbuild-ci:latest-202202021637
+        image: ghcr.io/osbuild/osbuild-ci:latest-202209070757
         run: |
           python3 -m pytest \
             --pyargs "${{ matrix.test }}" \

--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -20,13 +20,10 @@ documentation for `osbuil.util.udev.UdevInhibitor`.
 import argparse
 import os
 import sys
-
 from typing import Dict
 
-from osbuild import devices
-from osbuild import loop
+from osbuild import devices, loop
 from osbuild.util.udev import UdevInhibitor
-
 
 SCHEMA = """
 "additionalProperties": false,

--- a/devices/org.osbuild.luks2
+++ b/devices/org.osbuild.luks2
@@ -19,12 +19,10 @@ import stat
 import subprocess
 import sys
 import uuid
-
 from typing import Dict, Optional
 
 from osbuild import devices
 from osbuild.util.udev import UdevInhibitor
-
 
 SCHEMA = """
 "additionalProperties": false,

--- a/devices/org.osbuild.lvm2.lv
+++ b/devices/org.osbuild.lvm2.lv
@@ -34,11 +34,9 @@ import stat
 import subprocess
 import sys
 import time
-
 from typing import Dict, Tuple, Union
 
 from osbuild import devices
-
 
 SCHEMA = """
 "additionalProperties": false,

--- a/inputs/org.osbuild.containers
+++ b/inputs/org.osbuild.containers
@@ -22,7 +22,6 @@ import sys
 
 from osbuild import inputs
 
-
 SCHEMA = r"""
 "definitions": {
   "source-options": {

--- a/inputs/org.osbuild.files
+++ b/inputs/org.osbuild.files
@@ -20,7 +20,6 @@ import sys
 
 from osbuild import inputs
 
-
 SCHEMA = r"""
 "definitions": {
   "metadata": {

--- a/inputs/org.osbuild.ostree
+++ b/inputs/org.osbuild.ostree
@@ -12,13 +12,12 @@ contain `ref` it was specified.
 """
 
 
-import os
 import json
-import sys
+import os
 import subprocess
+import sys
 
 from osbuild import inputs
-
 
 SCHEMA = """
 "definitions": {

--- a/inputs/org.osbuild.ostree.checkout
+++ b/inputs/org.osbuild.ostree.checkout
@@ -8,13 +8,12 @@ Internally uses `ostree checkout`
 """
 
 
-import os
 import json
-import sys
+import os
 import subprocess
+import sys
 
 from osbuild import inputs
-
 
 SCHEMA = """
 "additionalProperties": false,

--- a/inputs/org.osbuild.tree
+++ b/inputs/org.osbuild.tree
@@ -12,7 +12,6 @@ import sys
 
 from osbuild import inputs
 
-
 SCHEMA = """
 "additionalProperties": false,
 "required": ["type", "origin", "references"],

--- a/mounts/org.osbuild.btrfs
+++ b/mounts/org.osbuild.btrfs
@@ -12,7 +12,6 @@ from typing import Dict
 
 from osbuild import mounts
 
-
 SCHEMA_2 = """
 "additionalProperties": false,
 "required": ["name", "type", "source", "target"],

--- a/mounts/org.osbuild.ext4
+++ b/mounts/org.osbuild.ext4
@@ -12,7 +12,6 @@ from typing import Dict
 
 from osbuild import mounts
 
-
 SCHEMA_2 = """
 "additionalProperties": false,
 "required": ["name", "type", "source", "target"],

--- a/mounts/org.osbuild.fat
+++ b/mounts/org.osbuild.fat
@@ -12,7 +12,6 @@ from typing import Dict
 
 from osbuild import mounts
 
-
 SCHEMA_2 = """
 "additionalProperties": false,
 "required": ["name", "type", "source", "target"],

--- a/mounts/org.osbuild.noop
+++ b/mounts/org.osbuild.noop
@@ -12,7 +12,6 @@ from typing import Dict
 
 from osbuild import mounts
 
-
 SCHEMA_2 = """
 "additionalProperties": false,
 "required": ["name", "type", "source", "target"],

--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -15,13 +15,12 @@ Host commands used: mount
 """
 
 import os
-import sys
 import subprocess
+import sys
 from typing import Dict
 
 from osbuild import mounts
 from osbuild.util import ostree
-
 
 SCHEMA_2 = """
 "additionalProperties": false,

--- a/mounts/org.osbuild.xfs
+++ b/mounts/org.osbuild.xfs
@@ -12,7 +12,6 @@ from typing import Dict
 
 from osbuild import mounts
 
-
 SCHEMA_2 = """
 "additionalProperties": false,
 "required": ["name", "type", "source", "target"],

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -1145,7 +1145,7 @@
               },
               {
                 "start": 413696,
-                "size": 20557791,
+                "size": 20555776,
                 "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
                 "uuid": "CA7D7CCB-63ED-4C53-861C-1742536059CC"
               }
@@ -1196,7 +1196,7 @@
               "options": {
                 "filename": "disk.img",
                 "start": 413696,
-                "size": 20557791,
+                "size": 20555776,
                 "lock": true
               }
             }
@@ -1221,7 +1221,7 @@
               "options": {
                 "filename": "disk.img",
                 "start": 413696,
-                "size": 20557791
+                "size": 20555776
               }
             },
             "device": {
@@ -1249,7 +1249,7 @@
               "options": {
                 "filename": "disk.img",
                 "start": 413696,
-                "size": 20557791
+                "size": 20555776
               }
             },
             "lvm": {
@@ -1313,7 +1313,7 @@
               "options": {
                 "filename": "disk.img",
                 "start": 413696,
-                "size": 20557791
+                "size": 20555776
               }
             },
             "lvm": {
@@ -1379,7 +1379,7 @@
               "options": {
                 "filename": "disk.img",
                 "start": 413696,
-                "size": 20557791
+                "size": 20555776
               }
             },
             "device": {

--- a/test/mod/test_fmt_v2.py
+++ b/test/mod/test_fmt_v2.py
@@ -344,7 +344,7 @@ class TestFormatV2(unittest.TestCase):
 
     def test_device_sorting(self):
         fmt = self.index.get_format_info("osbuild.formats.v2").module
-        assert(fmt)
+        assert fmt
 
         self_cycle = {
             "a": {"parent": "a"},

--- a/test/src/test_pylint.py
+++ b/test/src/test_pylint.py
@@ -76,7 +76,7 @@ def test_isort(source_files):
     # modules we have.
     #
 
-    r = subprocess.run(["isort", "-c"] + source_files, check=False)
+    r = subprocess.run(["isort", "--check", "--diff"] + source_files, check=False)
     if r.returncode != 0:
         pytest.fail("isort issues detected")
 

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -573,7 +573,8 @@ LocalFileSigLevel = Optional
             cfgfile.write(f"[{rid}]\n")
             cfgfile.write(f"Server = {url}\n")
 
-    def _pacman(self, *args):
+    @staticmethod
+    def _pacman(*args):
         return subprocess.check_output(["pacman", *args], encoding="utf-8")
 
     def resolve(self, packages, _):
@@ -1228,6 +1229,7 @@ class ManifestFile:
         name = desc.get("id", "image")
         self.vars[name] = Image.from_dict(desc)
 
+    # pylint: disable=no-self-use
     def get_pipeline_name(self, node):
         return node.get("name", "")
 

--- a/tools/tree-diff
+++ b/tools/tree-diff
@@ -81,6 +81,7 @@ def symlink_diff(name, dir_fd1, dir_fd2, path, differences):
         props["symlink"] = [os.fsdecode(target1), os.fsdecode(target2)]
 
 
+# pylint: disable=too-many-branches
 def diff_aux(dir_fd1, dir_fd2, path, report):
     entries1 = set()
     with os.scandir(dir_fd1) as it:


### PR DESCRIPTION
Improve the file-enumeration to first check for all files ending in `*.py`, and for everything else run `/bin/file` on it, and check for python mime-types.

Note that we expect the caller to open all those files anyway, and thus this should not any significant overhead, unless we end up with lots of non-python files in the repository (which is highly unlikely). But even then, `/bin/file` only reads the first few bytes of a file, and will default if those are not sufficient to detect the file type. Hence, not much overhead is expected by this.

This change will now start adding scripts in ./tools/ to the linter, including osbuild-mpp.

Not ready to be merged. The new linter report still has to be fixed first. Hence, marked as draft.

Fixes #897.