### PR TITLE
tree: fix newer pylint warnings

### DIFF
--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -18,11 +18,10 @@ documentation for `osbuil.util.udev.UdevInhibitor`.
 
 
 import argparse
-import errno
 import os
 import sys
 
-from typing import Dict, Optional
+from typing import Dict
 
 from osbuild import devices
 from osbuild import loop
@@ -64,6 +63,9 @@ class LoopbackService(devices.DeviceService):
     def __init__(self, args: argparse.Namespace):
         super().__init__(args)
         self.ctl = loop.LoopControl()
+        self.fd = None
+        self.lo = None
+        self.sector_size = None
 
     @staticmethod
     def setup_loop(lo: loop.Loop):

--- a/devices/org.osbuild.luks2
+++ b/devices/org.osbuild.luks2
@@ -140,11 +140,11 @@ class CryptDeviceService(devices.DeviceService):
         self.devname = None
 
         # finally close the device
-        res = subprocess.run(["cryptsetup", "-q", "close", name],
-                             check=self.check,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT,
-                             encoding="UTF-8")
+        subprocess.run(["cryptsetup", "-q", "close", name],
+                       check=self.check,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT,
+                       encoding="UTF-8")
 
 
 def main():

--- a/inputs/org.osbuild.ostree
+++ b/inputs/org.osbuild.ostree
@@ -133,7 +133,7 @@ class OSTreeInput(inputs.InputService):
         if origin == "org.osbuild.pipeline":
             for ref, options in refs.items():
                 source = store.read_tree(ref)
-                with open(os.path.join(source, "compose.json"), "r") as f:
+                with open(os.path.join(source, "compose.json"), "r", encoding="utf8") as f:
                     compose = json.load(f)
                 commit_id = compose["ostree-commit"]
                 reply = export({commit_id: options}, source, target)

--- a/inputs/org.osbuild.ostree.checkout
+++ b/inputs/org.osbuild.ostree.checkout
@@ -105,7 +105,7 @@ class OSTreeCheckoutInput(inputs.InputService):
         if origin == "org.osbuild.pipeline":
             for ref, options in refs.items():
                 source = store.read_tree(ref)
-                with open(os.path.join(source, "compose.json"), "r") as f:
+                with open(os.path.join(source, "compose.json"), "r", encoding="utf8") as f:
                     compose = json.load(f)
                 commit_id = compose["ostree-commit"]
                 ids.append(checkout({commit_id: options}, source, target))

--- a/mounts/org.osbuild.noop
+++ b/mounts/org.osbuild.noop
@@ -34,6 +34,7 @@ SCHEMA_2 = """
 
 
 class NoOpMount(mounts.MountService):
+    mountpoint = None
 
     def mount(self, args: Dict):
         root = args["root"]

--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -104,8 +104,6 @@ class OSTreeDeploymentMount(mounts.MountService):
         self.mountpoint = tree
         self.check = True
 
-        return None
-
     def umount(self):
 
         if not self.mountpoint:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,15 @@
 [pylint.MASTER]
-disable=missing-docstring,too-few-public-methods,invalid-name,duplicate-code,superfluous-parens,too-many-locals,too-many-arguments,consider-using-with,consider-using-from-import
+disable=missing-docstring,
+        too-few-public-methods,
+        invalid-name,
+        duplicate-code,
+        superfluous-parens,
+        too-many-locals,
+        too-many-arguments,
+        consider-using-with,
+        consider-using-from-import,
+        line-too-long,
+        useless-option-value
 
 [pylint.TYPECHECK]
 ignored-classes=osbuild.loop.LoopInfo

--- a/stages/org.osbuild.greenboot
+++ b/stages/org.osbuild.greenboot
@@ -65,10 +65,12 @@ def main(tree, options):
                 svcs = current.strip('\"\n').split(" ")
                 new_svcs = [ns for ns in value if ns not in svcs]
                 new_svcs.extend(svcs)
+                # pylint: disable=consider-using-f-string
                 sys.stdout.write('GREENBOOT_MONITOR_SERVICES="{0}"\n'.format(" ".join(new_svcs)))
     with open(config_file, "a", encoding="utf8") as f:
         for key, value in changes.items():
             if key == "monitor_services":
+                # pylint: disable=consider-using-f-string
                 f.write('GREENBOOT_MONITOR_SERVICES="{0}"\n'.format(" ".join(value)))
 
     return 0


### PR DESCRIPTION
Fix a set of new pylint warnings. This starts with assemblers/, devices/, inputs/, and mounts/. More to come.

This is triggered by #1106.