### PR TITLE
osbuild: explicit encodings for `open()`

### DIFF
--- a/assemblers/org.osbuild.oci-archive
+++ b/assemblers/org.osbuild.oci-archive
@@ -112,7 +112,7 @@ MEDIA_TYPES = {
 def sha256sum(path: str) -> str:
     ret = subprocess.run(["sha256sum", path],
                          stdout=subprocess.PIPE,
-                         encoding="utf-8",
+                         encoding="utf8",
                          check=True)
 
     return ret.stdout.strip().split(" ")[0]
@@ -135,7 +135,7 @@ def blobs_add_file(blobs: str, path: str, mtype: str):
 
 def blobs_add_json(blobs: str, js: str, mtype: str):
     js_file = os.path.join(blobs, "temporary.js")
-    with open(js_file, "w") as f:
+    with open(js_file, "w", encoding="utf8") as f:
         json.dump(js, f)
 
     return blobs_add_file(blobs, js_file, mtype)
@@ -246,11 +246,11 @@ def create_oci_dir(tree, output_dir, options):
 
     # index
     print("writing index")
-    with open(os.path.join(output_dir, "index.json"), "w") as f:
+    with open(os.path.join(output_dir, "index.json"), "w", encoding="utf8") as f:
         json.dump(index, f)
 
     # oci-layout tag
-    with open(os.path.join(output_dir, "oci-layout"), "w") as f:
+    with open(os.path.join(output_dir, "oci-layout"), "w", encoding="utf8") as f:
         json.dump({"imageLayoutVersion": "1.0.0"}, f)
 
 

--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -166,7 +166,7 @@ def main(tree, output_dir, options, meta):
                            stdout=sys.stderr,
                            check=True)
 
-        with open(os.path.join(output_dir, "compose.json"), "r") as f:
+        with open(os.path.join(output_dir, "compose.json"), "r", encoding="utf8") as f:
             compose = json.load(f)
 
         api.metadata({"compose": compose})

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -171,7 +171,7 @@ def mkfs_ext4(device, uuid, label):
     if label:
         opts = ["-L", label]
     subprocess.run(["mkfs.ext4", "-U", uuid] + opts + [device],
-                   input="y", encoding='utf-8', check=True)
+                   input="y", encoding='utf8', check=True)
 
 
 def mkfs_xfs(device, uuid, label):
@@ -179,7 +179,7 @@ def mkfs_xfs(device, uuid, label):
     if label:
         opts = ["-L", label]
     subprocess.run(["mkfs.xfs", "-m", f"uuid={uuid}"] + opts + [device],
-                   encoding='utf-8', check=True)
+                   encoding='utf8', check=True)
 
 
 def mkfs_btrfs(device, uuid, label):
@@ -187,7 +187,7 @@ def mkfs_btrfs(device, uuid, label):
     if label:
         opts = ["-L", label]
     subprocess.run(["mkfs.btrfs", "-U", uuid] + opts + [device],
-                   encoding='utf-8', check=True)
+                   encoding='utf8', check=True)
 
 
 def mkfs_vfat(device, uuid, label):
@@ -195,7 +195,7 @@ def mkfs_vfat(device, uuid, label):
     opts = []
     if label:
         opts = ["-n", label]
-    subprocess.run(["mkfs.vfat", "-i", volid] + opts + [device], encoding='utf-8', check=True)
+    subprocess.run(["mkfs.vfat", "-i", volid] + opts + [device], encoding='utf8', check=True)
 
 
 class Filesystem:
@@ -336,7 +336,7 @@ class PartitionTable:
 
         subprocess.run(["sfdisk", "-q", target],
                        input=command,
-                       encoding='utf-8',
+                       encoding='utf8',
                        check=True)
 
         if sync:
@@ -346,7 +346,7 @@ class PartitionTable:
         """Update and fill in missing information from disk"""
         r = subprocess.run(["sfdisk", "--json", target],
                            stdout=subprocess.PIPE,
-                           encoding='utf-8',
+                           encoding='utf8',
                            check=True)
         disk_table = json.loads(r.stdout)["partitiontable"]
         disk_parts = disk_table["partitions"]
@@ -596,7 +596,7 @@ def install_grub2(image: str, pt: PartitionTable, options):
 
 def parse_blsfile(blsfile):
     params = {}
-    with open(blsfile, "r") as bls:
+    with open(blsfile, "r", encoding="utf8") as bls:
         for line in bls:
             key, value = line.split(' ', 1)
             params[key] = value.strip()
@@ -698,7 +698,7 @@ def main(tree, output_dir, options, loop_client):
     if fmt == "raw":
         subprocess.run(["cp", image, f"{output_dir}/{filename}"], check=True)
     elif fmt == "raw.xz":
-        with open(f"{output_dir}/{filename}", "w") as f:
+        with open(f"{output_dir}/{filename}", "w", encoding="utf8") as f:
             subprocess.run(
                 ["xz", "--keep", "--stdout", "-0", image],
                 stdout=f,

--- a/assemblers/org.osbuild.rawfs
+++ b/assemblers/org.osbuild.rawfs
@@ -68,15 +68,15 @@ def mount(source, dest, *options):
 
 
 def mkfs_ext4(device, uuid):
-    subprocess.run(["mkfs.ext4", "-U", uuid, device], input="y", encoding='utf-8', check=True)
+    subprocess.run(["mkfs.ext4", "-U", uuid, device], input="y", encoding='utf8', check=True)
 
 
 def mkfs_xfs(device, uuid):
-    subprocess.run(["mkfs.xfs", "-m", f"uuid={uuid}", device], encoding='utf-8', check=True)
+    subprocess.run(["mkfs.xfs", "-m", f"uuid={uuid}", device], encoding='utf8', check=True)
 
 
 def mkfs_btrfs(device, uuid):
-    subprocess.run(["mkfs.btrfs", "-U", uuid, device], encoding='utf-8', check=True)
+    subprocess.run(["mkfs.btrfs", "-U", uuid, device], encoding='utf8', check=True)
 
 
 def main(tree, output_dir, options, loop_client):

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -147,7 +147,7 @@ class API(BaseAPI):
 
     def _set_metadata(self, message, fds):
         fd = message["metadata"]
-        with os.fdopen(fds.steal(fd), encoding="utf-8") as f:
+        with os.fdopen(fds.steal(fd), encoding="utf8") as f:
             data = json.load(f)
         self.metadata.update(data)
 
@@ -195,7 +195,7 @@ def exception_handler(path="/run/osbuild/api/osbuild"):
 
 def arguments(path="/run/osbuild/api/arguments"):
     """Retrieve the input arguments that were supplied to API"""
-    with open(path, "r", encoding="utf-8") as fp:
+    with open(path, "r", encoding="utf8") as fp:
         data = json.load(fp)
     return data
 
@@ -205,9 +205,9 @@ def metadata(data: Dict, path="/run/osbuild/api/osbuild"):
 
     def data_to_file():
         with tempfile.TemporaryFile() as f:
-            f.write(json.dumps(data).encode('utf-8'))
+            f.write(json.dumps(data).encode('utf8'))
             # re-open the file to get a read-only file descriptor
-            return open(f"/proc/self/fd/{f.fileno()}", "r")
+            return open(f"/proc/self/fd/{f.fileno()}", "r", encoding="utf8")
 
     with jsoncomm.Socket.new_client(path) as client, data_to_file() as f:
         msg = {

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -62,12 +62,12 @@ class ProcOverrides:
 
     @property
     def cmdline(self) -> str:
-        with open(os.path.join(self.path, "cmdline"), "r") as f:
+        with open(os.path.join(self.path, "cmdline"), "r", encoding="utf8") as f:
             return f.read().strip()
 
     @cmdline.setter
     def cmdline(self, value) -> None:
-        with open(os.path.join(self.path, "cmdline"), "w") as f:
+        with open(os.path.join(self.path, "cmdline"), "w", encoding="utf8") as f:
             f.write(value + "\n")
         self.overrides.add("cmdline")
 

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -27,7 +27,7 @@ def parse_manifest(path):
     if path == "-":
         manifest = json.load(sys.stdin)
     else:
-        with open(path) as f:
+        with open(path, encoding="utf8") as f:
             manifest = json.load(f)
 
     return manifest

--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -422,7 +422,7 @@ class ModuleInfo:
 
         path = os.path.join(root, base, name)
         try:
-            with open(path) as f:
+            with open(path, encoding="utf8") as f:
                 data = f.read()
         except FileNotFoundError:
             return None
@@ -572,7 +572,7 @@ class Index:
         if klass == "Manifest":
             path = f"{self.path}/schemas/osbuild{version}.json"
             with contextlib.suppress(FileNotFoundError):
-                with open(path, "r") as f:
+                with open(path, "r", encoding="utf8") as f:
                     schema = json.load(f)
         elif klass in ModuleInfo.MODULES:
             info = self.get_module_info(klass, name)

--- a/osbuild/util/lorax.py
+++ b/osbuild/util/lorax.py
@@ -25,7 +25,7 @@ def replace(target, patterns):
     finder = [(re.compile(p), s) for p, s in patterns]
     newfile = target + ".replace"
 
-    with open(target, "r") as i, open(newfile, "w") as o:
+    with open(target, "r", encoding="utf8") as i, open(newfile, "w", encoding="utf8") as o:
         for line in i:
             for p, s in finder:
                 line = p.sub(s, line)
@@ -95,7 +95,7 @@ class Script:
         dirname = os.path.dirname(target)
         os.makedirs(dirname, exist_ok=True)
         print(f"append '{target}' '{data}'")
-        with open(target, "a", encoding="utf-8") as f:
+        with open(target, "a", encoding="utf8") as f:
             f.write(bytes(data, "utf8").decode("unicode_escape"))
             f.write("\n")
 
@@ -192,7 +192,7 @@ def brace_expand_line(line):
 def render_template(path, args):
     """Render a template at `path` with arguments `args`"""
 
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf8") as f:
         data = f.read()
 
     tlp = mako.template.Template(text=data, filename=path)

--- a/osbuild/util/osrelease.py
+++ b/osbuild/util/osrelease.py
@@ -26,7 +26,7 @@ def parse_files(*paths):
 
     path = next((p for p in paths if os.path.exists(p)), None)
     if path:
-        with open(path) as f:
+        with open(path, encoding="utf8") as f:
             for line in f:
                 line = line.strip()
                 if not line:

--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -102,7 +102,7 @@ class Treefile:
             fd, name = tempfile.mkstemp(suffix=".json",
                                         text=True)
 
-            with os.fdopen(fd, "w+") as f:
+            with os.fdopen(fd, "w+", encoding="utf8") as f:
                 self.dump(f)
 
             yield name
@@ -120,7 +120,7 @@ def rev_parse(repo: PathLike, ref: str) -> str:
         repo = repo.decode("utf8")
 
     r = subprocess.run(["ostree", "rev-parse", ref, f"--repo={repo}"],
-                       encoding="utf-8",
+                       encoding="utf8",
                        stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT,
                        check=False)
@@ -141,7 +141,7 @@ def show(repo: PathLike, checksum: str) -> str:
         repo = repo.decode("utf8")
 
     r = subprocess.run(["ostree", "show", f"--repo={repo}", checksum],
-                       encoding="utf-8",
+                       encoding="utf8",
                        stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT,
                        check=False)
@@ -188,7 +188,7 @@ class PasswdLike:
             if not os.path.isfile(path):
                 return ret
 
-        with open(path, "r") as p:
+        with open(path, "r", encoding="utf8") as p:
             ret.db = cls._passwd_lines_to_dict(p.readlines())
         return ret
 
@@ -198,7 +198,7 @@ class PasswdLike:
             if not os.path.isfile(path):
                 return
 
-        with open(path, "r") as p:
+        with open(path, "r", encoding="utf8") as p:
             additional_passwd_dict = self._passwd_lines_to_dict(p.readlines())
             for name, passwd_line in additional_passwd_dict.items():
                 if name not in self.db:
@@ -206,7 +206,7 @@ class PasswdLike:
 
     def dump_to_file(self, path: PathLike):
         """Write the current database to a file"""
-        with open(path, "w") as p:
+        with open(path, "w", encoding="utf8") as p:
             p.writelines(list(self.db.values()))
 
     @staticmethod
@@ -250,13 +250,13 @@ class SubIdsDB:
 
     def read_from(self, path: PathLike) -> int:
         """Read a file and add the entries to the database"""
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, "r", encoding="utf8") as f:
             return self.read(f)
 
     def write_to(self, path: PathLike) -> None:
         """Write the database to a file"""
         data = self.dumps()
-        with open(path, "w", encoding="utf-8") as f:
+        with open(path, "w", encoding="utf8") as f:
             f.write(data)
 
     def __bool__(self) -> bool:

--- a/osbuild/util/rhsm.py
+++ b/osbuild/util/rhsm.py
@@ -43,7 +43,7 @@ class Subscriptions:
         """Read redhat.repo file and process the list of repositories in there."""
         ret = cls(None)
         with contextlib.suppress(FileNotFoundError):
-            with open("/etc/yum.repos.d/redhat.repo", "r") as fp:
+            with open("/etc/yum.repos.d/redhat.repo", "r", encoding="utf8") as fp:
                 ret = cls.parse_repo_file(fp)
 
         with contextlib.suppress(RuntimeError):

--- a/runners/org.osbuild.rhel7
+++ b/runners/org.osbuild.rhel7
@@ -9,7 +9,7 @@ import osbuild.api
 
 def ldconfig():
     # ld.so.conf must exist, or `ldconfig` throws a warning
-    with open("/etc/ld.so.conf", "w", ) as f:
+    with open("/etc/ld.so.conf", "w", encoding="utf8") as f:
         # qemu-img needs `libiscsi`, which is located in /usr/lib64/iscsi
         f.write("/usr/lib64/iscsi\n")
         f.flush()

--- a/runners/org.osbuild.rhel81
+++ b/runners/org.osbuild.rhel81
@@ -46,7 +46,7 @@ def os_release():
 
     # remove the symlink that systemd-nspawn creates
     os.remove("/etc/os-release")
-    with open("/etc/os-release", "w") as f:
+    with open("/etc/os-release", "w", encoding="utf8") as f:
         f.write('NAME="Red Hat Enterprise Linux"\n')
         f.write('VERSION="8.1 (Ootpa)"\n')
         f.write('ID="rhel"\n')

--- a/stages/org.osbuild.anaconda
+++ b/stages/org.osbuild.anaconda
@@ -45,7 +45,7 @@ def main(tree, options):
     product_dir = os.path.join(tree, "etc/anaconda/conf.d")
     os.makedirs(product_dir, exist_ok=True)
 
-    with open(os.path.join(product_dir, "90-osbuild.conf"), "w") as f:
+    with open(os.path.join(product_dir, "90-osbuild.conf"), "w", encoding="utf8") as f:
         f.write(CONFIG)
         for m in modules:
             f.write(f"    {m}\n")

--- a/stages/org.osbuild.bootiso.mono
+++ b/stages/org.osbuild.bootiso.mono
@@ -171,7 +171,7 @@ def replace(target, patterns):
     finder = [(re.compile(p), s) for p, s in patterns]
     newfile = target + ".replace"
 
-    with open(target, "r") as i, open(newfile, "w") as o:
+    with open(target, "r", encoding="utf8") as i, open(newfile, "w", encoding="utf8") as o:
         for line in i:
             for p, s in finder:
                 line = p.sub(s, line)
@@ -180,7 +180,7 @@ def replace(target, patterns):
 
 
 def make_rootfs(tree, image, size, workdir, loop_client):
-    with open(image, "w") as f:
+    with open(image, "w", encoding="utf8") as f:
         os.ftruncate(f.fileno(), size)
 
     root = os.path.join(workdir, "rootfs")
@@ -192,7 +192,7 @@ def make_rootfs(tree, image, size, workdir, loop_client):
                         "-b", "4096",
                         "-m", "0",
                         dev],
-                       input="y", encoding='utf-8', check=True)
+                       input="y", encoding='utf8', check=True)
 
         with mount(dev, root):
             print("copying tree")
@@ -267,7 +267,7 @@ def make_efi(efi, info, root, loop_client):
 
     # create the image
     image = os.path.join(info["imgdir"], "efiboot.img")
-    with open(image, "w") as f:
+    with open(image, "w", encoding="utf8") as f:
         os.ftruncate(f.fileno(), size)
 
     root = os.path.join(info["workdir"], "mnt")
@@ -277,7 +277,7 @@ def make_efi(efi, info, root, loop_client):
         subprocess.run(["mkfs.fat",
                         "-n", "ANACONDA",
                         dev],
-                       input="y", encoding='utf-8', check=True)
+                       input="y", encoding='utf8', check=True)
 
         with mount(dev, root):
             target = os.path.join(root, "EFI", "BOOT")

--- a/stages/org.osbuild.buildstamp
+++ b/stages/org.osbuild.buildstamp
@@ -74,7 +74,7 @@ def main(tree, options):
         "osbuild": "devel",
     }
 
-    with open(f"{tree}/.buildstamp", "w") as f:
+    with open(f"{tree}/.buildstamp", "w", encoding="utf8") as f:
         stamp.write(f)
 
     return 0

--- a/stages/org.osbuild.chrony
+++ b/stages/org.osbuild.chrony
@@ -154,7 +154,7 @@ def main(tree, options):
     # therefore default to 'None' to distinguish these two cases.
     leapsectz = options.get("leapsectz", None)
 
-    with open(f"{tree}/etc/chrony.conf") as f:
+    with open(f"{tree}/etc/chrony.conf", encoding="utf8") as f:
         chrony_conf = f.read()
 
     # Split to lines and remove ones starting with server, pool or peer.
@@ -172,7 +172,7 @@ def main(tree, options):
 
     new_chrony_conf = "\n".join(lines)
 
-    with open(f"{tree}/etc/chrony.conf", "w") as f:
+    with open(f"{tree}/etc/chrony.conf", "w", encoding="utf8") as f:
         f.write(new_chrony_conf)
 
     return 0

--- a/stages/org.osbuild.clevis.luks-bind
+++ b/stages/org.osbuild.clevis.luks-bind
@@ -68,7 +68,7 @@ def main(devices, options):
     os.symlink("/proc/self/fd", "/dev/fd")
 
     subprocess.run(command,
-                   encoding='utf-8', check=True,
+                   encoding='utf8', check=True,
                    input=passphrase)
 
 

--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -151,7 +151,7 @@ def main(tree, options):
 
     config_files_dir = f"{tree}/etc/cloud/cloud.cfg.d"
 
-    with open(f"{config_files_dir}/{filename}", "w") as f:
+    with open(f"{config_files_dir}/{filename}", "w", encoding="utf8") as f:
         yaml.dump(config, f, default_flow_style=False)
 
     return 0

--- a/stages/org.osbuild.containers.storage.conf
+++ b/stages/org.osbuild.containers.storage.conf
@@ -161,12 +161,12 @@ def main(tree, options):
     data = {}
 
     with contextlib.suppress(FileNotFoundError):
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, "r", encoding="utf8") as f:
             data = toml.load(f)
 
     merge_config("storage", data, config)
 
-    with open(path, "w", encoding="utf-8") as f:
+    with open(path, "w", encoding="utf8") as f:
         write_comment(f, HEADER)
         write_comment(f, comment)
 

--- a/stages/org.osbuild.cron.script
+++ b/stages/org.osbuild.cron.script
@@ -66,7 +66,7 @@ def main(tree, options):
     filename = options["filename"]
     filepath = os.path.join(tree, "etc", f"cron.{interval}", filename)
 
-    with open(filepath, "w", encoding="utf-8") as f:
+    with open(filepath, "w", encoding="utf8") as f:
         cmd = options["simple"]
         cmdline = cmd["command"]
         comment = cmd.get("comment")

--- a/stages/org.osbuild.crypttab
+++ b/stages/org.osbuild.crypttab
@@ -66,7 +66,7 @@ SCHEMA = """
 def main(tree, options):
     volumes = options["volumes"]
 
-    with open(f"{tree}/etc/crypttab", "w") as f:
+    with open(f"{tree}/etc/crypttab", "w", encoding="utf8") as f:
         for volume in volumes:
             name = volume["volume"]
             uuid = volume.get("uuid")

--- a/stages/org.osbuild.debug-shell
+++ b/stages/org.osbuild.debug-shell
@@ -56,7 +56,7 @@ KillSignal=SIGHUP
 UnsetEnvironment=LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION
 """
 
-    with open(f"{tree}/etc/systemd/system/osbuild-debug-shell.service", "w") as f:
+    with open(f"{tree}/etc/systemd/system/osbuild-debug-shell.service", "w", encoding="utf8") as f:
         f.write(unit)
 
     os.symlink("../osbuild-debug-shell.service",

--- a/stages/org.osbuild.discinfo
+++ b/stages/org.osbuild.discinfo
@@ -35,7 +35,7 @@ def main(tree, options):
     # Based on `pylorax/discinfo.py`
 
     timestamp = time.time()
-    with open(os.path.join(tree, ".discinfo"), "w") as f:
+    with open(os.path.join(tree, ".discinfo"), "w", encoding="utf8") as f:
         f.write(f"{timestamp}\n")
         f.write(f"{release}\n")
         f.write(f"{basearch}\n")

--- a/stages/org.osbuild.dnf-automatic.config
+++ b/stages/org.osbuild.dnf-automatic.config
@@ -68,7 +68,7 @@ def main(tree, options):
         return 0
 
     try:
-        with open(dnf_automatic_config_path, "r") as f:
+        with open(dnf_automatic_config_path, "r", encoding="utf8") as f:
             dnf_automatic_conf.readfp(f)
     except FileNotFoundError:
         print(f"Error: DNF automatic configuration file '{dnf_automatic_config_path}' does not exist.")
@@ -80,7 +80,7 @@ def main(tree, options):
                 value = bool_to_yes_no(value)
             dnf_automatic_conf.set(config_section, option, value)
 
-    with open(dnf_automatic_config_path, "w") as f:
+    with open(dnf_automatic_config_path, "w", encoding="utf8") as f:
         dnf_automatic_conf.write(f)
 
     return 0

--- a/stages/org.osbuild.dnf.config
+++ b/stages/org.osbuild.dnf.config
@@ -102,7 +102,7 @@ def configure_variable(tree, name, value):
     """
     vars_directory = "/etc/dnf/vars"
 
-    with open(f"{tree}{vars_directory}/{name}", "w", encoding="utf-8") as f:
+    with open(f"{tree}{vars_directory}/{name}", "w", encoding="utf8") as f:
         f.write(value + "\n")
 
 
@@ -133,7 +133,7 @@ def make_dnf_config(tree, config_options):
     dnf_config = iniparse.SafeConfigParser()
 
     try:
-        with open(dnf_config_path, "r", encoding="utf-8") as f:
+        with open(dnf_config_path, "r", encoding="utf8") as f:
             dnf_config.readfp(f)
     except FileNotFoundError:
         print(f"Warning: DNF configuration file '{dnf_config_path}' does not exist, will create it.")
@@ -142,7 +142,7 @@ def make_dnf_config(tree, config_options):
     for section, items in config_options.items():
         make_section(dnf_config, section, items)
 
-    with open(dnf_config_path, "w",  encoding="utf-8") as f:
+    with open(dnf_config_path, "w",  encoding="utf8") as f:
         os.fchmod(f.fileno(), 0o644)
         dnf_config.write(f)
 

--- a/stages/org.osbuild.dracut.conf
+++ b/stages/org.osbuild.dracut.conf
@@ -172,7 +172,7 @@ def main(tree, options):
         "reproducible": bool_option_writer
     }
 
-    with open(f"{config_files_dir}/{filename}", "w") as f:
+    with open(f"{config_files_dir}/{filename}", "w", encoding="utf8") as f:
         for option, value in config.items():
             try:
                 writter_func = SUPPORTED_OPTIONS[option]

--- a/stages/org.osbuild.first-boot
+++ b/stages/org.osbuild.first-boot
@@ -63,13 +63,13 @@ Type=oneshot
 {execs}"""
 
     os.makedirs(f"{tree}/usr/lib/systemd/system/default.target.wants", exist_ok=True)
-    with open(f"{tree}/usr/lib/systemd/system/osbuild-first-boot.service", "w") as f:
+    with open(f"{tree}/usr/lib/systemd/system/osbuild-first-boot.service", "w", encoding="utf8") as f:
         f.write(service)
     os.symlink("../osbuild-first-boot.service",
                f"{tree}/usr/lib/systemd/system/default.target.wants/osbuild-first-boot.service")
 
     os.makedirs(f"{tree}/etc", exist_ok=True)
-    open(f"{tree}/etc/osbuild-first-boot", 'a').close()
+    open(f"{tree}/etc/osbuild-first-boot", 'a', encoding="utf8").close()
 
 
 def main(tree, options):

--- a/stages/org.osbuild.fix-bls
+++ b/stages/org.osbuild.fix-bls
@@ -49,10 +49,10 @@ def main(tree, options):
     path_re = re.compile(r"(/.*)+/boot")
 
     for name in glob.glob(f"{tree}/boot/loader/entries/*.conf"):
-        with open(name) as f:
+        with open(name, encoding="utf8") as f:
             entry = f.read().splitlines(keepends=True)
 
-        with open(name, "w") as f:
+        with open(name, "w", encoding="utf8") as f:
             for line in entry:
                 f.write(path_re.sub(prefix, line))
 

--- a/stages/org.osbuild.fstab
+++ b/stages/org.osbuild.fstab
@@ -129,7 +129,7 @@ def main(tree, options):
 
         path = f"{root}/etc/fstab"
 
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf8") as f:
         for filesystem in filesystems:
             uuid = filesystem.get("uuid")
             path = filesystem["path"]

--- a/stages/org.osbuild.gcp.guest-agent.conf
+++ b/stages/org.osbuild.gcp.guest-agent.conf
@@ -257,7 +257,7 @@ def main(tree, options):
     parser = iniparse.SafeConfigParser()
 
     try:
-        with open(filepath, "r", encoding="utf-8") as f:
+        with open(filepath, "r", encoding="utf8") as f:
             parser.readfp(f)
     except FileNotFoundError:
         print(f"Creating new guest-agent configuration file at '{filepath}'.")
@@ -266,7 +266,7 @@ def main(tree, options):
     for section_id, section_content in config.items():
         make_section(parser, section_id, section_content)
 
-    with open(filepath, "w", encoding="utf-8") as f:
+    with open(filepath, "w", encoding="utf8") as f:
         parser.write(f)
 
     return 0

--- a/stages/org.osbuild.greenboot
+++ b/stages/org.osbuild.greenboot
@@ -67,7 +67,7 @@ def main(tree, options):
                 new_svcs = [ns for ns in value if ns not in svcs]
                 new_svcs.extend(svcs)
                 sys.stdout.write('GREENBOOT_MONITOR_SERVICES="{0}"\n'.format(" ".join(new_svcs)))
-    with open(config_file, mode="a") as f:
+    with open(config_file, "a", encoding="utf8") as f:
         for key, value in changes.items():
             if key == "monitor_services":
                 f.write('GREENBOOT_MONITOR_SERVICES="{0}"\n'.format(" ".join(value)))

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -440,7 +440,7 @@ class GrubConfig:
         tplt = string.Template(GRUB_CFG_TEMPLATE)
         data = tplt.safe_substitute(config)
 
-        with open(path, "w") as cfg:
+        with open(path, "w", encoding="utf8") as cfg:
             cfg.write(data)
 
     def write_redirect(self, tree, path):
@@ -456,7 +456,7 @@ class GrubConfig:
         tplt = string.Template(GRUB_REDIRECT_TEMPLATE)
         data = tplt.safe_substitute(config)
 
-        with open(os.path.join(tree, path), "w") as cfg:
+        with open(os.path.join(tree, path), "w", encoding="utf8") as cfg:
             cfg.write(data)
 
     def defaults(self):
@@ -530,7 +530,7 @@ def main(tree, options):
     # Create the configuration file that determines how grub.cfg is generated.
     if write_defaults:
         os.makedirs(f"{tree}/etc/default", exist_ok=True)
-        with open(f"{tree}/etc/default/grub", "w") as default:
+        with open(f"{tree}/etc/default/grub", "w", encoding="utf8") as default:
             default.write(config.defaults())
 
     os.makedirs(f"{tree}/boot/grub2", exist_ok=True)
@@ -545,7 +545,7 @@ def main(tree, options):
         except FileNotFoundError:
             pass
 
-    with open(grubenv, "w") as env:
+    with open(grubenv, "w", encoding="utf8") as env:
         fs_type, fs_id = fs_spec_decode(root_fs)
         data = "# GRUB Environment Block\n"
 

--- a/stages/org.osbuild.grub2.iso
+++ b/stages/org.osbuild.grub2.iso
@@ -145,7 +145,7 @@ def main(root, options):
     })
 
     config = os.path.join(efidir, "grub.cfg")
-    with open(config, "w") as cfg:
+    with open(config, "w", encoding="utf8") as cfg:
         cfg.write(data)
 
     if "IA32" in architectures:

--- a/stages/org.osbuild.grub2.legacy
+++ b/stages/org.osbuild.grub2.legacy
@@ -423,7 +423,7 @@ class GrubConfig:
 
         data += "\n"
 
-        with open(path, "w") as cfg:
+        with open(path, "w", encoding="utf8") as cfg:
             print(data)
             cfg.write(data)
 
@@ -478,13 +478,13 @@ def main(tree, options):
     # Create the configuration file that determines how grub.cfg is generated.
     if write_defaults:
         os.makedirs(f"{tree}/etc/default", exist_ok=True)
-        with open(f"{tree}/etc/default/grub", "w") as default:
+        with open(f"{tree}/etc/default/grub", "w", encoding="utf8") as default:
             default.write(config.defaults())
 
     os.makedirs(f"{tree}/boot/grub2", exist_ok=True)
     grubenv = f"{tree}/boot/grub2/grubenv"
 
-    with open(grubenv, "w") as env:
+    with open(grubenv, "w", encoding="utf8") as env:
         data = (
             "# GRUB Environment Block\n"
         )

--- a/stages/org.osbuild.gunzip
+++ b/stages/org.osbuild.gunzip
@@ -52,7 +52,7 @@ def main(inputs, output, options):
     source = parse_input(inputs)
     target = os.path.join(output, path.lstrip("/"))
 
-    with open(target, "w") as f:
+    with open(target, "w", encoding="utf8") as f:
         cmd = ["gunzip", "--stdout", source]
         subprocess.run(cmd, stdout=f,
                        check=True)

--- a/stages/org.osbuild.gzip
+++ b/stages/org.osbuild.gzip
@@ -53,7 +53,7 @@ def main(inputs, output, options):
     source = parse_input(inputs)
     target = os.path.join(output, filename)
 
-    with open(target, "w") as f:
+    with open(target, "w", encoding="utf8") as f:
         cmd = [
             "gzip", "--no-name", "--stdout", "-1", source
         ]

--- a/stages/org.osbuild.ignition
+++ b/stages/org.osbuild.ignition
@@ -44,7 +44,7 @@ def main(tree, options):
     # itself will be sourced this the 'ignition_network_kcmdline'
     # that is also in the "ignition_firstboot" variable can be
     # overwritten with the contents of `network`
-    with open(f"{tree}/boot/ignition.firstboot", "w") as f:
+    with open(f"{tree}/boot/ignition.firstboot", "w", encoding="utf8") as f:
         if network:
             netstr = " ".join(network)
             f.write(f"ignition_network_kcmdline={netstr}")

--- a/stages/org.osbuild.isolinux
+++ b/stages/org.osbuild.isolinux
@@ -228,7 +228,7 @@ def main(tree, inputs, options):
     })
 
     config = os.path.join(isolinux, "isolinux.cfg")
-    with open(config, "w") as cfg:
+    with open(config, "w", encoding="utf8") as cfg:
         cfg.write(data)
 
     # link the kernel

--- a/stages/org.osbuild.kernel-cmdline
+++ b/stages/org.osbuild.kernel-cmdline
@@ -52,7 +52,7 @@ def main(tree, options):
     base = os.path.join(tree, "etc/kernel")
     os.makedirs(base, exist_ok=True)
 
-    with open(f"{base}/cmdline", "w") as f:
+    with open(f"{base}/cmdline", "w", encoding="utf8") as f:
         f.write(" ".join(filter(len, params)))
 
     return 0

--- a/stages/org.osbuild.keymap
+++ b/stages/org.osbuild.keymap
@@ -70,7 +70,7 @@ Section "InputClass"
 EndSection
 """
 
-    with open(f"{tree}/etc/X11/xorg.conf.d/00-keyboard.conf", "w") as f:
+    with open(f"{tree}/etc/X11/xorg.conf.d/00-keyboard.conf", "w", encoding="utf8") as f:
         f.write(file_content)
 
 

--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -218,13 +218,13 @@ def main(tree, options):
     base = os.path.dirname(target)
     os.makedirs(base, exist_ok=True)
 
-    with open(target, "w") as f:
+    with open(target, "w", encoding="utf8") as f:
         if config:
             f.write("\n".join(config))
         f.write("\n")
 
     print(f"created kickstarted at: {path}\n")
-    with open(target, "r") as f:
+    with open(target, "r", encoding="utf8") as f:
         print(f.read())
 
     return 0

--- a/stages/org.osbuild.luks2.format
+++ b/stages/org.osbuild.luks2.format
@@ -172,7 +172,7 @@ def main(devices, options):
         command += ["--pbkdf-parallel", str(parallelism)]
 
     subprocess.run(command + [path],
-                   encoding='utf-8', check=True,
+                   encoding='utf8', check=True,
                    input=passphrase)
 
 

--- a/stages/org.osbuild.luks2.remove-key
+++ b/stages/org.osbuild.luks2.remove-key
@@ -51,7 +51,7 @@ def main(devices, options):
     ]
 
     subprocess.run(command + [path],
-                   encoding='utf-8', check=True,
+                   encoding='utf8', check=True,
                    input=passphrase)
 
 

--- a/stages/org.osbuild.lvm2.create
+++ b/stages/org.osbuild.lvm2.create
@@ -83,11 +83,11 @@ def main(devices, options):
     print(f"LVM2: using vg name '{vg_name}'")
 
     subprocess.run(["pvcreate", path],
-                   encoding='utf-8',
+                   encoding='utf8',
                    check=True)
 
     subprocess.run(["vgcreate", vg_name, path],
-                   encoding='utf-8',
+                   encoding='utf8',
                    check=True)
 
     for volume in volumes:
@@ -104,7 +104,7 @@ def main(devices, options):
 
         cmd += ["-n", name, vg_name]
 
-        subprocess.run(cmd, encoding='utf-8', check=True)
+        subprocess.run(cmd, encoding='utf8', check=True)
 
 
 if __name__ == '__main__':

--- a/stages/org.osbuild.mkfs.btrfs
+++ b/stages/org.osbuild.mkfs.btrfs
@@ -56,7 +56,7 @@ def main(devices, options):
         opts = ["-L", label]
 
     subprocess.run(["mkfs.btrfs", "-U", uuid] + opts + [device],
-                   encoding='utf-8', check=True)
+                   encoding='utf8', check=True)
 
 
 if __name__ == '__main__':

--- a/stages/org.osbuild.mkfs.ext4
+++ b/stages/org.osbuild.mkfs.ext4
@@ -56,7 +56,7 @@ def main(devices, options):
         opts = ["-L", label]
 
     subprocess.run(["mkfs.ext4", "-U", uuid] + opts + [device],
-                   encoding='utf-8', check=True)
+                   encoding='utf8', check=True)
 
 
 if __name__ == '__main__':

--- a/stages/org.osbuild.mkfs.fat
+++ b/stages/org.osbuild.mkfs.fat
@@ -69,7 +69,7 @@ def main(devices, options):
         opts = ["-F", str(fatsize)]
 
     subprocess.run(["mkfs.fat", "-I", "-i", volid] + opts + [device],
-                   encoding='utf-8', check=True)
+                   encoding='utf8', check=True)
 
 
 if __name__ == '__main__':

--- a/stages/org.osbuild.mkfs.xfs
+++ b/stages/org.osbuild.mkfs.xfs
@@ -56,7 +56,7 @@ def main(devices, options):
         opts = ["-L", label]
 
     subprocess.run(["mkfs.xfs", "-m", f"uuid={uuid}"] + opts + [device],
-                   encoding='utf-8', check=True)
+                   encoding='utf8', check=True)
 
 
 if __name__ == '__main__':

--- a/stages/org.osbuild.modprobe
+++ b/stages/org.osbuild.modprobe
@@ -102,7 +102,7 @@ def main(tree, options):
         else:
             raise ValueError()
 
-    with open(f"{config_dir}/{config_file}", "w") as f:
+    with open(f"{config_dir}/{config_file}", "w", encoding="utf8") as f:
         f.writelines(lines)
 
     return 0

--- a/stages/org.osbuild.nginx.conf
+++ b/stages/org.osbuild.nginx.conf
@@ -77,7 +77,7 @@ pid {pid};
 daemon {daemon};
 """
 
-    with open(target, "w") as f:
+    with open(target, "w", encoding="utf8") as f:
         f.write(content)
 
     return 0

--- a/stages/org.osbuild.nm.conf
+++ b/stages/org.osbuild.nm.conf
@@ -191,7 +191,7 @@ def main(tree, options):
         else:
             raise ValueError(f"Invalid section type: {type(items)}")
 
-    with open(cfgfile, "w") as f:
+    with open(cfgfile, "w", encoding="utf8") as f:
         os.fchmod(f.fileno(), 0o600)
         cfg.write(f, space_around_delimiters=False)
 

--- a/stages/org.osbuild.nm.conn
+++ b/stages/org.osbuild.nm.conn
@@ -210,7 +210,7 @@ def main(tree, options):
                 val = str(value)
             config.set(name, option, val)
 
-    with open(cfgfile, "w") as f:
+    with open(cfgfile, "w", encoding="utf8") as f:
         # need restrictive permissions
         os.fchmod(f.fileno(), 0o600)
         config.write(f, space_around_delimiters=False)

--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -179,7 +179,7 @@ XATTRS_WANT = r"^(user.|security\.ima|security\.capability)"
 def sha256sum(path: str) -> str:
     ret = subprocess.run(["sha256sum", path],
                          stdout=subprocess.PIPE,
-                         encoding="utf-8",
+                         encoding="utf8",
                          check=True)
 
     return ret.stdout.strip().split(" ")[0]
@@ -202,7 +202,7 @@ def blobs_add_file(blobs: str, path: str, mtype: str):
 
 def blobs_add_json(blobs: str, js: str, mtype: str):
     js_file = os.path.join(blobs, "temporary.js")
-    with open(js_file, "w", encoding="utf-8") as f:
+    with open(js_file, "w", encoding="utf8") as f:
         json.dump(js, f)
 
     return blobs_add_file(blobs, js_file, mtype)
@@ -333,12 +333,12 @@ def create_oci_dir(inputs, output_dir, options, create_time):
     # index
     print("writing index")
     index_path = os.path.join(output_dir, "index.json")
-    with open(index_path, "w", encoding="utf-8") as f:
+    with open(index_path, "w", encoding="utf8") as f:
         json.dump(index, f)
 
     # oci-layout tag
     layout_path = os.path.join(output_dir, "oci-layout")
-    with open(layout_path, "w", encoding="utf-8") as f:
+    with open(layout_path, "w", encoding="utf8") as f:
         json.dump({"imageLayoutVersion": "1.0.0"}, f)
 
 

--- a/stages/org.osbuild.oscap.remediation
+++ b/stages/org.osbuild.oscap.remediation
@@ -131,7 +131,7 @@ def main(tree, options):
 
     cmd.append(datastream)
 
-    res = subprocess.run(cmd, encoding="utf-8", stdout=sys.stderr, check=False)
+    res = subprocess.run(cmd, encoding="utf8", stdout=sys.stderr, check=False)
 
     # oscap return values are:
     # 0 → success

--- a/stages/org.osbuild.ostree
+++ b/stages/org.osbuild.ostree
@@ -146,7 +146,7 @@ def ostree(*args, _input=None, **kwargs):
     args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
     print("ostree " + " ".join(args), file=sys.stderr)
     subprocess.run(["ostree"] + args,
-                   encoding="utf-8",
+                   encoding="utf8",
                    stdout=sys.stderr,
                    input=_input,
                    check=True)
@@ -177,7 +177,7 @@ def populate_var(sysroot):
         res = subprocess.run(["systemd-tmpfiles", "--create", "--boot",
                               "--root=" + sysroot,
                               "--prefix=/var/" + target],
-                             encoding="utf-8",
+                             encoding="utf8",
                              stdout=sys.stderr,
                              check=False)
 
@@ -271,7 +271,7 @@ def main(tree, inputs, options):
         if not os.path.isfile(cfgfile):
             continue
 
-        with open(cfgfile, 'r') as f:
+        with open(cfgfile, 'r', encoding="utf8") as f:
             cfg = selinux.parse_config(f)
         se_policy = selinux.config_get_policy(cfg)
 

--- a/stages/org.osbuild.ostree.commit
+++ b/stages/org.osbuild.ostree.commit
@@ -104,7 +104,7 @@ def main(inputs, output_dir, options, meta):
                            stdout=sys.stderr,
                            check=True)
 
-        with open(os.path.join(output_dir, "compose.json"), "r") as f:
+        with open(os.path.join(output_dir, "compose.json"), "r", encoding="utf8") as f:
             compose = json.load(f)
 
         api.metadata({"compose": compose})

--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -56,7 +56,7 @@ def ostree(*args, _input=None, **kwargs):
     args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
     print("ostree " + " ".join(args), file=sys.stderr)
     subprocess.run(["ostree"] + args,
-                   encoding="utf-8",
+                   encoding="utf8",
                    stdout=sys.stderr,
                    input=_input,
                    check=True)

--- a/stages/org.osbuild.ostree.deploy
+++ b/stages/org.osbuild.ostree.deploy
@@ -86,7 +86,7 @@ def ostree(*args, _input=None, **kwargs):
     args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
     print("ostree " + " ".join(args), file=sys.stderr)
     subprocess.run(["ostree"] + args,
-                   encoding="utf-8",
+                   encoding="utf8",
                    stdout=sys.stderr,
                    input=_input,
                    check=True)

--- a/stages/org.osbuild.ostree.fillvar
+++ b/stages/org.osbuild.ostree.fillvar
@@ -57,7 +57,7 @@ def populate_var(sysroot):
         res = subprocess.run(["systemd-tmpfiles", "--create", "--boot",
                               "--root=" + sysroot,
                               "--prefix=/var/" + target],
-                             encoding="utf-8",
+                             encoding="utf8",
                              stdout=sys.stderr,
                              check=False)
 

--- a/stages/org.osbuild.ostree.init-fs
+++ b/stages/org.osbuild.ostree.init-fs
@@ -21,7 +21,7 @@ def ostree(*args, _input=None, **kwargs):
     args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
     print("ostree " + " ".join(args), file=sys.stderr)
     subprocess.run(["ostree"] + args,
-                   encoding="utf-8",
+                   encoding="utf8",
                    stdout=sys.stderr,
                    input=_input,
                    check=True)

--- a/stages/org.osbuild.ostree.os-init
+++ b/stages/org.osbuild.ostree.os-init
@@ -28,7 +28,7 @@ def ostree(*args, _input=None, **kwargs):
     args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
     print("ostree " + " ".join(args), file=sys.stderr)
     subprocess.run(["ostree"] + args,
-                   encoding="utf-8",
+                   encoding="utf8",
                    stdout=sys.stderr,
                    input=_input,
                    check=True)

--- a/stages/org.osbuild.ostree.passwd
+++ b/stages/org.osbuild.ostree.passwd
@@ -48,7 +48,7 @@ def ostree(*args, _input=None, **kwargs):
     args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
     print("ostree " + " ".join(args), file=sys.stderr)
     subprocess.run(["ostree"] + args,
-                   encoding="utf-8",
+                   encoding="utf8",
                    stdout=sys.stderr,
                    input=_input,
                    check=True)

--- a/stages/org.osbuild.ostree.pull
+++ b/stages/org.osbuild.ostree.pull
@@ -54,7 +54,7 @@ def ostree(*args, _input=None, **kwargs):
     args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
     print("ostree " + " ".join(args), file=sys.stderr)
     subprocess.run(["ostree"] + args,
-                   encoding="utf-8",
+                   encoding="utf8",
                    stdout=sys.stderr,
                    input=_input,
                    check=True)

--- a/stages/org.osbuild.ostree.remotes
+++ b/stages/org.osbuild.ostree.remotes
@@ -71,7 +71,7 @@ def ostree(*args, _input=None, **kwargs):
     args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
     print("ostree " + " ".join(args), file=sys.stderr)
     subprocess.run(["ostree"] + args,
-                   encoding="utf-8",
+                   encoding="utf8",
                    stdout=sys.stderr,
                    input=_input,
                    check=True)

--- a/stages/org.osbuild.ostree.selinux
+++ b/stages/org.osbuild.ostree.selinux
@@ -70,7 +70,7 @@ def main(tree, options):
         if not os.path.isfile(cfgfile):
             continue
 
-        with open(cfgfile, 'r') as f:
+        with open(cfgfile, 'r', encoding="utf8") as f:
             cfg = selinux.parse_config(f)
         se_policy = selinux.config_get_policy(cfg)
 

--- a/stages/org.osbuild.pacman.conf
+++ b/stages/org.osbuild.pacman.conf
@@ -75,7 +75,7 @@ LocalFileSigLevel = Optional
 
     os.makedirs(os.path.join(tree, "etc"), exist_ok=True)
     cfgpath = os.path.join(tree, "etc", "pacman.conf")
-    with open(cfgpath, "w", encoding="utf-8") as cfgfile:
+    with open(cfgpath, "w", encoding="utf8") as cfgfile:
         cfgfile.write(cfg)
 
     return 0

--- a/stages/org.osbuild.pacman.mirrorlist.conf
+++ b/stages/org.osbuild.pacman.mirrorlist.conf
@@ -35,7 +35,7 @@ def main(tree, options):
 
     os.makedirs(os.path.join(tree, *filepath.parts[:-1]), exist_ok=True)
     mirrorpath = os.path.join(tree, *filepath.parts)
-    with open(mirrorpath, "w", encoding="utf-8") as cfgfile:
+    with open(mirrorpath, "w", encoding="utf8") as cfgfile:
         cfgfile.write("\n".join(f"Server = {m}\n" for m in mirrors))
 
     return 0

--- a/stages/org.osbuild.pam.limits.conf
+++ b/stages/org.osbuild.pam.limits.conf
@@ -103,7 +103,7 @@ def main(tree, options):
         cfg_line = f'{cfg_item["domain"]} {cfg_item["type"]} {cfg_item["item"]} {cfg_item["value"]}\n'
         cfg_lines.append(cfg_line)
 
-    with open(f"{limitsd_config_dir}/{filename}", "w") as f:
+    with open(f"{limitsd_config_dir}/{filename}", "w", encoding="utf8") as f:
         f.writelines(cfg_lines)
 
     return 0

--- a/stages/org.osbuild.parted
+++ b/stages/org.osbuild.parted
@@ -138,12 +138,12 @@ class PartitionTable:
 
         subprocess.run(["parted", "-a", "none", "-s",
                         target, "--"] + commands,
-                       encoding='utf-8',
+                       encoding='utf8',
                        check=True)
 
         subprocess.run(["parted", "-a", "none", "-s",
                         target, "--", "print"],
-                       encoding='utf-8',
+                       encoding='utf8',
                        check=True)
 
 

--- a/stages/org.osbuild.pwquality.conf
+++ b/stages/org.osbuild.pwquality.conf
@@ -70,7 +70,7 @@ def main(tree, options):
                     sys.stdout.write(f"{key} = {value}\n")
                     continue
             sys.stdout.write(line)
-    with open(f"{tree}/etc/security/pwquality.conf", mode="a") as f:
+    with open(f"{tree}/etc/security/pwquality.conf", mode="a", encoding="utf8") as f:
         for key, value in changes.items():
             f.write(f"{key} = {value}\n")
 

--- a/stages/org.osbuild.resolv-conf
+++ b/stages/org.osbuild.resolv-conf
@@ -56,7 +56,7 @@ def main(tree, options):
         data += ["nameserver " + str(ns)]
 
     os.makedirs(os.path.join(tree, "etc"), exist_ok=True)
-    with open(fullpath, "w") as f:
+    with open(fullpath, "w", encoding="utf8") as f:
         f.write("\n".join(data) + "\n")
 
     return 0

--- a/stages/org.osbuild.rhsm
+++ b/stages/org.osbuild.rhsm
@@ -111,7 +111,7 @@ def configure_plugins(tree, path, plugins_options):
         plugin_conf = iniparse.SafeConfigParser()
 
         try:
-            with open(plugin_conf_path, "r") as f:
+            with open(plugin_conf_path, "r", encoding="utf8") as f:
                 plugin_conf.readfp(f)
         except FileNotFoundError:
             print(f"Error: {plugin} configuration file '{plugin_conf_path}' does not exist.")
@@ -129,7 +129,7 @@ def configure_plugins(tree, path, plugins_options):
                 print(f"Error: unknown property {option} specified for {plugin} plugin.")
                 return 1
 
-        with open(plugin_conf_path, "w") as f:
+        with open(plugin_conf_path, "w", encoding="utf8") as f:
             plugin_conf.write(f)
 
     return 0
@@ -144,7 +144,7 @@ def configure_rhsm(tree, rhsm_configuration_options):
     rhsm_conf = iniparse.SafeConfigParser()
 
     try:
-        with open(rhsm_config_path, "r") as f:
+        with open(rhsm_config_path, "r", encoding="utf8") as f:
             rhsm_conf.readfp(f)
     except FileNotFoundError:
         print(f"Error: RHSM configuration file '{rhsm_config_path}' does not exist.")
@@ -159,7 +159,7 @@ def configure_rhsm(tree, rhsm_configuration_options):
             value = str(value)
             rhsm_conf.set(config_section, option, value)
 
-    with open(rhsm_config_path, "w") as f:
+    with open(rhsm_config_path, "w", encoding="utf8") as f:
         rhsm_conf.write(f)
 
     return 0

--- a/stages/org.osbuild.rhsm.facts
+++ b/stages/org.osbuild.rhsm.facts
@@ -28,7 +28,7 @@ def main(tree, options):
 
     os.makedirs(path, exist_ok=True)
 
-    with open(file, "x", encoding="utf-8") as f:
+    with open(file, "x", encoding="utf8") as f:
         json.dump(options["facts"], f)
 
     os.makedirs(os.path.join(tree, "etc/rhsm/facts"), exist_ok=True)

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -204,7 +204,7 @@ def generate_package_metadata(tree, rpm_args):
     ]
 
     res = subprocess.run(cmd, stdout=subprocess.PIPE,
-                         check=True, encoding="utf-8")
+                         check=True, encoding="utf8")
 
     raw = res.stdout.strip()
     jsdata = '{"packages": [' + raw[:-1] + "]}"
@@ -271,7 +271,7 @@ def create_machine_id_if_needed(tree):
         return False
 
     os.makedirs(f"{tree}/etc", exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
+    with open(path, "w", encoding="utf8") as f:
         # create a fake machine ID to improve reproducibility
         f.write("ffffffffffffffffffffffffffffffff")
         os.fchmod(f.fileno(), 0o400)
@@ -323,7 +323,7 @@ def main(tree, inputs, options):
     if options.get("ostree_booted", False):
         os.makedirs(f"{tree}/run", exist_ok=True)
         ostree_booted = f"{tree}/{OSTREE_BOOTED_MARKER}"
-        with open(ostree_booted, "w", encoding="utf-8") as f:
+        with open(ostree_booted, "w", encoding="utf8") as f:
             f.write("")
 
     extra_args = []

--- a/stages/org.osbuild.rpm.macros
+++ b/stages/org.osbuild.rpm.macros
@@ -57,7 +57,7 @@ def main(tree, options):
     path = os.path.join(tree, filename)
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
-    with open(path, "w", encoding="utf-8") as f:
+    with open(path, "w", encoding="utf8") as f:
         for k, v in options["macros"].items():
             value = make_value(k, v)
             line = f"%{k} {value}\n"

--- a/stages/org.osbuild.selinux.config
+++ b/stages/org.osbuild.selinux.config
@@ -39,7 +39,7 @@ def main(tree, options):
     selinux_type_key = "SELINUXTYPE"
 
     selinux_config_lines = []
-    with open(f"{tree}{selinux_config_file}") as f:
+    with open(f"{tree}{selinux_config_file}", encoding="utf8") as f:
         selinux_config_lines = f.readlines()
 
     for idx, line in enumerate(selinux_config_lines):
@@ -53,7 +53,7 @@ def main(tree, options):
         elif line_key == selinux_type_key and policy_type:
             selinux_config_lines[idx] = f"{selinux_type_key}={policy_type}\n"
 
-    with open(f"{tree}{selinux_config_file}", "w") as f:
+    with open(f"{tree}{selinux_config_file}", "w", encoding="utf8") as f:
         f.writelines(selinux_config_lines)
 
     return 0

--- a/stages/org.osbuild.sfdisk
+++ b/stages/org.osbuild.sfdisk
@@ -165,7 +165,7 @@ class PartitionTable:
 
         subprocess.run(["sfdisk", "-q", "--no-tell-kernel", target],
                        input=command,
-                       encoding='utf-8',
+                       encoding='utf8',
                        check=True)
 
         if sync:
@@ -175,7 +175,7 @@ class PartitionTable:
         """Update and fill in missing information from disk"""
         r = subprocess.run(["sfdisk", "--json", target],
                            stdout=subprocess.PIPE,
-                           encoding='utf-8',
+                           encoding='utf8',
                            check=True)
         disk_table = json.loads(r.stdout)["partitiontable"]
         disk_parts = disk_table["partitions"]
@@ -214,7 +214,7 @@ def main(devices, options):
     pt.write_to(device)
 
     subprocess.run(["sfdisk", "--json", device],
-                   encoding='utf-8',
+                   encoding='utf8',
                    check=False)
 
 

--- a/stages/org.osbuild.sgdisk
+++ b/stages/org.osbuild.sgdisk
@@ -162,7 +162,7 @@ class PartitionTable:
             command += cmd
 
         subprocess.run(command,
-                       encoding='utf-8',
+                       encoding='utf8',
                        check=True)
 
 
@@ -189,7 +189,7 @@ def main(devices, options):
     pt.write_to(device)
 
     subprocess.run(["sgdisk", "-p", device],
-                   encoding='utf-8',
+                   encoding='utf8',
                    check=False)
 
 

--- a/stages/org.osbuild.sshd.config
+++ b/stages/org.osbuild.sshd.config
@@ -101,7 +101,7 @@ def main(tree, options):
                     sys.stdout.write(f"{key} {entry['value']}\n")
                     continue
             sys.stdout.write(line)
-    with open(f"{tree}/etc/ssh/sshd_config", mode="a") as f:
+    with open(f"{tree}/etc/ssh/sshd_config", mode="a", encoding="utf8") as f:
         for entry in changes.values():
             f.write(f"{entry['key']} {entry['value']}\n")
 

--- a/stages/org.osbuild.sysconfig
+++ b/stages/org.osbuild.sysconfig
@@ -168,7 +168,7 @@ def configure_kernel(tree, kernel_options):
     if not kernel_options:
         return
 
-    with open(f"{tree}/etc/sysconfig/kernel", 'w') as kernel_file:
+    with open(f"{tree}/etc/sysconfig/kernel", 'w', encoding="utf8") as kernel_file:
         for option, value in kernel_options.items():
             if option == "update_default":
                 kernel_file.write(f"UPDATEDEFAULT={bool_to_string(value)}\n")
@@ -183,7 +183,7 @@ def configure_network(tree, network_options):
     if not network_options:
         return
 
-    with open(f"{tree}/etc/sysconfig/network", 'w') as network_file:
+    with open(f"{tree}/etc/sysconfig/network", 'w', encoding="utf8") as network_file:
         for option, value in network_options.items():
             if option == "networking":
                 network_file.write(f"NETWORKING={bool_to_string(value)}\n")
@@ -230,7 +230,7 @@ def configure_network_scripts_ifcfg(tree, network_scripts_ifcfg_options):
                                  "config.")
 
         if lines:
-            with open(f"{tree}/etc/sysconfig/network-scripts/ifcfg-{ifname}", 'w') as ifcfg_file:
+            with open(f"{tree}/etc/sysconfig/network-scripts/ifcfg-{ifname}", 'w', encoding="utf8") as ifcfg_file:
                 ifcfg_file.writelines(lines)
 
 

--- a/stages/org.osbuild.sysctld
+++ b/stages/org.osbuild.sysctld
@@ -94,7 +94,7 @@ def main(tree, options):
         cfg_line = f"{key} = {value}\n" if value else f"{key}\n"
         cfg_lines.append(cfg_line)
 
-    with open(f"{sysctld_config_dir}/{filename}", "w") as f:
+    with open(f"{sysctld_config_dir}/{filename}", "w", encoding="utf8") as f:
         f.writelines(cfg_lines)
 
     return 0

--- a/stages/org.osbuild.systemd-logind
+++ b/stages/org.osbuild.systemd-logind
@@ -73,7 +73,7 @@ def main(tree, options):
         for option, value in opts.items():
             config.set(section, option, str(value))
 
-    with open(f"{dropins_dir}/{dropin_file}", "w") as f:
+    with open(f"{dropins_dir}/{dropin_file}", "w", encoding="utf8") as f:
         config.write(f, space_around_delimiters=False)
 
     return 0

--- a/stages/org.osbuild.systemd.unit
+++ b/stages/org.osbuild.systemd.unit
@@ -79,7 +79,7 @@ def main(tree, options):
         for option, value in opts.items():
             config.set(section, option, str(value))
 
-    with open(f"{unit_dropins_dir}/{dropin_file}", "w") as f:
+    with open(f"{unit_dropins_dir}/{dropin_file}", "w", encoding="utf8") as f:
         config.write(f, space_around_delimiters=False)
 
     return 0

--- a/stages/org.osbuild.test
+++ b/stages/org.osbuild.test
@@ -42,7 +42,7 @@ StandardOutput=file:/dev/vport0p1
 ExecStart={script}
 ExecStopPost=/usr/bin/systemctl poweroff
 """
-    with open(f"{tree}/etc/systemd/system/osbuild-test.service", "w") as f:
+    with open(f"{tree}/etc/systemd/system/osbuild-test.service", "w", encoding="utf8") as f:
         f.write(unit)
 
     os.symlink("../osbuild-test.service",

--- a/stages/org.osbuild.tmpfilesd
+++ b/stages/org.osbuild.tmpfilesd
@@ -109,7 +109,7 @@ def main(tree, options):
         cfg_line += "\n"
         cfg_lines.append(cfg_line)
 
-    with open(f"{tmpfilesd_config_dir}/{filename}", "w") as f:
+    with open(f"{tmpfilesd_config_dir}/{filename}", "w", encoding="utf8") as f:
         f.writelines(cfg_lines)
 
     return 0

--- a/stages/org.osbuild.tuned
+++ b/stages/org.osbuild.tuned
@@ -90,11 +90,11 @@ def main(tree, options):
             raise ValueError(f"TuneD profile '{profile}' does not exist")
 
     # Set the active profile
-    with open(f"{tree}{active_profile_file}", "w") as f:
+    with open(f"{tree}{active_profile_file}", "w", encoding="utf8") as f:
         f.write(" ".join(profiles) + "\n")
 
     # Mode needs to be set to "manual" if set explicitly
-    with open(f"{tree}{profile_mode_file}", "w") as f:
+    with open(f"{tree}{profile_mode_file}", "w", encoding="utf8") as f:
         f.write("manual\n")
 
     return 0

--- a/stages/org.osbuild.udev.rules
+++ b/stages/org.osbuild.udev.rules
@@ -304,7 +304,7 @@ def main(tree, options):
     rules = options["rules"]
 
     path = os.path.join(tree, filename.lstrip("/"))
-    with open(path, "w", encoding="utf-8") as f:
+    with open(path, "w", encoding="utf8") as f:
         for rule in rules:
             if isinstance(rule, dict):
                 comment = rule.get("comment")

--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -74,7 +74,7 @@ SCHEMA = """
 
 def getpwnam(root, name):
     """Similar to pwd.getpwnam, but takes a @root parameter"""
-    with open(f"{root}/etc/passwd") as f:
+    with open(f"{root}/etc/passwd", encoding="utf8") as f:
         for line in f:
             passwd = line.split(":")
             if passwd[0] == name:
@@ -131,7 +131,7 @@ def add_ssh_key(root, user, key):
         os.mkdir(ssh_dir, 0o700)
         os.chown(ssh_dir, int(uid), int(gid))
 
-    with open(authorized_keys, "a") as f:
+    with open(authorized_keys, "a", encoding="utf8") as f:
         f.write(f"{key}\n")
 
     os.chown(authorized_keys, int(uid), int(gid))

--- a/stages/org.osbuild.vagrant
+++ b/stages/org.osbuild.vagrant
@@ -79,8 +79,8 @@ Vagrant.configure("2") do |config|
   end
 end
 """
-    open(f"{tree}/Vagrantfile", "w").write(vagrantfile)
-    with open(f"{tree}/metadata.json", "w") as fp:
+    open(f"{tree}/Vagrantfile", "w", encoding="utf8").write(vagrantfile)
+    with open(f"{tree}/metadata.json", "w", encoding="utf8") as fp:
         json.dump(metadata, fp)
 
 

--- a/stages/org.osbuild.waagent.conf
+++ b/stages/org.osbuild.waagent.conf
@@ -73,7 +73,7 @@ def main(tree, options):
                     sys.stdout.write(f"{key}={entry['value']}\n")
                     continue
             sys.stdout.write(line)
-    with open(f"{tree}/etc/waagent.conf", mode="a") as f:
+    with open(f"{tree}/etc/waagent.conf", mode="a", encoding="utf8") as f:
         for entry in changes.values():
             f.write(f"{entry['key']}={entry['value']}\n")
 

--- a/stages/org.osbuild.xz
+++ b/stages/org.osbuild.xz
@@ -53,7 +53,7 @@ def main(inputs, output, options):
     source = parse_input(inputs)
     target = os.path.join(output, filename)
 
-    with open(target, "w") as f:
+    with open(target, "w", encoding="utf8") as f:
 
         env = {
             "XZ_OPT": "--threads 0"

--- a/stages/org.osbuild.yum.config
+++ b/stages/org.osbuild.yum.config
@@ -62,7 +62,7 @@ def configure_plugins(tree, plugins_options):
         plugin_conf = iniparse.SafeConfigParser()
 
         try:
-            with open(plugin_conf_path, "r") as f:
+            with open(plugin_conf_path, "r", encoding="utf8") as f:
                 plugin_conf.readfp(f)
         except FileNotFoundError:
             print(f"Warning: {plugin} configuration file '{plugin_conf_path}' does not exist, will create it.")
@@ -83,7 +83,7 @@ def configure_plugins(tree, plugins_options):
                 print(f"Error: unknown property {option} specified for {plugin} plugin.")
                 return 1
 
-        with open(plugin_conf_path, "w") as f:
+        with open(plugin_conf_path, "w", encoding="utf8") as f:
             plugin_conf.write(f)
 
     return 0
@@ -98,7 +98,7 @@ def main(tree, options):
 
     if config_options:
         try:
-            with open(yum_config_path, "r") as f:
+            with open(yum_config_path, "r", encoding="utf8") as f:
                 yum_config.readfp(f)
         except FileNotFoundError:
             print(f"Warning: YUM configuration file '{yum_config_path}' does not exist, will create it.")
@@ -110,7 +110,7 @@ def main(tree, options):
         for option, value in config_options.items():
             yum_config.set("main", option, value)
 
-        with open(yum_config_path, "w") as f:
+        with open(yum_config_path, "w", encoding="utf8") as f:
             yum_config.write(f)
 
     if configure_plugins(tree, plugins_options):

--- a/stages/org.osbuild.yum.repos
+++ b/stages/org.osbuild.yum.repos
@@ -181,7 +181,7 @@ def main(tree, options):
             parser.set(repo_id, key, option_value_to_str(value))
 
     # ensure that we won't overwrite an existing file
-    with open(f"{yum_repos_dir}/{filename}", "x") as f:
+    with open(f"{yum_repos_dir}/{filename}", "x", encoding="utf8") as f:
         parser.write(f, space_around_delimiters=False)
 
     return 0

--- a/stages/org.osbuild.zipl
+++ b/stages/org.osbuild.zipl
@@ -34,7 +34,7 @@ def main(tree, options):
     new_zipl_conf = "\n".join(config) + "\n"
 
     os.makedirs(f"{tree}/etc", exist_ok=True)
-    with open(f"{tree}/etc/zipl.conf", "w") as f:
+    with open(f"{tree}/etc/zipl.conf", "w", encoding="utf8") as f:
         f.write(new_zipl_conf)
 
     return 0

--- a/stages/org.osbuild.zipl.inst
+++ b/stages/org.osbuild.zipl.inst
@@ -55,7 +55,7 @@ SCHEMA_2 = r"""
 
 def parse_blsfile(blsfile):
     params = {}
-    with open(blsfile, "r") as bls:
+    with open(blsfile, "r", encoding="utf8") as bls:
         for line in bls:
             key, value = line.split(' ', 1)
             params[key] = value.strip()

--- a/test/initrd.py
+++ b/test/initrd.py
@@ -168,7 +168,7 @@ class Initrd:
                                          encoding=None,
                                          stdin=image,
                                          stderr=subprocess.DEVNULL)
-        return output.strip().decode('utf-8')
+        return output.strip().decode('utf8')
 
 
 def read_initrd(path):

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -55,14 +55,14 @@ def test_runner_fail(tempdir):
     logfile = os.path.join(tempdir, "log.txt")
 
     with BuildRoot("/", runner, libdir, var) as root, \
-            open(logfile, "w") as log:
+            open(logfile, "w", encoding="utf8") as log:
 
         monitor = LogMonitor(log.fileno())
 
         r = root.run(["/usr/bin/true"], monitor)
 
     assert r.returncode == 1
-    with open(logfile) as f:
+    with open(logfile, encoding="utf8") as f:
         log = f.read()
     assert log
     assert r.output
@@ -208,7 +208,7 @@ def test_env_isolation(tempdir):
         r = root.run(cmd, monitor, binds=[f"{ipc}:/ipc"])
 
     assert r.returncode == 0
-    with open(os.path.join(ipc, "env.txt")) as f:
+    with open(os.path.join(ipc, "env.txt"), encoding="utf8") as f:
         data = f.read().strip()
     assert data
     have = dict(map(lambda x: x.split("=", 1), data.split("\n")))
@@ -247,7 +247,7 @@ def test_caps(tempdir):
             r = root.run(cmd, monitor, binds=[f"{ipc}:/ipc"])
 
             assert r.returncode == 0
-            with open(os.path.join(ipc, "status"), encoding="utf-8") as f:
+            with open(os.path.join(ipc, "status"), encoding="utf8") as f:
                 data = f.readlines()
             assert data
 

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -67,13 +67,13 @@ class TestMonitor(unittest.TestCase):
 
             logfile = os.path.join(tmpdir, "log.txt")
 
-            with open(logfile, "w") as log, ObjectStore(storedir) as store:
+            with open(logfile, "w", encoding="utf8") as log, ObjectStore(storedir) as store:
                 monitor = LogMonitor(log.fileno())
                 res = pipeline.run(store,
                                    monitor,
                                    libdir=os.path.abspath(os.curdir))
 
-                with open(logfile) as f:
+                with open(logfile, encoding="utf8") as f:
                     log = f.read()
 
             assert res

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -122,7 +122,7 @@ class TestObjectStore(unittest.TestCase):
             with object_store.new() as tree:
                 path = tree.write()
                 with tree.write() as path, \
-                        open(os.path.join(path, "data"), "w") as f:
+                        open(os.path.join(path, "data"), "w", encoding="utf8") as f:
                     f.write(data)
                     st = os.fstat(f.fileno())
                     data_inode = st.st_ino
@@ -134,7 +134,7 @@ class TestObjectStore(unittest.TestCase):
                 # check that "data" is still the very
                 # same file after committing
                 with tree.read() as path:
-                    with open(os.path.join(path, "data"), "r") as f:
+                    with open(os.path.join(path, "data"), "r", encoding="utf8") as f:
                         st = os.fstat(f.fileno())
                         self.assertEqual(st.st_ino, data_inode)
                         data_read = f.read()
@@ -147,7 +147,7 @@ class TestObjectStore(unittest.TestCase):
             with object_store.new(base_id="x") as tree:
                 self.assertEqual(tree.base, "x")
                 with tree.read() as path:
-                    with open(os.path.join(path, "data"), "r") as f:
+                    with open(os.path.join(path, "data"), "r", encoding="utf8") as f:
                         # copy-on-write: since we have not written
                         # to the tree yet, "data" should be the
                         # very same file as that one of object "x"
@@ -303,7 +303,7 @@ class TestObjectStore(unittest.TestCase):
             assert Path(path) == mountpoint
             filepath = Path(mountpoint, "file.txt")
             assert filepath.exists()
-            txt = filepath.read_text()
+            txt = filepath.read_text(encoding="utf8")
             assert txt == "osbuild"
 
             # check we can mount subtrees via `read_tree_at`
@@ -314,7 +314,7 @@ class TestObjectStore(unittest.TestCase):
             path = client.read_tree_at("42", filemount, "/file.txt")
             filepath = Path(path)
             assert filepath.is_file()
-            txt = filepath.read_text()
+            txt = filepath.read_text(encoding="utf8")
             assert txt == "osbuild"
 
             dirmount = Path(tmpdir, "dir")

--- a/test/mod/test_util_linux.py
+++ b/test/mod/test_util_linux.py
@@ -26,7 +26,7 @@ def test_ioctl_get_immutable(tmpdir):
     # as intended.
     #
 
-    with open(f"{tmpdir}/immutable", "x") as f:
+    with open(f"{tmpdir}/immutable", "x", encoding="utf8") as f:
         assert not linux.ioctl_get_immutable(f.fileno())
 
 
@@ -37,7 +37,7 @@ def test_ioctl_toggle_immutable(tmpdir):
     # as intended.
     #
 
-    with open(f"{tmpdir}/immutable", "x") as f:
+    with open(f"{tmpdir}/immutable", "x", encoding="utf8") as f:
         # Check the file is mutable by default and if we clear it again.
         assert not linux.ioctl_get_immutable(f.fileno())
         linux.ioctl_toggle_immutable(f.fileno(), False)

--- a/test/mod/test_util_lorax.py
+++ b/test/mod/test_util_lorax.py
@@ -42,13 +42,13 @@ class TestUtilLorax(test.TestBase):
             os.makedirs(root)
             os.makedirs(tree)
 
-            with open(os.path.join(root, "hello.txt"), "w") as f:
+            with open(os.path.join(root, "hello.txt"), "w", encoding="utf8") as f:
                 f.write("Hello World\n")
 
             self.assertExists(root, "hello.txt")
 
             template = os.path.join(tmp, "template.tmpl")
-            with open(os.path.join(tmp, template), "w") as f:
+            with open(os.path.join(tmp, template), "w", encoding="utf8") as f:
                 f.write(BASIC_TEMPLATE)
 
             # parse the template and render it
@@ -76,7 +76,7 @@ class TestUtilLorax(test.TestBase):
             self.assertExists(tree, "foo.txt")
 
             for fn in ["a.txt", "b.txt"]:
-                with open(os.path.join(tree, fn), "r") as f:
+                with open(os.path.join(tree, fn), "r", encoding="utf8") as f:
                     data = f.read().strip()
                     self.assertEqual(data, "osbuild-42")
 

--- a/test/mod/test_util_lvm2.py
+++ b/test/mod/test_util_lvm2.py
@@ -24,7 +24,7 @@ def have_lvm() -> bool:
     try:
         r = subprocess.run(
             ["vgs"],
-            encoding="utf-8",
+            encoding="utf8",
             stdout=subprocess.PIPE,
             check=False
         )

--- a/test/mod/test_util_ostree.py
+++ b/test/mod/test_util_ostree.py
@@ -15,7 +15,7 @@ from osbuild.util import ostree
 from .. import test
 
 
-def run(*args, check=True, encoding="utf-8", **kwargs):
+def run(*args, check=True, encoding="utf8", **kwargs):
     res = subprocess.run(*args,
                          encoding=encoding,
                          check=check,
@@ -56,7 +56,7 @@ class TestObjectStore(test.TestBase):
         tf["ref"] = test_ref
 
         with tf.as_tmp_file() as path:
-            with open(path, "r") as f:
+            with open(path, "r", encoding="utf8") as f:
                 js = json.load(f)
                 self.assertEqual(js["ref"], test_ref)
                 self.assertEqual(tf["ref"], test_ref)
@@ -118,16 +118,16 @@ class TestPasswdLike(unittest.TestCase):
                 "lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin\n",
                 "sync:x:5:0:sync:/sbin:/bin/sync\n"
             ]
-            with open(os.path.join(tmpdir, "primary"), "w") as f:
+            with open(os.path.join(tmpdir, "primary"), "w", encoding="utf8") as f:
                 f.writelines(primary_file_lines)
-            with open(os.path.join(tmpdir, "secondary"), "w") as f:
+            with open(os.path.join(tmpdir, "secondary"), "w", encoding="utf8") as f:
                 f.writelines(secondary_file_lines)
 
             passwd = ostree.PasswdLike.from_file(os.path.join(tmpdir, "primary"))
             passwd.merge_with_file(os.path.join(tmpdir, "secondary"))
             passwd.dump_to_file(os.path.join(tmpdir, "result"))
 
-            with open(os.path.join(tmpdir, "result"), "r") as f:
+            with open(os.path.join(tmpdir, "result"), "r", encoding="utf8") as f:
                 self.assertEqual(sorted(f.readlines()), sorted(result_file_lines))
 
     def test_merge_group(self):
@@ -145,16 +145,16 @@ class TestPasswdLike(unittest.TestCase):
                 "bin:x:1:\n",
                 "daemon:x:2:\n"
             ]
-            with open(os.path.join(tmpdir, "primary"), "w") as f:
+            with open(os.path.join(tmpdir, "primary"), "w", encoding="utf8") as f:
                 f.writelines(primary_file_lines)
-            with open(os.path.join(tmpdir, "secondary"), "w") as f:
+            with open(os.path.join(tmpdir, "secondary"), "w", encoding="utf8") as f:
                 f.writelines(secondary_file_lines)
 
             passwd = ostree.PasswdLike.from_file(os.path.join(tmpdir, "primary"))
             passwd.merge_with_file(os.path.join(tmpdir, "secondary"))
             passwd.dump_to_file(os.path.join(tmpdir, "result"))
 
-            with open(os.path.join(tmpdir, "result"), "r") as f:
+            with open(os.path.join(tmpdir, "result"), "r", encoding="utf8") as f:
                 self.assertEqual(sorted(f.readlines()), sorted(result_file_lines))
 
     #pylint: disable=no-self-use

--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -30,7 +30,7 @@ class TestAssemblers(test.TestBase):
     def run_assembler(self, osb, name, options, output_path):
         with open(os.path.join(self.locate_test_data(),
                                "manifests/filesystem.json"),
-                               encoding="utf8") as f:
+                  encoding="utf8") as f:
             manifest = json.load(f)
         manifest["pipeline"] = dict(
             manifest["pipeline"],
@@ -115,7 +115,7 @@ class TestAssemblers(test.TestBase):
         with self.osbuild as osb:
             with open(os.path.join(self.locate_test_data(),
                                    "manifests/fedora-ostree-commit.json"),
-                                   encoding="utf8") as f:
+                      encoding="utf8") as f:
                 manifest = json.load(f)
 
             data = json.dumps(manifest)

--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -29,7 +29,8 @@ class TestAssemblers(test.TestBase):
     @contextlib.contextmanager
     def run_assembler(self, osb, name, options, output_path):
         with open(os.path.join(self.locate_test_data(),
-                               "manifests/filesystem.json")) as f:
+                               "manifests/filesystem.json"),
+                               encoding="utf8") as f:
             manifest = json.load(f)
         manifest["pipeline"] = dict(
             manifest["pipeline"],
@@ -51,7 +52,7 @@ class TestAssemblers(test.TestBase):
         self.assertEqual(info["virtual-size"], expected_size)
 
     def assertFilesystem(self, device, uuid, fstype, tree):
-        output = subprocess.check_output(["blkid", "--output", "export", device], encoding="utf-8")
+        output = subprocess.check_output(["blkid", "--output", "export", device], encoding="utf8")
         blkid = dict(line.split("=") for line in output.strip().split("\n"))
         self.assertEqual(blkid["UUID"], uuid)
         self.assertEqual(blkid["TYPE"], fstype)
@@ -113,7 +114,8 @@ class TestAssemblers(test.TestBase):
     def test_ostree(self):
         with self.osbuild as osb:
             with open(os.path.join(self.locate_test_data(),
-                                   "manifests/fedora-ostree-commit.json")) as f:
+                                   "manifests/fedora-ostree-commit.json"),
+                                   encoding="utf8") as f:
                 manifest = json.load(f)
 
             data = json.dumps(manifest)
@@ -122,7 +124,7 @@ class TestAssemblers(test.TestBase):
                 compose_file = os.path.join(output_dir, "ostree-commit", "compose.json")
                 repo = os.path.join(output_dir, "ostree-commit", "repo")
 
-                with open(compose_file) as f:
+                with open(compose_file, encoding="utf8") as f:
                     compose = json.load(f)
                 commit_id = compose["ostree-commit"]
                 ref = compose["ref"]
@@ -146,7 +148,7 @@ class TestAssemblers(test.TestBase):
                         "--repo", repo,
                         "--print-metadata-key=rpmostree.inputhash",
                         commit_id
-                    ], encoding="utf-8").strip()
+                    ], encoding="utf8").strip()
                 self.assertEqual(md, f"'{rpmostree_inputhash}'")
 
                 md = subprocess.check_output(
@@ -156,7 +158,7 @@ class TestAssemblers(test.TestBase):
                         "--repo", repo,
                         "--print-metadata-key=version",
                         commit_id
-                    ], encoding="utf-8").strip()
+                    ], encoding="utf8").strip()
                 self.assertEqual(md, f"'{os_version}'")
 
     @unittest.skipUnless(test.TestBase.have_tree_diff(), "tree-diff missing")
@@ -223,7 +225,7 @@ class TestAssemblers(test.TestBase):
                                         "org.osbuild.tar",
                                         options,
                                         filename) as (tree, image):
-                    output = subprocess.check_output(["file", "--mime-type", image], encoding="utf-8")
+                    output = subprocess.check_output(["file", "--mime-type", image], encoding="utf8")
                     _, mimetype = output.strip().split(": ")  # "filename: mimetype"
                     self.assertIn(mimetype, expected_mimetypes)
 
@@ -240,7 +242,7 @@ class TestAssemblers(test.TestBase):
                             "--xattrs", "--xattrs-include", "*",
                             "-xaf", image,
                             "-C", tmp]
-                        subprocess.check_output(args, encoding="utf-8")
+                        subprocess.check_output(args, encoding="utf8")
                         diff = self.tree_diff(tree, tmp)
                         self.assertEqual(diff["added_files"], [])
                         self.assertEqual(diff["deleted_files"], [])

--- a/test/run/test_boot.py
+++ b/test/run/test_boot.py
@@ -46,7 +46,7 @@ class TestBoot(test.TestBase):
                                 "-device", "virtserialport,chardev=stdio",
 
                                 qcow2],
-                               encoding="utf-8",
+                               encoding="utf8",
                                check=True)
-                with open(output_file, "r") as f:
+                with open(output_file, "r", encoding="utf8") as f:
                     self.assertEqual(f.read().strip(), "running")

--- a/test/run/test_devices.py
+++ b/test/run/test_devices.py
@@ -77,5 +77,5 @@ def test_loopback_basic(tmpdir):
         client.call("close", None)
 
         lo = loop.Loop(minor)
-        with open(filename, "r") as f:
+        with open(filename, "r", encoding="utf8") as f:
             assert not lo.is_bound_to(f.fileno())

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -35,7 +35,7 @@ libc.setns.errcheck = errcheck
 @contextlib.contextmanager
 def netns():
     # Grab a reference to the current namespace.
-    with open("/proc/self/ns/net") as oldnet:
+    with open("/proc/self/ns/net", encoding="utf8") as oldnet:
         # Create a new namespace and enter it.
         libc.unshare(CLONE_NEWNET)
         try:
@@ -76,7 +76,7 @@ def runFileServer(barrier, directory):
 
         def guess_type(self, path):
             try:
-                with open(path + ".mimetype", "r") as f:
+                with open(path + ".mimetype", "r", encoding="utf8") as f:
                     return f.read().strip()
             except FileNotFoundError:
                 pass
@@ -119,7 +119,7 @@ def test_sources(source, case, tmpdir):
     index = osbuild.meta.Index(os.curdir)
     sources = os.path.join(test.TestBase.locate_test_data(), "sources")
 
-    with open(f"{sources}/{source}/cases/{case}") as f:
+    with open(f"{sources}/{source}/cases/{case}", encoding="utf8") as f:
         case_options = json.load(f)
 
     info = index.get_module_info("Source", source)

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -25,7 +25,7 @@ def have_sfdisk_with_json():
     r = subprocess.run(["sfdisk", "--version"],
                        stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE,
-                       encoding="utf-8",
+                       encoding="utf8",
                        check=False)
 
     if r.returncode != 0:
@@ -187,7 +187,7 @@ class TestStages(test.TestBase):
                                      pprint.pformat(want).splitlines())
                 txt = "\n".join(diff)
                 path = f"/tmp/osbuild.metadata.{stageid}.json"
-                with open(path, "w") as f:
+                with open(path, "w", encoding="utf8") as f:
                     json.dump(have, f, indent=2)
                 self.fail(f"metadata for {stageid} differs:\n{txt}\n{path}")
 
@@ -224,14 +224,14 @@ class TestStages(test.TestBase):
 
             actual_diff = self.tree_diff(tree1, tree2)
 
-            with open(os.path.join(test_dir, "diff.json")) as f:
+            with open(os.path.join(test_dir, "diff.json"), encoding="utf8") as f:
                 expected_diff = json.load(f)
 
             self.assertTreeDiffsEqual(expected_diff, actual_diff)
 
             md_path = os.path.join(test_dir, "metadata.json")
             if os.path.exists(md_path):
-                with open(md_path, "r") as f:
+                with open(md_path, "r", encoding="utf8") as f:
                     metadata = json.load(f)
 
                 self.assertMetadata(metadata, res)
@@ -245,7 +245,7 @@ class TestStages(test.TestBase):
         datadir = self.locate_test_data()
         base = os.path.join(datadir, "stages/dracut")
 
-        with open(f"{base}/vanilla.json", "r") as f:
+        with open(f"{base}/vanilla.json", "r", encoding="utf8") as f:
             refs = json.load(f)
 
         with self.osbuild as osb, tempfile.TemporaryDirectory(dir="/var/tmp") as outdir:
@@ -273,7 +273,7 @@ class TestStages(test.TestBase):
         testdir = os.path.join(datadir, "stages", "selinux")
 
         def load_manifest(manifest_name):
-            with open(os.path.join(datadir, f"manifests/{manifest_name}")) as f:
+            with open(os.path.join(datadir, f"manifests/{manifest_name}"), encoding="utf8") as f:
                 manifest = json.load(f)
                 return manifest
 
@@ -281,7 +281,7 @@ class TestStages(test.TestBase):
 
             for t in glob.glob(f"{testdir}/test_*.json"):
                 manifest = load_manifest("f34-base.json")
-                with open(t) as f:
+                with open(t, encoding="utf8") as f:
                     check = json.load(f)
                 manifest["pipeline"]["stages"].append({
                     "name": "org.osbuild.selinux",
@@ -308,7 +308,7 @@ class TestStages(test.TestBase):
 
         checks_path = os.path.join(testdir, "checks.json")
         checks = {}
-        with open(checks_path) as f:
+        with open(checks_path, encoding="utf8") as f:
             checks = json.load(f)
 
         for image_name, test_data in checks.items():
@@ -326,7 +326,7 @@ class TestStages(test.TestBase):
                     ["qemu-img", "info", "--output=json", ip],
                     capture_output=True,
                     check=True,
-                    encoding="utf-8"
+                    encoding="utf8"
                 )
 
                 qemu_img_out = json.loads(qemu_img_run.stdout)
@@ -371,7 +371,7 @@ class TestStages(test.TestBase):
 
         imgname = "disk.img"
 
-        with open(os.path.join(testdir, f"{imgname}.json"), "r") as f:
+        with open(os.path.join(testdir, f"{imgname}.json"), "r", encoding="utf8") as f:
             want = json.load(f)
 
         with self.osbuild as osb, tempfile.TemporaryDirectory(dir="/var/tmp") as outdir:
@@ -388,7 +388,7 @@ class TestStages(test.TestBase):
             r = subprocess.run(["sfdisk", "--json", target],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE,
-                               encoding="utf-8",
+                               encoding="utf8",
                                check=False)
 
             have = json.loads(r.stdout)
@@ -419,7 +419,7 @@ class TestStages(test.TestBase):
 
         imgname = "disk.img"
 
-        with open(os.path.join(testdir, f"{imgname}.json"), "r") as f:
+        with open(os.path.join(testdir, f"{imgname}.json"), "r", encoding="utf8") as f:
             want = json.load(f)
 
         with self.osbuild as osb, tempfile.TemporaryDirectory(dir="/var/tmp") as outdir:
@@ -436,7 +436,7 @@ class TestStages(test.TestBase):
             r = subprocess.run(["sfdisk", "--json", target],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE,
-                               encoding="utf-8",
+                               encoding="utf8",
                                check=False)
 
             have = json.loads(r.stdout)

--- a/test/test.py
+++ b/test/test.py
@@ -133,9 +133,9 @@ class TestBase(unittest.TestCase):
             original = os.path.join(tmpdir, "original")
             mnt = os.path.join(tmpdir, "mnt")
 
-            with open(original, "w") as f:
+            with open(original, "w", encoding="utf8") as f:
                 f.write("foo")
-            with open(mnt, "w") as f:
+            with open(mnt, "w", encoding="utf8") as f:
                 f.write("bar")
 
             try:
@@ -153,7 +153,7 @@ class TestBase(unittest.TestCase):
                     stderr=subprocess.DEVNULL,
                     check=True,
                 )
-                with open(mnt, "r") as f:
+                with open(mnt, "r", encoding="utf8") as f:
                     assert f.read() == "foo"
                 return True
             except subprocess.CalledProcessError:
@@ -178,7 +178,7 @@ class TestBase(unittest.TestCase):
         try:
             r = subprocess.run(
                 ["autopep8-3", "--version"],
-                encoding="utf-8", stdout=subprocess.PIPE, check=False
+                encoding="utf8", stdout=subprocess.PIPE, check=False
             )
         except FileNotFoundError:
             return False
@@ -196,7 +196,7 @@ class TestBase(unittest.TestCase):
         try:
             r = subprocess.run(
                 ["rpm-ostree", "--version"],
-                encoding="utf-8", stdout=subprocess.PIPE, check=False
+                encoding="utf8", stdout=subprocess.PIPE, check=False
             )
         except FileNotFoundError:
             return False
@@ -333,7 +333,7 @@ class OSBuild(contextlib.AbstractContextManager):
 
             cmd_args += ["-"]
 
-            logfile_context = tempfile.NamedTemporaryFile(dir="/var/tmp", mode="w+", encoding="utf-8")
+            logfile_context = tempfile.NamedTemporaryFile(dir="/var/tmp", mode="w+", encoding="utf8")
             logfile = cm.enter_context(logfile_context)
 
             cmd_args += ["--monitor", "LogMonitor", "--monitor-fd", str(logfile.fileno())]
@@ -345,7 +345,7 @@ class OSBuild(contextlib.AbstractContextManager):
             try:
                 p = subprocess.Popen(
                     cmd_args,
-                    encoding="utf-8",
+                    encoding="utf8",
                     stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
@@ -376,7 +376,7 @@ class OSBuild(contextlib.AbstractContextManager):
         to `compile()`.
         """
 
-        with open(file_stdin, "r") as f:
+        with open(file_stdin, "r", encoding="utf8") as f:
             data_stdin = f.read()
             return self.compile(data_stdin, output_dir, checkpoints=checkpoints, exports=exports)
 


### PR DESCRIPTION
Provides explicit encodings for all calls to `open()`, this is a newer pylint warning but also just makes sense to do.

This is a change for enabling newer pylint versions: #1094.