### PR TITLE
osbuild-mpp: fix minor issues and coding-style

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -927,11 +927,11 @@ class ManifestFile:
             try:
                 data = yaml_load_ordered(f)
             except yaml.YAMLError as err:
-                pos = ""
+                prob = ""
                 if hasattr(err, 'problem_mark'):
                     mark = err.problem_mark
-                    pos = f" at line {mark.line+1} (col {mark.column+1})"
-                print(f"Invalid yaml in \"{path}\": {err.problem}{pos}")
+                    prob = f": {err.problem} at line {mark.line+1} (col {mark.column+1})"
+                print(f"Invalid yaml in \"{path}\"{prob}")
                 sys.exit(1)
         else:
             try:

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -1232,6 +1232,15 @@ class ManifestFile:
         self._process_embed_files(stage)
         self._process_container(stage)
 
+    def _process_depsolve(self, _stage, _pipeline_name):
+        raise NotImplementedError()
+
+    def _process_embed_files(self, _stage):
+        raise NotImplementedError()
+
+    def _process_container(self, _stage):
+        raise NotImplementedError()
+
 
 class ManifestFileV1(ManifestFile):
     def __init__(self, path, overrides, default_vars, data, searchdirs):

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -379,15 +379,15 @@ class ImageManifest:
 
     # Based on joseBase64UrlDecode() from docker
     @staticmethod
-    def _jose_base64url_decode(input):
+    def _jose_base64url_decode(data):
         # Strip whitespace
-        input.replace("\n", "")
-        input.replace(" ", "")
-        # Pad input with = to make it valid
-        rem = len(input) % 4
+        data.replace("\n", "")
+        data.replace(" ", "")
+        # Pad data with = to make it valid
+        rem = len(data) % 4
         if rem > 0:
-            input += "=" * (4 - rem)
-        return base64.urlsafe_b64decode(input)
+            data += "=" * (4 - rem)
+        return base64.urlsafe_b64decode(data)
 
     def _compute_digest(self):
         raw = self.raw
@@ -411,10 +411,10 @@ class ImageManifest:
         for m in self.json.get("manifests", []):
             platform = m.get("platform", {})
             arch = platform.get("architecture", "")
-            os = platform.get("os", "")
+            ostype = platform.get("os", "")
             variant = platform.get("variant", None)
 
-            if arch != wanted_arch or wanted_os != os:
+            if arch != wanted_arch or wanted_os != ostype:
                 continue
 
             if wanted_variant and wanted_variant != variant:
@@ -1497,7 +1497,7 @@ class ManifestFileV2(ManifestFile):
 
             main_manifest = ImageManifest.load(source, tag=tag, digest=digest)
 
-            os = image.get("os", "linux")
+            ostype = image.get("os", "linux")
 
             default_rpm_arch = self.get_vars()["arch"]
             rpm_arch = image.get("arch", default_rpm_arch)
@@ -1505,7 +1505,7 @@ class ManifestFileV2(ManifestFile):
 
             variant = image.get("variant", None)
 
-            resolved_manifest = main_manifest.resolve_list(oci_arch, os, variant)
+            resolved_manifest = main_manifest.resolve_list(oci_arch, ostype, variant)
 
             image_id = resolved_manifest.get_config_digest()
 

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -827,8 +827,7 @@ class PartitionTable:
             for part in self.partitions:
                 if part.id == key:
                     return part
-        else:
-            raise ValueError("unsupported type")
+        raise IndexError
 
     def write_to(self, target, sync=True):
         """Write the partition table to disk"""

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+# pylint: disable=too-many-lines
+
 """Manifest-Pre-Processor
 
 This manifest-pre-processor takes a path to a manifest, loads it,
@@ -405,7 +407,7 @@ class ImageManifest:
         self.digest = "sha256:" + hashlib.sha256(raw).hexdigest()
 
     def is_manifest_list(self):
-        return self.media_type == "application/vnd.docker.distribution.manifest.list.v2+json" or self.media_type == "application/vnd.oci.image.index.v1+json"
+        return self.media_type in ("application/vnd.docker.distribution.manifest.list.v2+json", "application/vnd.oci.image.index.v1+json")
 
     def _match_platform(self, wanted_arch, wanted_os, wanted_variant):
         for m in self.json.get("manifests", []):
@@ -461,11 +463,12 @@ class ImageManifest:
         return self.json.get("config", {}).get("digest", "")
 
 
+# pylint: disable=too-many-ancestors
 class YamlOrderedLoader(yaml.Loader):
     def construct_mapping(self, node, deep=False):
         if not isinstance(node, yaml.MappingNode):
             raise yaml.constructor.ConstructorError(None, None,
-                                                    "expected a mapping node, but found %s" % node.id,
+                                                    f"expected a mapping node, but found {node.id}",
                                                     node.start_mark)
         mapping = collections.OrderedDict()
         for key_node, value_node in node.value:
@@ -548,7 +551,7 @@ class PacmanSolver():
         os.makedirs(os.path.join(root, "var", "lib", "pacman"), exist_ok=True)
         os.makedirs(os.path.join(root, "etc"), exist_ok=True)
 
-    def reset(self, arch, _, module_platform_id, ignore_weak_deps):
+    def reset(self, arch, _, _module_platform_id, _ignore_weak_deps):
         self.setup_root()
         cfg = f"""
 [options]
@@ -823,7 +826,7 @@ class PartitionTable:
     def __getitem__(self, key) -> Partition:
         if isinstance(key, int):
             return self.partitions[key]
-        elif isinstance(key, str):
+        if isinstance(key, str):
             for part in self.partitions:
                 if part.id == key:
                     return part
@@ -914,10 +917,11 @@ class Image:
         return cls(size, table)
 
 
+# pylint: disable=too-many-instance-attributes
 class ManifestFile:
     @staticmethod
     def load(path, overrides, default_vars, searchdirs):
-        with open(path) as f:
+        with open(path, encoding="utf8") as f:
             return ManifestFile.load_from_fd(f, path, overrides, default_vars, searchdirs)
 
     @staticmethod
@@ -1013,11 +1017,11 @@ class ManifestFile:
             raise ValueError(f"Incompatible manifest version {m.version}")
         return m
 
-    def find_and_open_file(self, path, dirs, mode="r"):
+    def find_and_open_file(self, path, dirs, mode="r", encoding="utf8"):
         for p in [self.basedir] + dirs:
             with contextlib.suppress(FileNotFoundError):
                 fullpath = os.path.join(p, path)
-                return open(fullpath, mode), os.path.normpath(fullpath)
+                return open(fullpath, mode, encoding=encoding), os.path.normpath(fullpath)
         raise FileNotFoundError(f"Could not find file '{path}'")
 
     def find_and_load_manifest(self, path):
@@ -1098,8 +1102,7 @@ class ManifestFile:
         self._process_format(fakeroot)
         if not fakeroot:
             return None, True
-        else:
-            return fakeroot[0], False
+        return fakeroot[0], False
 
     def _format_dict_node(self, node, stack):
         if len(stack) > 0:
@@ -1116,6 +1119,7 @@ class ManifestFile:
             pipeline_name = self.get_pipeline_name(parent_node)
             self._process_stage(node, pipeline_name)
 
+    # pylint: disable=too-many-branches
     def _process_format(self, node):
         def _is_format(node):
             if not isinstance(node, dict):
@@ -1184,7 +1188,7 @@ class ManifestFile:
             self._format_dict_node(node, self.format_stack)
 
             for key in list(node.keys()):
-                self.format_stack.append( (node, key) )
+                self.format_stack.append((node, key))
                 value = node[key]
                 if _is_format(value):
                     val, remove = _eval_format(value, self.get_vars())
@@ -1427,7 +1431,7 @@ class ManifestFileV2(ManifestFile):
                 raise ValueError(f"Only one of 'path', 'url' or 'text' may be specified for '{uid}'")
 
             if path:
-                f, _ = self.find_and_open_file(path, [], mode="rb")
+                f, _ = self.find_and_open_file(path, [], mode="rb", encoding=None)
                 with f:
                     data = f.read()
             elif url:
@@ -1589,7 +1593,7 @@ def main():
         m.process_format()
         m.solver_factory = None
 
-    with sys.stdout if args.dst == "-" else open(args.dst, "w") as f:
+    with sys.stdout if args.dst == "-" else open(args.dst, "w", encoding="utf8") as f:
         m.write(f, args.sort_keys)
 
 


### PR DESCRIPTION
A set of 4 fixes to osbuild-mpp, mostly reported by `pylint` and `mypy`. I extracted the actual changes to the code into separate commits. The coding-style changes are grouped into a single commit.

Note that we are about to enable `pylint` for `osbuild-mpp`, so we want all these warnings fixed first.