### PR TITLE
stages/greenboot: use disable-next to ignore f-string suggestion

### DIFF
--- a/stages/org.osbuild.greenboot
+++ b/stages/org.osbuild.greenboot
@@ -65,12 +65,12 @@ def main(tree, options):
                 svcs = current.strip('\"\n').split(" ")
                 new_svcs = [ns for ns in value if ns not in svcs]
                 new_svcs.extend(svcs)
-                # pylint: disable=consider-using-f-string
+                # pylint: disable-next=consider-using-f-string
                 sys.stdout.write('GREENBOOT_MONITOR_SERVICES="{0}"\n'.format(" ".join(new_svcs)))
     with open(config_file, "a", encoding="utf8") as f:
         for key, value in changes.items():
             if key == "monitor_services":
-                # pylint: disable=consider-using-f-string
+                # pylint: disable-next=consider-using-f-string
                 f.write('GREENBOOT_MONITOR_SERVICES="{0}"\n'.format(" ".join(value)))
 
     return 0


### PR DESCRIPTION
When ignoring a pylint check on the next line, `disable-next` is required instead of `disable`.

---

See https://github.com/osbuild/osbuild/actions/runs/3046450631/jobs/4909274592