### PR TITLE
stages/greenboot: avoid new pylint suppressions

### DIFF
--- a/stages/org.osbuild.greenboot
+++ b/stages/org.osbuild.greenboot
@@ -65,13 +65,13 @@ def main(tree, options):
                 svcs = current.strip('\"\n').split(" ")
                 new_svcs = [ns for ns in value if ns not in svcs]
                 new_svcs.extend(svcs)
-                # pylint: disable=consider-using-f-string
-                sys.stdout.write('GREENBOOT_MONITOR_SERVICES="{0}"\n'.format(" ".join(new_svcs)))
+                svcs_str = " ".join(new_svcs)
+                sys.stdout.write(f"GREENBOOT_MONITOR_SERVICES=\"{svcs_str}\"\n")
     with open(config_file, "a", encoding="utf8") as f:
         for key, value in changes.items():
             if key == "monitor_services":
-                # pylint: disable=consider-using-f-string
-                f.write('GREENBOOT_MONITOR_SERVICES="{0}"\n'.format(" ".join(value)))
+                svcs_str = " ".join(value)
+                f.write(f"GREENBOOT_MONITOR_SERVICES=\"{svcs_str}\"\n")
 
     return 0
 


### PR DESCRIPTION
The `consider-using-f-string` suppression is new, thus old pylint will complain about unknown directives. If we start ignoring unknown directives for this reasons, we will no longer get warned about misspelled directives. Hence, lets avoid this for now and just use an f-string.