### PR TITLE
packit: add epel-9 to copr_build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -28,6 +28,8 @@ jobs:
     - centos-stream-9-x86_64
     - epel-8-aarch64
     - epel-8-x86_64
+    - epel-9-aarch64
+    - epel-9-x86_64
     - fedora-all-aarch64
     - fedora-all-s390x
     - fedora-all-ppc64le
@@ -45,6 +47,8 @@ jobs:
     - centos-stream-9-x86_64
     - epel-8-aarch64
     - epel-8-x86_64
+    - epel-9-aarch64
+    - epel-9-x86_64
     - fedora-all-aarch64
     - fedora-all-s390x
     - fedora-all-ppc64le


### PR DESCRIPTION
Currently, we build only in the CS9 chroot. It contains newer packages than RHEL 9 has which causes the package built in CS9 chroot uninstallable on RHEL 9 - selinux-policy is the usual suspect.

Let's enable builds in the EPEL 9 chroot (which is actually EPEL 9 on RHEL 9) in order to have a repository for users that use RHEL 9.

This was requested in the Image Builder chat room.