### PR TITLE
manifest-db: propage the osbuild SHA on manifest-db

### DIFF
--- a/.github/workflows/propagate_to_manifestdb.yml
+++ b/.github/workflows/propagate_to_manifestdb.yml
@@ -1,0 +1,78 @@
+name: Update osbuild ref in manifest-db
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  propagate:
+    runs-on: ubuntu-latest
+    env:
+      SCHUTZBOT_GH: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+    steps:
+      - name: Checkout OSBuild
+        uses: actions/checkout@v3
+        with:
+          path: osbuild
+          fetch-depth: 0
+
+      - name: Update Manifest-db
+        run: |
+          # update only if manifest-db SHA was updated in the last commit
+          cd osbuild
+          ACTUAL_MDB_SHA=$(git show HEAD:Schutzfile | jq -r '.global.dependencies."manifest-db".commit')
+          PREVIOUS_MDB_SHA=$(git show HEAD^:Schutzfile | jq -r '.global.dependencies."manifest-db".commit')
+          if [[ $ACTUAL_MDB_SHA == $PREVIOUS_MDB_SHA ]] ; then
+            echo "The manifest-db SHA was not updated in the last commit, ignoring the dependency update"
+            exit 0
+          fi
+          echo "updating the dependency in manifest-db"
+          OSBUILD_HEAD="${{ github.sha }}"
+          echo "Latest OSBuild SHA: $OSBUILD_HEAD"
+
+          # Clone manifest-db
+          cd ..
+          git clone https://github.com/osbuild/manifest-db.git
+
+          # Load the previous osbuild REF from manifest-db's Schutzfile and
+          # Generate the commit list between the two osbuild revisions for the
+          # PR
+          cd manifest-db
+          OLD_REF=$(jq -r '.global.dependencies.osbuild.commit' Schutzfile)
+          cd ../osbuild
+          COMMIT_LIST=$(git log --oneline $OLD_REF..$OSBUILD_HEAD | sed 's/.*/- https:\/\/github.com\/osbuild\/osbuild\/commit\/&/')
+
+          # Update the manifest-db's dependency to the newest OSBuild
+          #
+          # Login as Schutzbot
+          cd ../manifest-db
+          echo "${SCHUTZBOT_GH}" | gh auth login --with-token
+          git config --local user.name "SchutzBot"
+          git config --local user.email "imagebuilder-bots+schutzbot@redhat.com"
+
+          # Create a branch for the PR
+          now=$(date '+%Y-%m-%d-%H%M%S')
+          BRANCH_NAME="osbuild-update-$now"
+          git checkout -b $BRANCH_NAME
+
+          # change the value for the commit head in the schutzfile
+          jq --arg variable "$OSBUILD_HEAD" '.global.dependencies.osbuild.commit=$variable' Schutzfile > Schutzfile.tmp && mv Schutzfile.tmp Schutzfile
+
+          # create the PR
+          PR_BODY="$(cat <<-END
+          This PR updates the osbuild ref dependency for manifest-db. Between the
+          last time it was updated, and this new reference commit, these are the changes:
+
+          $COMMIT_LIST
+          END
+          )"
+          git remote add upstream https://schutzbot:"$SCHUTZBOT_GH"@github.com/schutzbot/manifest-db.git
+          git add -A && \
+              git commit -m "schutzfile: update osbuild ref $(date '+%Y-%m-%d')" && \
+              git push upstream "$BRANCH_NAME:$BRANCH_NAME" && \
+              gh pr create \
+                  --title "schutzfile: update osbuild ref $(date '+%Y-%m-%d')" \
+                  --body "$PR_BODY" \
+                  --repo "osbuild/manifest-db" \
+                  -r lavocatt


### PR DESCRIPTION
Add a bot to update the SHA dependency to OSBuild on manifest-db automatically.

The OSBuild SHA will be changed only if the manifest-db SHA was updated on the last commit landed on main. This way this ensure that CI ran successfully for this exact version of OSBuild against manifest-db's actual state. Therefore it is safe to assume that we can upgrade the manifest dependency without running the whole CI again.

Testing done:
* On my fork, after this commit, I added first another one ammending the manifest-db dependency. It successfully opened a PR on manifest-db: https://github.com/osbuild/manifest-db/pull/49
* Then I added a second commit on top of this one changing something else in the repo, the bot did not opened a PR on manifest-db. https://github.com/lavocatt/osbuild/actions/runs/3060823276/jobs/4939810608

Thus making this a success