### PR TITLE
packit: Enable Bodhi updates for unstable Fedoras

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -66,4 +66,4 @@ jobs:
 - job: bodhi_update
   trigger: commit
   dist_git_branches:
-    - fedora-stable # rawhide updates are created automatically
+    - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
As we don't only want to get Bodhi updates for the stable releases, but also the ones still in development, we need to use 'fedora-branched'.

See https://packit.dev/docs/configuration/#aliases