### PR TITLE
stages: fix ostree config stage

### DIFF
--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -63,13 +63,16 @@ def ostree(*args, _input=None, **kwargs):
 
 def main(tree, options):
     repo = os.path.join(tree, options["repo"].lstrip("/"))
-    config = options["config"]
+    sysroot_options = options["config"].get("sysroot", {})
 
-    for group, items in config.items():
-        for key, value in items.items():
-            name = f"{group}.{key}"
-            ostree("config", "set", name, str(value),
-                   repo=repo)
+    bootloader = sysroot_options.get("bootloader")
+    if bootloader:
+        ostree("config", "set", "sysroot.bootloader", bootloader, repo=repo)
+
+    readonly = sysroot_options.get("readonly")
+    if readonly is not None:  # can be False, which we would want to set
+        ro = "true" if readonly else "false"
+        ostree("config", "set", "sysroot.readonly", ro, repo=repo)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Small rewrite of https://github.com/osbuild/osbuild/pull/986 as I didn't have permission to modify it.

----

Currently we're using `str(value)` on a boolean which yields `True` or `False` - turns out ostree reads these values case sensitive and despite setting `True|False`, it doesn't just work.

From jlebon on slack:

> the syntax is readonly=true . it's case sensitive

Fix the above and also just remove the loop as, while it's handy, we'll have to differentiate between options' values anyway and it's just two options we support today.

Signed-off-by: Antonio Murdaca <runcom@linux.com>