### PR TITLE
osbuild: all modules have a default `main`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,9 @@ jobs:
     - name: "Run Tests"
       uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
       with:
-        image: ghcr.io/osbuild/osbuild-ci:latest-202209070757
+        image: ghcr.io/osbuild/osbuild-ci:latest-202211251057
         run: |
+          python3 -m pip install .
           python3 -m pytest \
             --pyargs "${{ matrix.test }}" \
             --rootdir=. \

--- a/assemblers/org.osbuild.error
+++ b/assemblers/org.osbuild.error
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Return an error
 

--- a/assemblers/org.osbuild.error
+++ b/assemblers/org.osbuild.error
@@ -30,6 +30,7 @@ def main(options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args.get("options", {}))
     sys.exit(r)

--- a/assemblers/org.osbuild.noop
+++ b/assemblers/org.osbuild.noop
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 No-op assembler
 

--- a/assemblers/org.osbuild.noop
+++ b/assemblers/org.osbuild.noop
@@ -22,6 +22,7 @@ def main(_tree, _output_dir, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     args_input = args["inputs"]["tree"]["path"]
     args_output = args["tree"]

--- a/assemblers/org.osbuild.oci-archive
+++ b/assemblers/org.osbuild.oci-archive
@@ -276,6 +276,7 @@ def main(tree, output_dir, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     args_input = args["inputs"]["tree"]["path"]
     args_output = args["tree"]

--- a/assemblers/org.osbuild.oci-archive
+++ b/assemblers/org.osbuild.oci-archive
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assemble an OCI image archive
 

--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -186,6 +186,7 @@ def main(tree, output_dir, options, meta):
 
 
 if __name__ == '__main__':
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
     args = api.arguments()
     args_input = args["inputs"]["tree"]["path"]
     args_output = args["tree"]

--- a/assemblers/org.osbuild.ostree.commit
+++ b/assemblers/org.osbuild.ostree.commit
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assemble a file system tree into a ostree commit
 

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -739,6 +739,7 @@ def main(tree, output_dir, options, loop_client):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     args_input = args["inputs"]["tree"]["path"]
     args_output = args["tree"]

--- a/assemblers/org.osbuild.qemu
+++ b/assemblers/org.osbuild.qemu
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assemble a bootable partitioned disk image with qemu-img
 

--- a/assemblers/org.osbuild.rawfs
+++ b/assemblers/org.osbuild.rawfs
@@ -106,6 +106,7 @@ def main(tree, output_dir, options, loop_client):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     args_input = args["inputs"]["tree"]["path"]
     args_output = args["tree"]

--- a/assemblers/org.osbuild.rawfs
+++ b/assemblers/org.osbuild.rawfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assemble tree into a raw filesystem image
 

--- a/assemblers/org.osbuild.tar
+++ b/assemblers/org.osbuild.tar
@@ -108,6 +108,7 @@ def main(tree, output_dir, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
     args = osbuild.api.arguments()
     args_input = args["inputs"]["tree"]["path"]
     args_output = args["tree"]

--- a/assemblers/org.osbuild.tar
+++ b/assemblers/org.osbuild.tar
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assembles the tree into a tar archive named `filename`.
 

--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Loopback device host service
 

--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -23,7 +23,7 @@ import os
 import sys
 from typing import Dict
 
-from osbuild import devices, loop
+from osbuild import api, devices, loop
 from osbuild.util import ctx
 from osbuild.util.udev import UdevInhibitor
 
@@ -154,6 +154,7 @@ class LoopbackService(devices.DeviceService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = LoopbackService.from_args(sys.argv[1:])
     service.main()
 

--- a/devices/org.osbuild.luks2
+++ b/devices/org.osbuild.luks2
@@ -20,7 +20,7 @@ import sys
 import uuid
 from typing import Dict, Optional
 
-from osbuild import devices
+from osbuild import api, devices
 from osbuild.util.udev import UdevInhibitor
 
 SCHEMA = """
@@ -145,6 +145,7 @@ class CryptDeviceService(devices.DeviceService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = CryptDeviceService.from_args(sys.argv[1:])
     service.main()
 

--- a/devices/org.osbuild.luks2
+++ b/devices/org.osbuild.luks2
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Host service for Linux Unified Key Setup (LUKS, format 2) devices.
 

--- a/devices/org.osbuild.lvm2.lv
+++ b/devices/org.osbuild.lvm2.lv
@@ -35,7 +35,7 @@ import sys
 import time
 from typing import Dict, Tuple, Union
 
-from osbuild import devices
+from osbuild import api, devices
 
 SCHEMA = """
 "additionalProperties": false,
@@ -223,6 +223,7 @@ class LVService(devices.DeviceService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = LVService.from_args(sys.argv[1:])
     service.main()
 

--- a/devices/org.osbuild.lvm2.lv
+++ b/devices/org.osbuild.lvm2.lv
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Host service for providing access to LVM2 logical volumes
 

--- a/inputs/org.osbuild.containers
+++ b/inputs/org.osbuild.containers
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """Inputs for container images
 
 This reads images from the `org.osbuild.containers` directory in the

--- a/inputs/org.osbuild.containers
+++ b/inputs/org.osbuild.containers
@@ -20,7 +20,7 @@ root of the tree is used as the oci archive file to install.
 import os
 import sys
 
-from osbuild import inputs
+from osbuild import api, inputs
 
 SCHEMA = r"""
 "definitions": {
@@ -208,6 +208,7 @@ class ContainersInput(inputs.InputService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = ContainersInput.from_args(sys.argv[1:])
     service.main()
 

--- a/inputs/org.osbuild.files
+++ b/inputs/org.osbuild.files
@@ -18,7 +18,7 @@ import os
 import pathlib
 import sys
 
-from osbuild import inputs
+from osbuild import api, inputs
 
 SCHEMA = r"""
 "definitions": {
@@ -218,6 +218,7 @@ class FilesInput(inputs.InputService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = FilesInput.from_args(sys.argv[1:])
     service.main()
 

--- a/inputs/org.osbuild.files
+++ b/inputs/org.osbuild.files
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Inputs for individual files
 

--- a/inputs/org.osbuild.noop
+++ b/inputs/org.osbuild.noop
@@ -11,7 +11,7 @@ import os
 import sys
 import uuid
 
-from osbuild import inputs
+from osbuild import api, inputs
 
 SCHEMA = """
 "additionalProperties": true
@@ -36,6 +36,7 @@ class NoopInput(inputs.InputService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = NoopInput.from_args(sys.argv[1:])
     service.main()
 

--- a/inputs/org.osbuild.noop
+++ b/inputs/org.osbuild.noop
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 No-op inputs
 

--- a/inputs/org.osbuild.ostree
+++ b/inputs/org.osbuild.ostree
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Inputs for ostree commits
 

--- a/inputs/org.osbuild.ostree
+++ b/inputs/org.osbuild.ostree
@@ -17,7 +17,7 @@ import os
 import subprocess
 import sys
 
-from osbuild import inputs
+from osbuild import api, inputs
 
 SCHEMA = """
 "definitions": {
@@ -144,6 +144,7 @@ class OSTreeInput(inputs.InputService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = OSTreeInput.from_args(sys.argv[1:])
     service.main()
 

--- a/inputs/org.osbuild.ostree.checkout
+++ b/inputs/org.osbuild.ostree.checkout
@@ -13,7 +13,7 @@ import os
 import subprocess
 import sys
 
-from osbuild import inputs
+from osbuild import api, inputs
 
 SCHEMA = """
 "additionalProperties": false,
@@ -123,6 +123,7 @@ class OSTreeCheckoutInput(inputs.InputService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = OSTreeCheckoutInput.from_args(sys.argv[1:])
     service.main()
 

--- a/inputs/org.osbuild.ostree.checkout
+++ b/inputs/org.osbuild.ostree.checkout
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Inputs for checkouts of ostree commits
 

--- a/inputs/org.osbuild.tree
+++ b/inputs/org.osbuild.tree
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Tree inputs
 

--- a/inputs/org.osbuild.tree
+++ b/inputs/org.osbuild.tree
@@ -10,7 +10,7 @@ string it returns an empty tree.
 
 import sys
 
-from osbuild import inputs
+from osbuild import api, inputs
 
 SCHEMA = """
 "additionalProperties": false,
@@ -90,6 +90,7 @@ class TreeInput(inputs.InputService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = TreeInput.from_args(sys.argv[1:])
     service.main()
 

--- a/mounts/org.osbuild.btrfs
+++ b/mounts/org.osbuild.btrfs
@@ -10,7 +10,7 @@ Host commands used: mount
 import sys
 from typing import Dict
 
-from osbuild import mounts
+from osbuild import api, mounts
 
 SCHEMA_2 = """
 "additionalProperties": false,
@@ -45,6 +45,7 @@ class BtrfsMount(mounts.FileSystemMountService):
 
 
 def main():
+    api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     service = BtrfsMount.from_args(sys.argv[1:])
     service.main()
 

--- a/mounts/org.osbuild.btrfs
+++ b/mounts/org.osbuild.btrfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 btrfs mount service
 

--- a/mounts/org.osbuild.ext4
+++ b/mounts/org.osbuild.ext4
@@ -10,7 +10,7 @@ Host commands used: mount
 import sys
 from typing import Dict
 
-from osbuild import mounts
+from osbuild import api, mounts
 
 SCHEMA_2 = """
 "additionalProperties": false,
@@ -45,6 +45,7 @@ class Ext4Mount(mounts.FileSystemMountService):
 
 
 def main():
+    api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     service = Ext4Mount.from_args(sys.argv[1:])
     service.main()
 

--- a/mounts/org.osbuild.ext4
+++ b/mounts/org.osbuild.ext4
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 ext4 mount service
 

--- a/mounts/org.osbuild.fat
+++ b/mounts/org.osbuild.fat
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 FAT mount service
 

--- a/mounts/org.osbuild.fat
+++ b/mounts/org.osbuild.fat
@@ -10,7 +10,7 @@ Host commands used: mount
 import sys
 from typing import Dict
 
-from osbuild import mounts
+from osbuild import api, mounts
 
 SCHEMA_2 = """
 "additionalProperties": false,
@@ -45,6 +45,7 @@ class FatMount(mounts.FileSystemMountService):
 
 
 def main():
+    api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     service = FatMount.from_args(sys.argv[1:])
     service.main()
 

--- a/mounts/org.osbuild.noop
+++ b/mounts/org.osbuild.noop
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 No-op mount service
 

--- a/mounts/org.osbuild.noop
+++ b/mounts/org.osbuild.noop
@@ -10,7 +10,7 @@ import os
 import sys
 from typing import Dict
 
-from osbuild import mounts
+from osbuild import api, mounts
 
 SCHEMA_2 = """
 "additionalProperties": false,
@@ -54,6 +54,7 @@ class NoOpMount(mounts.MountService):
 
 
 def main():
+    api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     service = NoOpMount.from_args(sys.argv[1:])
     service.main()
 

--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -19,7 +19,7 @@ import subprocess
 import sys
 from typing import Dict
 
-from osbuild import mounts
+from osbuild import api, mounts
 from osbuild.util import ostree
 
 SCHEMA_2 = """
@@ -128,6 +128,7 @@ class OSTreeDeploymentMount(mounts.MountService):
 
 
 def main():
+    api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     service = OSTreeDeploymentMount.from_args(sys.argv[1:])
     service.main()
 

--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 OSTree deployment mount service
 

--- a/mounts/org.osbuild.xfs
+++ b/mounts/org.osbuild.xfs
@@ -10,7 +10,7 @@ Host commands used: mount
 import sys
 from typing import Dict
 
-from osbuild import mounts
+from osbuild import api, mounts
 
 SCHEMA_2 = """
 "additionalProperties": false,
@@ -45,6 +45,7 @@ class XfsMount(mounts.FileSystemMountService):
 
 
 def main():
+    api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     service = XfsMount.from_args(sys.argv[1:])
     service.main()
 

--- a/mounts/org.osbuild.xfs
+++ b/mounts/org.osbuild.xfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 XFS mount service
 

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -47,7 +47,7 @@ class BaseAPI(abc.ABC):
         self.thread = None
         self._socketdir = None
 
-    @property
+    @property  # type: ignore
     @classmethod
     @abc.abstractmethod
     def endpoint(cls):

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -82,7 +82,7 @@ class SourceService(host.Service):
             for _ in executor.map(self.fetch_one, *zip(*transformed)):
                 pass
 
-    @property
+    @property  # type: ignore
     @classmethod
     @abstractmethod
     def content_type(cls):

--- a/osbuild/util/lvm2.py
+++ b/osbuild/util/lvm2.py
@@ -114,7 +114,7 @@ class CStruct:
 class Header:
     """Abstract base class for all headers"""
 
-    @property
+    @property  # type: ignore
     @classmethod
     @abc.abstractmethod
     def struct(cls) -> Union[struct.Struct, CStruct]:

--- a/runners/org.osbuild.arch
+++ b/runners/org.osbuild.arch
@@ -1,1 +1,8 @@
-org.osbuild.linux
+#!/usr/bin/python3
+
+import subprocess
+import sys
+
+if __name__ == "__main__":
+    r = subprocess.run(sys.argv[1:], check=False)
+    sys.exit(r.returncode)

--- a/runners/org.osbuild.arch
+++ b/runners/org.osbuild.arch
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import subprocess
 import sys

--- a/runners/org.osbuild.centos8
+++ b/runners/org.osbuild.centos8
@@ -1,1 +1,83 @@
-org.osbuild.rhel82
+#!/usr/libexec/platform-python
+
+import os
+import platform
+import subprocess
+import sys
+
+import osbuild.api
+
+
+def quirks():
+    # Platform specific quirks
+    env = os.environ.copy()
+
+    if platform.machine() == "aarch64":
+        # Work around a bug in qemu-img on aarch64 that can lead to qemu-img
+        # hangs when more then one coroutine is use (which is the default)
+        # See https://bugs.launchpad.net/qemu/+bug/1805256
+        env["OSBUILD_QEMU_IMG_COROUTINES"] = "1"
+
+    return env
+
+
+def ldconfig():
+    # ld.so.conf must exist, or `ldconfig` throws a warning
+    subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
+    subprocess.run(["ldconfig"], check=True)
+
+
+def sysusers():
+    try:
+        subprocess.run(["systemd-sysusers"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as error:
+        sys.stderr.write(error.stdout)
+        sys.exit(1)
+
+
+def tmpfiles():
+    # Allow systemd-tmpfiles to return non-0. Some packages want to create
+    # directories owned by users that are not set up with systemd-sysusers.
+    subprocess.run(["systemd-tmpfiles", "--create"], check=False)
+
+
+def nsswitch():
+    # the default behavior is fine, but using nss-resolve does not
+    # necessarily work in a non-booted container, so make sure that
+    # is not configured.
+    try:
+        os.remove("/etc/nsswitch.conf")
+    except FileNotFoundError:
+        pass
+
+
+def python_alternatives():
+    """/usr/bin/python3 is a symlink to /etc/alternatives/python3, which points
+    to /usr/bin/python3.6 by default. Recreate the link in /etc, so that
+    shebang lines in stages and assemblers work.
+    """
+    os.makedirs("/etc/alternatives", exist_ok=True)
+    try:
+        os.symlink("/usr/bin/python3.6", "/etc/alternatives/python3")
+    except FileExistsError:
+        pass
+
+
+def main():
+    with osbuild.api.exception_handler():
+        ldconfig()
+        sysusers()
+        tmpfiles()
+        nsswitch()
+        python_alternatives()
+
+        env = quirks()
+
+        r = subprocess.run(sys.argv[1:],
+                           env=env,
+                           check=False)
+        sys.exit(r.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/runners/org.osbuild.centos9
+++ b/runners/org.osbuild.centos9
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import subprocess

--- a/runners/org.osbuild.fedora30
+++ b/runners/org.osbuild.fedora30
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import subprocess

--- a/runners/org.osbuild.linux
+++ b/runners/org.osbuild.linux
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import subprocess
 import sys

--- a/runners/org.osbuild.rhel7
+++ b/runners/org.osbuild.rhel7
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import subprocess

--- a/runners/org.osbuild.ubuntu1804
+++ b/runners/org.osbuild.ubuntu1804
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import subprocess

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Source for downloading files from URLs.
 

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -19,7 +19,7 @@ import sys
 import tempfile
 import urllib.parse
 
-from osbuild import sources
+from osbuild import api, sources
 from osbuild.util.checksum import verify_file
 from osbuild.util.rhsm import Subscriptions
 
@@ -170,6 +170,7 @@ class CurlSource(sources.SourceService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = CurlSource.from_args(sys.argv[1:])
     service.main()
 

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """Source for binary data encoded inline in the manifest
 
 This source can be used to transport data in the source

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -16,7 +16,7 @@ import contextlib
 import os
 import sys
 
-from osbuild import sources
+from osbuild import api, sources
 from osbuild.util.checksum import verify_file
 
 SCHEMA = """
@@ -79,6 +79,7 @@ class InlineSource(sources.SourceService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = InlineSource.from_args(sys.argv[1:])
     service.main()
 

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """Fetch OSTree commits from an repository
 
 Uses ostree to pull specific commits from (remote) repositories

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -12,7 +12,7 @@ import subprocess
 import sys
 import uuid
 
-from osbuild import sources
+from osbuild import api, sources
 from osbuild.util.ostree import show
 from osbuild.util.rhsm import Subscriptions
 
@@ -157,6 +157,7 @@ class OSTreeSource(sources.SourceService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = OSTreeSource.from_args(sys.argv[1:])
     service.main()
 

--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import tempfile
 
-from osbuild import sources
+from osbuild import api, sources
 from osbuild.util import ctx
 
 SCHEMA = """
@@ -117,6 +117,7 @@ class SkopeoSource(sources.SourceService):
 
 
 def main():
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     service = SkopeoSource.from_args(sys.argv[1:])
     service.main()
 

--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """Fetch container image from a registry using skopeo
 
 Buildhost commands used: `skopeo`.

--- a/stages/org.osbuild.anaconda
+++ b/stages/org.osbuild.anaconda
@@ -50,6 +50,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["options"])

--- a/stages/org.osbuild.anaconda
+++ b/stages/org.osbuild.anaconda
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure basic aspects of the anaconda installer
 

--- a/stages/org.osbuild.authconfig
+++ b/stages/org.osbuild.authconfig
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure authentication sources using authconfig.
 

--- a/stages/org.osbuild.authconfig
+++ b/stages/org.osbuild.authconfig
@@ -36,6 +36,7 @@ def main(tree):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"])
     sys.exit(r)

--- a/stages/org.osbuild.authselect
+++ b/stages/org.osbuild.authselect
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Select system identity and authentication sources with authselect.
 

--- a/stages/org.osbuild.authselect
+++ b/stages/org.osbuild.authselect
@@ -58,6 +58,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.bootiso.mono
+++ b/stages/org.osbuild.bootiso.mono
@@ -428,6 +428,7 @@ def main(inputs, root, options, workdir, loop_client):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     _output_dir = args["tree"]
     with tempfile.TemporaryDirectory(dir=_output_dir) as _workdir:

--- a/stages/org.osbuild.bootiso.mono
+++ b/stages/org.osbuild.bootiso.mono
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assemble a file system tree for a bootable iso
 

--- a/stages/org.osbuild.buildstamp
+++ b/stages/org.osbuild.buildstamp
@@ -80,6 +80,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.buildstamp
+++ b/stages/org.osbuild.buildstamp
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create a /.buildstamp file describing the system
 

--- a/stages/org.osbuild.chmod
+++ b/stages/org.osbuild.chmod
@@ -65,5 +65,6 @@ def main(tree, options):
 
 
 if __name__ == "__main__":
+    osbuild.api.default_main(schema_2=SCHEMA_2)
     args = osbuild.api.arguments()
     sys.exit(main(args["tree"], args["options"]))

--- a/stages/org.osbuild.chmod
+++ b/stages/org.osbuild.chmod
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Change file mode bits
 

--- a/stages/org.osbuild.chrony
+++ b/stages/org.osbuild.chrony
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure chrony to set system time from the network.
 

--- a/stages/org.osbuild.chrony
+++ b/stages/org.osbuild.chrony
@@ -178,6 +178,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.clevis.luks-bind
+++ b/stages/org.osbuild.clevis.luks-bind
@@ -71,6 +71,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2)
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.clevis.luks-bind
+++ b/stages/org.osbuild.clevis.luks-bind
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Bind a LUKS device using the specified policy.
 

--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure cloud-init
 

--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -157,6 +157,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.containers.storage.conf
+++ b/stages/org.osbuild.containers.storage.conf
@@ -200,6 +200,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.containers.storage.conf
+++ b/stages/org.osbuild.containers.storage.conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Edit containers-storage.conf(5) files.
 

--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -137,6 +137,7 @@ def main(args, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
     _args = osbuild.api.arguments()
     r = main(_args, _args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Copy items
 

--- a/stages/org.osbuild.cpio.out
+++ b/stages/org.osbuild.cpio.out
@@ -134,6 +134,7 @@ def main(inputs, output_dir, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.cpio.out
+++ b/stages/org.osbuild.cpio.out
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assembles the tree into a CPIO archive.
 

--- a/stages/org.osbuild.cron.script
+++ b/stages/org.osbuild.cron.script
@@ -78,6 +78,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args.get("options", {}))
     sys.exit(r)

--- a/stages/org.osbuild.cron.script
+++ b/stages/org.osbuild.cron.script
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Run a script at regular intervals.
 

--- a/stages/org.osbuild.crypttab
+++ b/stages/org.osbuild.crypttab
@@ -85,6 +85,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.crypttab
+++ b/stages/org.osbuild.crypttab
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create /etc/crypttab entries for encrypted block devices
 

--- a/stages/org.osbuild.debug-shell
+++ b/stages/org.osbuild.debug-shell
@@ -65,6 +65,7 @@ UnsetEnvironment=LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETAR
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.debug-shell
+++ b/stages/org.osbuild.debug-shell
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Set up an early root shell on a certain tty
 

--- a/stages/org.osbuild.discinfo
+++ b/stages/org.osbuild.discinfo
@@ -43,6 +43,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.discinfo
+++ b/stages/org.osbuild.discinfo
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create a `.discinfo` file describing disk
 

--- a/stages/org.osbuild.dnf-automatic.config
+++ b/stages/org.osbuild.dnf-automatic.config
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Change DNF Automatic configuration.
 

--- a/stages/org.osbuild.dnf-automatic.config
+++ b/stages/org.osbuild.dnf-automatic.config
@@ -87,6 +87,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.dnf.config
+++ b/stages/org.osbuild.dnf.config
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Change DNF configuration.
 

--- a/stages/org.osbuild.dnf.config
+++ b/stages/org.osbuild.dnf.config
@@ -161,6 +161,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.dracut
+++ b/stages/org.osbuild.dracut
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create (re-create) the initial RAM file-system
 

--- a/stages/org.osbuild.dracut
+++ b/stages/org.osbuild.dracut
@@ -203,6 +203,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.dracut.conf
+++ b/stages/org.osbuild.dracut.conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure dracut.
 

--- a/stages/org.osbuild.dracut.conf
+++ b/stages/org.osbuild.dracut.conf
@@ -181,6 +181,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.error
+++ b/stages/org.osbuild.error
@@ -30,6 +30,7 @@ def main(_tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args.get("options", {}))
     sys.exit(r)

--- a/stages/org.osbuild.error
+++ b/stages/org.osbuild.error
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Return an error
 

--- a/stages/org.osbuild.fdo
+++ b/stages/org.osbuild.fdo
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 FDO stage to write down the initial DIUN pub key root certificates
 to be read by the manufacturer client

--- a/stages/org.osbuild.fdo
+++ b/stages/org.osbuild.fdo
@@ -49,6 +49,7 @@ def main(inputs, tree):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"])
     sys.exit(r)

--- a/stages/org.osbuild.firewall
+++ b/stages/org.osbuild.firewall
@@ -152,6 +152,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.firewall
+++ b/stages/org.osbuild.firewall
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure firewall
 

--- a/stages/org.osbuild.first-boot
+++ b/stages/org.osbuild.first-boot
@@ -83,6 +83,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.first-boot
+++ b/stages/org.osbuild.first-boot
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Execute commands on first-boot
 

--- a/stages/org.osbuild.fix-bls
+++ b/stages/org.osbuild.fix-bls
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Fix paths in /boot/loader/entries
 

--- a/stages/org.osbuild.fix-bls
+++ b/stages/org.osbuild.fix-bls
@@ -59,6 +59,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.fstab
+++ b/stages/org.osbuild.fstab
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create /etc/fstab entries for filesystems
 

--- a/stages/org.osbuild.fstab
+++ b/stages/org.osbuild.fstab
@@ -155,6 +155,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.gcp.guest-agent.conf
+++ b/stages/org.osbuild.gcp.guest-agent.conf
@@ -272,6 +272,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.gcp.guest-agent.conf
+++ b/stages/org.osbuild.gcp.guest-agent.conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Crate or modify the GCP guest-agent config
 

--- a/stages/org.osbuild.greenboot
+++ b/stages/org.osbuild.greenboot
@@ -77,6 +77,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.greenboot
+++ b/stages/org.osbuild.greenboot
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure greenboot
 

--- a/stages/org.osbuild.groups
+++ b/stages/org.osbuild.groups
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create group accounts
 

--- a/stages/org.osbuild.groups
+++ b/stages/org.osbuild.groups
@@ -59,6 +59,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -598,6 +598,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.grub2
+++ b/stages/org.osbuild.grub2
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure GRUB2 bootloader and set boot options
 

--- a/stages/org.osbuild.grub2.inst
+++ b/stages/org.osbuild.grub2.inst
@@ -300,6 +300,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.grub2.inst
+++ b/stages/org.osbuild.grub2.inst
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Install the grub2 boot loader for non-UEFI systems or hybrid boot
 

--- a/stages/org.osbuild.grub2.iso
+++ b/stages/org.osbuild.grub2.iso
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create a boot filesystem tree, can be consumed to create
 an efiboot.img.

--- a/stages/org.osbuild.grub2.iso
+++ b/stages/org.osbuild.grub2.iso
@@ -169,6 +169,7 @@ def main(root, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["tree"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.grub2.legacy
+++ b/stages/org.osbuild.grub2.legacy
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure GRUB2 bootloader and set boot options (legacy, i.e. non-BLS)
 

--- a/stages/org.osbuild.grub2.legacy
+++ b/stages/org.osbuild.grub2.legacy
@@ -528,6 +528,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.gunzip
+++ b/stages/org.osbuild.gunzip
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Extract a gzipped file
 

--- a/stages/org.osbuild.gunzip
+++ b/stages/org.osbuild.gunzip
@@ -60,6 +60,7 @@ def main(inputs, output, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.gzip
+++ b/stages/org.osbuild.gzip
@@ -65,6 +65,7 @@ def main(inputs, output, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.gzip
+++ b/stages/org.osbuild.gzip
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Compress a file using gzip
 

--- a/stages/org.osbuild.hostname
+++ b/stages/org.osbuild.hostname
@@ -42,6 +42,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.hostname
+++ b/stages/org.osbuild.hostname
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Set system hostname
 

--- a/stages/org.osbuild.ignition
+++ b/stages/org.osbuild.ignition
@@ -52,6 +52,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=STAGE_OPTS, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args.get("options", {}))
     sys.exit(r)

--- a/stages/org.osbuild.ignition
+++ b/stages/org.osbuild.ignition
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Setup ignition so it will be triggered on first boot.
 

--- a/stages/org.osbuild.implantisomd5
+++ b/stages/org.osbuild.implantisomd5
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Implant an MD5 checksum in an ISO9660 image
 

--- a/stages/org.osbuild.implantisomd5
+++ b/stages/org.osbuild.implantisomd5
@@ -40,6 +40,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.isolinux
+++ b/stages/org.osbuild.isolinux
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create an isolinux bootloader
 

--- a/stages/org.osbuild.isolinux
+++ b/stages/org.osbuild.isolinux
@@ -239,6 +239,7 @@ def main(tree, inputs, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["tree"], args["inputs"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.kernel-cmdline
+++ b/stages/org.osbuild.kernel-cmdline
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure the kernel command-line parameters
 

--- a/stages/org.osbuild.kernel-cmdline
+++ b/stages/org.osbuild.kernel-cmdline
@@ -58,6 +58,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.keymap
+++ b/stages/org.osbuild.keymap
@@ -110,6 +110,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.keymap
+++ b/stages/org.osbuild.keymap
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Set image's default keymap for vconsole and X11 keyboard.
 

--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create an Anaconda kickstart file
 

--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -229,6 +229,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.locale
+++ b/stages/org.osbuild.locale
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Set system language.
 

--- a/stages/org.osbuild.locale
+++ b/stages/org.osbuild.locale
@@ -45,6 +45,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.lorax-script
+++ b/stages/org.osbuild.lorax-script
@@ -89,6 +89,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["options"])

--- a/stages/org.osbuild.lorax-script
+++ b/stages/org.osbuild.lorax-script
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Run a lorax template script on the tree
 

--- a/stages/org.osbuild.luks2.format
+++ b/stages/org.osbuild.luks2.format
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create an LUKS2 container via `cryptsetup`.
 

--- a/stages/org.osbuild.luks2.format
+++ b/stages/org.osbuild.luks2.format
@@ -175,6 +175,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.luks2.remove-key
+++ b/stages/org.osbuild.luks2.remove-key
@@ -54,6 +54,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.luks2.remove-key
+++ b/stages/org.osbuild.luks2.remove-key
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Removes the supplied passphrase from the LUKS device.
 

--- a/stages/org.osbuild.lvm2.create
+++ b/stages/org.osbuild.lvm2.create
@@ -106,6 +106,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.lvm2.create
+++ b/stages/org.osbuild.lvm2.create
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create LVM2 physical volumes, volume groups and logical volumes
 

--- a/stages/org.osbuild.lvm2.metadata
+++ b/stages/org.osbuild.lvm2.metadata
@@ -79,6 +79,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.lvm2.metadata
+++ b/stages/org.osbuild.lvm2.metadata
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Set LVM2 volume group metadata
 

--- a/stages/org.osbuild.mkdir
+++ b/stages/org.osbuild.mkdir
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create directories within the tree.
 

--- a/stages/org.osbuild.mkdir
+++ b/stages/org.osbuild.mkdir
@@ -66,5 +66,6 @@ def main(tree, options):
 
 
 if __name__ == "__main__":
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     sys.exit(main(args["tree"], args["options"]))

--- a/stages/org.osbuild.mkfs.btrfs
+++ b/stages/org.osbuild.mkfs.btrfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Construct an btrfs file-system via mkfs.btrfs(8)
 

--- a/stages/org.osbuild.mkfs.btrfs
+++ b/stages/org.osbuild.mkfs.btrfs
@@ -58,6 +58,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.mkfs.ext4
+++ b/stages/org.osbuild.mkfs.ext4
@@ -58,6 +58,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.mkfs.ext4
+++ b/stages/org.osbuild.mkfs.ext4
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Construct an ext4 file-system via mkfs.ext4(8)
 

--- a/stages/org.osbuild.mkfs.fat
+++ b/stages/org.osbuild.mkfs.fat
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Construct an FAT file-system via mkfs.fat(8)
 

--- a/stages/org.osbuild.mkfs.fat
+++ b/stages/org.osbuild.mkfs.fat
@@ -71,6 +71,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.mkfs.xfs
+++ b/stages/org.osbuild.mkfs.xfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Construct an XFS file-system via mkfs.xfs(8)
 

--- a/stages/org.osbuild.mkfs.xfs
+++ b/stages/org.osbuild.mkfs.xfs
@@ -58,6 +58,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.mkinitcpio
+++ b/stages/org.osbuild.mkinitcpio
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Run mkinitcpio for Arch based distributions
 

--- a/stages/org.osbuild.mkinitcpio
+++ b/stages/org.osbuild.mkinitcpio
@@ -38,6 +38,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.modprobe
+++ b/stages/org.osbuild.modprobe
@@ -108,6 +108,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.modprobe
+++ b/stages/org.osbuild.modprobe
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure modprobe
 

--- a/stages/org.osbuild.nginx.conf
+++ b/stages/org.osbuild.nginx.conf
@@ -84,5 +84,6 @@ daemon {daemon};
 
 
 if __name__ == "__main__":
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     sys.exit(main(args["tree"], args["options"]))

--- a/stages/org.osbuild.nginx.conf
+++ b/stages/org.osbuild.nginx.conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Write nginx configuration
 """

--- a/stages/org.osbuild.nm.conf
+++ b/stages/org.osbuild.nm.conf
@@ -198,6 +198,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.nm.conf
+++ b/stages/org.osbuild.nm.conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create NetworkManager configuration files.
 

--- a/stages/org.osbuild.nm.conn
+++ b/stages/org.osbuild.nm.conn
@@ -218,6 +218,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.nm.conn
+++ b/stages/org.osbuild.nm.conn
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure Network Manager Connections
 

--- a/stages/org.osbuild.noop
+++ b/stages/org.osbuild.noop
@@ -36,6 +36,7 @@ def main(_tree, inputs, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args.get("inputs", {}), args.get("options", {}))
     sys.exit(r)

--- a/stages/org.osbuild.noop
+++ b/stages/org.osbuild.noop
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Do Nothing
 

--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assemble an OCI image archive
 

--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -379,6 +379,7 @@ def main(inputs, output_dir, options, meta):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"], args["meta"])
     sys.exit(r)

--- a/stages/org.osbuild.oscap.remediation
+++ b/stages/org.osbuild.oscap.remediation
@@ -142,6 +142,7 @@ def main(tree, options):
 
 
 if __name__ == "__main__":
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.oscap.remediation
+++ b/stages/org.osbuild.oscap.remediation
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Execute oscap remediation
 

--- a/stages/org.osbuild.ostree
+++ b/stages/org.osbuild.ostree
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Initialize the sysroot and pull and deploy an OStree commit
 

--- a/stages/org.osbuild.ostree
+++ b/stages/org.osbuild.ostree
@@ -310,6 +310,7 @@ def main(tree, inputs, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["inputs"],

--- a/stages/org.osbuild.ostree.commit
+++ b/stages/org.osbuild.ostree.commit
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assemble a file system tree into a ostree commit
 

--- a/stages/org.osbuild.ostree.commit
+++ b/stages/org.osbuild.ostree.commit
@@ -110,6 +110,8 @@ def main(inputs, output_dir, options, meta):
 
 
 if __name__ == '__main__':
+    api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
+
     args = api.arguments()
 
     r = main(args["inputs"],

--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -76,6 +76,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["options"])

--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Change OSTree configuration
 

--- a/stages/org.osbuild.ostree.deploy
+++ b/stages/org.osbuild.ostree.deploy
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Deploy an OStree commit
 

--- a/stages/org.osbuild.ostree.deploy
+++ b/stages/org.osbuild.ostree.deploy
@@ -133,6 +133,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["options"])

--- a/stages/org.osbuild.ostree.fillvar
+++ b/stages/org.osbuild.ostree.fillvar
@@ -84,6 +84,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["options"])

--- a/stages/org.osbuild.ostree.fillvar
+++ b/stages/org.osbuild.ostree.fillvar
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Pre-populate /var directory for a given stateroot.
 """

--- a/stages/org.osbuild.ostree.init
+++ b/stages/org.osbuild.ostree.init
@@ -51,6 +51,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     args_tree = args["tree"]
     r = main(args_tree, args["options"])

--- a/stages/org.osbuild.ostree.init
+++ b/stages/org.osbuild.ostree.init
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create an ostree repository
 

--- a/stages/org.osbuild.ostree.init-fs
+++ b/stages/org.osbuild.ostree.init-fs
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Initialize a new root file system
 

--- a/stages/org.osbuild.ostree.init-fs
+++ b/stages/org.osbuild.ostree.init-fs
@@ -35,6 +35,7 @@ def main(tree):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"])
     sys.exit(r)

--- a/stages/org.osbuild.ostree.os-init
+++ b/stages/org.osbuild.ostree.os-init
@@ -43,6 +43,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["options"])

--- a/stages/org.osbuild.ostree.os-init
+++ b/stages/org.osbuild.ostree.os-init
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Initialize a new stateroot for a new OS
 

--- a/stages/org.osbuild.ostree.passwd
+++ b/stages/org.osbuild.ostree.passwd
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Populate buildroot with /etc/passwd and /etc/group from an OSTree checkout
 

--- a/stages/org.osbuild.ostree.passwd
+++ b/stages/org.osbuild.ostree.passwd
@@ -108,6 +108,7 @@ def main(tree, inputs, _options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["inputs"],

--- a/stages/org.osbuild.ostree.preptree
+++ b/stages/org.osbuild.ostree.preptree
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Transforms the tree to an ostree layout
 

--- a/stages/org.osbuild.ostree.preptree
+++ b/stages/org.osbuild.ostree.preptree
@@ -170,6 +170,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
     args = api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.ostree.pull
+++ b/stages/org.osbuild.ostree.pull
@@ -87,6 +87,7 @@ def main(tree, inputs, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["inputs"],

--- a/stages/org.osbuild.ostree.pull
+++ b/stages/org.osbuild.ostree.pull
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Pull OSTree commits into an existing repo
 

--- a/stages/org.osbuild.ostree.remotes
+++ b/stages/org.osbuild.ostree.remotes
@@ -115,6 +115,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["options"])

--- a/stages/org.osbuild.ostree.remotes
+++ b/stages/org.osbuild.ostree.remotes
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure OSTree remotes for a repository.
 """

--- a/stages/org.osbuild.ostree.selinux
+++ b/stages/org.osbuild.ostree.selinux
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Fix SELinux labels for an OSTree deployment[1].
 

--- a/stages/org.osbuild.ostree.selinux
+++ b/stages/org.osbuild.ostree.selinux
@@ -90,6 +90,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
     stage_args = osbuild.api.arguments()
     r = main(stage_args["tree"],
              stage_args["options"])

--- a/stages/org.osbuild.pacman
+++ b/stages/org.osbuild.pacman
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Verify, and install pacman packages
 

--- a/stages/org.osbuild.pacman
+++ b/stages/org.osbuild.pacman
@@ -18,10 +18,16 @@ import sys
 import tempfile
 from operator import itemgetter
 
-# pylint: disable=import-error
-import pyalpm
-
 from osbuild import api
+
+# This seems weird but because we execute modules to get their schema all
+# modules should be importable to be able to reach `main`.
+try:
+    # pylint: disable=import-error
+    import pyalpm
+except ImportError:
+    pass
+
 
 SCHEMA_2 = """
 "options": {
@@ -138,6 +144,8 @@ def main(tree, inputs):
 
 
 if __name__ == '__main__':
+    api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
+
     args = api.arguments()
     r = main(args["tree"], args["inputs"])
     sys.exit(r)

--- a/stages/org.osbuild.pacman-keyring
+++ b/stages/org.osbuild.pacman-keyring
@@ -37,6 +37,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.pacman-keyring
+++ b/stages/org.osbuild.pacman-keyring
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Initialize the Arch Linux keyring for Arch based distributions
 

--- a/stages/org.osbuild.pacman.conf
+++ b/stages/org.osbuild.pacman.conf
@@ -81,6 +81,7 @@ LocalFileSigLevel = Optional
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.pacman.conf
+++ b/stages/org.osbuild.pacman.conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 configure pacman
 """

--- a/stages/org.osbuild.pacman.mirrorlist.conf
+++ b/stages/org.osbuild.pacman.mirrorlist.conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 configure pacman's mirrorlist
 """

--- a/stages/org.osbuild.pacman.mirrorlist.conf
+++ b/stages/org.osbuild.pacman.mirrorlist.conf
@@ -41,6 +41,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.pam.limits.conf
+++ b/stages/org.osbuild.pam.limits.conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create pam_limits module configuration.
 

--- a/stages/org.osbuild.pam.limits.conf
+++ b/stages/org.osbuild.pam.limits.conf
@@ -109,6 +109,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.parted
+++ b/stages/org.osbuild.parted
@@ -158,6 +158,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.parted
+++ b/stages/org.osbuild.parted
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Partition a target using parted(8)
 

--- a/stages/org.osbuild.pwquality.conf
+++ b/stages/org.osbuild.pwquality.conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure libpwquality.
 

--- a/stages/org.osbuild.pwquality.conf
+++ b/stages/org.osbuild.pwquality.conf
@@ -77,6 +77,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.qemu
+++ b/stages/org.osbuild.qemu
@@ -216,6 +216,7 @@ def main(inputs, output, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.qemu
+++ b/stages/org.osbuild.qemu
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Convert a disk image to a different format.
 

--- a/stages/org.osbuild.resolv-conf
+++ b/stages/org.osbuild.resolv-conf
@@ -62,6 +62,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.resolv-conf
+++ b/stages/org.osbuild.resolv-conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure the resolver
 

--- a/stages/org.osbuild.rhsm
+++ b/stages/org.osbuild.rhsm
@@ -181,6 +181,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args.get("options", {}))
     sys.exit(r)

--- a/stages/org.osbuild.rhsm
+++ b/stages/org.osbuild.rhsm
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure Red Hat Subscription Management (RHSM)
 

--- a/stages/org.osbuild.rhsm.facts
+++ b/stages/org.osbuild.rhsm.facts
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 This stage allows storing artifact-properties of the Red Hat Subscription
 Manager (rhsm-facts) in the built image.

--- a/stages/org.osbuild.rhsm.facts
+++ b/stages/org.osbuild.rhsm.facts
@@ -41,6 +41,7 @@ def main(tree, options):
 
 
 if __name__ == "__main__":
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Verify, and install RPM packages
 

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -395,6 +395,7 @@ def main(tree, inputs, options):
 
 
 if __name__ == '__main__':
+    api.default_main(schema_1=SCHEMA, schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = api.arguments()
     r = main(args["tree"], args["inputs"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.rpm-ostree
+++ b/stages/org.osbuild.rpm-ostree
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Transforms the tree to an ostree layout
 

--- a/stages/org.osbuild.rpm-ostree
+++ b/stages/org.osbuild.rpm-ostree
@@ -82,6 +82,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.rpm.macros
+++ b/stages/org.osbuild.rpm.macros
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Persistently set RPM macros
 

--- a/stages/org.osbuild.rpm.macros
+++ b/stages/org.osbuild.rpm.macros
@@ -64,6 +64,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.rpmkeys.import
+++ b/stages/org.osbuild.rpmkeys.import
@@ -50,6 +50,7 @@ def main(inputs, tree, _options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.rpmkeys.import
+++ b/stages/org.osbuild.rpmkeys.import
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Import public keys into the RPM database
 """

--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Set SELinux file contexts
 

--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -71,6 +71,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.selinux.config
+++ b/stages/org.osbuild.selinux.config
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure the SELinux state on the system.
 

--- a/stages/org.osbuild.selinux.config
+++ b/stages/org.osbuild.selinux.config
@@ -59,6 +59,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.sfdisk
+++ b/stages/org.osbuild.sfdisk
@@ -217,6 +217,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.sfdisk
+++ b/stages/org.osbuild.sfdisk
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Partition a target using sfdisk(8)
 """

--- a/stages/org.osbuild.sgdisk
+++ b/stages/org.osbuild.sgdisk
@@ -193,6 +193,7 @@ def main(devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["devices"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.sgdisk
+++ b/stages/org.osbuild.sgdisk
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Partition a target using sgdisk(8)
 

--- a/stages/org.osbuild.skopeo
+++ b/stages/org.osbuild.skopeo
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Install an container image into the container store.
 This supports both oci archives and docker archives, and uses the containers

--- a/stages/org.osbuild.skopeo
+++ b/stages/org.osbuild.skopeo
@@ -111,6 +111,7 @@ def main(inputs, output, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.squashfs
+++ b/stages/org.osbuild.squashfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create a squashfs named `filename`.
 

--- a/stages/org.osbuild.squashfs
+++ b/stages/org.osbuild.squashfs
@@ -84,6 +84,7 @@ def main(inputs, output_dir, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.sshd.config
+++ b/stages/org.osbuild.sshd.config
@@ -108,6 +108,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.sshd.config
+++ b/stages/org.osbuild.sshd.config
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure the SSH daemon.
 

--- a/stages/org.osbuild.sysconfig
+++ b/stages/org.osbuild.sysconfig
@@ -249,6 +249,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.sysconfig
+++ b/stages/org.osbuild.sysconfig
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 
 Configure sysconfig files

--- a/stages/org.osbuild.sysctld
+++ b/stages/org.osbuild.sysctld
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure kernel parameters at boot via sysctl.d.
 

--- a/stages/org.osbuild.sysctld
+++ b/stages/org.osbuild.sysctld
@@ -100,6 +100,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.systemd
+++ b/stages/org.osbuild.systemd
@@ -77,6 +77,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.systemd
+++ b/stages/org.osbuild.systemd
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure Systemd services.
 

--- a/stages/org.osbuild.systemd-journald
+++ b/stages/org.osbuild.systemd-journald
@@ -108,6 +108,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.systemd-journald
+++ b/stages/org.osbuild.systemd-journald
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configures systemd-journald
 

--- a/stages/org.osbuild.systemd-logind
+++ b/stages/org.osbuild.systemd-logind
@@ -85,6 +85,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.systemd-logind
+++ b/stages/org.osbuild.systemd-logind
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure systemd-logind
 

--- a/stages/org.osbuild.systemd.unit
+++ b/stages/org.osbuild.systemd.unit
@@ -85,6 +85,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.systemd.unit
+++ b/stages/org.osbuild.systemd.unit
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure Systemd services via unit file dropins
 

--- a/stages/org.osbuild.tar
+++ b/stages/org.osbuild.tar
@@ -126,6 +126,7 @@ def main(inputs, output_dir, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__, capabilities=CAPABILITIES)
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.tar
+++ b/stages/org.osbuild.tar
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assembles the tree into a tar archive named `filename`.
 

--- a/stages/org.osbuild.test
+++ b/stages/org.osbuild.test
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Enable osbuild Boot Test service
 

--- a/stages/org.osbuild.test
+++ b/stages/org.osbuild.test
@@ -51,6 +51,7 @@ ExecStopPost=/usr/bin/systemctl poweroff
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.timezone
+++ b/stages/org.osbuild.timezone
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Set system timezone
 

--- a/stages/org.osbuild.timezone
+++ b/stages/org.osbuild.timezone
@@ -48,6 +48,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.tmpfilesd
+++ b/stages/org.osbuild.tmpfilesd
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create tmpfiles.d configuration.
 

--- a/stages/org.osbuild.tmpfilesd
+++ b/stages/org.osbuild.tmpfilesd
@@ -115,6 +115,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.truncate
+++ b/stages/org.osbuild.truncate
@@ -49,6 +49,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["tree"], args["options"])
     sys.exit(ret)

--- a/stages/org.osbuild.truncate
+++ b/stages/org.osbuild.truncate
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create, shrink or extend a file.
 

--- a/stages/org.osbuild.tuned
+++ b/stages/org.osbuild.tuned
@@ -100,6 +100,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.tuned
+++ b/stages/org.osbuild.tuned
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Sets active TuneD profile.
 

--- a/stages/org.osbuild.udev.rules
+++ b/stages/org.osbuild.udev.rules
@@ -315,6 +315,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.udev.rules
+++ b/stages/org.osbuild.udev.rules
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create a udev rules file
 

--- a/stages/org.osbuild.uki
+++ b/stages/org.osbuild.uki
@@ -171,6 +171,7 @@ def main(tree, inputs, options) -> int:
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["inputs"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.uki
+++ b/stages/org.osbuild.uki
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create a Unified Kernel Image
 

--- a/stages/org.osbuild.untar
+++ b/stages/org.osbuild.untar
@@ -70,6 +70,7 @@ def main(inputs, output, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip(), capabilities=CAPABILITIES)
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.untar
+++ b/stages/org.osbuild.untar
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Extract a tarball
 

--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -166,6 +166,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Add or modify user accounts
 

--- a/stages/org.osbuild.vagrant
+++ b/stages/org.osbuild.vagrant
@@ -85,6 +85,7 @@ end
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"], args["inputs"])
     sys.exit(r)

--- a/stages/org.osbuild.vagrant
+++ b/stages/org.osbuild.vagrant
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create a Vagrant box
 

--- a/stages/org.osbuild.waagent.conf
+++ b/stages/org.osbuild.waagent.conf
@@ -80,6 +80,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.waagent.conf
+++ b/stages/org.osbuild.waagent.conf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure the WALinuxAgent.
 

--- a/stages/org.osbuild.xorrisofs
+++ b/stages/org.osbuild.xorrisofs
@@ -153,6 +153,7 @@ def main(inputs, output_dir, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     ret = main(args["inputs"],
                args["tree"],

--- a/stages/org.osbuild.xorrisofs
+++ b/stages/org.osbuild.xorrisofs
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Assemble a Rock Ridge enhanced ISO 9660 filesystem (iso)
 

--- a/stages/org.osbuild.xz
+++ b/stages/org.osbuild.xz
@@ -70,6 +70,7 @@ def main(inputs, output, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.xz
+++ b/stages/org.osbuild.xz
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Compress a file
 

--- a/stages/org.osbuild.yum.config
+++ b/stages/org.osbuild.yum.config
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure yellowdog updater modified (YUM)
 

--- a/stages/org.osbuild.yum.config
+++ b/stages/org.osbuild.yum.config
@@ -120,6 +120,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.yum.repos
+++ b/stages/org.osbuild.yum.repos
@@ -187,6 +187,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.yum.repos
+++ b/stages/org.osbuild.yum.repos
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Create YUM / DNF repo file in /etc/yum.repos.d
 

--- a/stages/org.osbuild.zipl
+++ b/stages/org.osbuild.zipl
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Configure the z Initial Program Loader (zipl)
 

--- a/stages/org.osbuild.zipl
+++ b/stages/org.osbuild.zipl
@@ -40,6 +40,7 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_1=SCHEMA, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.zipl.inst
+++ b/stages/org.osbuild.zipl.inst
@@ -109,6 +109,7 @@ def main(paths, devices, options):
 
 
 if __name__ == '__main__':
+    osbuild.api.default_main(schema_2=SCHEMA_2, info=sys.modules["__main__"].__doc__.strip())
     args = osbuild.api.arguments()
     r = main(args["paths"], args["devices"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.zipl.inst
+++ b/stages/org.osbuild.zipl.inst
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Install the Z Initial Program Loader (zipl)
 


### PR DESCRIPTION
# Default `main`

Adding a `default_main` function to `osbuild` which is to be used by all stages before they go into their own `main`. This allows us to define a 'protocol' for command line arguments that stages must support.

This is preliminary work for supporting arbitrary binaries as stages, paving the way for stages implemented in other languages.

The 'protocol' so far is:
- Must expose `-a/--all` which returns all information necessary for `osbuildmeta`.

## Example

```
€ venv/bin/python3 mounts/org.osbuild.ext4 --schema-1
"additionalProperties": false,
"required": ["name", "type", "source", "target"],
"properties": {
  "name": { "type": "string" },
  "type": { "type": "string" },
  "source": {
    "type": "string"
  },
  "target": {
    "type": "string"
  },
  "options": {
    "type": "object",
    "additionalProperties": true
  }
}
```