### PR TITLE
Extend firewall stage to add sources

### DIFF
--- a/stages/org.osbuild.firewall
+++ b/stages/org.osbuild.firewall
@@ -62,6 +62,30 @@ SCHEMA = """
   "default_zone": {
     "description": "Set default zone for connections and interfaces where no zone has been selected.",
     "type": "string"
+  },
+  "sources": {
+    "description": "Bind the source to a zone",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sources"],
+      "properties": {
+        "sources": {
+          "description": "A list of sources",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "description": "A source: <source>[/<mask>]|<MAC>|ipset:<ipset>"
+          }
+        },
+        "zone": {
+          "description": "The zone to apply the source to",
+          "type": "string"
+        }
+      }
+    }
   }
 }
 """
@@ -74,6 +98,7 @@ def main(tree, options):
     # you can also define you own XML files in /etc/firewalld.
     enabled_services = options.get("enabled_services", [])
     disabled_services = options.get("disabled_services", [])
+    sources = options.get("sources", [])
 
     default_zone = options.get("default_zone", "")
 
@@ -90,6 +115,15 @@ def main(tree, options):
                        list(map(lambda x: f"--port={x}", ports)) +
                        list(map(lambda x: f"--service={x}", enabled_services)) +
                        list(map(lambda x: f"--remove-service={x}", disabled_services)),
+                       check=True)
+
+    for zone_sources in sources:
+        # specifying an empty zone flag results in the source being applied to the default zone
+        zone = zone_sources.get("zone", "")
+        subprocess.run(["chroot",
+                        tree,
+                        "firewall-offline-cmd", f"--zone={zone}"] +
+                       list(map(lambda x: f"--add-source={x}", zone_sources["sources"])),
                        check=True)
 
     return 0


### PR DESCRIPTION
this would add support for specifying sources in firewalld similar to https://github.com/openshift/microshift/blob/main/scripts/image-builder/config/kickstart.ks.template#L59

Signed-off-by: Antonio Murdaca <runcom@linux.com>