### PR TITLE
sources/ostree: pull from remote using rhsm mTLS certs

### DIFF
--- a/osbuild/util/rhsm.py
+++ b/osbuild/util/rhsm.py
@@ -38,6 +38,20 @@ class Subscriptions:
 
         raise RuntimeError("no matching rhsm key and cert")
 
+    @staticmethod
+    def get_consumer_secrets():
+        """Returns the consumer identity certificate which uniquely identifies the system"""
+        key = "/etc/pki/consumer/cert.pem"
+        cert = "/etc/pki/consumer/key.pem"
+
+        if not (os.path.exists(key) and os.path.exists(cert)):
+            raise RuntimeError("rhsm consumer key and cert not found")
+
+        return {
+            'consumer_key': key,
+            'consumer_cert': cert
+        }
+
     @classmethod
     def from_host_system(cls):
         """Read redhat.repo file and process the list of repositories in there."""

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -14,6 +14,7 @@ import uuid
 
 from osbuild import sources
 from osbuild.util.ostree import show
+from osbuild.util.rhsm import Subscriptions
 
 SCHEMA = """
 "additionalProperties": false,
@@ -42,6 +43,19 @@ SCHEMA = """
                 "items": {
                   "type": "string",
                   "description": "GPG keys to verify the commits"
+                }
+              },
+              "secrets": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the secrets provider."
+                  }
                 }
               }
             }
@@ -89,13 +103,18 @@ class OSTreeSource(sources.SourceService):
         gpg = remote.get("gpgkeys", [])
         uid = str(uuid.uuid4())
 
-        verify_args = []
+        remote_add_args = []
         if not gpg:
-            verify_args = ["--no-gpg-verify"]
+            remote_add_args = ["--no-gpg-verify"]
+
+        if remote.get("secrets", {}).get("name") == "org.osbuild.rhsm.consumer":
+            secrets = Subscriptions.get_consumer_secrets()
+            remote_add_args.append("--tls-client-key-path=%s", secrets['consumer_key'])
+            remote_add_args.append("--tls-client-cert-path=%s", secrets['consumer_cert'])
 
         ostree("remote", "add",
                uid, url,
-               *verify_args,
+               *remote_add_args,
                repo=self.repo)
 
         for key in gpg:


### PR DESCRIPTION
The consumer certs are used to uniquely identify a system against candlepin. These consumer certs can be used to identify the system when pulling from RH controlled ostree repositories.