### PR TITLE
stages/rpm: make the fake machine-id newline-terminated

### DIFF
--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -272,7 +272,7 @@ def create_machine_id_if_needed(tree):
     os.makedirs(f"{tree}/etc", exist_ok=True)
     with open(path, "w", encoding="utf8") as f:
         # create a fake machine ID to improve reproducibility
-        f.write("ffffffffffffffffffffffffffffffff")
+        f.write("ffffffffffffffffffffffffffffffff\n")
         os.fchmod(f.fileno(), 0o400)
 
     return True


### PR DESCRIPTION
From machine-id(5): machine ID is a single *newline-terminated*, hexadecimal, 32-character, lowercase ID.

This commit fixes that by adding a newline.

This broke us on Fedora 38:
This pull request added `set -e` to kernel-install:

https://github.com/systemd/systemd/pull/23881

This caused F38 pipeline failing because the script also runs `read -r MACHINE_ID </etc/machine-id`. `read` returns 1 if the input doesn't contain a newline, thus after the addition of `set -e`, the script started crashing with our bad machine-id. This caused crashing of the whole image build in the grub2 stage which requires kernel-install to work (because kernel-install is responsible for putting vmlinuz into /boot).