### PR TITLE
stages/ostree.preptree: link to rpm-ostree code

### DIFF
--- a/stages/org.osbuild.ostree.preptree
+++ b/stages/org.osbuild.ostree.preptree
@@ -29,7 +29,7 @@ in `etc_group_members` will be stored in /etc/groups instead of
 /usr/etc/groups (which is read-only). Therefore all groups that
 human users need to be part of.
 
-[1] https://ostree.readthedocs.io/en/latest/manual/adapting-existing/
+[1] https://ostreedev.github.io/ostree/adapting-existing/
 [2] https://rpm-ostree.readthedocs.io/en/latest/manual/treefile/
 """
 

--- a/stages/org.osbuild.ostree.preptree
+++ b/stages/org.osbuild.ostree.preptree
@@ -67,7 +67,9 @@ SCHEMA = """
 """
 
 
+# Corresponds to https://github.com/coreos/rpm-ostree/blob/7b9a20b20ecd5a2ceb11ca9edf86984dc3065183/rust/src/composepost.rs#L58
 TOPLEVEL_DIRS = ["dev", "proc", "run", "sys", "sysroot", "var"]
+# Corresponds to https://github.com/coreos/rpm-ostree/blob/7b9a20b20ecd5a2ceb11ca9edf86984dc3065183/rust/src/composepost.rs#L123
 TOPLEVEL_LINKS = {
     "home": "var/home",
     "media": "run/media",
@@ -83,8 +85,9 @@ def move(name, source, dest):
     os.rename(os.path.join(source, name), os.path.join(dest, name))
 
 
+# See https://ostreedev.github.io/ostree/adapting-existing/
 def init_rootfs(root, tmp_is_dir):
-    """Initialize a pristine root file-system"""
+    """Initialize a root filesystem in OSTree layout."""
 
     fd = os.open(root, os.O_DIRECTORY)
 


### PR DESCRIPTION
Pick up an old patch by Colin and fix the mentioned broken link.

Replaces #676.