### PR TITLE
stages/logind-systemd: add `ReserveVT` option

### DIFF
--- a/stages/org.osbuild.systemd-logind
+++ b/stages/org.osbuild.systemd-logind
@@ -10,6 +10,7 @@ Drop-in configuration files can currently specify the following subset of
 options:
   - 'Login' section
     - 'NAutoVTs' option
+    - 'ReserveVT' option
 
 At least one option must be specified in the 'Login' section.
 """
@@ -46,6 +47,11 @@ SCHEMA = r"""
             "type": "integer",
             "minimum": 0,
             "description": "Configures how many virtual terminals (VTs) to allocate by default."
+          },
+          "ReserveVT": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Reserve a VT exclusively for autovt@.service activation (defaults to 6)."
           }
         }
       }

--- a/test/data/stages/systemd-logind/b.json
+++ b/test/data/stages/systemd-logind/b.json
@@ -460,7 +460,8 @@
           "filename": "10-ec2-getty-fix.conf",
           "config": {
             "Login": {
-              "NAutoVTs": 0
+              "NAutoVTs": 0,
+              "ReserveVT": 2
             }
           }
         }

--- a/test/data/stages/systemd-logind/b.mpp.json
+++ b/test/data/stages/systemd-logind/b.mpp.json
@@ -35,7 +35,8 @@
           "filename": "10-ec2-getty-fix.conf",
           "config": {
             "Login": {
-              "NAutoVTs": 0
+              "NAutoVTs": 0,
+              "ReserveVT": 2
             }
           }
         }


### PR DESCRIPTION
Add option to reserve a VT exclusively for `autovt@.service` activation. See logind.conf(5) for more details.