### PR TITLE
Extend firewall stage to add sources (continues from PR #1137)

### DIFF
--- a/stages/org.osbuild.firewall
+++ b/stages/org.osbuild.firewall
@@ -63,26 +63,29 @@ SCHEMA = """
     "description": "Set default zone for connections and interfaces where no zone has been selected.",
     "type": "string"
   },
-  "sources": {
-    "description": "Bind the source to a zone",
+  "zones": {
+    "description": "Bind a list of network sources to a zone to restrict traffic from those sources based on the settings of the zone.",
     "type": "array",
+    "minItems": 1,
     "items": {
-      "type": "object",
       "additionalProperties": false,
-      "required": ["sources"],
+      "type": "object",
+      "description": "configuration for each zone",
+      "required": ["name", "sources"],
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the zone, if left empty the sources will apply to the default zone.",
+          "pattern": "^[a-zA-Z0-9_-]+$"
+        },
         "sources": {
-          "description": "A list of sources",
           "type": "array",
-          "minItems": 1,
+          "description": "list of sources for the zone",
           "items": {
+            "additionalProperties": false,
             "type": "string",
             "description": "A source: <source>[/<mask>]|<MAC>|ipset:<ipset>"
           }
-        },
-        "zone": {
-          "description": "The zone to apply the source to",
-          "type": "string"
         }
       }
     }
@@ -98,7 +101,7 @@ def main(tree, options):
     # you can also define you own XML files in /etc/firewalld.
     enabled_services = options.get("enabled_services", [])
     disabled_services = options.get("disabled_services", [])
-    sources = options.get("sources", [])
+    zones = options.get("zones", [])
 
     default_zone = options.get("default_zone", "")
 
@@ -117,14 +120,33 @@ def main(tree, options):
                        list(map(lambda x: f"--remove-service={x}", disabled_services)),
                        check=True)
 
-    for zone_sources in sources:
-        # specifying an empty zone flag results in the source being applied to the default zone
-        zone = zone_sources.get("zone", "")
-        subprocess.run(["chroot",
-                        tree,
-                        "firewall-offline-cmd", f"--zone={zone}"] +
-                       list(map(lambda x: f"--add-source={x}", zone_sources["sources"])),
-                       check=True)
+    for zone_item in zones:
+        # specifying an empty zone flag results in the source being applied to
+        # the default zone
+        zone_name = zone_item['name']
+        # check that the given zone exists, if not create it
+        if zone_name != "":
+            res = subprocess.run(["chroot",
+                                  tree,
+                                  "firewall-offline-cmd",
+                                  f"--info-zone={zone_name}"],
+                                 check=False)
+            # INVALID_ZONE error code
+            if res.returncode == 112:
+                res = subprocess.run(["chroot",
+                                      tree,
+                                      "firewall-offline-cmd",
+                                      f"--new-zone={zone_name}"],
+                                     check=False)
+            if res.returncode != 0:
+                return 1
+        if zone_item.get("sources", []):
+            subprocess.run(["chroot",
+                            tree,
+                            "firewall-offline-cmd", f"--zone={zone_name}"] +
+                           list(map(lambda x: f"--add-source={x}",
+                                    zone_item['sources'])),
+                           check=True)
 
     return 0
 

--- a/stages/org.osbuild.firewall
+++ b/stages/org.osbuild.firewall
@@ -62,6 +62,30 @@ SCHEMA = """
   "default_zone": {
     "description": "Set default zone for connections and interfaces where no zone has been selected.",
     "type": "string"
+  },
+  "sources": {
+    "description": "Bind the source to a zone",
+    "type": "array",
+    "items": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sources"],
+      "properties": {
+        "sources": {
+          "description": "A list of sources",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "description": "A source: <source>[/<mask>]|<MAC>|ipset:<ipset>"
+          }
+        },
+        "zone": {
+          "description": "The zone to apply the source to",
+          "type": "string"
+        }
+      }
+    }
   }
 }
 """
@@ -74,6 +98,7 @@ def main(tree, options):
     # you can also define you own XML files in /etc/firewalld.
     enabled_services = options.get("enabled_services", [])
     disabled_services = options.get("disabled_services", [])
+    sources = options.get("sources", [])
 
     default_zone = options.get("default_zone", "")
 
@@ -90,6 +115,15 @@ def main(tree, options):
                        list(map(lambda x: f"--port={x}", ports)) +
                        list(map(lambda x: f"--service={x}", enabled_services)) +
                        list(map(lambda x: f"--remove-service={x}", disabled_services)),
+                       check=True)
+
+    for zone_sources in sources:
+        # specifying an empty zone flag results in the source being applied to the default zone
+        zone = zone_sources.get("zone", "")
+        subprocess.run(["chroot",
+                        tree,
+                        "firewall-offline-cmd", f"--zone={zone}"] +
+                       list(map(lambda x: f"--add-source={x}", zone_sources["sources"])),
                        check=True)
 
     return 0

--- a/test/data/stages/firewall/b.json
+++ b/test/data/stages/firewall/b.json
@@ -496,6 +496,19 @@
             "telnet"
           ]
         }
+      },
+      {
+        "name": "org.osbuild.firewall",
+        "options": {
+          "zones": [
+            {
+              "name": "new-zone",
+              "sources": [
+                "192.0.2.0/24"
+              ]
+            }
+          ]
+        }
       }
     ]
   },

--- a/test/data/stages/firewall/b.mpp.json
+++ b/test/data/stages/firewall/b.mpp.json
@@ -50,6 +50,19 @@
             "telnet"
           ]
         }
+      },
+      {
+        "name": "org.osbuild.firewall",
+        "options": {
+          "zones": [
+            {
+              "name": "new-zone",
+              "sources": [
+                "192.0.2.0/24"
+              ]
+            }
+          ]
+        }
       }
     ]
   }

--- a/test/data/stages/firewall/diff.json
+++ b/test/data/stages/firewall/diff.json
@@ -2,7 +2,9 @@
   "added_files": [
     "/etc/firewalld/firewalld.conf.old",
     "/etc/firewalld/zones/trusted.xml",
-    "/etc/firewalld/zones/trusted.xml.old"
+    "/etc/firewalld/zones/trusted.xml.old",
+    "/etc/firewalld/zones/new-zone.xml",
+    "/etc/firewalld/zones/new-zone.xml.old"
   ],
   "deleted_files": [],
   "differences": {


### PR DESCRIPTION
> this would add support for specifying sources in firewalld similar to https://github.com/openshift/microshift/blob/main/scripts/image-builder/config/kickstart.ks.template#L59

Continues Antonio's (@runcom ) work made on PR #1137 (because I cannot add more commits to that PR since I'm not  a maintainer) after @dvdhrm 's review. 
