### PR TITLE
Update test runners for 8.8 & 9.2 nightly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,6 +69,8 @@ OSTree Images:
           - aws/fedora-37-x86_64
           - aws/rhel-8.7-ga-x86_64
           - aws/rhel-9.1-ga-x86_64
+          - aws/rhel-8.8-nightly-x86_64
+          - aws/rhel-9.2-nightly-x86_64
         INTERNAL_NETWORK: "true"
 
 SonarQube:


### PR DESCRIPTION
remove old references to 8.7 and 9.1 nightly