### PR TITLE
ci: upgrade to actions/checkout@v3

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
           pip install docutils
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: osbuild
 
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Clone Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: "Regenerate Test Data"
       uses: osbuild/containers/src/actions/privdocker@1e349b1c69884f9f38f7afa567869b975104828c
       with:
@@ -51,7 +51,7 @@ jobs:
     name: "Spell check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: codespell-project/actions-codespell@master
         with:
           ignore_words_list: msdos, pullrequest
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Clone Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: "Run Tests"
       uses: osbuild/containers/src/actions/privdocker@1e349b1c69884f9f38f7afa567869b975104828c
       with:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: osbuild
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         - "test.src"
     steps:
     - name: "Clone Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
            fetch-depth: 2  # codecov requires this (https://github.com/codecov/codecov-action/issues/190)
     - name: "Run Tests"

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt install -y jq
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0


### PR DESCRIPTION
This uses the new node 16 version (see [1]), which is the future proof version, since node 12 will be deprecated by summer 2023 (see [2]).

[1] upstream commits:
https://github.com/actions/checkout/commit/8f9e05e482293f862823fcca12d9eddfb3723131 https://github.com/actions/checkout/commit/a12a3943b4bdde767164f792f33f40b04645d846

[2] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/