### PR TITLE
ci: update to containers/privdocker@552e30c

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,7 +40,7 @@ jobs:
     - name: "Clone Repository"
       uses: actions/checkout@v3
     - name: "Regenerate Test Data"
-      uses: osbuild/containers/src/actions/privdocker@1e349b1c69884f9f38f7afa567869b975104828c
+      uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
       with:
         image: ghcr.io/osbuild/osbuild-ci:latest-202209070757
         run: |
@@ -64,7 +64,7 @@ jobs:
     - name: "Clone Repository"
       uses: actions/checkout@v3
     - name: "Run Tests"
-      uses: osbuild/containers/src/actions/privdocker@1e349b1c69884f9f38f7afa567869b975104828c
+      uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
       with:
         image: ghcr.io/osbuild/osbuild-ci:latest-202209070757
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       with:
            fetch-depth: 2  # codecov requires this (https://github.com/codecov/codecov-action/issues/190)
     - name: "Run Tests"
-      uses: osbuild/containers/src/actions/privdocker@1e349b1c69884f9f38f7afa567869b975104828c
+      uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
       with:
         image: ghcr.io/osbuild/osbuild-ci:latest-202209070757
         run: |


### PR DESCRIPTION
The privdocker action got update to node 16, since node 12 is deprecated and support for it will be remove by summer 2023[1].

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/