### PR TITLE
❌ 🐮 Remove copy-on-write support for `Object` (no-cow)

### DIFF
--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -308,7 +308,7 @@ class ObjectStore(contextlib.AbstractContextManager):
 
         return obj
 
-    def commit(self, obj: Object, object_id: str) -> str:
+    def commit(self, obj: Object, object_id: str, clone: bool = False) -> str:
         """Commits a Object to the object store
 
         Move the contents of the obj (Object) to object directory
@@ -323,7 +323,11 @@ class ObjectStore(contextlib.AbstractContextManager):
         # The object is stored in the objects directory using its unique
         # name. This means that each commit will always result in a new
         # object in the store, even if an identical one exists.
-        object_name = obj.store_tree()
+        if clone:
+            object_name = str(uuid.uuid4())
+            obj.clone(os.path.join(self.objects, object_name))
+        else:
+            object_name = obj.store_tree()
 
         # symlink the object_id (config hash) in the refs directory to the
         # object name in the objects directory. If a symlink by that name

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -306,8 +306,8 @@ class ObjectStore(contextlib.AbstractContextManager):
         Returns: The name of the object
         """
 
-        # the object is stored in the objects directory using its unique
-        # name. This means that eatch commit will always result in a new
+        # The object is stored in the objects directory using its unique
+        # name. This means that each commit will always result in a new
         # object in the store, even if an identical one exists.
         object_name = obj.store_tree()
 

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -140,13 +140,6 @@ class Object:
         name = f"object-{self._id[:7]}-"
         return self.store.tempdir(prefix=name, suffix=suffix)
 
-    def __enter__(self):
-        self._check_mode(Object.Mode.WRITE)
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.cleanup()
-
     def export(self, to_directory: PathLike):
         """Copy object into an external directory"""
         with self.read() as from_directory:

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -184,6 +184,20 @@ class Object:
                 check=True,
             )
 
+    def clone(self, to_directory: PathLike):
+        """Clone the object to the specified directory"""
+        with self.read() as from_directory:
+            subprocess.run(
+                [
+                    "cp",
+                    "--reflink=auto",
+                    "-a",
+                    os.fspath(from_directory) + "/.",
+                    os.fspath(to_directory),
+                ],
+                check=True,
+            )
+
 
 class HostTree:
     """Read-only access to the host file system

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -359,7 +359,7 @@ class Pipeline:
             tree.id = stage.id
 
             if stage.checkpoint:
-                object_store.commit(tree, stage.id)
+                object_store.commit(tree, stage.id, clone=bool(todo))
 
         return results
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -354,7 +354,7 @@ class Pipeline:
                 return results
 
             if stage.checkpoint:
-                object_store.commit(tree, stage.id, clone=bool(todo))
+                object_store.commit(tree, stage.id)
 
         tree.finalize()
 

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -113,7 +113,7 @@ class TestObjectStore(unittest.TestCase):
                     data_inode = st.st_ino
 
                 # commit the object as "x", making a copy
-                store.commit(tree, "x", clone=True)
+                store.commit(tree, "x")
 
                 # check that "data" got indeed copied
                 tree = store.get("x")
@@ -191,7 +191,7 @@ class TestObjectStore(unittest.TestCase):
                 p.touch()
 
             assert not store.contains("a")
-            store.commit(tree, "a", clone=True)
+            store.commit(tree, "a")  # store via "a", creates a clone
             assert store.contains("a")
 
             with tree.write() as path:

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -26,16 +26,11 @@ def store_path(store: objectstore.ObjectStore, ref: str, path: str) -> bool:
 @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
 class TestObjectStore(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.store = os.getenv("OSBUILD_TEST_STORE")
-        if not cls.store:
-            cls.store = tempfile.mkdtemp(prefix="osbuild-test-", dir="/var/tmp")
+    def setUp(self):
+        self.store = tempfile.mkdtemp(prefix="osbuild-test-", dir="/var/tmp")
 
-    @classmethod
-    def tearDownClass(cls):
-        if not os.getenv("OSBUILD_TEST_STORE"):
-            shutil.rmtree(cls.store)
+    def tearDown(self):
+        shutil.rmtree(self.store)
 
     def test_basic(self):
         # always use a temporary store so item counting works


### PR DESCRIPTION
Remove copy-on-write support from `objectstore.Object`. The main reason for introducing copy-on-write was to save an additional copy in the non DAG-pipeline model[1]. With the introduction of the latter and the explicit `--export` option, we can achieve the same result without the complexity of copy-on-write semantics.

[1] See commit https://github.com/osbuild/osbuild/commit/39213b7f44a8ac7e8a29b0cd4df10f20a67e89ea, part of PR #225 [changeset](https://github.com/osbuild/osbuild/compare/3b7c87d563c90256afd80cf08c37ea97efa42108..42a365d12ff6b0dc764941a5b0eaf9935cce4b2b).