### PR TITLE
ignition: fix ignition_network_kcmdline

### DIFF
--- a/stages/org.osbuild.ignition
+++ b/stages/org.osbuild.ignition
@@ -46,7 +46,7 @@ def main(tree, options):
     with open(f"{tree}/boot/ignition.firstboot", "w", encoding="utf8") as f:
         if network:
             netstr = " ".join(network)
-            f.write(f"ignition_network_kcmdline={netstr}")
+            f.write(f"set ignition_network_kcmdline={netstr}")
 
     return 0
 


### PR DESCRIPTION
was just missing a `set` as the file is sourced

Signed-off-by: Antonio Murdaca <runcom@linux.com>
Signed-off-by: Antonio Murdaca <antoniomurdaca@gmail.com>