### PR TITLE
`stages/containers.storage.conf`: ability to specify a base file 

### DIFF
--- a/stages/org.osbuild.containers.storage.conf
+++ b/stages/org.osbuild.containers.storage.conf
@@ -87,6 +87,10 @@ SCHEMA = r"""
       "/usr/share/containers/storage.conf"
     ]
   },
+  "filebase": {
+    "type": "string",
+    "description": "Read the base configuration from this file."
+  },
   "comment": {
     "type": "array",
     "items": {
@@ -166,14 +170,24 @@ def main(tree, options):
     location = options.get("filename", DEFAULT_LOCATION)
     config = options["config"]
     comment = options.get("comment", [])
+    filebase = options.get("filebase")
 
     path = os.path.join(tree, location.lstrip("/"))
     data = {}
 
-    with contextlib.suppress(FileNotFoundError):
-        with open(path, "r", encoding="utf8") as f:
+    # if a filebase was specified, we use it as base
+    if filebase:
+        with open(filebase, "r", encoding="utf8") as f:
             data = toml.load(f)
 
+    # if the target exists, we merge it
+    with contextlib.suppress(FileNotFoundError):
+        with open(path, "r", encoding="utf8") as f:
+            have = toml.load(f)
+
+            merge_config("storage", data, have)
+
+    # now merge our configuration into data
     merge_config("storage", data, config)
 
     with open(path, "w", encoding="utf8") as f:

--- a/stages/org.osbuild.containers.storage.conf
+++ b/stages/org.osbuild.containers.storage.conf
@@ -128,14 +128,26 @@ HEADER = [
 
 
 def merge_config(section: str, data: Dict, config: Dict):
+    """Merge the given section of config into data
+
+    Items in config overwrite existing ones in data.
+    New items will be added. Sections will be merged
+    recursively.
+    """
     want = config.get(section)
-    have = data.get(section)
 
     if not want:
         return
 
+    have = data.setdefault(section, {})
+
     for k in list(want.keys()):
-        if isinstance(want[k], dict):
+        # if both entries are of type dict, we merge them
+        # recursively, otherwise want will override have
+        # via the update below.
+        w, h = want[k], have.get(k)
+
+        if isinstance(w, dict) and isinstance(h, dict):
             merge_config(k, have, want)
             del want[k]
 


### PR DESCRIPTION
In newer version of the container storage package the config file moved from `/etc/containers` to `/usr/share/containers/`. The latler is not marked as config in the spec file, so we don't want to change it. The current containers code[1] will read _either_ a file in `usr` or in `etc` depending on the existence of the latter. This means we can not just write the keys we want into a file in `/etc/containers` without losing all other defaults set in the config file. A new option `filebase` is therefore added, that when given will be read and form the basis of the configuration data. Then data from the target file (given via `filename`) will be merged into it and finally the actual configuration will be applied on top.

[1] https://github.com/containers/storage/blob/232bf398bd68595d2a6e53ec07d8b3c4424be3c0/types/options.go#L85