### PR TITLE
test/data: persist the journal for ostree images

### DIFF
--- a/test/data/manifests/fedora-ostree-commit.json
+++ b/test/data/manifests/fedora-ostree-commit.json
@@ -902,6 +902,17 @@
           }
         },
         {
+          "type": "org.osbuild.systemd-journald",
+          "options": {
+            "filename": "10-persistent.conf",
+            "config": {
+              "Journal": {
+                "Storage": "persistent"
+              }
+            }
+          }
+        },
+        {
           "type": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora-ostree-commit.mpp.json
+++ b/test/data/manifests/fedora-ostree-commit.mpp.json
@@ -109,6 +109,17 @@
           }
         },
         {
+          "type": "org.osbuild.systemd-journald",
+          "options": {
+            "filename": "10-persistent.conf",
+            "config": {
+              "Journal": {
+                "Storage": "persistent"
+              }
+            }
+          }
+        },
+        {
           "type": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -1014,6 +1014,7 @@
               "label": "root"
             },
             "kernel_opts": [
+              "rw",
               "console=tty0",
               "console=ttyS0",
               "systemd.log_target=console",

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -902,6 +902,17 @@
           }
         },
         {
+          "type": "org.osbuild.systemd-journald",
+          "options": {
+            "filename": "10-persistent.conf",
+            "config": {
+              "Journal": {
+                "Storage": "persistent"
+              }
+            }
+          }
+        },
+        {
           "type": "org.osbuild.selinux",
           "options": {
             "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora-ostree-image.mpp.json
+++ b/test/data/manifests/fedora-ostree-image.mpp.json
@@ -128,6 +128,7 @@
               "label": "root"
             },
             "kernel_opts": [
+              "rw",
               "console=tty0",
               "console=ttyS0",
               "systemd.log_target=console",


### PR DESCRIPTION
Include the new journald config stage to configure journald to persist the journal. This is needed since we don't create the `/var/log/journal` directory that journald uses to switch the default to persistent storage. But instead of creating that directory, we explicitly configure journald via the new stage.

This is also what Fedora CoreOS does, see [`10-coreos-persistent.conf`](https://github.com/coreos/fedora-coreos-config/blob/d709e4f5fc3970fb6b938dc7bcfdb8d602d2db94/overlay.d/05core/usr/lib/systemd/journald.conf.d/10-coreos-persistent.conf)