### PR TITLE
`objectstore`: use direct path input/output for `Object`

### DIFF
--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -63,6 +63,7 @@ class OSTreeDeploymentMount(mounts.MountService):
     def __init__(self, args):
         super().__init__(args)
 
+        self.tree = None
         self.mountpoint = None
         self.check = False
 
@@ -71,6 +72,7 @@ class OSTreeDeploymentMount(mounts.MountService):
         subprocess.run([
             "mount", "--bind", "--make-private", source, target,
         ], check=True)
+        return target
 
     def mount(self, args: Dict):
 
@@ -81,6 +83,13 @@ class OSTreeDeploymentMount(mounts.MountService):
         osname = deployment["osname"]
         ref = deployment["ref"]
         serial = deployment.get("serial", 0)
+
+        # create a private mountpoint for the tree, which is needed
+        # in order to be able to move the `root` mountpoint, which
+        # is contained inside tree, since "moving a mount residing
+        # under a shared mount is invalid and unsupported."
+        #                                              - `mount(8)`
+        self.tree = self.bind_mount(tree, tree)
 
         root = ostree.deployment_path(tree, osname, ref, serial)
 
@@ -104,16 +113,18 @@ class OSTreeDeploymentMount(mounts.MountService):
         self.check = True
 
     def umount(self):
+        if self.mountpoint:
+            subprocess.run(["sync", "-f", self.mountpoint],
+                           check=self.check)
 
-        if not self.mountpoint:
-            return
+            subprocess.run(["umount", "-R", self.mountpoint],
+                           check=self.check)
+            self.mountpoint = None
 
-        subprocess.run(["sync", "-f", self.mountpoint],
-                       check=self.check)
-
-        subprocess.run(["umount", "-R", self.mountpoint],
-                       check=self.check)
-        self.mountpoint = None
+        if self.tree:
+            subprocess.run(["umount", "-R", self.tree],
+                           check=self.check)
+            self.tree = None
 
 
 def main():

--- a/osbuild/devices.py
+++ b/osbuild/devices.py
@@ -75,7 +75,7 @@ class DeviceManager:
         args = {
             # global options
             "dev": self.devpath,
-            "tree": self.tree,
+            "tree": os.fspath(self.tree),
 
             "parent": parent,
 

--- a/osbuild/mounts.py
+++ b/osbuild/mounts.py
@@ -60,12 +60,14 @@ class MountManager:
 
         source = self.devices.device_abspath(mount.device)
 
+        root = os.fspath(self.root)
+
         args = {
             "source": source,
             "target": mount.target,
 
-            "root": self.root,
-            "tree": self.devices.tree,
+            "root": root,
+            "tree": os.fspath(self.devices.tree),
 
             "options": mount.options,
         }
@@ -80,10 +82,10 @@ class MountManager:
             self.mounts[mount.name] = res
             return res
 
-        if not path.startswith(self.root):
+        if not path.startswith(root):
             raise RuntimeError(f"returned path '{path}' has wrong prefix")
 
-        path = os.path.relpath(path, self.root)
+        path = os.path.relpath(path, root)
 
         self.mounts[mount.name] = path
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -304,7 +304,7 @@ class Pipeline:
         # build on the host
 
         if not self.build:
-            build_tree = objectstore.HostTree(object_store)
+            build_tree = object_store.host_tree
         else:
             build_tree = object_store.get(self.build)
 
@@ -333,19 +333,18 @@ class Pipeline:
 
         while todo:
             stage = todo.pop()
-            with build_tree.read() as build_path, tree.write() as path:
 
-                monitor.stage(stage)
+            monitor.stage(stage)
 
-                r = stage.run(path,
-                              self.runner,
-                              build_path,
-                              object_store,
-                              monitor,
-                              libdir,
-                              stage_timeout)
+            r = stage.run(tree,
+                          self.runner,
+                          build_tree,
+                          object_store,
+                          monitor,
+                          libdir,
+                          stage_timeout)
 
-                monitor.result(r)
+            monitor.result(r)
 
             results["stages"].append(r)
             if not r.success:

--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -80,9 +80,10 @@ class TestFormatV1(unittest.TestCase):
         storedir = pathlib.Path(tmpdir, "store")
         monitor = NullMonitor(sys.stderr.fileno())
         libdir = os.path.abspath(os.curdir)
-        store = ObjectStore(storedir)
 
-        res = manifest.build(store, manifest.pipelines, monitor, libdir)
+        with ObjectStore(storedir) as store:
+            res = manifest.build(store, manifest.pipelines, monitor, libdir)
+
         return res
 
     def test_canonical(self):


### PR DESCRIPTION
The `Object.{read,write}` methods were introduced to implement copy on write support. Calling `write` would trigger the copy, if the object had a `base`. Additionally, a level of indirection was introduced via bind mounts, which allowed to hide the actual path of the object in the store and make sure that `read` really returned a read-only path.

Support for copy-on-write was recently removed[1], and thus the need for the `read` and `write` methods. We lose the benefits of the indirection, but they are not really needed: the path to the object is not really hidden since one can always use the `resolve_ref` method to obtain the actual store object path. The read only property of build trees is ensured via read only bind mounts in the build root. 

Instead of using `read` and `write`, `Object` now gained a new `tree` property that is the path to the objects tree and also is implementing `__fspath__` and so behaves like an `os.PathLike` object and can thus transparently be used in many places, like e.g. `os.path.join` or `pathlib.Path`.