### PR TITLE
devices: tolerate existing device nodes

### DIFF
--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -18,11 +18,13 @@ documentation for `osbuil.util.udev.UdevInhibitor`.
 
 
 import argparse
+import errno
 import os
 import sys
 from typing import Dict
 
 from osbuild import devices, loop
+from osbuild.util import ctx
 from osbuild.util.udev import UdevInhibitor
 
 SCHEMA = """
@@ -106,7 +108,8 @@ class LoopbackService(devices.DeviceService):
         dir_fd = -1
         try:
             dir_fd = os.open(devpath, os.O_CLOEXEC | os.O_PATH)
-            self.lo.mknod(dir_fd)
+            with ctx.suppress_oserror(errno.EEXIST):
+                self.lo.mknod(dir_fd)
         finally:
             if dir_fd > -1:
                 os.close(dir_fd)

--- a/devices/org.osbuild.luks2
+++ b/devices/org.osbuild.luks2
@@ -15,7 +15,6 @@ Host commands used: `cryptsetup`, `dmsetup`
 import argparse
 import contextlib
 import os
-import stat
 import subprocess
 import sys
 import uuid
@@ -112,7 +111,7 @@ class CryptDeviceService(devices.DeviceService):
         subpath = os.path.join("mapper", devname)
         fullpath = os.path.join(devpath, subpath)
         os.makedirs(os.path.join(devpath, "mapper"), exist_ok=True)
-        os.mknod(fullpath, 0o666 | stat.S_IFBLK, os.makedev(major, minor))
+        self.ensure_device_node(fullpath, major, minor)
 
         data = {
             "path": subpath,

--- a/devices/org.osbuild.lvm2.lv
+++ b/devices/org.osbuild.lvm2.lv
@@ -30,7 +30,6 @@ Required host tools: lvchange, pvdisplay, lvdisplay
 
 import json
 import os
-import stat
 import subprocess
 import sys
 import time
@@ -198,7 +197,7 @@ class LVService(devices.DeviceService):
         fullpath = os.path.join(devpath, devname)
 
         os.makedirs(os.path.join(devpath, vg), exist_ok=True)  # type: ignore
-        os.mknod(fullpath, 0o666 | stat.S_IFBLK, os.makedev(major, minor))
+        self.ensure_device_node(fullpath, major, minor)
 
         data = {
             "path": devname,


### PR DESCRIPTION
It is not an error if the device node already exist, which is e.g. the case when we are using `/dev` of the host.