### PR TITLE
🗄 write and read metadata from the store

### DIFF
--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -394,6 +394,18 @@ def load(description: Dict, index: Index) -> Manifest:
 def output(manifest: Manifest, res: Dict) -> Dict:
     """Convert a result into the v2 format"""
 
+    def collect_metadata(p: Pipeline) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        r = res.get(p.id, {})
+        for stage in r.get("stages", []):
+            md = stage.metadata
+            if not md:
+                continue
+            val = data.setdefault(stage.name, {})
+            val.update(md)
+
+        return data
+
     result: Dict[str, Any] = {}
 
     if not res["success"]:
@@ -424,16 +436,7 @@ def output(manifest: Manifest, res: Dict) -> Dict:
 
         # gather all the metadata
         for p in manifest.pipelines.values():
-            data: Dict[str, Any] = {}
-            r = res.get(p.id, {})
-            for stage in r.get("stages", []):
-                md = stage.metadata
-                if not md:
-                    continue
-                name = stage.name
-                val = data.setdefault(name, {})
-                val.update(md)
-
+            data: Dict[str, Any] = collect_metadata(p)
             if data:
                 result["metadata"][p.name] = data
 

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -169,7 +169,7 @@ def osbuild_cli():
                     export(pid, output_directory, object_store, manifest)
 
             if args.json:
-                r = fmt.output(manifest, r)
+                r = fmt.output(manifest, r, object_store)
                 json.dump(r, sys.stdout)
                 sys.stdout.write("\n")
             else:

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -168,21 +168,21 @@ def osbuild_cli():
                 for pid in exports:
                     export(pid, output_directory, object_store, manifest)
 
+            if args.json:
+                r = fmt.output(manifest, r)
+                json.dump(r, sys.stdout)
+                sys.stdout.write("\n")
+            else:
+                if r["success"]:
+                    for name, pl in manifest.pipelines.items():
+                        print(f"{name + ':': <10}\t{pl.id}")
+                else:
+                    print()
+                    print(f"{vt.reset}{vt.bold}{vt.red}Failed{vt.reset}")
+
+            return 0 if r["success"] else 1
+
     except KeyboardInterrupt:
         print()
         print(f"{vt.reset}{vt.bold}{vt.red}Aborted{vt.reset}")
         return 130
-
-    if args.json:
-        r = fmt.output(manifest, r)
-        json.dump(r, sys.stdout)
-        sys.stdout.write("\n")
-    else:
-        if r["success"]:
-            for name, pl in manifest.pipelines.items():
-                print(f"{name + ':': <10}\t{pl.id}")
-        else:
-            print()
-            print(f"{vt.reset}{vt.bold}{vt.red}Failed{vt.reset}")
-
-    return 0 if r["success"] else 1

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -236,6 +236,9 @@ class Stage:
                                readonly_binds=ro_binds,
                                extra_env=extra_env)
 
+            if r.returncode == 0:
+                tree.meta.set(self.id, api.metadata)
+
         return BuildResult(self, r.returncode, r.output, api.metadata, api.error)
 
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -43,12 +43,11 @@ def cleanup(*objs):
 
 
 class BuildResult:
-    def __init__(self, origin, returncode, output, metadata, error):
+    def __init__(self, origin, returncode, output, error):
         self.name = origin.name
         self.id = origin.id
         self.success = returncode == 0
         self.output = output
-        self.metadata = metadata
         self.error = error
 
     def as_dict(self):
@@ -239,7 +238,7 @@ class Stage:
             if r.returncode == 0:
                 tree.meta.set(self.id, api.metadata)
 
-        return BuildResult(self, r.returncode, r.output, api.metadata, api.error)
+        return BuildResult(self, r.returncode, r.output, api.error)
 
 
 class Runner:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -185,6 +185,10 @@ class Stage:
                 "mounts": mounts,
             }
 
+            meta = cm.enter_context(
+                tree.meta.write(self.id)
+            )
+
             ro_binds = [
                 f"{self.info.path}:/run/osbuild/bin/{self.name}",
                 f"{inputs_tmpdir}:{inputs_mapped}",
@@ -193,6 +197,7 @@ class Stage:
 
             binds = [
                 os.fspath(tree) + ":/run/osbuild/tree",
+                meta.name + ":/run/osbuild/meta",
                 f"{mounts_tmpdir}:{mounts_mapped}"
             ]
 
@@ -234,9 +239,6 @@ class Stage:
                                binds=binds,
                                readonly_binds=ro_binds,
                                extra_env=extra_env)
-
-            if r.returncode == 0:
-                tree.meta.set(self.id, api.metadata)
 
         return BuildResult(self, r.returncode, r.output, api.error)
 

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -2,8 +2,10 @@
 # Test for API infrastructure
 #
 
+import json
 import multiprocessing as mp
 import os
+import pathlib
 import tempfile
 import unittest
 
@@ -99,19 +101,14 @@ class TestAPI(unittest.TestCase):
         # Check that `api.metadata` leads to `API.metadata` being
         # set correctly
         tmpdir = self.tmp.name
-        path = os.path.join(tmpdir, "osbuild-api")
+        path = pathlib.Path(tmpdir, "metadata")
+        path.touch()
 
-        def metadata(path):
-            data = {"meta": "42"}
-            osbuild.api.metadata(data, path=path)
-            return 0
+        data = {"meta": "42"}
+        osbuild.api.metadata(data, path=path)
 
-        api = osbuild.api.API(socket_address=path)
-        with api:
-            p = mp.Process(target=metadata, args=(path, ))
-            p.start()
-            p.join()
-            self.assertEqual(p.exitcode, 0)
-        metadata = api.metadata  # pylint: disable=no-member
+        with open(path, "r", encoding="utf8") as f:
+            metadata = json.load(f)
+
         assert metadata
-        self.assertEqual(metadata, {"meta": "42"})
+        self.assertEqual(metadata, data)

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -20,7 +20,7 @@ def store_path(store: objectstore.ObjectStore, ref: str, path: str) -> bool:
     obj = store.resolve_ref(ref)
     if not obj or not os.path.exists(obj):
         return False
-    return os.path.exists(os.path.join(obj, path))
+    return os.path.exists(os.path.join(obj, "data", "tree", path))
 
 
 @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -254,6 +254,32 @@ class TestObjectStore(unittest.TestCase):
 
             md.set("a", data)
             assert md.get("a") == data
+
+        with objectstore.ObjectStore(self.store) as store:
+            obj = store.new("a")
+            p = Path(obj, "A")
+            p.touch()
+
+            obj.meta.set("md", data)
+            assert obj.meta.get("md") == data
+
+            store.commit(obj, "x")
+            obj.meta.set("extra", extra)
+            assert obj.meta.get("extra") == extra
+
+            store.commit(obj, "a")
+
+        with objectstore.ObjectStore(self.store) as store:
+            obj = store.get("a")
+
+            assert obj.meta.get("md") == data
+            assert obj.meta.get("extra") == extra
+
+            ext = store.get("x")
+
+            assert ext.meta.get("md") == data
+            assert ext.meta.get("extra") is None
+
     def test_host_tree(self):
         with objectstore.ObjectStore(self.store) as store:
             host = store.host_tree

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -303,7 +303,7 @@ class TestObjectStore(unittest.TestCase):
         with contextlib.ExitStack() as stack:
 
             store = objectstore.ObjectStore(self.store)
-            stack.enter_context(stack)
+            stack.enter_context(store)
 
             tmpdir = tempfile.TemporaryDirectory()
             tmpdir = stack.enter_context(tmpdir)

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -40,16 +40,16 @@ class TestDescriptions(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
 
-            data = pathlib.Path(tmpdir, "data")
             storedir = pathlib.Path(tmpdir, "store")
             root = pathlib.Path("/")
             runner = Runner(index.detect_host_runner())
             monitor = NullMonitor(sys.stderr.fileno())
             libdir = os.path.abspath(os.curdir)
             store = ObjectStore(storedir)
-            data.mkdir()
 
-            res = stage.run(data, runner, root, store, monitor, libdir)
+            with ObjectStore(storedir) as store:
+                data = store.new(stage.id)
+                res = stage.run(data, runner, root, store, monitor, libdir)
 
         self.assertEqual(res.success, True)
         self.assertEqual(res.id, stage.id)


### PR DESCRIPTION
Enhance `Object` to be able to store arbitrary metadata alongside its tree and change the stage code to do so. When serialising the results, read the metadata from via the `Object` instead of getting it from `BuildResult`. When the object is later committed the metadata will also be saved. This ensures that all metadata is also present for the object when later builds are resumed from that object, or a previously built object is exported. 