### PR TITLE
🗄Write and read metadata from the store and integrate `FsCache` into `ObjectStore`

### DIFF
--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -43,6 +43,9 @@ is not listed here, **osbuild** will deny startup and exit with an error.
                                 are stored
 -l DIR, --libdir=DIR            directory containing stages, assemblers, and
                                 the osbuild library
+--cache-max-size=SIZE           maximum size of the cache (bytes) or 'unlimited'
+                                for no restriction (size may include an optional
+                                unit suffix, like kB, kiB, MB, MiB and so on)
 --checkpoint=CHECKPOINT         stage to commit to the object store during
                                 build (can be passed multiple times)
 --export=OBJECT                 object to export (can be passed multiple times)

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -394,6 +394,18 @@ def load(description: Dict, index: Index) -> Manifest:
 def output(manifest: Manifest, res: Dict) -> Dict:
     """Convert a result into the v2 format"""
 
+    def collect_metadata(p: Pipeline) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        r = res.get(p.id, {})
+        for stage in r.get("stages", []):
+            md = stage.metadata
+            if not md:
+                continue
+            val = data.setdefault(stage.name, {})
+            val.update(md)
+
+        return data
+
     result: Dict[str, Any] = {}
 
     if not res["success"]:
@@ -424,16 +436,7 @@ def output(manifest: Manifest, res: Dict) -> Dict:
 
         # gather all the metadata
         for p in manifest.pipelines.values():
-            data: Dict[str, Any] = {}
-            r = res.get(p.id, {})
-            for stage in r.get("stages", []):
-                md = stage.metadata
-                if not md:
-                    continue
-                name = stage.name
-                val = data.setdefault(name, {})
-                val.update(md)
-
+            data: Dict[str, Any] = collect_metadata(p)
             if data:
                 result["metadata"][p.name] = data
 

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -169,7 +169,7 @@ def osbuild_cli():
                     export(pid, output_directory, object_store, manifest)
 
             if args.json:
-                r = fmt.output(manifest, r)
+                r = fmt.output(manifest, r, object_store)
                 json.dump(r, sys.stdout)
                 sys.stdout.write("\n")
             else:

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -15,6 +15,7 @@ import osbuild
 import osbuild.meta
 import osbuild.monitor
 from osbuild.objectstore import ObjectStore
+from osbuild.util.parsing import parse_size
 from osbuild.util.term import fmt as vt
 
 
@@ -66,6 +67,8 @@ def parse_arguments(sys_argv):
                         help="directory where intermediary os trees are stored")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath, default="/usr/lib/osbuild",
                         help="directory containing stages, assemblers, and the osbuild library")
+    parser.add_argument("--cache-max-size", metavar="SIZE", type=parse_size, default=None,
+                        help="maximum size of the cache (bytes) or 'unlimited' for no restriction")
     parser.add_argument("--checkpoint", metavar="ID", action="append", type=str, default=None,
                         help="stage to commit to the object store during build (can be passed multiple times)")
     parser.add_argument("--export", metavar="ID", action="append", type=str, default=[],
@@ -150,6 +153,9 @@ def osbuild_cli():
 
     try:
         with ObjectStore(args.store) as object_store:
+            if args.cache_max_size is not None:
+                object_store.maximum_size = args.cache_max_size
+
             stage_timeout = args.stage_timeout
 
             pipelines = manifest.depsolve(object_store, exports)

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -168,21 +168,21 @@ def osbuild_cli():
                 for pid in exports:
                     export(pid, output_directory, object_store, manifest)
 
+            if args.json:
+                r = fmt.output(manifest, r)
+                json.dump(r, sys.stdout)
+                sys.stdout.write("\n")
+            else:
+                if r["success"]:
+                    for name, pl in manifest.pipelines.items():
+                        print(f"{name + ':': <10}\t{pl.id}")
+                else:
+                    print()
+                    print(f"{vt.reset}{vt.bold}{vt.red}Failed{vt.reset}")
+
+            return 0 if r["success"] else 1
+
     except KeyboardInterrupt:
         print()
         print(f"{vt.reset}{vt.bold}{vt.red}Aborted{vt.reset}")
         return 130
-
-    if args.json:
-        r = fmt.output(manifest, r)
-        json.dump(r, sys.stdout)
-        sys.stdout.write("\n")
-    else:
-        if r["success"]:
-            for name, pl in manifest.pipelines.items():
-                print(f"{name + ':': <10}\t{pl.id}")
-        else:
-            print()
-            print(f"{vt.reset}{vt.bold}{vt.red}Failed{vt.reset}")
-
-    return 0 if r["success"] else 1

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -236,6 +236,9 @@ class Stage:
                                readonly_binds=ro_binds,
                                extra_env=extra_env)
 
+            if r.returncode == 0:
+                tree.meta.set(self.id, api.metadata)
+
         return BuildResult(self, r.returncode, r.output, api.metadata, api.error)
 
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -43,12 +43,11 @@ def cleanup(*objs):
 
 
 class BuildResult:
-    def __init__(self, origin, returncode, output, metadata, error):
+    def __init__(self, origin, returncode, output, error):
         self.name = origin.name
         self.id = origin.id
         self.success = returncode == 0
         self.output = output
-        self.metadata = metadata
         self.error = error
 
     def as_dict(self):
@@ -239,7 +238,7 @@ class Stage:
             if r.returncode == 0:
                 tree.meta.set(self.id, api.metadata)
 
-        return BuildResult(self, r.returncode, r.output, api.metadata, api.error)
+        return BuildResult(self, r.returncode, r.output, api.error)
 
 
 class Runner:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -185,6 +185,10 @@ class Stage:
                 "mounts": mounts,
             }
 
+            meta = cm.enter_context(
+                tree.meta.write(self.id)
+            )
+
             ro_binds = [
                 f"{self.info.path}:/run/osbuild/bin/{self.name}",
                 f"{inputs_tmpdir}:{inputs_mapped}",
@@ -193,6 +197,7 @@ class Stage:
 
             binds = [
                 os.fspath(tree) + ":/run/osbuild/tree",
+                meta.name + ":/run/osbuild/meta",
                 f"{mounts_tmpdir}:{mounts_mapped}"
             ]
 
@@ -234,9 +239,6 @@ class Stage:
                                binds=binds,
                                readonly_binds=ro_binds,
                                extra_env=extra_env)
-
-            if r.returncode == 0:
-                tree.meta.set(self.id, api.metadata)
 
         return BuildResult(self, r.returncode, r.output, api.error)
 

--- a/osbuild/util/parsing.py
+++ b/osbuild/util/parsing.py
@@ -1,0 +1,33 @@
+"""Helpers related to parsing"""
+
+import re
+from typing import Union
+
+
+def parse_size(s: str) -> Union[int, str]:
+    """Parse a size string into a number or 'unlimited'.
+
+    Supported suffixes: kB, kiB, MB, MiB, GB, GiB, TB, TiB
+    """
+    units = [
+        (r'^\s*(\d+)\s*kB$', 1000, 1),
+        (r'^\s*(\d+)\s*KiB$', 1024, 1),
+        (r'^\s*(\d+)\s*MB$', 1000, 2),
+        (r'^\s*(\d+)\s*MiB$', 1024, 2),
+        (r'^\s*(\d+)\s*GB$', 1000, 3),
+        (r'^\s*(\d+)\s*GiB$', 1024, 3),
+        (r'^\s*(\d+)\s*TB$', 1000, 4),
+        (r'^\s*(\d+)\s*TiB$', 1024, 4),
+        (r'^\s*(\d+)$', 1, 1),
+        (r'^unlimited$', "unlimited", 1),
+    ]
+
+    for pat, base, power in units:
+        m = re.fullmatch(pat, s)
+        if m:
+            if isinstance(base, int):
+                return int(m.group(1)) * base ** power
+            if base == "unlimited":
+                return "unlimited"
+
+    raise TypeError(f"invalid size value: '{s}'")

--- a/schutzbot/manifest_tests.sh
+++ b/schutzbot/manifest_tests.sh
@@ -16,6 +16,9 @@ git checkout "$MANIFEST_DB_COMMIT"
 OSBUILD_LABEL=$(matchpathcon -n /usr/bin/osbuild)
 chcon $OSBUILD_LABEL tools/image-info
 
+# set the maximum cache size to unlimited
+echo "{}" | sudo osbuild --cache-max-size unlimited -
+
 # run the tests from the manifest-db for this arch+distro
 echo "Running the osbuild-image-test for arch $ARCH and ditribution $DISTRO_CODE"
 sudo tools/osbuild-image-test --arch=$ARCH --distro=$DISTRO_CODE --image-info-path=tools/image-info

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -2,8 +2,10 @@
 # Test for API infrastructure
 #
 
+import json
 import multiprocessing as mp
 import os
+import pathlib
 import tempfile
 import unittest
 
@@ -99,19 +101,14 @@ class TestAPI(unittest.TestCase):
         # Check that `api.metadata` leads to `API.metadata` being
         # set correctly
         tmpdir = self.tmp.name
-        path = os.path.join(tmpdir, "osbuild-api")
+        path = pathlib.Path(tmpdir, "metadata")
+        path.touch()
 
-        def metadata(path):
-            data = {"meta": "42"}
-            osbuild.api.metadata(data, path=path)
-            return 0
+        data = {"meta": "42"}
+        osbuild.api.metadata(data, path=path)
 
-        api = osbuild.api.API(socket_address=path)
-        with api:
-            p = mp.Process(target=metadata, args=(path, ))
-            p.start()
-            p.join()
-            self.assertEqual(p.exitcode, 0)
-        metadata = api.metadata  # pylint: disable=no-member
+        with open(path, "r", encoding="utf8") as f:
+            metadata = json.load(f)
+
         assert metadata
-        self.assertEqual(metadata, {"meta": "42"})
+        self.assertEqual(metadata, data)

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -20,7 +20,7 @@ def store_path(store: objectstore.ObjectStore, ref: str, path: str) -> bool:
     obj = store.resolve_ref(ref)
     if not obj or not os.path.exists(obj):
         return False
-    return os.path.exists(os.path.join(obj, path))
+    return os.path.exists(os.path.join(obj, "data", "tree", path))
 
 
 @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -254,6 +254,32 @@ class TestObjectStore(unittest.TestCase):
 
             md.set("a", data)
             assert md.get("a") == data
+
+        with objectstore.ObjectStore(self.store) as store:
+            obj = store.new("a")
+            p = Path(obj, "A")
+            p.touch()
+
+            obj.meta.set("md", data)
+            assert obj.meta.get("md") == data
+
+            store.commit(obj, "x")
+            obj.meta.set("extra", extra)
+            assert obj.meta.get("extra") == extra
+
+            store.commit(obj, "a")
+
+        with objectstore.ObjectStore(self.store) as store:
+            obj = store.get("a")
+
+            assert obj.meta.get("md") == data
+            assert obj.meta.get("extra") == extra
+
+            ext = store.get("x")
+
+            assert ext.meta.get("md") == data
+            assert ext.meta.get("extra") is None
+
     def test_host_tree(self):
         with objectstore.ObjectStore(self.store) as store:
             host = store.host_tree

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -303,7 +303,7 @@ class TestObjectStore(unittest.TestCase):
         with contextlib.ExitStack() as stack:
 
             store = objectstore.ObjectStore(self.store)
-            stack.enter_context(stack)
+            stack.enter_context(store)
 
             tmpdir = tempfile.TemporaryDirectory()
             tmpdir = stack.enter_context(tmpdir)

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -40,16 +40,16 @@ class TestDescriptions(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
 
-            data = pathlib.Path(tmpdir, "data")
             storedir = pathlib.Path(tmpdir, "store")
             root = pathlib.Path("/")
             runner = Runner(index.detect_host_runner())
             monitor = NullMonitor(sys.stderr.fileno())
             libdir = os.path.abspath(os.curdir)
             store = ObjectStore(storedir)
-            data.mkdir()
 
-            res = stage.run(data, runner, root, store, monitor, libdir)
+            with ObjectStore(storedir) as store:
+                data = store.new(stage.id)
+                res = stage.run(data, runner, root, store, monitor, libdir)
 
         self.assertEqual(res.success, True)
         self.assertEqual(res.id, stage.id)

--- a/test/mod/test_util_parsing.py
+++ b/test/mod/test_util_parsing.py
@@ -1,0 +1,39 @@
+"""Unit tests for osbuild.util.parsing"""
+
+import pytest
+
+from osbuild.util import parsing
+
+
+def test_parse_size():
+    cases = [
+        ("123", True, 123),
+        ("123 kB", True, 123000),
+        ("123 KiB", True, 123 * 1024),
+        ("123 MB", True, 123 * 1000 * 1000),
+        ("123 MiB", True, 123 * 1024 * 1024),
+        ("123 GB", True, 123 * 1000 * 1000 * 1000),
+        ("123 GiB", True, 123 * 1024 * 1024 * 1024),
+        ("123 TB", True, 123 * 1000 * 1000 * 1000 * 1000),
+        ("123 TiB", True, 123 * 1024 * 1024 * 1024 * 1024),
+        ("123kB", True, 123000),
+        ("123KiB", True, 123 * 1024),
+        (" 123", True, 123),
+        ("  123kB", True, 123000),
+        ("  123KiB", True, 123 * 1024),
+        ("unlimited", True, "unlimited"),
+        ("string", False, 0),
+        ("123 KB", False, 0),
+        ("123 mb", False, 0),
+        ("123 PB", False, 0),
+        ("123 PiB", False, 0),
+
+    ]
+
+    for s, success, num in cases:
+        if not success:
+            with pytest.raises(TypeError):
+                parsing.parse_size(s)
+        else:
+            res = parsing.parse_size(s)
+            assert res == num, f"{s} parsed as {res} (wanted {num})"

--- a/test/test.py
+++ b/test/test.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 
 import osbuild.meta
+from osbuild.objectstore import ObjectStore
 from osbuild.util import linux
 
 
@@ -277,6 +278,8 @@ class OSBuild(contextlib.AbstractContextManager):
     _exitstack = None
     _cachedir = None
 
+    maximum_cache_size = 20 * 1024 * 1024 * 1024  # 20 GB
+
     def __init__(self, *, cache_from=None):
         self._cache_from = cache_from
 
@@ -296,6 +299,9 @@ class OSBuild(contextlib.AbstractContextManager):
                     os.path.join(self._cache_from, "."),
                     self._cachedir
                 ], check=True)
+
+            with ObjectStore(self._cachedir) as store:
+                store.maximum_size = self.maximum_cache_size
 
             # Keep our ExitStack for `__exit__()`.
             self._exitstack = self._exitstack.pop_all()


### PR DESCRIPTION
This is a combination of two "patch series":

1) #1186
2) Integrate `FsCache` into `ObjectStore`

## 🗄 write and read metadata from the store

Enhance `Object` to be able to store arbitrary metadata alongside its tree and change the stage code to do so. When serialising the results, read the metadata from via the `Object` instead of getting it from `BuildResult`. When the object is later committed the metadata will also be saved. This ensures that all metadata is also present for the object when later builds are resumed from that object, or a previously built object is exported. 

## Integrate FsCache into ObjectStore

Integrate the recently added file system cache `FsCache` into our object store `ObjectStore`. NB: This changes the semantics of it: previously a call to `ObjectStore.commit` resulted in the object being in the cache (i/o errors aside). But `FsCache.store`, which is now the backing store for objects, will only commit objects if there is enough space left. Thus we cannot rely that objects are present for reading after a call to `FsCache.store`. To cope with this we now always copy the object into the cache, even for cases where we previously moved it: for the case where commit is called with `object_id` matching `Object.id`, which is the case for when `commit` is called for last stage in the pipeline. We could keep this optimization but then we would have to special case it and not call `commit` for these cases but only after we exported all objects; or in other words, after we are sure we will never read from any committed object again. The extra complexity seems not worth it for the little gain of the optimization.
Convert all the tests for the new semantic and also remove a lot of them that make no sense under this new paradigm.

Add a new command line option `--cache-max-size` which will set the maximum size of the cache, if specified.