### PR TITLE
stages/users: accept identical uid for existing users

### DIFF
--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -151,7 +151,8 @@ def main(tree, options):
 
         passwd = getpwnam(tree, name)
         if passwd is not None:
-            if uid is not None:
+            # `pw_uid` is the third field of `struct passwd` see `getpwnam(3)`
+            if uid is not None and passwd[2] != str(uid):
                 print(f"Error: can't set uid of existing user '{name}'")
                 return 1
             usermod(tree, name, gid, groups, description, home, shell, password)


### PR DESCRIPTION
Accept a `uid` option for an existing user if it is the existing one. This allows to have the same options for existing as well as new users, which in turn allows for the same blueprint in Composer for new and upgrade OSTree commits. In the latter we pre-fill the password database from a previous commit, which is needed to make sure that uids do not change. Since Composer can't know which of the specified users in the blueprint are new ones or existing ones it cannot easily omit the corresponding stage options. Thus the stage options have to be the same for new and existing users.