### PR TITLE
selinux: properly label 'rhsm.facts' file

### DIFF
--- a/selinux/osbuild.fc
+++ b/selinux/osbuild.fc
@@ -2,3 +2,4 @@
 /usr/lib/osbuild/assemblers/.*	--	gen_context(system_u:object_r:osbuild_exec_t,s0)
 /usr/lib/osbuild/stages/.*	--	gen_context(system_u:object_r:osbuild_exec_t,s0)
 /usr/lib/osbuild/sources/.*	--	gen_context(system_u:object_r:osbuild_exec_t,s0)
+/usr/share/osbuild/self/rhsm.facts -- gen_context(system_u:object_r:rhsmcertd_config_t,s0)


### PR DESCRIPTION
Files in `/etc/rhsm/facts` are labelled as `rhsmcertd_config_t`, so the file `/usr/share/osbuild/self/rhsm.facts`, which is created by the `org.osbuild.rhsm.facts` stage should be labelled with the same label. This ensures that all proceses can properly read said file.