### PR TITLE
fscache: introduce versioning

### DIFF
--- a/test/mod/test_util_fscache.py
+++ b/test/mod/test_util_fscache.py
@@ -4,6 +4,7 @@
 
 # pylint: disable=protected-access
 
+import json
 import os
 import tempfile
 
@@ -194,7 +195,7 @@ def test_scaffolding(tmpdir):
     assert len(list(os.scandir(os.path.join(tmpdir, cache._dirname_stage)))) == 0
 
     with open(os.path.join(tmpdir, cache._filename_cache_info), "r", encoding="utf8") as f:
-        assert f.read() == "{}"
+        assert json.load(f) == {"version": 1}
     with open(os.path.join(tmpdir, cache._filename_cache_lock), "r", encoding="utf8") as f:
         assert f.read() == ""
     with open(os.path.join(tmpdir, cache._filename_cache_size), "r", encoding="utf8") as f:
@@ -210,7 +211,7 @@ def test_cache_info(tmpdir):
     cache = fscache.FsCache("osbuild-test-appid", tmpdir)
 
     with cache:
-        assert cache._info == fscache.FsCacheInfo()
+        assert cache._info == fscache.FsCacheInfo(version=1)
         assert cache.info == cache._info
 
         assert cache.info.maximum_size is None


### PR DESCRIPTION
Introduce a "version" field to the cache-metadata and prevent the cache-implementation from modifying the cache in any way if it is not compatible to the version of the calling code. Additionally, avoid lookups, so we do not conflict with newer locking models.

Note that this does not block access to the staging area. The idea is that we commit to backwards-compatible changes in the staging area forever. This guarantees that we can always build in the staging-area, regardless of the version of the cache. If we ever need incompatible extensions, we can always add `<cache>/staging2/` or similar.

Lastly, this implementation tries to hide the versioning from the caller and always trying to pretend as if the cache is fully operational. This simplifies the call-sites at the cost of more expensive fallbacks if we run on an incompatible cache. This seems like a fair trade-off to me, though.