### PR TITLE
test/fscache: drop PathLike annotation

### DIFF
--- a/test/mod/test_util_fscache.py
+++ b/test/mod/test_util_fscache.py
@@ -39,7 +39,7 @@ def test_calculate_size(tmpdir):
     assert fscache.FsCache._calculate_size(os.path.join(tmpdir, "dir")) == 6
 
 
-def test_pathlike(tmpdir: os.PathLike[str]):
+def test_pathlike(tmpdir):
     #
     # Verify behavior of `__fspath__()`.
     #


### PR DESCRIPTION
Drop the PathLike annotation, since it is not compatible to py-3.6. Fixed our test-suite on RHEL-8.8.