### PR TITLE
[v2] util/fscache: introduce versioning

### DIFF
--- a/test/mod/test_util_fscache.py
+++ b/test/mod/test_util_fscache.py
@@ -4,6 +4,7 @@
 
 # pylint: disable=protected-access
 
+import json
 import os
 import tempfile
 
@@ -194,7 +195,7 @@ def test_scaffolding(tmpdir):
     assert len(list(os.scandir(os.path.join(tmpdir, cache._dirname_stage)))) == 0
 
     with open(os.path.join(tmpdir, cache._filename_cache_info), "r", encoding="utf8") as f:
-        assert f.read() == "{}"
+        assert json.load(f) == {"version": 1}
     with open(os.path.join(tmpdir, cache._filename_cache_lock), "r", encoding="utf8") as f:
         assert f.read() == ""
     with open(os.path.join(tmpdir, cache._filename_cache_size), "r", encoding="utf8") as f:
@@ -210,7 +211,7 @@ def test_cache_info(tmpdir):
     cache = fscache.FsCache("osbuild-test-appid", tmpdir)
 
     with cache:
-        assert cache._info == fscache.FsCacheInfo()
+        assert cache._info == fscache.FsCacheInfo(version=1)
         assert cache.info == cache._info
 
         assert cache.info.maximum_size is None


### PR DESCRIPTION
(duplicate PR to work around github-actions-CI weirdness)

Add a new field to the cache-information called `version`, which is a simple integer that is incremented on any backward-incompatible change.

The cache-implementation is modified to avoid any access to the cache except for `<cache>/staging/`. This means, changes to the staging area must be backwards compatible at all cost. Furthermore, it means we can always successfully run osbuild even on possibly incompatible caches, because we can always just ignore the cache and fully rely on the staging area being accessible.

The `load()` method will always return cache-misses. The `store()` method simply discards the entry instead of storing it. Note that `store()` needs to provide a context to the caller, hence this implementation simply creates another staging-context to provide to the caller and then discard. This is non-optimal, but keeps the API simple and avoids raising an exception to the caller (but this can be changed if it turns out to be problematic or unwanted).

Lastly, the `cache.info` field behaves as usual, since this is also the field used to read the cache-version. However, this file is never written to improve resiliency and allow blacklisting buggy versions from the past.