### PR TITLE
schutzbot: set the cache size for the correct store

### DIFF
--- a/schutzbot/manifest_tests.sh
+++ b/schutzbot/manifest_tests.sh
@@ -17,7 +17,7 @@ OSBUILD_LABEL=$(matchpathcon -n /usr/bin/osbuild)
 chcon $OSBUILD_LABEL tools/image-info
 
 # set the maximum cache size to unlimited
-echo "{}" | sudo osbuild --cache-max-size unlimited -
+echo "{}" | sudo osbuild --store /var/lib/osbuild/store --cache-max-size unlimited -
 
 # run the tests from the manifest-db for this arch+distro
 echo "Running the osbuild-image-test for arch $ARCH and ditribution $DISTRO_CODE"


### PR DESCRIPTION
The default cache location for `osbuild-image-test` is actually `/var/osbuild/store`. Pass that to `osbuild` when setting the maximum cache size to set the size for the correct location.