### PR TITLE
spec: split out containers sub-package

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -69,6 +69,16 @@ Summary:        %{summary}
 %description -n python3-%{pypi_name}
 A build system for OS images
 
+%package        containers
+Summary:        Containers support
+Requires:       %{name} = %{version}-%{release}
+Requires:       skopeo
+Obsoletes:      osbuild < 74-1
+
+%description containers
+Contains the necessary stages and input host
+services to embed container images.
+
 %package        lvm2
 Summary:        LVM2 support
 Requires:       %{name} = %{version}-%{release}
@@ -193,6 +203,10 @@ exit 0
 %{_datadir}/osbuild/schemas
 %{pkgdir}
 %{_udevrulesdir}/*.rules
+# the following files are in the containers sub-package
+%exclude %{pkgdir}/inputs/org.osbuild.containers
+%exclude %{pkgdir}/sources/org.osbuild.skopeo
+%exclude %{pkgdir}/stages/org.osbuild.skopeo
 # the following files are in the lvm2 sub-package
 %exclude %{pkgdir}/devices/org.osbuild.lvm2*
 %exclude %{pkgdir}/stages/org.osbuild.lvm2*
@@ -212,6 +226,11 @@ exit 0
 %doc README.md
 %{python3_sitelib}/%{pypi_name}-*.egg-info/
 %{python3_sitelib}/%{pypi_name}/
+
+%files containers
+%{pkgdir}/inputs/org.osbuild.containers
+%{pkgdir}/sources/org.osbuild.skopeo
+%{pkgdir}/stages/org.osbuild.skopeo
 
 %files lvm2
 %{pkgdir}/devices/org.osbuild.lvm2*

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -55,4 +55,4 @@ sudo dnf -y install osbuild-composer-tests
 sudo mkdir -p /etc/osbuild-composer/repositories
 
 # Temp fix until composer gains these dependencies
-sudo dnf -y install osbuild-luks2 osbuild-lvm2
+sudo dnf -y install osbuild-luks2 osbuild-lvm2 osbuild-containers


### PR DESCRIPTION
Split out all inputs, sources and stages that are needed to embed container images into a new `osbuild-containers` subpackage. This is mostly because all of them are dependent on `skopeo` and since this is also true for the source, the host osbuild will also need to depend on it. Add this dependency for the new `containers` sub package (and only there).

```
λ ~/C/o/osbuild → rpm -ql rpmbuild/RPMS/noarch/osbuild-containers-74-1.20221212git8e3cfbc.fc37.noarch.rpm
/usr/lib/osbuild/inputs/org.osbuild.containers
/usr/lib/osbuild/sources/org.osbuild.skopeo
/usr/lib/osbuild/stages/org.osbuild.skopeo
λ ~/C/o/osbuild → rpm -qR rpmbuild/RPMS/noarch/osbuild-containers-74-1.20221212git8e3cfbc.fc37.noarch.rpm
/usr/bin/python3
osbuild = 74-1.20221212git8e3cfbc.fc37
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsZstd) <= 5.4.18-1
```

Closes #1105 