### PR TITLE
ostree.config: add aboot (Android) bootloader config option

### DIFF
--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -37,7 +37,7 @@ SCHEMA = """
           "bootloader": {
             "description": "Configure the bootloader that OSTree uses (use 'none' for BLS).",
             "type": "string",
-            "enum": ["none", "auto", "grub2", "syslinux", "uboot", "zipl"]
+            "enum": ["none", "auto", "grub2", "syslinux", "uboot", "zipl", "aboot"]
           },
           "readonly": {
             "description": "Read only sysroot and boot",


### PR DESCRIPTION
We want to add aboot to the list of possible bootloaders so we can distinguish if we are using aboot or one of the other bootloaders.

Signed-off-by: Eric Curtin <ecurtin@redhat.com>