### PR TITLE
runners: add AutoSD runner

### DIFF
--- a/runners/org.osbuild.AutoSD9
+++ b/runners/org.osbuild.AutoSD9
@@ -1,0 +1,1 @@
+org.osbuild.centos9


### PR DESCRIPTION
AutoSD9 is a CentOS 9 stream derivate.

See https://gitlab.com/CentOS/automotive/sample-images/-/issues/12

Closes #1209