### PR TITLE
util/fscache: introduce cache maintenance

### DIFF
--- a/osbuild/util/fscache.py
+++ b/osbuild/util/fscache.py
@@ -34,11 +34,15 @@ class FsCacheInfo(NamedTuple):
     tuple and used to query or set the configuration of a cache.
 
     creation_boot_id - Hashed linux boot-id at the time of cache-creation
+    high_watermark - Cache size watermark as percentage to start reclaim
+    low_watermark - Cache size watermark as percentage to stop reclaim
     maximum_size - Maximum cache size in bytes, or "unlimited"
     version - version of the cache data structures
     """
 
     creation_boot_id: Optional[str] = None
+    high_watermark: Optional[int] = None
+    low_watermark: Optional[int] = None
     maximum_size: MaximumSizeType = None
     version: Optional[int] = None
 
@@ -55,6 +59,8 @@ class FsCacheInfo(NamedTuple):
             return cls()
 
         creation_boot_id = None
+        high_watermark = None
+        low_watermark = None
         maximum_size: MaximumSizeType = None
         version = None
 
@@ -62,6 +68,16 @@ class FsCacheInfo(NamedTuple):
         _creation_boot_id = data.get("creation-boot-id")
         if isinstance(_creation_boot_id, str) and len(_creation_boot_id) == 32:
             creation_boot_id = _creation_boot_id
+
+        # parse "high-watermark"
+        _high_watermark = data.get("high-watermark")
+        if isinstance(_high_watermark, int) and (0 <= _high_watermark <= 100):
+            high_watermark = _high_watermark
+
+        # parse "low-watermark"
+        _low_watermark = data.get("low-watermark")
+        if isinstance(_low_watermark, int) and (0 <= _low_watermark <= 100):
+            low_watermark = _low_watermark
 
         # parse "maximum-size"
         _maximum_size = data.get("maximum-size")
@@ -78,6 +94,8 @@ class FsCacheInfo(NamedTuple):
         # create immutable tuple
         return cls(
             creation_boot_id,
+            high_watermark,
+            low_watermark,
             maximum_size,
             version,
         )
@@ -93,6 +111,10 @@ class FsCacheInfo(NamedTuple):
         data: Dict[str, Any] = {}
         if self.creation_boot_id is not None:
             data["creation-boot-id"] = self.creation_boot_id
+        if self.high_watermark is not None:
+            data["high-watermark"] = self.high_watermark
+        if self.low_watermark is not None:
+            data["low-watermark"] = self.low_watermark
         if self.maximum_size is not None:
             data["maximum-size"] = self.maximum_size
         if self.version is not None:

--- a/osbuild/util/fscache.py
+++ b/osbuild/util/fscache.py
@@ -767,6 +767,9 @@ class FsCache(contextlib.AbstractContextManager, os.PathLike):
         assert self._is_active()
         assert self._is_compatible()
 
+        if diff == 0:
+            return True
+
         # Open the cache-size and lock it for writing. But instead of writing
         # directly to it, we replace it with a new file. This guarantees that
         # we cannot crash while writing a partial size, but always atomically

--- a/osbuild/util/fscache.py
+++ b/osbuild/util/fscache.py
@@ -1081,6 +1081,11 @@ class FsCache(contextlib.AbstractContextManager, os.PathLike):
                     raise self.MissError() from None
                 raise e
 
+            # Update the timestamps of the entry root directory to mark this
+            # entry as used and thus lessen the chances of it being garbage
+            # collected by cache maintenance.
+            os.utime(self._path(self._dirname_objects, name), follow_symlinks=False)
+
             yield os.path.join(
                 self._dirname_objects,
                 name,

--- a/osbuild/util/fscache.py
+++ b/osbuild/util/fscache.py
@@ -1037,6 +1037,28 @@ class FsCache(contextlib.AbstractContextManager, os.PathLike):
                     raise self.MissError() from None
                 raise e
 
+            # If no object-info is present, the object is corrupted and we
+            # must not consider it valid. Bail out and treat this as a cache
+            # miss.
+            try:
+                with open(
+                    self._path(
+                        self._dirname_objects,
+                        name,
+                        self._filename_object_info,
+                    ),
+                    "r",
+                    encoding="utf8",
+                ):
+                    # So far we are not interested in the object-info, but
+                    # in the future, we will parse and return this alongside
+                    # to the caller.
+                    pass
+            except OSError as e:
+                if e.errno in [errno.ENOENT, errno.ENOTDIR]:
+                    raise self.MissError() from None
+                raise e
+
             yield os.path.join(
                 self._dirname_objects,
                 name,

--- a/test/mod/test_util_fscache.py
+++ b/test/mod/test_util_fscache.py
@@ -533,7 +533,8 @@ def test_stale_discard(tmpdir):
             n_stage += 1
             os.mkdir(os.path.join(cache, cache._dirname_stage, "uuid-live-4"))
             f = es.enter_context(
-                open(os.path.join(cache, cache._dirname_stage, "uuid-live-4", cache._filename_object_lock), "x+", encoding="utf8")
+                open(os.path.join(cache, cache._dirname_stage, "uuid-live-4",
+                     cache._filename_object_lock), "x+", encoding="utf8")
             )
             linux.fcntl_flock(f.fileno(), linux.fcntl.F_RDLCK)
 
@@ -607,7 +608,8 @@ def test_stale_discard(tmpdir):
             n_objects += 1
             os.mkdir(os.path.join(cache, cache._dirname_objects, "live-4"))
             f = es.enter_context(
-                open(os.path.join(cache, cache._dirname_objects, "live-4", cache._filename_object_lock), "x+", encoding="utf8")
+                open(os.path.join(cache, cache._dirname_objects, "live-4",
+                     cache._filename_object_lock), "x+", encoding="utf8")
             )
             linux.fcntl_flock(f.fileno(), linux.fcntl.F_RDLCK)
 
@@ -615,7 +617,8 @@ def test_stale_discard(tmpdir):
             n_objects += 1
             os.mkdir(os.path.join(cache, cache._dirname_objects, "uuid-live-4"))
             f = es.enter_context(
-                open(os.path.join(cache, cache._dirname_objects, "uuid-live-4", cache._filename_object_lock), "x+", encoding="utf8")
+                open(os.path.join(cache, cache._dirname_objects, "uuid-live-4",
+                     cache._filename_object_lock), "x+", encoding="utf8")
             )
             linux.fcntl_flock(f.fileno(), linux.fcntl.F_RDLCK)
 

--- a/test/mod/test_util_fscache.py
+++ b/test/mod/test_util_fscache.py
@@ -231,17 +231,34 @@ def test_cache_info(tmpdir):
         assert cache._info == fscache.FsCacheInfo(version=1)
         assert cache.info == cache._info
 
+        assert cache.info.high_watermark is None
+        assert cache.info.low_watermark is None
         assert cache.info.maximum_size is None
         assert cache.info.creation_boot_id is None
+
         cache.info = fscache.FsCacheInfo(maximum_size=1024)
         assert cache.info.maximum_size == 1024
         assert cache.info.creation_boot_id is None
+
         cache.info = fscache.FsCacheInfo(creation_boot_id="0"*32)
         assert cache.info.maximum_size == 1024
         assert cache.info.creation_boot_id == "0"*32
+
         cache.info = fscache.FsCacheInfo(maximum_size=2048, creation_boot_id="1"*32)
         assert cache.info.maximum_size == 2048
         assert cache.info.creation_boot_id == "1"*32
+
+        cache.info = fscache.FsCacheInfo(high_watermark=80, low_watermark=50)
+        assert cache.info.high_watermark == 80
+        assert cache.info.low_watermark == 50
+
+        cache.info = fscache.FsCacheInfo(high_watermark=-10, low_watermark=-10)
+        assert cache.info.high_watermark is None
+        assert cache.info.low_watermark is None
+
+        cache.info = fscache.FsCacheInfo(high_watermark=120, low_watermark=120)
+        assert cache.info.high_watermark is None
+        assert cache.info.low_watermark is None
 
     assert not fscache.FsCacheInfo().to_json()
     assert fscache.FsCacheInfo(creation_boot_id="0"*32).to_json() == {
@@ -271,6 +288,23 @@ def test_cache_info(tmpdir):
         "unknown0": "foobar",
         "unknown1": ["foo", "bar"],
     }) == fscache.FsCacheInfo(creation_boot_id="0"*32)
+
+    info_json = {
+        "creation-boot-id": "0"*32,
+        "high-watermark": 80,
+        "low-watermark": 50,
+        "maximum-size": 1024,
+        "version": 1,
+    }
+    info_typed = fscache.FsCacheInfo(
+        creation_boot_id="0"*32,
+        high_watermark=80,
+        low_watermark=50,
+        maximum_size=1024,
+        version=1,
+    )
+    assert fscache.FsCacheInfo.from_json(info_json) == info_typed
+    assert info_typed.to_json() == info_json
 
 
 def test_store(tmpdir):


### PR DESCRIPTION
Introduce a new function on FsCache: `maintenance()`

This function runs cache-maintenance operations on demand. This series implements 3 maintenance tasks:

 * Delete any staging entries that are unused.
 * Delete any stale objects.
 * Reclaim cache space.

The test-suite is extended to verify those calls work. However, this does not yet hook up the maintenance from `osbuild`. However, if agreed upon, we can easily call `cache.maintenance()` unconditionally from osbuild after the build finished (or before, or...).