### PR TITLE
runners: add Fedora Asahi runner

### DIFF
--- a/runners/org.osbuild.asahi-fedora-remix
+++ b/runners/org.osbuild.asahi-fedora-remix
@@ -1,0 +1,1 @@
+org.osbuild.fedora30


### PR DESCRIPTION
Fedora Asahi is just a minor fork of mainstream Fedora with some Apple Silicon hardware enablement.

See https://github.com/osbuild/osbuild/issues/1215