### PR TITLE
stages/rhsm.facts: create facts file in /etc

### DIFF
--- a/stages/org.osbuild.rhsm.facts
+++ b/stages/org.osbuild.rhsm.facts
@@ -22,20 +22,13 @@ SCHEMA = r"""
 
 
 def main(tree, options):
-    path = os.path.join(tree, "usr/share/osbuild/self")
-    file = os.path.join(path, "rhsm.facts")
+    path = os.path.join(tree, "etc/rhsm/facts")
+    file = os.path.join(path, "osbuild.facts")
 
     os.makedirs(path, exist_ok=True)
 
     with open(file, "x", encoding="utf8") as f:
         json.dump(options["facts"], f)
-
-    os.makedirs(os.path.join(tree, "etc/rhsm/facts"), exist_ok=True)
-
-    os.symlink(
-        "/usr/share/osbuild/self/rhsm.facts",
-        os.path.join(tree, "etc/rhsm/facts/osbuild.facts"),
-    )
 
     return 0
 

--- a/test/data/stages/rhsm.facts/diff.json
+++ b/test/data/stages/rhsm.facts/diff.json
@@ -1,8 +1,5 @@
 {
   "added_files": [
-    "/usr/share/osbuild",
-    "/usr/share/osbuild/self",
-    "/usr/share/osbuild/self/rhsm.facts",
     "/etc/rhsm",
     "/etc/rhsm/facts",
     "/etc/rhsm/facts/osbuild.facts"


### PR DESCRIPTION
Instead of creating the file in /usr/share and symlinking to /etc, create it directly in /etc.  This fixes an issue with SELinux labeling.  The file in /usr/share does not get labelled correctly because it doesn't match the policy and causes issues with some tools (rhc).

See [rhbz#2147450](https://bugzilla.redhat.com/show_bug.cgi?id=2147450) for the bug regarding the failure of the `rhc` tool.
See also https://github.com/osbuild/osbuild/pull/1191 for a previous discussion on this issue.  The original plan of adding the policy upstream was abandoned (or postponed?) but in a follow-up discussion with @teg and @gicmo we decided it's not necessary to put the facts file in the alternate location.