### PR TITLE
osbuild.spec: migrate the license field to SPDX

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -10,7 +10,7 @@ Version:        76
 
 Name:           %{pypi_name}
 Release:        1%{?dist}
-License:        ASL 2.0
+License:        Apache-2.0
 
 URL:            %{forgeurl}
 


### PR DESCRIPTION
See the relevant Fedora change:
https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1

We already verified that the SPDX format works well in the Enterprise Linux pipeline.