### PR TITLE
sources/ostree: fix quotation marks in mTLS remote options

### DIFF
--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -116,8 +116,8 @@ class OSTreeSource(sources.SourceService):
 
         if remote.get("secrets", {}).get("name") == "org.osbuild.rhsm.consumer":
             secrets = Subscriptions.get_consumer_secrets()
-            remote_add_args.append(f"--set=\"tls-client-key-path={secrets['consumer_key']}\"")
-            remote_add_args.append(f"--set=\"tls-client-cert-path={secrets['consumer_cert']}\"")
+            remote_add_args.append(f"--set=tls-client-key-path={secrets['consumer_key']}")
+            remote_add_args.append(f"--set=tls-client-cert-path={secrets['consumer_cert']}")
 
         ostree("remote", "add",
                uid, url,


### PR DESCRIPTION
Example of broken repo config:
```
...
"tls-client-key-path=/etc/pki/consumer/key.pem"
"tls-client-cert-path=/etc/pki/consumer/cert.pem"
```

---

I managed to build a manifest with rhsm: true using this patch, resulted in:
```
...
tls-client-key-path=/etc/pki/consumer/key.pem
tls-client-cert-path=/etc/pki/consumer/cert.pem
```