### PR TITLE
stages/mkdir: explicitly set mode using `chmod` and support handling of existing directories

### DIFF
--- a/stages/org.osbuild.mkdir
+++ b/stages/org.osbuild.mkdir
@@ -36,8 +36,12 @@ SCHEMA_2 = r"""
             "type": "boolean",
             "description": "Create intermediate directories",
             "default": false
+          },
+          "exist_ok": {
+            "type": "boolean",
+            "description": "Do not fail if the directory already exists",
+            "default": false
           }
-
         }
       }
     }
@@ -50,17 +54,21 @@ def main(tree, options):
     for item in options["paths"]:
         path = item["path"]
         mode = item.get("mode", 0o777)
-
         parents = item.get("parents", False)
+        exist_ok = item.get("exist_ok", False)
 
         target = os.path.join(tree, path.lstrip("/"))
         if not in_tree(target, tree):
             raise ValueError(f"path {path} not in tree")
 
         if parents:
-            os.makedirs(target, mode=mode)
+            os.makedirs(target, mode=mode, exist_ok=exist_ok)
         else:
-            os.mkdir(target, mode)
+            try:
+                os.mkdir(target, mode)
+            except FileExistsError:
+                if not exist_ok:
+                    raise
 
         # Documentation for os.mkdir() says that the mode is
         # ignored on some systems. Also umask value may affect

--- a/stages/org.osbuild.mkdir
+++ b/stages/org.osbuild.mkdir
@@ -62,6 +62,11 @@ def main(tree, options):
         else:
             os.mkdir(target, mode)
 
+        # Documentation for os.mkdir() says that the mode is
+        # ignored on some systems. Also umask value may affect
+        # the final mode. So we set the mode explicitly.
+        os.chmod(target, mode, follow_symlinks=False)
+
     return 0
 
 

--- a/test/data/stages/mkdir/a.json
+++ b/test/data/stages/mkdir/a.json
@@ -362,6 +362,10 @@
             "paths": [
               {
                 "path": "a"
+              },
+              {
+                "path": "c/d",
+                "parents": true
               }
             ]
           }

--- a/test/data/stages/mkdir/a.mpp.json
+++ b/test/data/stages/mkdir/a.mpp.json
@@ -18,6 +18,10 @@
             "paths": [
               {
                 "path": "a"
+              },
+              {
+                "path": "c/d",
+                "parents": true
               }
             ]
           }

--- a/test/data/stages/mkdir/b.json
+++ b/test/data/stages/mkdir/b.json
@@ -364,12 +364,21 @@
                 "path": "a"
               },
               {
+                "path": "c/d",
+                "parents": true
+              },
+              {
                 "path": "a/b",
                 "mode": 448
               },
               {
                 "path": "b/c/d",
                 "parents": true
+              },
+              {
+                "path": "c",
+                "mode": 448,
+                "exist_ok": true
               }
             ]
           }

--- a/test/data/stages/mkdir/b.mpp.json
+++ b/test/data/stages/mkdir/b.mpp.json
@@ -20,12 +20,21 @@
                 "path": "a"
               },
               {
+                "path": "c/d",
+                "parents": true
+              },
+              {
                 "path": "a/b",
                 "mode": 448
               },
               {
                 "path": "b/c/d",
                 "parents": true
+              },
+              {
+                "path": "c",
+                "mode": 448,
+                "exist_ok": true
               }
             ]
           }

--- a/test/data/stages/mkdir/diff.json
+++ b/test/data/stages/mkdir/diff.json
@@ -6,5 +6,5 @@
     "/b/c/d"
   ],
   "deleted_files": [],
-  "differences": {}
+  "differences": {"/c": {"mode": [16877, 16832]}}
 }


### PR DESCRIPTION
* Explicitly set `mode` using `os.chmod()`. The documentation mentions that the mode passed to `os.mkdir()` may be ignored and also the `umask` value set for the process affects it.
* Add new `exist_ok` stage options property to allow gracefully handling situation when a directory with the specified path already exists. This will make it easier to implement support for creating custom directories in osbuild-composer.