### PR TITLE
stages/mkdir: revert explicitly setting mode using `os.chmod`

### DIFF
--- a/stages/org.osbuild.mkdir
+++ b/stages/org.osbuild.mkdir
@@ -3,7 +3,14 @@
 Create directories within the tree.
 
 Can create one or more directories, optionally also the
-intermediate directories.
+intermediate directories. The stage can gracefully handle
+directories that already exist.
+
+Please note that the stage won't change the mode of existing
+directories. If you want to change the mode of an existing
+directory, you need to use the `org.osbuild.chmod` stage.
+Mode is applied only to newly created directories and umask
+value is taken into account.
 """
 
 import os

--- a/stages/org.osbuild.mkdir
+++ b/stages/org.osbuild.mkdir
@@ -70,11 +70,6 @@ def main(tree, options):
                 if not exist_ok:
                     raise
 
-        # Documentation for os.mkdir() says that the mode is
-        # ignored on some systems. Also umask value may affect
-        # the final mode. So we set the mode explicitly.
-        os.chmod(target, mode, follow_symlinks=False)
-
     return 0
 
 

--- a/test/data/stages/mkdir/diff.json
+++ b/test/data/stages/mkdir/diff.json
@@ -6,5 +6,5 @@
     "/b/c/d"
   ],
   "deleted_files": [],
-  "differences": {"/c": {"mode": [16877, 16832]}}
+  "differences": {}
 }


### PR DESCRIPTION
As it turned out, the original behavior was intentional. Revert the change. Also enhance the stage documentation to cover the stage behavior in this regard.