### PR TITLE
stages/squashfs: add support for zstd compression

### DIFF
--- a/stages/org.osbuild.squashfs
+++ b/stages/org.osbuild.squashfs
@@ -26,7 +26,7 @@ SCHEMA_2 = """
       "required": ["method"],
       "properties": {
         "method": {
-          "enum": ["gzip", "xz", "lz4"]
+          "enum": ["gzip", "lz4", "xz", "zstd"]
         },
         "options": {
           "type": "object",


### PR DESCRIPTION
Fedora and RHEL 9 kernels support it and since it's an interesting alternative to other compression methods, we should support it in osbuild.

I also took the liberty of sorting the compression methods alphabetically.