### PR TITLE
mounts: add the norecovery option for xfs and ext4

### DIFF
--- a/mounts/org.osbuild.btrfs
+++ b/mounts/org.osbuild.btrfs
@@ -32,6 +32,11 @@ SCHEMA_2 = """
         "description": "mount the source as a readonly device",
         "type": "boolean",
         "default": false
+      },
+      "norecovery": {
+        "description": "Don't load the journal on mounting",
+        "type": "boolean",
+        "default": false
       }
     }
   }

--- a/mounts/org.osbuild.ext4
+++ b/mounts/org.osbuild.ext4
@@ -32,6 +32,11 @@ SCHEMA_2 = """
         "description": "mount the source as a readonly device",
         "type": "boolean",
         "default": false
+      },
+      "norecovery": {
+        "description": "Don't load the journal on mounting",
+        "type": "boolean",
+        "default": false
       }
     }
   }

--- a/mounts/org.osbuild.xfs
+++ b/mounts/org.osbuild.xfs
@@ -32,6 +32,11 @@ SCHEMA_2 = """
         "description": "mount the source as a readonly device",
         "type": "boolean",
         "default": false
+      },
+      "norecovery": {
+        "description": "Don't load the journal on mounting",
+        "type": "boolean",
+        "default": false
       }
     }
   }

--- a/osbuild/mounts.py
+++ b/osbuild/mounts.py
@@ -129,6 +129,8 @@ class FileSystemMountService(MountService):
         opts = []
         if options.get("readonly"):
             opts.append("ro")
+        if options.get("norecovery"):
+            opts.append("norecovery")
         if "uid" in options:
             opts.append(f"uid={options['uid']}")
         if "gid" in options:


### PR DESCRIPTION
To avoid kernel panics if the kernel attempts to recover the filesystem when it's mounted as readonly image-info needs to set this flag for ext4 and xfs FS.