### PR TITLE
stages/shell.init: add pattern for env var names

### DIFF
--- a/stages/org.osbuild.shell.init
+++ b/stages/org.osbuild.shell.init
@@ -12,26 +12,33 @@ import osbuild.api
 
 SCHEMA_2 = r"""
 "options": {
+  "additionalProperties": false,
   "properties": {
-    "patternProperties": {
-      "^[a-zA-Z0-9\\.\\-_]{1,250}$": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "env": {
-            "type": "array",
-            "description": "Environment variables to set and export on shell init.",
-            "minItems": 1,
-            "items": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["key", "value"],
-              "properties": {
-                "key": {
-                  "type": "string",
-                  "pattern": "^[A-Z_][A-Z0-9_]*$"
-                },
-                "value": "string"
+    "files": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9\\.\\-_]{1,250}$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "env": {
+              "type": "array",
+              "description": "Environment variables to set and export on shell init.",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["key", "value"],
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "pattern": "^[A-Z_][A-Z0-9_]*$"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -44,7 +51,8 @@ SCHEMA_2 = r"""
 
 
 def main(tree, options):
-    for filename, opts in options.items():
+    files = options.get("files", {})
+    for filename, opts in files.items():
         lines = []
         for item in opts["env"]:
             key = item["key"]

--- a/stages/org.osbuild.shell.init
+++ b/stages/org.osbuild.shell.init
@@ -27,7 +27,10 @@ SCHEMA_2 = r"""
               "additionalProperties": false,
               "required": ["key", "value"],
               "properties": {
-                "key": "string",
+                "key": {
+                  "type": "string",
+                  "pattern": "^[A-Z_][A-Z0-9_]*$"
+                },
                 "value": "string"
               }
             }

--- a/stages/org.osbuild.shell.init
+++ b/stages/org.osbuild.shell.init
@@ -14,7 +14,7 @@ SCHEMA_2 = r"""
 "options": {
   "properties": {
     "patternProperties": {
-      "^[\\w.-_]{1,250}$": {
+      "^[a-zA-Z0-9\\.\\-_]{1,250}$": {
         "type": "object",
         "additionalProperties": false,
         "properties": {

--- a/test/data/stages/shell.init/b.json
+++ b/test/data/stages/shell.init/b.json
@@ -394,25 +394,27 @@
         {
           "type": "org.osbuild.shell.init",
           "options": {
-            "test_env": {
-              "env": [
-                {
-                  "key": "VAR",
-                  "value": "val"
-                }
-              ]
-            },
-            "test_env.2": {
-              "env": [
-                {
-                  "key": "ONE",
-                  "value": "1"
-                },
-                {
-                  "key": "TWO",
-                  "value": "2"
-                }
-              ]
+            "files": {
+              "test_env": {
+                "env": [
+                  {
+                    "key": "VAR",
+                    "value": "val"
+                  }
+                ]
+              },
+              "test_env.2": {
+                "env": [
+                  {
+                    "key": "ONE",
+                    "value": "1"
+                  },
+                  {
+                    "key": "TWO",
+                    "value": "2"
+                  }
+                ]
+              }
             }
           }
         }

--- a/test/data/stages/shell.init/b.json
+++ b/test/data/stages/shell.init/b.json
@@ -397,7 +397,7 @@
             "test_env": {
               "env": [
                 {
-                  "key": "var",
+                  "key": "VAR",
                   "value": "val"
                 }
               ]
@@ -405,11 +405,11 @@
             "test_env.2": {
               "env": [
                 {
-                  "key": "one",
+                  "key": "ONE",
                   "value": "1"
                 },
                 {
-                  "key": "two",
+                  "key": "TWO",
                   "value": "2"
                 }
               ]

--- a/test/data/stages/shell.init/b.mpp.json
+++ b/test/data/stages/shell.init/b.mpp.json
@@ -51,25 +51,27 @@
         {
           "type": "org.osbuild.shell.init",
           "options": {
-            "test_env": {
-              "env": [
-                {
-                  "key": "VAR",
-                  "value": "val"
-                }
-              ]
-            },
-            "test_env.2": {
-              "env": [
-                {
-                  "key": "ONE",
-                  "value": "1"
-                },
-                {
-                  "key": "TWO",
-                  "value": "2"
-                }
-              ]
+            "files": {
+              "test_env": {
+                "env": [
+                  {
+                    "key": "VAR",
+                    "value": "val"
+                  }
+                ]
+              },
+              "test_env.2": {
+                "env": [
+                  {
+                    "key": "ONE",
+                    "value": "1"
+                  },
+                  {
+                    "key": "TWO",
+                    "value": "2"
+                  }
+                ]
+              }
             }
           }
         }

--- a/test/data/stages/shell.init/b.mpp.json
+++ b/test/data/stages/shell.init/b.mpp.json
@@ -54,7 +54,7 @@
             "test_env": {
               "env": [
                 {
-                  "key": "var",
+                  "key": "VAR",
                   "value": "val"
                 }
               ]
@@ -62,11 +62,11 @@
             "test_env.2": {
               "env": [
                 {
-                  "key": "one",
+                  "key": "ONE",
                   "value": "1"
                 },
                 {
-                  "key": "two",
+                  "key": "TWO",
                   "value": "2"
                 }
               ]


### PR DESCRIPTION
Pattern for valid environment variable names as defined in The Open Group Base Specifications Issue 7, 2018 edition IEEE Std 1003.1-2017 (Revision of IEEE Std 1003.1-2008)

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html