### PR TITLE
ci: update manifest tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,19 +98,27 @@ Manifests:
   parallel:
     matrix:
       - RUNNER:
-          - aws/fedora-35-x86_64
-          - aws/fedora-35-aarch64
           - aws/fedora-36-x86_64
           - aws/fedora-36-aarch64
+          - aws/fedora-37-x86_64
+          - aws/fedora-37-aarch64
           - aws/centos-stream-8-x86_64
           - aws/centos-stream-8-aarch64
+          - aws/centos-stream-9-x86_64
+          - aws/centos-stream-9-aarch64
       - RUNNER:
           - aws/rhel-8.6-ga-x86_64
           - aws/rhel-8.6-ga-aarch64
+          - aws/rhel-8.7-ga-x86_64
+          - aws/rhel-8.7-ga-aarch64
+          - aws/rhel-8.8-nightly-x86_64
+          - aws/rhel-8.8-nightly-aarch64
           - aws/rhel-9.0-ga-x86_64
           - aws/rhel-9.0-ga-aarch64
-          - aws/rhel-8.7-nightly-x86_64
-          - aws/rhel-8.7-nightly-aarch64
+          - aws/rhel-9.1-ga-x86_64
+          - aws/rhel-9.1-ga-aarch64
+          - aws/rhel-9.2-nightly-x86_64
+          - aws/rhel-9.2-nightly-aarch64
         INTERNAL_NETWORK: "true"
 
 finish:

--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "global": {
     "dependencies": {
       "manifest-db": {
-        "commit": "159a90f83ddc64fcd030d299bea333a7c663247f"
+        "commit": "fdc3d56fd370c76e8a0db6e4932855682d2bd707"
       }
     }
   },

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -33,6 +33,7 @@ Requires:       glibc
 Requires:       policycoreutils
 Requires:       qemu-img
 Requires:       systemd
+Requires:       skopeo
 Requires:       tar
 Requires:       util-linux
 Requires:       python3-%{pypi_name} = %{version}-%{release}


### PR DESCRIPTION
Manifest-db is finally unblocked and we can update the reference commit. Done manually this time to speed up the process.
I'm also updating the set of distributions we are testing on, upgrading it to what's is generated on manifest db.