### PR TITLE
org.osbuild.rpm: Add some context to rpmkeys failure

### DIFF
--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -303,13 +303,17 @@ def main(tree, inputs, options):
 
     for filename, data in packages.items():
         if data.get("rpm.check_gpg"):
-            subprocess.run([
-                "rpmkeys",
-                *rpm_args,
-                "--root", tree,
-                "--checksig",
-                filename
-            ], cwd=pkgpath, stdout=subprocess.DEVNULL, check=True)
+            try:
+                subprocess.run([
+                    "rpmkeys",
+                    *rpm_args,
+                    "--root", tree,
+                    "--checksig",
+                    filename
+                ], cwd=pkgpath, stdout=subprocess.DEVNULL, check=True)
+            except Exception:
+                print(f"Signature check failed on {filename}, lookup package name in manifest.")
+                raise
 
     for source in ("/dev", "/sys", "/proc"):
         target = os.path.join(tree, source.lstrip("/"))


### PR DESCRIPTION
This will hopefully help debug problems when the signature check fails. You need to manually take the hash and look it up in the manifest sources list to figure out what package failed since this stage doesn't have access to sources.