### PR TITLE
stages/ignition: support multi kargs in network kcmdline

### DIFF
--- a/stages/org.osbuild.ignition
+++ b/stages/org.osbuild.ignition
@@ -21,7 +21,8 @@ import sys
 
 import osbuild.api
 
-STAGE_OPTS = """
+SCHEMA = """
+"additionalProperties": false,
 "properties": {
   "network": {
     "type": "array",
@@ -46,7 +47,7 @@ def main(tree, options):
     with open(f"{tree}/boot/ignition.firstboot", "w", encoding="utf8") as f:
         if network:
             netstr = " ".join(network)
-            f.write(f"set ignition_network_kcmdline={netstr}")
+            f.write(f"set ignition_network_kcmdline='{netstr}'")
 
     return 0
 


### PR DESCRIPTION
As of today the functionality is broken if somebody passes more than one karg as the join would simply unify the strings but ignition_network_kcmdline is unquoted and results in just the very first karg to be consumed by the set command.