### PR TITLE
stages/ostree.preptree: add recommends argument

### DIFF
--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -67,6 +67,7 @@ class Treefile:
         "boot-location": Param(str),
         "etc-group-members": Param(List[str]),
         "machineid-compat": Param(bool),
+        "recommends": Param(bool),
         "initramfs-args": Param(List[str]),
     }
 

--- a/stages/org.osbuild.ostree.preptree
+++ b/stages/org.osbuild.ostree.preptree
@@ -58,6 +58,11 @@ SCHEMA = """
     "type": "array",
     "items": { "type": "string" }
   },
+  "recommends": {
+    "description": "Install `Recommends`",
+    "type": "boolean",
+    "default": true
+  },
   "tmp-is-dir": {
     "description": "Create a regular directory for /tmp",
     "type": "boolean",
@@ -112,6 +117,7 @@ def main(tree, options):
     etc_group_members = options.get("etc_group_members", [])
     initramfs = options.get("initramfs-args", [])
     tmp_is_dir = options.get("tmp-is-dir", True)
+    recommends = options.get("recommends", True)
 
     # rpm-ostree will either ensure that machine-id is empty
     # when machineid-compat is 'true' is or will remove it
@@ -160,6 +166,7 @@ def main(tree, options):
     treefile = ostree.Treefile()
     treefile["boot-location"] = "new"
     treefile["machineid-compat"] = machineid_compat
+    treefile["recommends"] = recommends
     treefile["etc-group-members"] = etc_group_members
     treefile["initramfs-args"] = initramfs
 


### PR DESCRIPTION
recommends allow creating a commit with rpm's Recommends or not. It's true by default as per https://github.com/coreos/rpm-ostree/pull/1513/files

Fix https://github.com/osbuild/osbuild/issues/1267 - another PR in osbuild-composer will be needed