### PR TITLE
ci: remove codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,9 +1,0 @@
-coverage:
-  status:
-    patch: no
-    project:
-      default:
-        threshold: 5%
-codecov:
-  require_ci_to_pass: yes
-comment: no

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
     - name: "Clone Repository"
       uses: actions/checkout@v3
-      with:
-           fetch-depth: 2  # codecov requires this (https://github.com/codecov/codecov-action/issues/190)
     - name: "Run Tests"
       uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
       with:
@@ -33,5 +31,3 @@ jobs:
             --rootdir=. \
             --cov-report=xml --cov=osbuild \
             -v
-    - name: Send coverage to codecov.io
-      run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
`codecov` often reports weird diffs and we rarely take action on a codecov failure in CI.

This closes #1263.