### PR TITLE
stages/org.osbuild.ovf: support older python3 versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,15 +48,15 @@ RPM:
           - aws/centos-stream-9-aarch64
           - aws/rhel-8.6-ga-x86_64
           - aws/rhel-8.6-ga-aarch64
+          - aws/rhel-8.7-ga-x86_64
+          - aws/rhel-8.7-ga-aarch64
           - aws/rhel-9.0-ga-x86_64
           - aws/rhel-9.0-ga-aarch64
+          - aws/rhel-9.1-ga-x86_64
+          - aws/rhel-9.1-ga-aarch64
       - RUNNER:
-          - aws/rhel-8.7-nightly-x86_64
-          - aws/rhel-8.7-nightly-aarch64
           - aws/rhel-8.8-nightly-x86_64
           - aws/rhel-8.8-nightly-aarch64
-          - aws/rhel-9.1-nightly-x86_64
-          - aws/rhel-9.1-nightly-aarch64
           - aws/rhel-9.2-nightly-x86_64
           - aws/rhel-9.2-nightly-aarch64
         INTERNAL_NETWORK: "true"
@@ -72,9 +72,8 @@ OSTree Images:
       - RUNNER:
           - aws/fedora-35-x86_64
           - aws/fedora-36-x86_64
-          - aws/rhel-8.6-ga-x86_64
-          - aws/rhel-8.7-nightly-x86_64
-          - aws/rhel-9.1-nightly-x86_64
+          - aws/rhel-8.7-ga-x86_64
+          - aws/rhel-9.1-ga-x86_64
         INTERNAL_NETWORK: "true"
 
 SonarQube:

--- a/Schutzfile
+++ b/Schutzfile
@@ -301,47 +301,6 @@
       }
     ]
   },
-  "rhel-8.7": {
-    "repos": [
-      {
-        "file": "/etc/yum.repos.d/rhel8internal.repo",
-        "x86_64": [
-          {
-            "title": "RHEL-8-RPMREPO-NIGHTLY-BaseOS",
-            "name": "baseos",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221115"
-          },
-          {
-            "title": "RHEL-8-RPMREPO-NIGHTLY-AppStream",
-            "name": "appstream",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221115"
-          },
-          {
-            "title": "RHEL-8-RPMREPO-NIGHTLY-CRB",
-            "name": "crb",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-crb-n8.7-20221115"
-          }
-        ],
-        "aarch64": [
-          {
-            "title": "RHEL-8-RPMREPO-NIGHTLY-BaseOS",
-            "name": "baseos",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-baseos-n8.7-20221115"
-          },
-          {
-            "title": "RHEL-8-RPMREPO-NIGHTLY-AppStream",
-            "name": "appstream",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221115"
-          },
-          {
-            "title": "RHEL-8-RPMREPO-NIGHTLY-CRB",
-            "name": "crb",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-crb-n8.7-20221115"
-          }
-        ]
-      }
-    ]
-  },
   "rhel-8.8": {
     "repos": [
       {
@@ -378,47 +337,6 @@
             "title": "RHEL-8-RPMREPO-NIGHTLY-CRB",
             "name": "crb",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-crb-n8.8-20221115"
-          }
-        ]
-      }
-    ]
-  },
-  "rhel-9.1": {
-    "repos": [
-      {
-        "file": "/etc/yum.repos.d/rhel9internal.repo",
-        "x86_64": [
-          {
-            "title": "RHEL-9-RPMREPO-NIGHTLY-BaseOS",
-            "name": "baseos",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221115"
-          },
-          {
-            "title": "RHEL-9-RPMREPO-NIGHTLY-AppStream",
-            "name": "appstream",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221115"
-          },
-          {
-            "title": "RHEL-9-RPMREPO-NIGHTLY-CRB",
-            "name": "crb",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-crb-n9.1-20221115"
-          }
-        ],
-        "aarch64": [
-          {
-            "title": "RHEL-9-RPMREPO-NIGHTLY-BaseOS",
-            "name": "baseos",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.1-20221115"
-          },
-          {
-            "title": "RHEL-9-RPMREPO-NIGHTLY-AppStream",
-            "name": "appstream",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221115"
-          },
-          {
-            "title": "RHEL-9-RPMREPO-NIGHTLY-CRB",
-            "name": "crb",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-crb-n9.1-20221115"
           }
         ]
       }

--- a/stages/org.osbuild.ovf
+++ b/stages/org.osbuild.ovf
@@ -117,7 +117,7 @@ OVF_TEMPLATE = """<?xml version="1.0"?>
 
 def virtual_size(vmdk):
     cmd = ["qemu-img", "info", "--output=json", vmdk]
-    res = subprocess.run(cmd, check=True, capture_output=True)
+    res = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, encoding="utf8")
     if res.returncode != 0:
         raise RuntimeError("Unable to determine vmdk size")
     return json.loads(res.stdout)["virtual-size"]


### PR DESCRIPTION
The `capture_output` option was added in python3.7, yet el8 has python3.6 by default.

---

See osbuild/osbuild-composer#3371