### PR TITLE
mockbuild.sh: use dnf to install local package, not rpm

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ stages:
 .terraform:
   before_script:
     - schutzbot/ci_details.sh > ci-details-before-run
+    - cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
   after_script:
     - schutzbot/ci_details.sh > ci-details-after-run
     - schutzbot/update_github_status.sh update

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -7,9 +7,6 @@ DNF_REPO_BASEURL=http://osbuild-composer-repos.s3.amazonaws.com
 source /etc/os-release
 ARCH=$(uname -m)
 
-# Add osbuild team ssh keys.
-cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
-
 # Distro version that this script is running on.
 DISTRO_VERSION=${ID}-${VERSION_ID}
 

--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -90,7 +90,7 @@ if [[ $ID == rhel || $ID == centos ]] && ! rpm -q epel-release; then
     greenprint "📦 Setting up EPEL repository"
     curl -Ls --retry 5 --output /tmp/epel.rpm \
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-${VERSION_ID%.*}.noarch.rpm
-    sudo rpm -Uvh /tmp/epel.rpm
+    sudo dnf install -y /tmp/epel.rpm
 fi
 
 # Install requirements for building RPMs in mock.


### PR DESCRIPTION
DNF has more elaborate locking system and can wait for other instances of
itself when installing packages. Using rpm directly to install local
package is causing failures in CI due to it not being able to acquire
lock on `/var/lib/rpm/.rpm.lock`.

Using DNF should improve the situation, although there is no good
documentation to link and support this claim for sure.