### PR TITLE
Python 3.6 compatibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please refer to the [developer guide](https://www.osbuild.org/guides/developer-g
 The requirements for this project are:
 
  * `bubblewrap >= 0.4.0`
- * `python >= 3.7`
+ * `python >= 3.6`
 
 Additionally, the built-in stages require:
 

--- a/test/run/test_mount.py
+++ b/test/run/test_mount.py
@@ -163,7 +163,7 @@ def test_all_options(tmpdir):
                 assert st.st_gid == 0
 
                 shortname_tested = False
-                proc = subprocess.run("mount", capture_output=True, check=True)
+                proc = subprocess.run("mount", stdout=subprocess.PIPE, check=True)
                 for line in proc.stdout.splitlines():
                     strline = line.decode("utf-8")
                     if mountpoint in strline:

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -73,7 +73,13 @@ def can_setup_netns() -> bool:
 def runFileServer(barrier, directory):
     class Handler(http.server.SimpleHTTPRequestHandler):
         def __init__(self, request, client_address, server):
-            super().__init__(request, client_address, server, directory=directory)
+            super().__init__(request, client_address, server)
+
+        def translate_path(self, path: str) -> str:
+            translated_path = super().translate_path(path)
+            common = os.path.commonpath([translated_path, directory])
+            translated_path = os.path.join(directory, os.path.relpath(translated_path, common))
+            return translated_path
 
         def guess_type(self, path):
             try:

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -325,7 +325,7 @@ class TestStages(test.TestBase):
 
                 qemu_img_run = subprocess.run(
                     ["qemu-img", "info", "--output=json", ip],
-                    capture_output=True,
+                    stdout=subprocess.PIPE,
                     check=True,
                     encoding="utf8"
                 )
@@ -490,7 +490,7 @@ class TestStages(test.TestBase):
             assert ovf_tree_file.attrib["{http://schemas.dmtf.org/ovf/envelope/1}size"] == str(os.stat(vmdk).st_size)
 
             ovf_tree_disk = ovf_tree_root[1][1]
-            res = subprocess.run(["qemu-img", "info", "--output=json", vmdk], check=True, capture_output=True)
+            res = subprocess.run(["qemu-img", "info", "--output=json", vmdk], check=True, stdout=subprocess.PIPE)
             capacity = ovf_tree_disk.attrib["{http://schemas.dmtf.org/ovf/envelope/1}capacity"]
             assert capacity == str(json.loads(res.stdout)["virtual-size"])
             pop_size = ovf_tree_disk.attrib["{http://schemas.dmtf.org/ovf/envelope/1}populatedSize"]

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -360,7 +360,7 @@ class ImageManifest:
             src = f"docker://{imagename}"
 
         res = subprocess.run(["skopeo", "inspect", "--raw", src],
-                             capture_output=True,
+                             stdout=subprocess.PIPE,
                              check=True)
         m = ImageManifest(res.stdout)
         m.name = imagename


### PR DESCRIPTION
- README: update required Python version to 3.6
- Don't use `directory` argument with SimpleHTTPRequestHandler constructor
- Don't use `capture_output=True` with `subprocess.run()`

https://github.com/osbuild/osbuild/pull/1262 adds testing on Python 3.6