### PR TITLE
Support GPT partition attribute bits when creating images

### DIFF
--- a/stages/org.osbuild.sfdisk
+++ b/stages/org.osbuild.sfdisk
@@ -149,12 +149,22 @@ class PartitionTable:
             fields = []
             for field in ["start", "size", "type", "name", "uuid", "attrs"]:
                 value = getattr(partition, field)
-                if value:
-                    if field == "attrs":
-                        # make a list into a comma-separated string
-                        attr_list = [str(element) for element in value]
-                        value = ",".join(attr_list)
-                    fields += [f'{field}="{value}"']
+                if not value:
+                    continue
+                if field == "attrs":
+                    resv = {
+                        0: "RequiredPartition",
+                        1: "NoBlockIOProtocol",
+                        2: "LegacyBIOSBootable"
+                    }
+                    attrs = []
+                    for bit in value:
+                        if bit in resv:
+                            attrs.append(resv[bit])
+                        elif 48 <= bit <= 63:
+                            attrs.append(str(bit))
+                    value = ",".join(attrs)
+                fields += [f'{field}="{value}"']
             if partition.bootable:
                 fields += ["bootable"]
             command += "\n" + ", ".join(fields)

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -245,6 +245,7 @@ Example:
           "type": "21686148-6449-6E6F-744E-656564454649",
           "bootable": true,
           "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+          "attrs": [ 60 ]
         },
         ...
     }
@@ -315,7 +316,7 @@ import sys
 import tempfile
 import urllib.parse
 import urllib.request
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import dnf
 import hawkey
@@ -771,7 +772,8 @@ class Partition:
                  size: int = None,
                  bootable: bool = False,
                  name: str = None,
-                 uuid: str = None):
+                 uuid: str = None,
+                 attrs: List[int] = None):
         self.id = uid
         self.type = pttype
         self.start = start
@@ -779,6 +781,7 @@ class Partition:
         self.bootable = bootable
         self.name = name
         self.uuid = uuid
+        self.attrs = attrs
         self.index = None
 
     @property
@@ -797,7 +800,8 @@ class Partition:
                 size=js.get("size"),
                 bootable=js.get("bootable"),
                 name=js.get("name"),
-                uuid=js.get("uuid"))
+                uuid=js.get("uuid"),
+                attrs=js.get("attrs"))
         return p
 
     def to_dict(self):
@@ -815,6 +819,8 @@ class Partition:
             data["name"] = self.name
         if self.uuid:
             data["uuid"] = self.uuid
+        if self.attrs:
+            data["attrs"] = list(self.attrs)
 
         return data
 
@@ -840,10 +846,24 @@ class PartitionTable:
         command = f"label: {self.label}\nlabel-id: {self.uuid}"
         for partition in self.partitions:
             fields = []
-            for field in ["start", "size", "type", "name", "uuid"]:
+            for field in ["start", "size", "type", "name", "uuid", "attrs"]:
                 value = getattr(partition, field)
-                if value:
-                    fields += [f'{field}="{value}"']
+                if not value:
+                    continue
+                if field == "attrs":
+                    resv = {
+                        0: "RequiredPartition",
+                        1: "NoBlockIOProtocol",
+                        2: "LegacyBIOSBootable"
+                    }
+                    attrs = []
+                    for bit in value:
+                        if bit in resv:
+                            attrs.append(resv[bit])
+                        elif 48 <= bit <= 63:
+                            attrs.append(str(bit))
+                    value = ",".join(attrs)
+                fields += [f'{field}="{value}"']
             if partition.bootable:
                 fields += ["bootable"]
             command += "\n" + ", ".join(fields)


### PR DESCRIPTION
`org.osbuild.sfdisk` provides a [schema](https://github.com/osbuild/osbuild/blob/v84/stages/org.osbuild.sfdisk#L69) that allows passing `"attrs"` to set `"Attributes of the partition (GPT)"`. This works fine with the GUID specific bits, but `sfdisk` will error out for bit0-47 passed as indices. There's nothing to do for bit3-47. These are considered to be reserved for future use and sfdisk will return an error if asked to set them. For bit0-2, they are described in the [manpage](https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/disk-utils/sfdisk.8.adoc?h=v2.38.1#n94) and have to be set using their names.

Additionally, `osbuild-mpp` does not support setting GPT attributes at all. So use the same logic for the `mpp-define-image` use-case.