### PR TITLE
sources: add an org.osbuild.librepo source

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,6 +28,7 @@ RUN dnf install -y \
     python3-iniparse \
     python3-mako \
     python3-jsonschema \
+    python3-librepo \
     python3-pip \
     python3-pycodestyle \
     python3-pylint \

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -42,7 +42,7 @@ jobs:
     - name: "Regenerate Test Data"
       uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
       with:
-        image: ghcr.io/osbuild/osbuild-ci:latest-202304251412
+        image: ghcr.io/osbuild/osbuild-ci:latest-202306151618
         run: |
           make test-data
           git diff --exit-code -- ./test/data

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Additionally, the built-in stages require:
  * `tar >= 1.32`
  * `util-linux >= 235`
  * `skopeo`
+ * `python3-librepo`
 
 At build-time, the following software is required:
 

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -38,6 +38,7 @@ Requires:       tar
 Requires:       util-linux
 Requires:       python3-%{pypi_name} = %{version}-%{release}
 Requires:       (%{name}-selinux if selinux-policy-%{selinuxtype})
+Requires:       python3-librepo
 
 # Turn off dependency generators for runners. The reason is that runners are
 # tailored to the platform, e.g. on RHEL they are using platform-python. We

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -133,6 +133,8 @@ def load_source(name: str, description: Dict, index: Index, manifest: Manifest):
         items = description["urls"]
     elif name == "org.osbuild.ostree":
         items = description["commits"]
+    elif name == "org.osbuild.librepo":
+        items = description["items"]
     else:
         raise ValueError(f"Unknown source type: {name}")
 

--- a/sources/org.osbuild.librepo
+++ b/sources/org.osbuild.librepo
@@ -1,0 +1,243 @@
+#!/usr/bin/python3
+"""
+Source for downloading rpms using librepo.
+
+Download the list of rpms using a metalink or mirrorlist URL, trying new
+mirrors if there is an error. The files are written to the osbuild file cache
+using the hash as the filename.
+
+It can download files that require secrets. The only secret provider currently
+supported is `org.osbuild.rhsm` for downloading Red Hat content that requires a
+subscriptions.
+"""
+
+import sys
+from typing import Dict
+
+import librepo
+
+from osbuild import sources
+from osbuild.util.rhsm import Subscriptions
+
+# NOTE: The top level schema properties are limited to items and options by the
+# v2 schema definition
+SCHEMA_2 = """
+"properties": {
+  "items": {
+        "description": "List of the packages and their hash to download from the mirror",
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "(md5|sha1|sha256|sha384|sha512):[0-9a-f]{32,128}": {
+             "required": [
+               "path", "mirror"
+             ],
+             "properties": {
+               "path": {
+                 "description": "Name or path of the package file. Supports bare name or relative paths",
+                 "type": "string"
+               },
+               "mirror": {
+                 "description": "The mirror to use for this package",
+                 "type": "string"
+               }
+            }
+          }
+        }
+  },
+  "options": {
+      "required": ["mirrors"],
+      "properties": {
+          "mirrors": {
+            "description": "List of mirrors to be used for downloading packages",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+              "[0-9a-f]+": {
+                "required": ["url", "type"],
+                "properties": {
+                  "url": {
+                    "description": "URL of the mirrorlist or metalink",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Type of mirror: mirrorlist or metalink",
+                    "type": "string",
+                    "enum": ["mirrorlist", "metalink", "baseurl"]
+                  },
+                  "max-parallels": {
+                    "description": "Maximum number of parallel downloads.",
+                    "type": "number"
+                  },
+                  "fastest-mirror": {
+                    "description": "When true the mirrorlist is sorted by connection speed.",
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "insecure": {
+                    "description": "Skip the verification step for secure connections and proceed without checking",
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "secrets": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the secrets provider.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        }
+    }
+  }
+}
+"""
+
+
+class LibRepoSource(sources.SourceService):
+    """Use librepo to download rpm files.
+
+    This will download rpms, in parallel, retrying with a new mirror on errors,
+    and saving them into the store using their hash.
+
+    It support org.osbuild.rhsm secrets for downloading RHEL content.
+    """
+    content_type = "org.osbuild.files"
+
+    CHKSUM_TYPE = {
+        "sha256": librepo.SHA256,
+        "sha384": librepo.SHA384,
+        "sha512": librepo.SHA512,
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.subscriptions = None
+        self.errors = []
+
+    def fetch_one(self, checksum, desc) -> None:
+        raise RuntimeError("fetch_one is not used in org.osbuild.librepo")
+
+    def _setup_rhsm(self, handle, mirror):
+        """Setup the mirror's certificates if the secrets provider is org.osbuild.rhsm"""
+        # check if url needs rhsm secrets
+        if "secrets" not in mirror or mirror["secrets"].get("name") != "org.osbuild.rhsm":
+            return
+
+        # rhsm secrets only need to be retrieved once and can then be reused
+        if self.subscriptions is None:
+            self.subscriptions = Subscriptions.from_host_system()
+
+        secrets = self.subscriptions.get_secrets(mirror["url"])
+        if secrets:
+            if secrets.get('ssl_ca_cert'):
+                handle.sslcacert = secrets.get('ssl_ca_cert')
+            if secrets.get('ssl_client_cert'):
+                handle.sslclientcert = secrets.get('ssl_client_cert')
+            if secrets.get('ssl_client_key'):
+                handle.sslclientkey = secrets.get('ssl_client_key')
+
+    # This gets called when done
+    # data comes from cbdata
+    # status is librepo.TRANSFER_*
+    #   librepo.TRANSFER_SUCCESSFUL
+    #   librepo.TRANSFER_ALREADYEXISTS
+    #   librepo.TRANSFER_ERROR
+    def _endcb(self, data, status, msg):
+        """Callback for librepo transfers
+
+        data is the name/path of the package
+        status is a librepo TRANSFER_* status code
+        msg is a status message or error
+
+        TRANSFER_ERROR is returned if all mirrors are tried and it cannot download
+        the file.
+        """
+        if status == librepo.TRANSFER_ERROR:
+            self.errors.append(f"{data}: {msg}")
+
+    def make_pkg_target(self, handle, dest, path, checksum):
+        """Return a librepo.PackageTarget populated with the package data
+
+        This specifies what to download, where to save it, the checksum, etc.
+        """
+        chksum_type, checksum = checksum.split(":")
+        return librepo.PackageTarget(
+            path,
+            handle=handle,
+            checksum_type=self.CHKSUM_TYPE[chksum_type],
+            checksum=checksum,
+            dest=dest,
+            cbdata=path,
+            endcb=self._endcb)
+
+    def download(self, items: Dict) -> None:
+        """Use librepo to download the packages"""
+        # Organize the packages by the mirror id
+        packages = dict()
+        for id, pkg in items.items():
+            if pkg["mirror"] not in self.options["mirrors"]:
+                raise RuntimeError(f'Missing mirror: {pkg["mirror"]}')
+
+            if pkg["mirror"] not in packages:
+                packages[pkg["mirror"]] = [(pkg["path"], id)]
+            else:
+                packages[pkg["mirror"]].append((pkg["path"], id))
+
+        # Download packages from each of the mirror ids
+        for m in packages:
+            mirror = self.options["mirrors"][m]
+            handle = librepo.Handle()
+            handle.repotype = librepo.YUMREPO
+            if mirror["type"] == "metalink":
+                handle.metalinkurl = mirror["url"]
+            elif mirror["type"] == "mirrorlist":
+                handle.mirrorlisturl = mirror["url"]
+            elif mirror["type"] == "baseurl":
+                handle.urls = [mirror["url"]]
+
+            if mirror.get("insecure"):
+                # Disable peer certificate verification
+                handle.sslverifypeer = False
+                # Disable host name verification
+                handle.sslverifyhost = False
+            else:
+                handle.sslverifypeer = True
+                handle.sslverifyhost = True
+
+            if "max-parallels" in mirror:
+                handle.maxparalleldownloads = mirror["max-parallels"]
+
+            if mirror.get("fastest-mirror", False):
+                handle.fastestmirror = True
+
+            # If this mirror has secrets, set them up on the librepo handle
+            if "secrets" in m:
+                self._setup_rhsm(handle, mirror)
+
+            download = []
+            for path, checksum in packages[m]:
+                download.append(self.make_pkg_target(handle, f"{self.cache}/{checksum}", path, checksum))
+
+            # Download everything from this mirror
+            librepo.download_packages(download)
+
+        if self.errors:
+            raise RuntimeError(",".join(self.errors))
+
+
+def main():
+    service = LibRepoSource.from_args(sys.argv[1:])
+    service.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/data/sources/org.osbuild.librepo/cases/404-metalink.json
+++ b/test/data/sources/org.osbuild.librepo/cases/404-metalink.json
@@ -1,0 +1,39 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:e99efe314a66334179236e5fb6a2e6a6431daf6aeb516162e01517a0ac708252": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/one404.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/404-mirrorlist.json
+++ b/test/data/sources/org.osbuild.librepo/cases/404-mirrorlist.json
@@ -1,0 +1,39 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:e99efe314a66334179236e5fb6a2e6a6431daf6aeb516162e01517a0ac708252": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/one404",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/bad-baseurl-checksum.json
+++ b/test/data/sources/org.osbuild.librepo/cases/bad-baseurl-checksum.json
@@ -1,0 +1,37 @@
+{
+  "expects": "error",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/",
+            "type": "baseurl",
+            "name": "baseurl"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/updates/",
+            "type": "baseurl",
+            "name": "updates"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/bad-metalink-checksum.json
+++ b/test/data/sources/org.osbuild.librepo/cases/bad-metalink-checksum.json
@@ -1,0 +1,39 @@
+{
+  "expects": "error",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/bad-mirrorlist-checksum.json
+++ b/test/data/sources/org.osbuild.librepo/cases/bad-mirrorlist-checksum.json
@@ -1,0 +1,39 @@
+{
+  "expects": "error",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/baseurl.json
+++ b/test/data/sources/org.osbuild.librepo/cases/baseurl.json
@@ -1,0 +1,25 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/",
+            "type": "baseurl",
+            "fastest-mirror": true,
+            "name": "baseurl"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/one-metalink.json
+++ b/test/data/sources/org.osbuild.librepo/cases/one-metalink.json
@@ -1,0 +1,25 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/one-mirrorlist.json
+++ b/test/data/sources/org.osbuild.librepo/cases/one-mirrorlist.json
@@ -1,0 +1,25 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/two-metalink.json
+++ b/test/data/sources/org.osbuild.librepo/cases/two-metalink.json
@@ -1,0 +1,39 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:e99efe314a66334179236e5fb6a2e6a6431daf6aeb516162e01517a0ac708252": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/two-mirrorlist.json
+++ b/test/data/sources/org.osbuild.librepo/cases/two-mirrorlist.json
@@ -1,0 +1,39 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:e99efe314a66334179236e5fb6a2e6a6431daf6aeb516162e01517a0ac708252": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/data/Packages/a/a
+++ b/test/data/sources/org.osbuild.librepo/data/Packages/a/a
@@ -1,0 +1,1 @@
+DUMMY PACKAGE a

--- a/test/data/sources/org.osbuild.librepo/data/Packages/b/b
+++ b/test/data/sources/org.osbuild.librepo/data/Packages/b/b
@@ -1,0 +1,1 @@
+DUMMY PACKAGE b

--- a/test/data/sources/org.osbuild.librepo/data/metalink/fedora.xml
+++ b/test/data/sources/org.osbuild.librepo/data/metalink/fedora.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <metalink version="3.0" xmlns="http://www.metalinker.org/">
+   <files>
+     <file name="repomd.xml">
+       <resources maxconnections="1">
+           <url protocol="http" type="http" location="us" preference="100">http://localhost/sources/org.osbuild.librepo/data/repodata/repomd.xml</url>
+       </resources>
+     </file>
+   </files>
+ </metalink>

--- a/test/data/sources/org.osbuild.librepo/data/metalink/one404.xml
+++ b/test/data/sources/org.osbuild.librepo/data/metalink/one404.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <metalink version="3.0" xmlns="http://www.metalinker.org/">
+   <files>
+     <file name="repomd.xml">
+       <resources maxconnections="1">
+           <url protocol="http" type="http" location="us" preference="100">http://localhost/sources/org.osbuild.librepo/data/404/repodata/repomd.xml</url>
+           <url protocol="http" type="http" location="us" preference="50">http://localhost/sources/org.osbuild.librepo/data/repodata/repomd.xml</url>
+       </resources>
+     </file>
+   </files>
+ </metalink>

--- a/test/data/sources/org.osbuild.librepo/data/metalink/updates.xml
+++ b/test/data/sources/org.osbuild.librepo/data/metalink/updates.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <metalink version="3.0" xmlns="http://www.metalinker.org/">
+   <files>
+     <file name="repomd.xml">
+       <resources maxconnections="1">
+           <url protocol="http" type="http" location="us" preference="100">http://localhost/sources/org.osbuild.librepo/data/updates/repodata/repomd.xml</url>
+       </resources>
+     </file>
+   </files>
+ </metalink>

--- a/test/data/sources/org.osbuild.librepo/data/mirrorlist/fedora
+++ b/test/data/sources/org.osbuild.librepo/data/mirrorlist/fedora
@@ -1,0 +1,1 @@
+http://localhost/sources/org.osbuild.librepo/data/

--- a/test/data/sources/org.osbuild.librepo/data/mirrorlist/one404
+++ b/test/data/sources/org.osbuild.librepo/data/mirrorlist/one404
@@ -1,0 +1,2 @@
+http://localhost/sources/org.osbuild.librepo/data/404/
+http://localhost/sources/org.osbuild.librepo/data/

--- a/test/data/sources/org.osbuild.librepo/data/mirrorlist/updates
+++ b/test/data/sources/org.osbuild.librepo/data/mirrorlist/updates
@@ -1,0 +1,1 @@
+http://localhost/sources/org.osbuild.librepo/data/updates/

--- a/test/data/sources/org.osbuild.librepo/data/updates/Packages/c/c
+++ b/test/data/sources/org.osbuild.librepo/data/updates/Packages/c/c
@@ -1,0 +1,1 @@
+DUMMY PACKAGE c

--- a/test/data/sources/org.osbuild.librepo/data/updates/Packages/d/d
+++ b/test/data/sources/org.osbuild.librepo/data/updates/Packages/d/d
@@ -1,0 +1,1 @@
+DUMMY PACKAGE d

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -277,6 +277,10 @@ class TestDescriptions(unittest.TestCase):
             klass, name = module
             try:
                 info = osbuild.meta.ModuleInfo.load(os.curdir, klass, name)
+                if not info.opts[version]:
+                    print(f"{klass} '{name}' does not support version '{version}'")
+                    continue
+
                 schema = osbuild.meta.Schema(info.get_schema(version), name)
                 res = schema.check()
                 if not res:
@@ -285,6 +289,9 @@ class TestDescriptions(unittest.TestCase):
                     self.fail(str(res) + "\n  " + err)
             except json.decoder.JSONDecodeError as e:
                 msg = f"{klass} '{name}' has invalid STAGE_OPTS\n\t" + str(e)
+                self.fail(msg)
+            except Exception as e:
+                msg = f"{klass} '{name}': " + str(e)
                 self.fail(msg)
 
     def test_moduleinfo(self):

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -134,6 +134,14 @@ def test_sources(source, case, tmpdir):
     items = desc.get("items", {})
     options = desc.get("options", {})
 
+    # What version to use for validation?
+    version = "2" if info.opts["2"] else "1"
+    schema = osbuild.meta.Schema(info.get_schema(version=version), source)
+    res = schema.validate(desc)
+    # NOTE: ValidationResult overrides __bool__ to return res.valid
+    if not res:
+        raise RuntimeError(f"Validation failed on {source}:{case}:{res.as_dict()}")
+
     src = osbuild.sources.Source(info, items, options)
 
     with osbuild.objectstore.ObjectStore(tmpdir) as store, \


### PR DESCRIPTION
Currently a draft for comments until I get the corresponding osbuild-composer part added.

The current SCHEMA works, but when I use a v2 pipeline with it, it doesn't pass and I cannot figure out why.
It works fine using v1 in the pipeline.

Running the tests with `python3 -m pytest --pyargs test.run.test_sources --rootdir=. -v` works. Luckily the metalink and mirror list server support can be simulated using static files.
