### PR TITLE
stages/org.osbuild.ovf: support older python3 versions

### DIFF
--- a/stages/org.osbuild.ovf
+++ b/stages/org.osbuild.ovf
@@ -127,7 +127,7 @@ def write_template(vmdk):
     dirname, basename = os.path.split(vmdk)
     ovf_data = OVF_TEMPLATE.format(vmdk_size=os.stat(vmdk).st_size,
                                    vmdk_capacity=virtual_size(vmdk), image_name=basename)
-    ovf = f"{os.path.join(dirname, basename.removesuffix('.vmdk'))}.ovf"
+    ovf = f"{os.path.join(dirname, os.path.splitext(basename)[0])}.ovf"
     with open(ovf, "w", encoding="utf8") as f:
         f.write(ovf_data)
     return ovf
@@ -135,7 +135,7 @@ def write_template(vmdk):
 
 def write_manifest(vmdk, ovf):
     dirname, basename = os.path.split(vmdk)
-    mf = f"{os.path.join(dirname, basename.removesuffix('.vmdk'))}.mf"
+    mf = f"{os.path.join(dirname, os.path.splitext(basename)[0])}.mf"
     with open(mf, "w", encoding="utf8") as f:
         f.write(f"SHA256({os.path.basename(ovf)})= {checksum.hexdigest_file(ovf, 'sha256')}\n")
         f.write(f"SHA256({basename})= {checksum.hexdigest_file(vmdk, 'sha256')}\n")


### PR DESCRIPTION
`str.removesuffix` was introduced in python3.9, yet el8 uses python3.6 by default.

---

Similar to https://github.com/osbuild/osbuild/pull/1276, there was another unsupported function.