### PR TITLE
runners: add fedora-38 specific logic for SHA1 key support

### DIFF
--- a/runners/org.osbuild.fedora38
+++ b/runners/org.osbuild.fedora38
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+
+import os
+import shutil
+import subprocess
+import sys
+
+import osbuild.api
+
+
+def ldconfig():
+    # ld.so.conf must exist, or `ldconfig` throws a warning
+    subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
+    subprocess.run(["ldconfig"], check=True)
+
+
+def sysusers():
+    try:
+        subprocess.run(["systemd-sysusers"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as error:
+        sys.stderr.write(error.stdout)
+        sys.exit(1)
+
+
+def tmpfiles():
+    # Allow systemd-tmpfiles to return non-0. Some packages want to create
+    # directories owned by users that are not set up with systemd-sysusers.
+    subprocess.run(["systemd-tmpfiles", "--create"], check=False)
+
+
+def nsswitch():
+    # the default behavior is fine, but using nss-resolve does not
+    # necessarily work in a non-booted container, so make sure that
+    # is not configured.
+    try:
+        os.remove("/etc/nsswitch.conf")
+    except FileNotFoundError:
+        pass
+
+
+def sequoia():
+    # This provides a default set of crypto-policies which is important for
+    # re-enabling SHA1 support with rpm (so we can cross-build CentOS-Stream-9
+    # images).
+    os.makedirs("/etc/crypto-policies", exist_ok=True)
+    shutil.copytree(
+        "/usr/share/crypto-policies/back-ends/DEFAULT", "/etc/crypto-policies/back-ends"
+    )
+
+
+if __name__ == "__main__":
+    with osbuild.api.exception_handler():
+        ldconfig()
+        sysusers()
+        tmpfiles()
+        nsswitch()
+        sequoia()
+
+        r = subprocess.run(sys.argv[1:], check=False)
+        sys.exit(r.returncode)


### PR DESCRIPTION
This fixes an issue where Fedora-38 hosts can not build CentOS-Stream-9 images due to an incompatible gpg key with the default settings for rpm.

On Fedora-38, rpm has changed to use a new backend for key verification and by default does not support SHA1 anymore, although the support for SHA1 can be re-enabled via a config file. The (current) CentOS-Stream-9 keys however still require SHA1 support in order to be importable so they are unusable on Fedora-38 unless SHA1 support is re-enabled.

In OSBuild, the initial chroot does not contain the config files and so SHA1 support is disabled when rpmkeys from the host is called. It does not matter if the crypto-policies on the host machine is configured with the exception to support SHA1 because the chroot filters that out. This means it may not be possible to assemble CentOS-Stream-9 based images without disabling the key check.

This patch adds an explicit conditional case for Fedora-38 to inject the needed configuration file into /etc/crypto-policies/back-ends to enable SHA1 support for rpm by default. This adds compatibility to match the build environment on Fedora-37 and earlier.