### PR TITLE
stages/isolinux: default list

### DIFF
--- a/stages/org.osbuild.isolinux
+++ b/stages/org.osbuild.isolinux
@@ -190,7 +190,7 @@ def main(tree, inputs, options):
     version = options["product"]["version"]
 
     kdir = options["kernel"]["dir"]
-    kopts = options["kernel"].get("opts")
+    kopts = options["kernel"].get("opts", [])
     debug = options.get("debug", False)
 
     data = inputs["data"]["path"]


### PR DESCRIPTION
Otherwise when `opts` (which isn't `required`) is left out we fail the stage.

```
Traceback (most recent call last):
  File "/run/osbuild/bin/org.osbuild.isolinux", line 243, in <module>
    ret = main(args["tree"], args["inputs"], args["options"])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/run/osbuild/bin/org.osbuild.isolinux", line 227, in main
    "cmdline": " ".join(kopts)
               ^^^^^^^^^^^^^^^
TypeError: can only join an iterable
```
Fix on the other side is here: https://github.com/osbuild/osbuild-composer/pull/3439