### PR TITLE
stages/sgdisk: option to not quote partition names passed to sgdisk

### DIFF
--- a/stages/org.osbuild.sgdisk
+++ b/stages/org.osbuild.sgdisk
@@ -30,6 +30,11 @@ SCHEMA_2 = r"""
       "description": "UUID for the disk image's partition table",
       "type": "string"
     },
+    "quote_partition_name": {
+      "description": "Quote partition names passed to sgdisk, so that they end up quoted in the partition table. This is old behavior kept for backward compatibility.",
+      "type": "boolean",
+      "default": true
+    },
     "partitions": {
       "description": "Partition layout ",
       "type": "array",
@@ -109,7 +114,7 @@ class PartitionTable:
     def __getitem__(self, key) -> Partition:
         return self.partitions[key]
 
-    def write_to(self, target):
+    def write_to(self, target, quote_partition_name):
         """Write the partition table to disk"""
         # generate the command for sfdisk to create the table
 
@@ -138,8 +143,9 @@ class PartitionTable:
             ]
 
             if part.name:
+                part_name = f'"{part.name}"' if quote_partition_name else part.name
                 cmd += [
-                    "-c", f'{idx}:"{part.name}"'
+                    "-c", f"{idx}:{part_name}"
                 ]
 
             if part.uuid:
@@ -180,12 +186,13 @@ def main(devices, options):
     device = devices["device"]["path"]
 
     ptuuid = options["uuid"]
+    quote_partition_name = options.get("quote_partition_name", True)
     partitions = options.get("partitions")
 
     parts = [partition_from_json(p) for p in partitions]
     pt = PartitionTable(ptuuid, parts)
 
-    pt.write_to(device)
+    pt.write_to(device, quote_partition_name)
 
     subprocess.run(["sgdisk", "-p", device],
                    encoding='utf8',

--- a/test/data/stages/sgdisk/disk.img.json
+++ b/test/data/stages/sgdisk/disk.img.json
@@ -13,7 +13,7 @@
         "size": 1024000,
         "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
         "uuid": "80B68AE7-3531-478C-A5FF-9B80F1CB07E9",
-        "name": "\"EFI System Partition\"",
+        "name": "EFI System Partition",
         "attrs": "LegacyBIOSBootable"
       },
       {
@@ -22,7 +22,7 @@
         "size": 1024000,
         "type": "BC13C2FF-59E6-4262-A352-B275FD6F7172",
         "uuid": "CFE2BEB6-0BB8-4FB6-9075-2E79413AB707",
-        "name": "\"boot\"",
+        "name": "boot",
         "attrs": "LegacyBIOSBootable"
       },
       {
@@ -31,7 +31,7 @@
         "size": 4096,
         "type": "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
         "uuid": "6E2E131D-14C4-4278-876A-5067C40EAECD",
-        "name": "\"BIOS boot\""
+        "name": "BIOS boot"
       },
       {
         "node": "disk.img4",
@@ -39,7 +39,7 @@
         "size": 18917343,
         "type": "E6D6D379-F507-44C2-A23C-238F2A3DF928",
         "uuid": "646E1B09-9358-4A9C-B630-E3C0C296F7C6",
-        "name": "\"LVM\""
+        "name": "LVM"
       }
     ]
   }

--- a/test/data/stages/sgdisk/sgdisk.json
+++ b/test/data/stages/sgdisk/sgdisk.json
@@ -375,6 +375,7 @@
           },
           "options": {
             "uuid": "68ad7ade-3fa7-4844-8b2f-1c4cd30bef70",
+            "quote_partition_name": false,
             "partitions": [
               {
                 "uuid": "80b68ae7-3531-478c-a5ff-9b80f1cb07e9",

--- a/test/data/stages/sgdisk/sgdisk.mpp.json
+++ b/test/data/stages/sgdisk/sgdisk.mpp.json
@@ -31,6 +31,7 @@
           },
           "options": {
             "uuid": "68ad7ade-3fa7-4844-8b2f-1c4cd30bef70",
+            "quote_partition_name": false,
             "partitions": [
               {
                 "uuid": "80b68ae7-3531-478c-a5ff-9b80f1cb07e9",


### PR DESCRIPTION
The partition name in the sgdisk stage was previously quoted when passed to sgdisk as an argument. I think that this was done because the sgdisk man page states that:

```
If you want to set a name that includes a space, enclose it in
quotation marks, as in sgdisk -c 1:"Sample Name" /dev/sdb.
```

However, this should apply only when sgdisk is run in a shell, so that the argument is not split by shell into multiple arguments and passes as a single string.

The stage is executing sgdisk using Python `subprocess` module, which does not need strings with spaces to be quoted, because they are passed to the command as separate items which are not split in any way.

The previous behavior of the stage was that these quotes became part of the actual partition name in the partition table.

After a discussion within the team, we determined that this is a bug. However, fixing it would result in osbuild producing a different artifact for the same manifest, compared to osbuild version without such fix. This is undesired.

For backward compatibility, a new `no_quote_partition_names` property is added to the stage options, which will make the stage not quote the partition name when passed to `sgdisk`. As a result, the partition name won't be quoted in the partition table.

Modify unit tests to use this option by default.