### PR TITLE
Spec: use `%forgeautosetup` macro in `%prep` phase

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -121,7 +121,7 @@ Contains additional tools and utilities for development of
 manifests and osbuild.
 
 %prep
-%forgesetup
+%forgeautosetup -p1
 
 %build
 %py3_build


### PR DESCRIPTION
Use %forgeautosetup macro to prepare sources in the %prep phase to auto-apply any potential downstream patches just by listing them in the spec file using `PatchX`. Otherwise, the macro needs to be modified each time a downstream patch needs to be applied in downstream.