### PR TITLE
inputs: Move arguments for InputService.map to a temporary file

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -209,7 +209,7 @@ class Stage:
 
             ipmgr = InputManager(mgr, storeapi, inputs_tmpdir)
             for key, ip in self.inputs.items():
-                data = ipmgr.map(ip)
+                data = ipmgr.map(ip, store)
                 inputs[key] = data
 
             devmgr = DeviceManager(mgr, build_root.dev, tree)


### PR DESCRIPTION
Prior this commit, the arguments for the input service were passed inline. However, jsoncomm uses the SOCK_SEQPACKET socket type underneath that has a fixed maximum packet size. On my system, it's 212960 bytes. Unfortunately, that's not enough for big inputs (e.g. when building packages with a lot of rpms).

This commit moves all arguments to a temporary file. Then, just a file descriptor is sent. Thus, we are now able to send arbitrarily sized args for inputs, making osbuild work even for large image builds.

Supersedes #1303