### PR TITLE
stages/rpm: chmod `machine-id` to 0444

### DIFF
--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -378,7 +378,7 @@ def main(tree, inputs, options):
         print("deleting the fake machine id")
         machine_id_file = pathlib.Path(f"{tree}/etc/machine-id")
         machine_id_file.unlink()
-        machine_id_file.touch()
+        machine_id_file.touch(mode=0o444)
 
     if ostree_booted:
         os.unlink(ostree_booted)


### PR DESCRIPTION
~Two commits:~

~stages/rpm: set machine-id to uninitialized instead of an empty one~

~From machine-id(5):~

> ~If /etc/machine-id exists and is empty, a boot is not considered the first~
> ~boot.~

~This doesn't seem correct because we obviously want the first boot be considered as a one. Thus, we want to actually write "uninitialized"~
~into the file so the following behaviour is triggered:~

> ~If /etc/machine-id contains the string "uninitialized", a boot is also~
> ~considered the first boot.~

~Note that there's also an option not to create the file at all, but that~
~doesn't work on Fedora/RHEL, because /etc is mounted read-only during~
~early boot (from initramfs) and systemd cannot neither write the machine-id~
~nor bind-mount over it.~

---

stages/rpm: set machine-id to 444

According to the systemd spec file, /etc/machine-id should have the 444
permissions. Thus, we need to chmod the file to 444 after it's created.

See:
- https://src.fedoraproject.org/rpms/systemd/blob/9c05b44a4b8922cdd4671298107e067302509afc/f/systemd.spec#_821
- https://bugzilla.redhat.com/show_bug.cgi?id=2221269
- https://issues.redhat.com/browse/COMPOSER-1992
