### PR TITLE
stages: Add stages to support ostree signatures and composefs

### DIFF
--- a/stages/org.osbuild.experimental.ostree.config
+++ b/stages/org.osbuild.experimental.ostree.config
@@ -1,0 +1,64 @@
+#!/usr/bin/python3
+"""
+Change OSTree configuration experimental options
+
+NOTE: This stage is experimental and subject to changes
+
+Change the configuration for an OSTree repository.
+Currently only the following values are supported:
+  - `integrity.composefs`
+
+See `ostree.repo-config(5)` for more information.
+"""
+
+import os
+import sys
+
+import osbuild.api
+from osbuild.util import ostree
+
+SCHEMA = """
+"additionalProperties": false,
+"required": ["repo"],
+"properties": {
+  "repo": {
+    "description": "Location of the OSTree repo.",
+    "type": "string"
+  },
+  "config": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "OSTree configuration groups",
+    "properties": {
+      "integrity": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Options concerning the sysroot",
+        "properties": {
+          "composefs": {
+            "description": "Enable composefs image generation on deploy.",
+            "type": "string",
+            "enum": ["true", "false", "maybe"]
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def main(tree, options):
+    repo = os.path.join(tree, options["repo"].lstrip("/"))
+    integrity_options = options["config"].get("integrity", {})
+
+    composefs = integrity_options.get("composefs")
+    if composefs is not None:
+        ostree.cli("config", "set", "ex-integrity.composefs", composefs, repo=repo)
+
+
+if __name__ == '__main__':
+    stage_args = osbuild.api.arguments()
+    r = main(stage_args["tree"],
+             stage_args["options"])
+    sys.exit(r)

--- a/stages/org.osbuild.ostree.post-copy
+++ b/stages/org.osbuild.ostree.post-copy
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+"""Apply post-copy updates to an ostree repo/deployment
+
+The way osbuild works the ostree deployment is built in a chroot and
+stored as a regular directory of files before finally being copied to
+the physical filesystem. This means that for example, ostree fs-verity
+support doesn't work, as the fs-verity setting of files is not copied.
+
+To support fs-verity in generated images you have to run this stage
+after copying the final ostree tree onto the target filesystem.
+
+Notes:
+ - Ensure the target filesystem supports fs-verity. See e.g. the
+   `verity` option in org.osbuild.mkfs.ext4.
+ - Requires ostree version 2023.8 or later in the buildroot.
+"""
+
+import os
+import sys
+
+import osbuild.api
+from osbuild.util import ostree
+
+SCHEMA_2 = r"""
+"options": {
+  "additionalProperties": false,
+  "properties": {
+     "sysroot": {
+       "type": "string",
+      "description": "Custom sysroot path",
+      "pattern": "^\\/(?!\\.\\.)((?!\\/\\.\\.\\/).)+$"
+    }
+  }
+},
+"devices": {
+  "type": "object",
+  "additionalProperties": true
+},
+"mounts": {
+  "type": "array"
+}
+"""
+
+
+def main(paths, options):
+    custom_sysroot = options.get("sysroot")
+    root = paths["mounts"]
+
+    sysroot = root
+    if custom_sysroot:
+        sysroot = os.path.join(root, custom_sysroot.lstrip("/"))
+
+    ostree.cli("admin", "post-copy", sysroot=sysroot)
+
+
+if __name__ == '__main__':
+    stage_args = osbuild.api.arguments()
+    r = main(stage_args["paths"],
+             stage_args["options"])
+    sys.exit(r)


### PR DESCRIPTION
This adds two stages to support ostree ed25519 signatures (`org.osbuild.ostree.genkey` and `org.osbuild.ostree.sign`) and support for composefs (`composefs` key in `org.osbuild.ostree.config` and a new `org.osbuild.ostree.deploy-verity` stage).

Using these with a recent ostree release (2023.4) you can generate a signed ostree digest and build an image with composefs integration working.  Additionally, with the work happening in [ostree-prepare-root](https://github.com/ostreedev/ostree/pull/2921) we will have the ability to verify the generated signatures from the initrd and thus get a fully trusted boot all the way into `/usr`.

For an example of how using this may look, see: https://gitlab.com/CentOS/automotive/sample-images/-/merge_requests/333