### PR TITLE
Expand `sysconfig` stage with `livesys` and `desktop`

### DIFF
--- a/stages/org.osbuild.sysconfig
+++ b/stages/org.osbuild.sysconfig
@@ -153,6 +153,17 @@ SCHEMA = r"""
         }
       }
     }
+  },
+  "livesys": {
+    "additionalProperties": false,
+    "type": "object",
+    "required": ["session"],
+    "properties": {
+      "session": {
+        "type": "string",
+        "description": "Livesys session to use"
+      }
+    }
   }
 }
 """
@@ -161,6 +172,17 @@ SCHEMA = r"""
 # sysconfig uses yes and no instead of true and false
 def bool_to_string(value):
     return "yes" if value else "no"
+
+
+def configure_livesys(tree, livesys_options):
+    if not livesys_options:
+        return
+
+    with open(f"{tree}/etc/sysconfig/livesys", "w", encoding="utf8") as livesys_file:
+        livesys_file.write("livesys_session=\"{livesys_options['session']}\"\n")
+
+        os.fchown(livesys_file.fileno(), 0, 0)
+        os.fchmod(livesys_file.fileno(), 0o644)
 
 
 def configure_kernel(tree, kernel_options):
@@ -240,10 +262,12 @@ def main(tree, options):
     kernel_options = options.get("kernel", {})
     network_options = options.get("network", {})
     network_scripts_options = options.get("network-scripts", {})
+    livesys_options = options.get("livesys", {})
 
     configure_kernel(tree, kernel_options)
     configure_network(tree, network_options)
     configure_network_scripts(tree, network_scripts_options)
+    configure_livesys(tree, livesys_options)
 
     return 0
 

--- a/stages/org.osbuild.sysconfig
+++ b/stages/org.osbuild.sysconfig
@@ -164,6 +164,24 @@ SCHEMA = r"""
         "description": "Livesys session to use"
       }
     }
+  },
+  "desktop": {
+    "additionalProperties": false,
+    "type": "object",
+    "anyOf": [
+      {"required": ["preferred"]},
+      {"required": ["displaymanager"]}
+    ],
+    "properties": {
+      "preferred": {
+        "type": "string",
+        "description": "Preferred desktop to use."
+      },
+      "displaymanager": {
+        "type": "string",
+        "description": "Displaymanager to use."
+      }
+    }
   }
 }
 """
@@ -183,6 +201,21 @@ def configure_livesys(tree, livesys_options):
 
         os.fchown(livesys_file.fileno(), 0, 0)
         os.fchmod(livesys_file.fileno(), 0o644)
+
+
+def configure_desktop(tree, desktop_options):
+    if not desktop_options:
+        return
+
+    with open(f"{tree}/etc/sysconfig/desktop", "w", encoding="utf8") as desktop_file:
+        if "preferred" in desktop_options:
+            desktop_file.write("PREFERRED={desktop_options['preferred']}\n")
+
+        if "displaymanager" in desktop_options:
+            desktop_file.write("DISPLAYMANAGER={desktop_options['displaymanager']}\n")
+
+        os.fchown(desktop_file.fileno(), 0, 0)
+        os.fchmod(desktop_file.fileno(), 0o644)
 
 
 def configure_kernel(tree, kernel_options):
@@ -263,11 +296,13 @@ def main(tree, options):
     network_options = options.get("network", {})
     network_scripts_options = options.get("network-scripts", {})
     livesys_options = options.get("livesys", {})
+    desktop_options = options.get("desktop", {})
 
     configure_kernel(tree, kernel_options)
     configure_network(tree, network_options)
     configure_network_scripts(tree, network_scripts_options)
     configure_livesys(tree, livesys_options)
+    configure_desktop(tree, desktop_options)
 
     return 0
 

--- a/test/data/stages/sysconfig/b.json
+++ b/test/data/stages/sysconfig/b.json
@@ -303,6 +303,13 @@
                 "ipv6init": true
               }
             }
+          },
+          "livesys": {
+            "session": "gnome"
+          },
+          "desktop": {
+            "preferred": "/usr/bin/gnome",
+            "displaymanager": "/usr/bin/gdm"
           }
         }
       }

--- a/test/data/stages/sysconfig/b.mpp.json
+++ b/test/data/stages/sysconfig/b.mpp.json
@@ -39,6 +39,13 @@
                 "ipv6init": true
               }
             }
+          },
+          "livesys": {
+            "session": "gnome"
+          },
+          "desktop": {
+            "preferred": "/usr/bin/gnome",
+            "displaymanager": "/usr/bin/gdm"
           }
         }
       }

--- a/test/data/stages/sysconfig/diff.json
+++ b/test/data/stages/sysconfig/diff.json
@@ -2,7 +2,9 @@
   "added_files": [
     "/etc/sysconfig/network-scripts",
     "/etc/sysconfig/network-scripts/ifcfg-eth0",
-    "/etc/sysconfig/network-scripts/ifcfg-eth1"
+    "/etc/sysconfig/network-scripts/ifcfg-eth1",
+    "/etc/sysconfig/desktop",
+    "/etc/sysconfig/livesys"
   ],
   "deleted_files": [],
   "differences": {


### PR DESCRIPTION
expands sysconfig with configuration for `livesys` and `desktop` necessary for fedora spins/editions (they *all* configure this).

note that this pr will remove the need for the current `org.osbuild.livesys` stage but that one got in without noticing that this stage would be the better place for it to live. it isn't removed in this pr due to backwards compatibility.