### PR TITLE
Schutzfile: Fix f38 snapshot references

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -230,14 +230,14 @@
           {
             "title": "fedora",
             "name": "fedora",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230316"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413"
           }
         ],
         "aarch64": [
           {
             "title": "fedora",
             "name": "fedora",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-branched-20230316"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413"
           }
         ]
       },
@@ -247,14 +247,48 @@
           {
             "title": "fedora-modular",
             "name": "fedora-modular",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-modular-20230316"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-modular-20230413"
           }
         ],
         "aarch64": [
           {
             "title": "fedora-modular",
             "name": "fedora-modular",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-branched-modular-20230316"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-modular-20230413"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates.repo",
+        "x86_64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230701"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230701"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates-modular.repo",
+        "x86_64": [
+          {
+            "title": "updates-modular",
+            "name": "updates-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-modular-20230701"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates-modular",
+            "name": "updates-modular",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-modular-20230701"
           }
         ]
       }


### PR DESCRIPTION
Fedora 38 is no longer branched. Switch to the release names for the snapshots.