### PR TITLE
org.osbuild.curl: output current file

### DIFF
--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -120,6 +120,9 @@ class CurlSource(sources.SourceService):
         secrets = desc.get("secrets")
         insecure = desc.get("insecure")
         url = self._quote_url(desc.get("url"))
+
+        print("downloading", url)
+
         # Download to a temporary sub cache until we have verified the checksum. Use a
         # subdirectory, so we avoid copying across block devices.
         with tempfile.TemporaryDirectory(prefix="osbuild-unverified-file-", dir=self.cache) as tmpdir:

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -157,6 +157,7 @@ class CurlSource(sources.SourceService):
                 return_code = curl.returncode
                 if return_code == 0:
                     break
+                print("retrying", url)
             else:
                 raise RuntimeError(f"curl: error downloading {url}: error code {return_code}")
 


### PR DESCRIPTION
Currently the `org.osbuild.curl` source is entirely silent. Make it print:
1. urls being downloaded
2. urls being retried
3. fix the unlocked sys.stdout so messages don't intersperse.