### PR TITLE
test_stages: speed up the test execution time by aggresive caching

### DIFF
--- a/test/data/stages/first-boot/a.json
+++ b/test/data/stages/first-boot/a.json
@@ -1,6 +1,12 @@
 {
   "sources": {},
   "pipeline": {
+    "build": {
+      "runner": "org.osbuild.fedora34",
+      "pipeline": {
+        "stages": []
+      }
+    },
     "stages": [
       {
         "name": "org.osbuild.noop"

--- a/test/data/stages/first-boot/b.json
+++ b/test/data/stages/first-boot/b.json
@@ -1,6 +1,12 @@
 {
   "sources": {},
   "pipeline": {
+    "build": {
+      "runner": "org.osbuild.fedora34",
+      "pipeline": {
+        "stages": []
+      }
+    },
     "stages": [
       {
         "name": "org.osbuild.first-boot",

--- a/test/data/stages/pwquality.conf/a.json
+++ b/test/data/stages/pwquality.conf/a.json
@@ -453,9 +453,6 @@
             "sha256:0ebe43a9bef7ec2dc4cb98350fbde2e55dae886f905e2d9cea837da3fb613c87"
           ]
         }
-      },
-      {
-        "name": "org.osbuild.pwquality.conf"
       }
     ]
   },

--- a/test/data/stages/pwquality.conf/a.mpp.yaml
+++ b/test/data/stages/pwquality.conf/a.mpp.yaml
@@ -17,4 +17,3 @@ pipeline:
               baseurl: https://rpmrepo.osbuild.org/v2/mirror/public/f34/f34-x86_64-fedora-20210512/
           packages:
             - libpwquality
-    - name: org.osbuild.pwquality.conf

--- a/test/data/stages/pwquality.conf/diff.json
+++ b/test/data/stages/pwquality.conf/diff.json
@@ -7,24 +7,6 @@
         "sha256:8c6951c20f2489549e8793711818cfb0318e26fe8ced35da930a70a3cac757c8",
         "sha256:ba383e6179fd1a8a0d4851936788514584ccea3d6a0047cefff3788177c48d41"
       ]
-    },
-    "/etc/pki/ca-trust/extracted/java/cacerts": {
-      "content": [
-        null,
-        null
-      ]
-    },
-    "/var/cache/ldconfig/aux-cache": {
-      "content": [
-        null,
-        null
-      ]
-    },
-    "/var/lib/rpm/rpmdb.sqlite": {
-      "content": [
-        null,
-        null
-      ]
     }
   }
 }

--- a/test/data/stages/rpm/a.json
+++ b/test/data/stages/rpm/a.json
@@ -1,5 +1,11 @@
 {
   "sources": {},
+  "build": {
+    "runner": "org.osbuild.fedora34",
+    "pipeline": {
+      "stages": []
+    }
+  },
   "pipeline": {
     "stages": [
       {

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -241,12 +241,12 @@ class TestStages(test.TestBase):
 
             out_a = stack.enter_context(tempfile.TemporaryDirectory(dir="/var/tmp"))
             _ = osb.compile_file(os.path.join(test_dir, "a.json"),
-                                 checkpoints=["tree"],
+                                 checkpoints=["build", "tree"],
                                  exports=["tree"], output_dir=out_a)
 
             out_b = stack.enter_context(tempfile.TemporaryDirectory(dir="/var/tmp"))
             res = osb.compile_file(os.path.join(test_dir, "b.json"),
-                                   checkpoints=["tree"],
+                                   checkpoints=["build", "tree"],
                                    exports=["tree"], output_dir=out_b)
 
             tree1 = os.path.join(out_a, "tree")
@@ -277,7 +277,7 @@ class TestStages(test.TestBase):
             osb = self.osbuild
 
             osb.compile_file(f"{base}/template.json",
-                             checkpoints=["tree"],
+                             checkpoints=["build", "tree"],
                              exports=["tree"],
                              output_dir=outdir)
             tree = os.path.join(outdir, "tree")
@@ -314,7 +314,7 @@ class TestStages(test.TestBase):
 
                 jsdata = json.dumps(manifest)
                 osb.compile(jsdata,
-                            checkpoints=["tree"],
+                            checkpoints=["build", "tree"],
                             exports=["tree"],
                             output_dir=outdir)
                 tree = os.path.join(outdir, "tree")
@@ -336,6 +336,7 @@ class TestStages(test.TestBase):
             with tempfile.TemporaryDirectory(dir="/var/tmp") as outdir:
                 osb = self.osbuild
                 osb.compile_file(os.path.join(testdir, "qemu.json"),
+                                 checkpoints=["build"],
                                  exports=[image_name],
                                  output_dir=outdir)
 
@@ -363,6 +364,7 @@ class TestStages(test.TestBase):
         with tempfile.TemporaryDirectory(dir="/var/tmp") as outdir:
             osb = self.osbuild
             osb.compile_file(os.path.join(testdir, "tar.json"),
+                             checkpoints=["build"],
                              exports=["tree"],
                              output_dir=outdir)
 
@@ -401,7 +403,7 @@ class TestStages(test.TestBase):
             osb = self.osbuild
 
             osb.compile_file(os.path.join(testdir, f"{stage_name}.json"),
-                             checkpoints=["tree"],
+                             checkpoints=["build", "tree"],
                              exports=["tree"],
                              output_dir=outdir)
 
@@ -477,7 +479,10 @@ class TestStages(test.TestBase):
 
         with tempfile.TemporaryDirectory(dir="/var/tmp") as outdir:
             osb = self.osbuild
-            osb.compile_file(os.path.join(testdir, "ovf.json"), exports=["vmdk"], output_dir=outdir)
+            osb.compile_file(os.path.join(testdir, "ovf.json"),
+                             checkpoints=["build"],
+                             exports=["vmdk"],
+                             output_dir=outdir)
 
             vmdk = os.path.join(outdir, "vmdk", "image.vmdk")
             assert os.path.isfile(vmdk)

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -246,7 +246,7 @@ class TestStages(test.TestBase):
 
             out_b = stack.enter_context(tempfile.TemporaryDirectory(dir="/var/tmp"))
             res = osb.compile_file(os.path.join(test_dir, "b.json"),
-                                   checkpoints=["build", "tree"],
+                                   checkpoints=["build"],
                                    exports=["tree"], output_dir=out_b)
 
             tree1 = os.path.join(out_a, "tree")
@@ -277,7 +277,7 @@ class TestStages(test.TestBase):
             osb = self.osbuild
 
             osb.compile_file(f"{base}/template.json",
-                             checkpoints=["build", "tree"],
+                             checkpoints=["build"],
                              exports=["tree"],
                              output_dir=outdir)
             tree = os.path.join(outdir, "tree")
@@ -314,7 +314,7 @@ class TestStages(test.TestBase):
 
                 jsdata = json.dumps(manifest)
                 osb.compile(jsdata,
-                            checkpoints=["build", "tree"],
+                            checkpoints=["build"],
                             exports=["tree"],
                             output_dir=outdir)
                 tree = os.path.join(outdir, "tree")
@@ -403,7 +403,7 @@ class TestStages(test.TestBase):
             osb = self.osbuild
 
             osb.compile_file(os.path.join(testdir, f"{stage_name}.json"),
-                             checkpoints=["build", "tree"],
+                             checkpoints=["build"],
                              exports=["tree"],
                              output_dir=outdir)
 


### PR DESCRIPTION
Let's speed up the execution by:

- sharing the osbuild store across all tests
- checkpointing the build pipelines

If you see any issues with this approach, please raise your concerns. :)