### PR TITLE
Improve the linting setup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,14 +19,6 @@ jobs:
   python_code_linters:
       name: "Python Linters"
       runs-on: ubuntu-latest
-      strategy:
-        fail-fast: false
-        matrix:
-          linter:
-          - "ruff"
-          - "pylint"
-          - "autopep8"
-          - "isort"
       steps:
       - name: "Clone Repository"
         uses: actions/checkout@v3
@@ -35,25 +27,7 @@ jobs:
         with:
           image: ghcr.io/osbuild/osbuild-ci:latest-202304251412
           run: |
-            tox -e "${{ matrix.linter }}"
-
-  python_code_types:
-    name: "Python Typing"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        typer:
-        - "mypy"
-    steps:
-    - name: "Clone Repository"
-      uses: actions/checkout@v3
-    - name: "Run Linters"
-      uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
-      with:
-        image: ghcr.io/osbuild/osbuild-ci:latest-202304251412
-        run: |
-          tox -e "${{ matrix.typer }}"
+            make lint
 
   shell_linters:
     name: "Shell Linters"

--- a/Makefile
+++ b/Makefile
@@ -234,12 +234,6 @@ test-run:
 			--rootdir=$(SRCDIR) \
 			-v
 
-.PHONY: test-src
-test-src:
-	@$(PYTHON3) -m pytest \
-			$(SRCDIR)/test/src \
-			--rootdir=$(SRCDIR) \
-			-v
 
 .PHONY: test-all
 test-all:

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,16 @@ test-all:
 			-v
 
 #
+# Linting the code
+#
+# Just run `make lint` and see if our linters like your code.
+#
+
+.PHONY: lint
+lint:
+	tox run-parallel -e ruff,pylint,autopep8,isort,mypy
+
+#
 # Building packages
 #
 # The following rules build osbuild packages from the current HEAD commit,


### PR DESCRIPTION
This PR:

- removes the old `test.src` tests (they were empty anyway)
- adds a new `lint` target to `Makefile` to run all linters
- uses the new target in the CI