### PR TITLE
stages/dracut: add dracut omit drivers option

### DIFF
--- a/stages/org.osbuild.dracut
+++ b/stages/org.osbuild.dracut
@@ -72,6 +72,14 @@ SCHEMA = """
       "description": "A kernel module without the .ko extension"
     }
   },
+  "omit_drivers": {
+    "description": "Omit specific kernel modules.",
+    "type": "array",
+    "items": {
+      "type": "string",
+      "description": "A kernel module without the .ko extension."
+    }
+  },
   "force_drivers": {
     "description": "Add driver and ensure that they are tried to be loaded.",
     "type": "array",
@@ -138,6 +146,7 @@ def main(tree, options):
     omit_modules = options.get("omit_modules", [])
     drivers = options.get("drivers", [])  # kernel modules
     add_drivers = options.get("add_drivers", [])
+    omit_drivers = options.get("omit_drivers", [])
     force_drivers = options.get("force_drivers", [])
     filesystems = options.get("filesystems", [])
     include = options.get("include", [])
@@ -171,6 +180,9 @@ def main(tree, options):
 
     if add_drivers:
         opts += ["--add-drivers", " ".join(add_drivers)]
+
+    if omit_drivers:
+        opts += ["--omit-drivers", " ".join(omit_drivers)]
 
     if force_drivers:
         opts += ["--force-drivers", " ".join(force_drivers)]

--- a/stages/org.osbuild.dracut.conf
+++ b/stages/org.osbuild.dracut.conf
@@ -17,6 +17,7 @@ Supported configuration options:
   - omit_dracutmodules
   - drivers
   - add_drivers
+  - omit_drivers
   - force_drivers
   - filesystems
   - install_items
@@ -81,6 +82,14 @@ SCHEMA = r"""
       },
       "add_drivers": {
         "description": "Add a specific kernel modules.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "A kernel module without the .ko extension."
+        }
+      },
+      "omit_drivers": {
+        "description": "Omit specific kernel modules.",
         "type": "array",
         "items": {
           "type": "string",
@@ -163,6 +172,7 @@ def main(tree, options):
         "omit_dracutmodules": list_option_writer,
         "drivers": list_option_writer,
         "add_drivers": list_option_writer,
+        "omit_drivers": list_option_writer,
         "force_drivers": list_option_writer,
         "filesystems": list_option_writer,
         "install_items": list_option_writer,


### PR DESCRIPTION
Add option to exclude specific kernel modules from the initramfs that's generated by dracut.