### PR TITLE
tests/ostree-container: Drop hardcoded max layers

### DIFF
--- a/test/data/manifests/fedora-ostree-native-container.json
+++ b/test/data/manifests/fedora-ostree-native-container.json
@@ -1039,8 +1039,7 @@
         {
           "type": "org.osbuild.ostree.encapsulate",
           "options": {
-            "filename": "ostree-container.tar",
-            "max_layers": 4
+            "filename": "ostree-container.tar"
           },
           "inputs": {
             "commit": {

--- a/test/data/manifests/fedora-ostree-native-container.mpp.yaml
+++ b/test/data/manifests/fedora-ostree-native-container.mpp.yaml
@@ -18,9 +18,6 @@ pipelines:
       - type: org.osbuild.ostree.encapsulate
         options:
           filename: ostree-container.tar
-          # max_layers < 4 is currently broken (or unsupported)
-          # see https://github.com/coreos/rpm-ostree/issues/4530
-          max_layers: 4
         inputs:
           commit:
             type: org.osbuild.ostree


### PR DESCRIPTION
This should just defer to rpm-ostree.
xref https://github.com/coreos/rpm-ostree/issues/4530

(If someone cares about reproducibility here, they can specify it;
 alternatively and more reliably, they can create builder container
 images and pin to those)