### PR TITLE
runners: add autosd runner

### DIFF
--- a/runners/org.osbuild.autosd
+++ b/runners/org.osbuild.autosd
@@ -1,0 +1,1 @@
+org.osbuild.centos9


### PR DESCRIPTION
autosd is a CentOS Stream 9 derivate. User reported:

 "ValueError: No suitable runner for org.osbuild.autosd"

in Automotive SIG community Matrix. We are going through some name changes at the moment.