### PR TITLE
docs: update the samples used in osbuild.1.rst

### DIFF
--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -125,16 +125,16 @@ produces no output:
     | # echo {} | osbuild -
     |
 
-Example 1: Build a Fedora 30 qcow2 image
+Example 1: Build a Fedora 34 qcow2 image
 ----------------------------------------
 
-To build a basic qcow2 image of Fedora 30, use:
+To build a basic qcow2 image of Fedora 34, use:
 
     |
-    | # osbuild ./samples/base-qcow2.json
+    | # osbuild ./samples/fedora-boot.json
     |
 
-The pipeline definition ``./samples/base-rpm-qcow2.json`` is provided in the
+The pipeline definition ``./samples/fedora-boot.json`` is provided in the
 upstream source repository of **osbuild**.
 
 Example 2: Run from a local checkout
@@ -143,7 +143,7 @@ Example 2: Run from a local checkout
 To run **osbuild** from a local checkout, use:
 
     |
-    | # python3 -m osbuild --libdir . samples/base-rpm-qcow2.json
+    | # python3 -m osbuild --libdir . samples/fedora-boot.json
     |
 
 This will make sure to execute the **osbuild** module from the current


### PR DESCRIPTION
The file `./samples/base-qcow2.json` used in the osbuild.1.rst man-page does no longer exists. It was removed in e92b409 and `samples` is now a symlink into the test data. The closest in the test data to the original `base-qcow2.json` seems to be the `fedora-boot.json` so this is now used in the examples section.

This removes the references to `./samples/base-rpm-qcow2.json` which was remove in fe95d93. Here `fedora-boot.json` is also used.