### PR TITLE
stages/ostree.deploy: drop requirement on rootfs option

### DIFF
--- a/stages/org.osbuild.ostree.deploy
+++ b/stages/org.osbuild.ostree.deploy
@@ -29,7 +29,7 @@ from osbuild.util.mnt import MountGuard
 CAPABILITIES = ["CAP_MAC_ADMIN"]
 
 SCHEMA = """
-"required": ["osname", "rootfs", "ref"],
+"required": ["osname", "ref"],
 "properties": {
   "mounts": {
     "description": "Mount points of the final file system",


### PR DESCRIPTION
For Fedora CoreOS we don't actually have any root= kernel command line option in our baked images. We have services that rely on this and set up sysroot on first boot. The code in this stage doesn't require for this option to have been provided and actually gracefully handles when it's not provided. Let's just change the schema to also not require it.