### PR TITLE
tools/osbuild-mpp: Really fix empty ostree commit object in deploy stage

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -1621,8 +1621,6 @@ class ManifestFileV2(ManifestFile):
             ["org.osbuild.ostree.pull", "org.osbuild.ostree.deploy"]:
             return
 
-        inputs = element_enter(stage, "inputs", {})
-
         # The ostree.deploy stage accepts both containers or
         # ostree commits as input. If this is an ostree.deploy
         # stage and there are no commits in the inputs then let's
@@ -1630,8 +1628,10 @@ class ManifestFileV2(ManifestFile):
         # from being created when a container image is used as
         # an input to ostree.deploy and not an ostree commit.
         if stage.get("type", "") == "org.osbuild.ostree.deploy":
-            if "commits" not in inputs:
+            if "commits" not in stage.get("inputs", {}):
                 return
+
+        inputs = element_enter(stage, "inputs", {})
 
         inputs_commits = element_enter(inputs, "commits", {})
 


### PR DESCRIPTION
The fix in 980ca03685e674ef6cda7b5383aede84dff44560 ensured that no empty commit object was created, but it still created an (empty) input object, which causes failures, like:
 https://gitlab.com/CentOS/automotive/sample-images/-/merge_requests/388

We need to move the check before the line that adds the empty default input object.