### PR TITLE
stages/mkdir: fix its schema

### DIFF
--- a/stages/org.osbuild.mkdir
+++ b/stages/org.osbuild.mkdir
@@ -11,6 +11,15 @@ directories. If you want to change the mode of an existing
 directory, you need to use the `org.osbuild.chmod` stage.
 Mode is applied only to newly created directories and umask
 value is taken into account.
+
+In the initial version of this stage, there was a bug that caused
+the stage to accept relative paths. This behaviour is kept for
+backward compatibility, thus the following paths are equal:
+
+/path/to/directory
+path/to/directory
+
+However, using relative paths is strongly discouraged.
 """
 
 import os
@@ -26,14 +35,14 @@ SCHEMA_2 = r"""
     "paths": {
       "type": "array",
       "additionalItems": false,
-      "paths": {
+      "items": {
         "type": "object",
         "additionalProperties": false,
         "required": ["path"],
         "properties": {
           "path": {
             "type": "string",
-            "pattern": "^\\/(?!\\.\\.)((?!\\/\\.\\.\\/).)+$"
+            "pattern": "^\\/?(?!\\.\\.)((?!\\/\\.\\.\\/).)+$"
           },
           "mode": {
             "type": "number",
@@ -63,6 +72,9 @@ def main(tree, options):
         mode = item.get("mode", 0o777)
         parents = item.get("parents", False)
         exist_ok = item.get("exist_ok", False)
+
+        if not path.startswith("/"):
+            print("WARNING: relative path used, this is discouraged!")
 
         target = os.path.join(tree, path.lstrip("/"))
         if not in_tree(target, tree):

--- a/test/data/manifests/fedora-ostree-bootiso-xz.json
+++ b/test/data/manifests/fedora-ostree-bootiso-xz.json
@@ -1921,7 +1921,7 @@
           "options": {
             "paths": [
               {
-                "path": "LiveOS"
+                "path": "/LiveOS"
               }
             ]
           }

--- a/test/data/manifests/fedora-ostree-bootiso-xz.mpp.yaml
+++ b/test/data/manifests/fedora-ostree-bootiso-xz.mpp.yaml
@@ -379,7 +379,7 @@ pipelines:
       - type: org.osbuild.mkdir
         options:
           paths:
-            - path: LiveOS
+            - path: /LiveOS
       - type: org.osbuild.truncate
         options:
           filename: LiveOS/rootfs.img

--- a/test/data/manifests/fedora-ostree-bootiso.json
+++ b/test/data/manifests/fedora-ostree-bootiso.json
@@ -1921,7 +1921,7 @@
           "options": {
             "paths": [
               {
-                "path": "LiveOS"
+                "path": "/LiveOS"
               }
             ]
           }

--- a/test/data/manifests/fedora-ostree-bootiso.mpp.yaml
+++ b/test/data/manifests/fedora-ostree-bootiso.mpp.yaml
@@ -379,7 +379,7 @@ pipelines:
       - type: org.osbuild.mkdir
         options:
           paths:
-            - path: LiveOS
+            - path: /LiveOS
       - type: org.osbuild.truncate
         options:
           filename: LiveOS/rootfs.img

--- a/test/data/stages/mkdir/a.json
+++ b/test/data/stages/mkdir/a.json
@@ -450,10 +450,10 @@
           "options": {
             "paths": [
               {
-                "path": "a"
+                "path": "/a"
               },
               {
-                "path": "c/d",
+                "path": "/c/d",
                 "parents": true
               }
             ]

--- a/test/data/stages/mkdir/a.mpp.yaml
+++ b/test/data/stages/mkdir/a.mpp.yaml
@@ -13,6 +13,6 @@ pipelines:
       - type: org.osbuild.mkdir
         options:
           paths:
-            - path: a
-            - path: c/d
+            - path: /a
+            - path: /c/d
               parents: true

--- a/test/data/stages/mkdir/b.json
+++ b/test/data/stages/mkdir/b.json
@@ -450,24 +450,27 @@
           "options": {
             "paths": [
               {
-                "path": "a"
+                "path": "/a"
               },
               {
-                "path": "c/d",
+                "path": "/c/d",
                 "parents": true
               },
               {
-                "path": "a/b",
+                "path": "/a/b",
                 "mode": 448
               },
               {
-                "path": "b/c/d",
+                "path": "/b/c/d",
                 "parents": true
               },
               {
-                "path": "c",
+                "path": "/c",
                 "mode": 448,
                 "exist_ok": true
+              },
+              {
+                "path": "i_am_relative"
               }
             ]
           }

--- a/test/data/stages/mkdir/b.mpp.yaml
+++ b/test/data/stages/mkdir/b.mpp.yaml
@@ -13,13 +13,14 @@ pipelines:
       - type: org.osbuild.mkdir
         options:
           paths:
-            - path: a
-            - path: c/d
+            - path: /a
+            - path: /c/d
               parents: true
-            - path: a/b
+            - path: /a/b
               mode: 448
-            - path: b/c/d
+            - path: /b/c/d
               parents: true
-            - path: c
+            - path: /c
               mode: 448
               exist_ok: true
+            - path: i_am_relative

--- a/test/data/stages/mkdir/diff.json
+++ b/test/data/stages/mkdir/diff.json
@@ -3,7 +3,8 @@
     "/a/b",
     "/b",
     "/b/c",
-    "/b/c/d"
+    "/b/c/d",
+    "/i_am_relative"
   ],
   "deleted_files": [],
   "differences": {}


### PR DESCRIPTION
The items of an array are defined under the `items` key, not under `paths`. Let's fix this.

Btw, this is possible because JSON Schema itself doesn't use additionalProperties = false. This allows extending the schemas easily, but is sadly a bit error-prone.