### PR TITLE
objectstore: also mount /etc/containers for "host" buildroot

### DIFF
--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -283,14 +283,22 @@ class HostTree:
         self._root = self.store.tempdir(prefix="host")
 
         root = self._root.name
-        # Create a bare bones root file system
-        # with just /usr mounted from the host
+        # Create a bare bones root file system. Starting with just
+        # /usr mounted from the host.
         usr = os.path.join(root, "usr")
         os.makedirs(usr)
+        # Also add in /etc/containers, which will allow us to access
+        # /etc/containers/policy.json and enable moving containers
+        # (skopeo): https://github.com/osbuild/osbuild/pull/1410
+        # If https://github.com/containers/image/issues/2157 ever gets
+        # fixed we can probably remove this bind mount.
+        etc_containers = os.path.join(root, "etc", "containers")
+        os.makedirs(etc_containers)
 
         # ensure / is read-only
         mount(root, root)
         mount("/usr", usr)
+        mount("/etc/containers", etc_containers)
 
     @property
     def tree(self) -> os.PathLike:


### PR DESCRIPTION
In the case we are not using a buildroot (i.e. we are using the host as the buildroot) let's also mount in /etc into the environment. There are sometimes where software running from /usr can't operate without configuration in /etc and this will allow it to work.

An example of software hitting this problem is skopeo. With a simple config like:

```
version: '2'
mpp-vars:
  release: 38
pipelines:
  - name: skopeo-tree
    # build: name:build
    source-epoch: 1659397331
    stages:
      - type: org.osbuild.skopeo
        inputs:
          images:
            type: org.osbuild.containers
            origin: org.osbuild.source
            mpp-resolve-images:
              images:
                - source: quay.io/fedora/fedora-coreos
                  tag: stable
                  name: localhost/fcos
        options:
          destination:
            type: containers-storage
            storage-path: /usr/share/containers/storage
```

We end up hitting an error like this:

```
time="2023-10-24T18:27:14Z" level=fatal msg="Error loading trust policy: open /etc/containers/policy.json: no such file or directory"
Traceback (most recent call last):
  File "/run/osbuild/bin/org.osbuild.skopeo", line 90, in <module>
    r = main(args["inputs"], args["tree"], args["options"])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/run/osbuild/bin/org.osbuild.skopeo", line 73, in main
    subprocess.run(["skopeo", "copy", image_source, dest], check=True)
  File "/usr/lib64/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['skopeo', 'copy', 'dir:/tmp/tmp5_qcng99/image', 'containers-storage:[overlay@/run/osbuild/tree/usr/share/containers/storage+/run/containers/storage]localhost/fcos']' returned non-zero exit status 1.
```

This PR adds in a mount for /etc/ from the host so that /etc/containers/policy.json can be accessed.