### PR TITLE
depsolve-dnf: enable weak deps selection

### DIFF
--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -199,13 +199,11 @@ class Solver():
     def depsolve(self, transactions):
         last_transaction = []
 
-        for idx, transaction in enumerate(transactions):
+        for transaction in transactions:
             self.base.reset(goal=True)
             self.base.sack.reset_excludes()
 
-            # don't install weak-deps for transactions after the 1st transaction
-            if idx > 0:
-                self.base.conf.install_weak_deps = False
+            self.base.conf.install_weak_deps = transaction.get("install_weak_deps", False)
 
             # set the packages from the last transaction as installed
             for installed_pkg in last_transaction:


### PR DESCRIPTION
The import of `dnf-json` came from `osbuild-composer`, as we sadly have/had multiple copies this wasn't the *right* version as it was lacking previous work to disable weak dependencies.