### PR TITLE
Add selinux-label-version to the org.osbuild.ostree.commit stage

### DIFF
--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -57,6 +57,7 @@ class Treefile:
       - boot-location: postprocess
       - etc-group-members: postprocess
       - machineid-compat
+      - selinux-label-version: commit
 
     NB: 'ref' and 'repos' are mandatory and must be
     present, even if they are not used in the given
@@ -71,6 +72,7 @@ class Treefile:
         "etc-group-members": Param(List[str]),
         "machineid-compat": Param(bool),
         "initramfs-args": Param(List[str]),
+        "selinux-label-version": Param(int),
     }
 
     def __init__(self):

--- a/stages/org.osbuild.ostree.commit
+++ b/stages/org.osbuild.ostree.commit
@@ -43,6 +43,11 @@ SCHEMA_2 = """
     "parent": {
       "description": "commit id of the parent commit",
       "type": "string"
+    },
+    "selinux-label-version": {
+      "description": "Set selinux label version",
+      "type": "integer",
+      "default": 0
     }
   }
 },
@@ -62,6 +67,7 @@ SCHEMA_2 = """
 
 def main(inputs, output_dir, options, meta):
     tree = inputs["tree"]["path"]
+    selinux_label_version = options.get("selinux-label-version", 0)
 
     ref = options["ref"]
     os_version = options.get("os_version", None)
@@ -79,6 +85,9 @@ def main(inputs, output_dir, options, meta):
 
         treefile = ostree.Treefile()
         treefile["ref"] = ref
+        if selinux_label_version != 0:
+            # Don't set if 0 (default), to support older rpm-ostree versions
+            treefile["selinux-label-version"] = selinux_label_version
 
         argv = ["rpm-ostree", "compose", "commit"]
         argv += [f"--repo={repo}"]


### PR DESCRIPTION
This is a feature that was added in rpm-ostree 2023.10 and is needed for the new transient /etc feature to work. What it does is change the labeling of /usr/etc to match those of /etc, so that /usr/etc can be used directly as a bind-mount or an overlay mount when mounted on /etc.

See https://github.com/coreos/rpm-ostree/pull/4640 for details.