### PR TITLE
stage/copy: fix exception msg when parsing mounts and inputs

### DIFF
--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -92,7 +92,7 @@ def parse_mount(url: ParseResult, args: Dict):
     if name:
         root = args["mounts"].get(name, {}).get("path")
         if not root:
-            raise ValueError(f"Unknown mount '{root}'")
+            raise ValueError(f"Unknown mount '{name}'")
     else:
         root = args["paths"]["mounts"]
 
@@ -103,7 +103,7 @@ def parse_input(url: ParseResult, args: Dict):
     name = url.netloc
     root = args["inputs"].get(name, {}).get("path")
     if root is None:
-        raise ValueError(f"Unknown input '{root}'")
+        raise ValueError(f"Unknown input '{name}'")
 
     return root
 


### PR DESCRIPTION
Functions for parsing mounts and inputs raise an exception if the referenced entity can't be found in the stage options. However, the exception message always included the value of the `root` variable, which is `None` when an exception is risen. Instead of the `root` value, the `name` variable with the entity name should be used.