### PR TITLE
stages: add new unit test for kickstart stage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         - "test.run.test_noop"
         - "test.run.test_sources"
         - "test.run.test_stages"
+        - "-k stages/test"
         environment:
         - "py36"
         - "py39"

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -152,7 +152,7 @@ bzip2 -9 osbuild.pp
 %py3_install
 
 mkdir -p %{buildroot}%{pkgdir}/stages
-install -p -m 0755 $(find stages -type f) %{buildroot}%{pkgdir}/stages/
+install -p -m 0755 $(find stages -type f -not -name "test_*.py") %{buildroot}%{pkgdir}/stages/
 
 mkdir -p %{buildroot}%{pkgdir}/assemblers
 install -p -m 0755 $(find assemblers -type f) %{buildroot}%{pkgdir}/assemblers/

--- a/osbuild/testutil/__init__.py
+++ b/osbuild/testutil/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test related utilities
+"""

--- a/osbuild/testutil/imports.py
+++ b/osbuild/testutil/imports.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+"""
+Import related utilities
+"""
+import importlib
+from types import ModuleType
+
+
+def import_module_from_path(fullname, path: str) -> ModuleType:
+    """import_module_from_path imports the given path as a python module
+
+    This helper is useful when importing things that are not in the
+    import path or have invalid python import filenames, e.g. all
+    filenames in the stages/ dir of osbuild.
+
+    Keyword arguments:
+    fullname -- The absolute name of the module (can be arbitrary, used on in ModuleSpec.name)
+    path     -- The full path to the python file
+    """
+    loader = importlib.machinery.SourceFileLoader(fullname, path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    if spec is None:
+        # mypy warns that spec might be None so handle it
+        raise ImportError(f"cannot import {fullname} from {path}, got None as the spec")
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+
+import os.path
+
+import pytest
+
+from osbuild.testutil.imports import import_module_from_path
+
+
+@pytest.mark.parametrize("test_input,expected", [
+    ({"lang": "en_US.UTF-8"}, "lang en_US.UTF-8"),
+    ({"keyboard": "us"}, "keyboard us"),
+    ({"timezone": "UTC"}, "timezone UTC"),
+    ({"lang": "en_US.UTF-8",
+      "keyboard": "us",
+      "timezone": "UTC",
+      },
+     "lang en_US.UTF-8\nkeyboard us\ntimezone UTC"),
+])
+def test_kickstart(tmp_path, test_input, expected):
+    ks_stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.kickstart")
+    ks_stage = import_module_from_path("ks_stage", ks_stage_path)
+
+    ks_path = "kickstart/kfs.cfg"
+    options = {"path": ks_path}
+    options.update(test_input)
+
+    ks_stage.main(tmp_path, options)
+
+    with open(os.path.join(tmp_path, ks_path), encoding="utf-8") as fp:
+        ks_content = fp.read()
+    assert ks_content == expected + "\n"

--- a/test/mod/test_testutil_imports.py
+++ b/test/mod/test_testutil_imports.py
@@ -1,0 +1,17 @@
+#
+# Tests for the 'osbuild.util.testutil' module.
+#
+import os.path
+import tempfile
+
+import pytest
+
+from osbuild.testutil.imports import import_module_from_path
+
+
+canary = "import-went-okay"
+
+
+def test_import_module_from_path_happy():
+    mod = import_module_from_path("myself", __file__)
+    assert mod.canary == "import-went-okay"

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     pyyaml
 
 setenv =
-    LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/* stages/*
+    LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/* stages/*.* stages/test/*.py
     TYPEABLES = osbuild
 
 passenv =


### PR DESCRIPTION
This commit adds a simple and lightweight unit test for the new kickstart options. It's pretty trivial but also cheap and runs fast. The idea behind it is that the code of the kickstart stage is tested without the need for a full osbuild tree, just passing the test input options and observing the expected file content. The same pattern could potentially be used for other stages (like the user stage) to check that the content of the output has the expected format (or that options that are mutually exclusive are handled correctly). 

While this is trivial now and looks a bit like a waste of time I think this will become useful as more kickstart stage options get implemented. The goal is to eventually support the options in https://github.com/RedHatInsights/edge-api/blob/main/templates/templateKickstart.ks in a declarative manner and part of this will involve supporting more things that kickstart is currently doing, e.g https://github.com/RedHatInsights/edge-api/blob/main/templates/templateKickstart.ks#L77 and here we will need to be careful about things like input validation/escaping so having this unit tested seems quite useful. I personally also like it because it tells me at a glance what the kickstart file should look like (test as docuementation).

Note that this is not urgent at all and given how trivial it is I'm fine with being told that this is over-testing. We could keep it in draft stage (or close it even) until there is a more complex use case (as stated above I anticipate there will be one for kickstart).

I'm not happy with chage chage in line 22 (tox.ini), it's needed because with the "*" glob pylint will consider the test dir a python module but because it has no __init__.py that fails. Adding a __init__.py will ake pytest fail. The alternative would be to move this under the top level `test/` dir (e.g. under `test/unit/stages` or something.

Having said all this - I would love your intput and feedback :)