### PR TITLE
tools: add Fedora 38 runner for OSTree image tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,6 +71,7 @@ OSTree Images:
     matrix:
       - RUNNER:
           - aws/fedora-37-x86_64
+          - aws/fedora-38-x86_64
           - aws/rhel-8.8-ga-x86_64
           - aws/rhel-9.2-ga-x86_64
           - aws/rhel-8.9-nightly-x86_64


### PR DESCRIPTION
OSTree tests are executed on RHEL 8, RHEL 9 and F37 runners. This commit adds F38 to the runners list.