### PR TITLE
stages: add kernel-cmdline.bls-append stage

### DIFF
--- a/stages/org.osbuild.kernel-cmdline.bls-append
+++ b/stages/org.osbuild.kernel-cmdline.bls-append
@@ -1,0 +1,86 @@
+#!/usr/bin/python3
+"""
+Add kernel command line parameters to a BLS [1] config either in
+the tree or in a mount.
+
+[1] https://freedesktop.org/wiki/Specifications/BootLoaderSpec/
+"""
+
+
+import glob
+import sys
+from urllib.parse import urlparse
+
+import osbuild.api
+
+SCHEMA_2 = r"""
+"options": {
+  "additionalProperties": false,
+  "required": ["kernel_opts"],
+  "properties": {
+    "kernel_opts": {
+      "description": "Additional kernel command line options",
+      "type": "array",
+      "items": {
+        "description": "A single kernel command line option",
+        "type": "string"
+      }
+    },
+    "bootpath": {
+      "type": "string",
+      "description": "The mounted location of the boot filesystem tree where the BLS entries will be under ./loader/entries/*.conf",
+      "pattern": "^(mount|tree):\/\/\/",
+      "examples": ["tree:///boot", "mount:///", "mount:///boot"],
+      "default": "tree:///boot"
+    }
+  }
+},
+"devices": {
+  "type": "object",
+  "additionalProperties": true
+},
+"mounts": {
+  "type": "array"
+}
+"""
+
+
+def main(paths, tree, options):
+    kopts = options.get("kernel_opts", [])
+    bootpath = options.get("bootpath", "tree:///boot")
+
+    url = urlparse(bootpath)
+    scheme = url.scheme
+    if scheme == "tree":
+        root = tree
+    elif scheme == "mount":
+        root = paths["mounts"]
+    else:
+        raise ValueError(f"Unsupported scheme '{scheme}'")
+
+    assert url.path.startswith("/")
+    bootroot = root + url.path
+
+    # There is unlikely to be more than one bls config, but just
+    # in case we'll iterate over them.
+    entries = []
+    for entry in glob.glob(f"{bootroot}/loader/entries/*.conf"):
+        entries.append(entry)
+        # Read in the file and then append to the options line.
+        with open(entry, encoding="utf8") as f:
+            lines = f.read().splitlines()
+        with open(entry, "w", encoding="utf8") as f:
+            for line in lines:
+                if line.startswith('options '):
+                    f.write(f"{line} {' '.join(kopts)}\n")
+                else:
+                    f.write(f"{line}\n")
+    assert len(entries) != 0
+    print(f"Added {','.join(kopts)} to: {','.join(entries)}")
+    return 0
+
+
+if __name__ == '__main__':
+    args = osbuild.api.arguments()
+    r = main(args["paths"], args["tree"], args["options"])
+    sys.exit(r)

--- a/test/cases/ostree-images
+++ b/test/cases/ostree-images
@@ -95,8 +95,11 @@ def run_tests(args, tmpdir):
         "fedora-coreos-container": {
             "manifest": "fedora-coreos-container.json",
             "exports": {
-                "qcow2": {
-                    "artifact": "disk.qcow2"
+                "qemu": {
+                    "artifact": "qemu.qcow2"
+                },
+                "metal": {
+                    "artifact": "metal.raw"
                 }
             },
         }

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -442,7 +442,7 @@
       ]
     },
     {
-      "name": "image-tree",
+      "name": "tree",
       "build": "name:build",
       "source-epoch": 1659397331,
       "stages": [
@@ -492,9 +492,6 @@
             ],
             "kernel_opts": [
               "rw",
-              "console=tty0",
-              "console=ttyS0",
-              "ignition.platform.id=qemu",
               "$ignition_firstboot"
             ]
           },
@@ -541,7 +538,7 @@
       ]
     },
     {
-      "name": "image",
+      "name": "raw-image",
       "build": "name:build",
       "stages": [
         {
@@ -654,7 +651,7 @@
               "type": "org.osbuild.tree",
               "origin": "org.osbuild.pipeline",
               "references": [
-                "name:image-tree"
+                "name:tree"
               ]
             }
           },
@@ -735,7 +732,141 @@
       ]
     },
     {
-      "name": "qcow2",
+      "name": "raw-metal-image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:raw-image"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/disk.img",
+                "to": "tree:///disk.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.kernel-cmdline.bls-append",
+          "options": {
+            "bootpath": "mount:///",
+            "kernel_opts": [
+              "ignition.platform.id=metal"
+            ]
+          },
+          "devices": {
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 264192,
+                "size": 786432
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "boot",
+              "type": "org.osbuild.ext4",
+              "source": "boot",
+              "target": "/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "raw-qemu-image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:raw-image"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/disk.img",
+                "to": "tree:///disk.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.kernel-cmdline.bls-append",
+          "options": {
+            "bootpath": "mount:///",
+            "kernel_opts": [
+              "console=tty0",
+              "console=ttyS0,115200n8",
+              "ignition.platform.id=qemu"
+            ]
+          },
+          "devices": {
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 264192,
+                "size": 786432
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "boot",
+              "type": "org.osbuild.ext4",
+              "source": "boot",
+              "target": "/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "metal",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:raw-metal-image"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/disk.img",
+                "to": "tree:///metal.raw"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "qemu",
       "build": "name:build",
       "stages": [
         {
@@ -745,14 +876,14 @@
               "type": "org.osbuild.files",
               "origin": "org.osbuild.pipeline",
               "references": {
-                "name:image": {
+                "name:raw-qemu-image": {
                   "file": "disk.img"
                 }
               }
             }
           },
           "options": {
-            "filename": "disk.qcow2",
+            "filename": "qemu.qcow2",
             "format": {
               "type": "qcow2",
               "compat": "1.1"

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -33,7 +33,7 @@ pipelines:
       id: build
     runner:
       mpp-format-string: org.osbuild.fedora{release}
-  - name: image-tree
+  - name: tree
     build: name:build
     source-epoch: 1659397331
     stages:
@@ -63,9 +63,6 @@ pipelines:
             - /boot/efi
           kernel_opts:
             - rw
-            - console=tty0
-            - console=ttyS0
-            - ignition.platform.id=qemu
             - '$ignition_firstboot'
         inputs:
           images:
@@ -93,7 +90,7 @@ pipelines:
           write_defaults: false
           greenboot: false
           ignition: true
-  - name: image
+  - name: raw-image
     build: name:build
     stages:
       - type: org.osbuild.truncate
@@ -157,7 +154,7 @@ pipelines:
             type: org.osbuild.tree
             origin: org.osbuild.pipeline
             references:
-              - name:image-tree
+              - name:tree
         options:
           paths:
             - from: input://tree/
@@ -217,7 +214,89 @@ pipelines:
             number:
               mpp-format-int: '{image.layout[''boot''].index}'
             path: /grub2
-  - name: qcow2
+  - name: raw-metal-image
+    build: name:build
+    stages:
+      - type: org.osbuild.copy
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:raw-image
+        options:
+          paths:
+            - from: input://tree/disk.img
+              to: tree:///disk.img
+      - type: org.osbuild.kernel-cmdline.bls-append
+        options:
+          bootpath: mount:///
+          kernel_opts:
+            - ignition.platform.id=metal
+        devices:
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''boot''].start}'
+              size:
+                mpp-format-int: '{image.layout[''boot''].size}'
+        mounts:
+          - name: boot
+            type: org.osbuild.ext4
+            source: boot
+            target: /
+  - name: raw-qemu-image
+    build: name:build
+    stages:
+      - type: org.osbuild.copy
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:raw-image
+        options:
+          paths:
+            - from: input://tree/disk.img
+              to: tree:///disk.img
+      - type: org.osbuild.kernel-cmdline.bls-append
+        options:
+          bootpath: mount:///
+          kernel_opts:
+            - console=tty0
+            - console=ttyS0,115200n8
+            - ignition.platform.id=qemu
+        devices:
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''boot''].start}'
+              size:
+                mpp-format-int: '{image.layout[''boot''].size}'
+        mounts:
+          - name: boot
+            type: org.osbuild.ext4
+            source: boot
+            target: /
+  - name: metal
+    build: name:build
+    stages:
+      - type: org.osbuild.copy
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:raw-metal-image
+        options:
+          paths:
+            - from: input://tree/disk.img
+              to: tree:///metal.raw
+  - name: qemu
     build: name:build
     stages:
       - type: org.osbuild.qemu
@@ -226,10 +305,10 @@ pipelines:
             type: org.osbuild.files
             origin: org.osbuild.pipeline
             references:
-              name:image:
+              name:raw-qemu-image:
                 file: disk.img
         options:
-          filename: disk.qcow2
+          filename: qemu.qcow2
           format:
             type: qcow2
             compat: '1.1'


### PR DESCRIPTION
This adds a stage to be able to add kernel arguments on a system by
appending to the BLS [1] config directly either in the tree or in
a mount. This is useful on say systems that don't use `grubby` and
thus can't use the org.osbuild.kernel-cmdline stage.

[1] https://freedesktop.org/wiki/Specifications/BootLoaderSpec/
