### PR TITLE
stages(kickstart): run ksvalidator as part of the tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,9 @@ deps =
     mako
     iniparse
     pyyaml
+    pykickstart
+    # required by pykickstart but not pulled in automatically :/
+    requests
 
 setenv =
     LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/* stages/*.* stages/test/*.py


### PR DESCRIPTION
Run `ksvalidator` as part of the test_kickstart.py tests. This ensures that the file we write is valid.

This addresses the suggestion from @bcl in https://github.com/osbuild/osbuild/pull/1424#issuecomment-1796054555 (thank for that!).

One thing that I noticed while adding this is that the "ostree.url" requires a valid file/http/https url so I wonder if we should make our schema stricter?

Alternatively (if we want to avoid the extra test dependency) something like https://github.com/osbuild/osbuild/compare/main...mvo5:kickstart-integration?expand=1#diff-e1602f2a3af5d3fe5bd7f3cbbc64aa2ac0a61fea3b9847668f0c59ff11825ee4R645 could be done and we install/run ksvalidaor inside the stage and test there. However it takes longer and is less flexible so I opted for this approach. But happy to switch if you feel the other approach is preferable (or even do both).