### PR TITLE
stages(kickstart): implement "reboot" option

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -139,6 +139,13 @@ SCHEMA = r"""
   "clearpart": {
     "description": "Removes partitions from the system, prior to creation of new partitions",
     "type": "object",
+    "anyOf": [
+      {"required": ["all"]},
+      {"required": ["drives"]},
+      {"required": ["list"]},
+      {"required": ["disklabel"]},
+      {"required": ["linux"]}
+    ],
     "properties": {
       "all": {
         "description": "Erases all partitions from the system",

--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -170,6 +170,27 @@ SCHEMA = r"""
         "type": "boolean"
       }
     }
+  },
+  "reboot": {
+    "description": "Reboot after the installation is successfully completed",
+    "oneOf": [
+    {
+      "type": "boolean"
+    }, {
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [{"required": ["eject"]}, {"required": ["kexec"]}],
+      "properties": {
+        "eject": {
+          "description": "Attempt to eject the installation media before rebooting",
+          "type": "boolean"
+        },
+        "kexec": {
+          "description": "Use this option to reboot into the new system using the kexec",
+          "type": "boolean"
+        }
+      }
+    }]
   }
 }
 """
@@ -259,6 +280,19 @@ def make_clearpart(options: Dict) -> str:
     return cmd
 
 
+def make_reboot(options):
+    reboot = options.get("reboot", None)
+    if not reboot:
+        return ""
+    cmd = "reboot"
+    if isinstance(reboot, dict):
+        if reboot.get("eject"):
+            cmd += " --eject"
+        if reboot.get("kexec"):
+            cmd += " --kexec"
+    return cmd
+
+
 def main(tree, options):
     path = options["path"].lstrip("/")
     ostree = options.get("ostree")
@@ -301,6 +335,10 @@ def main(tree, options):
     clearpart = make_clearpart(options)
     if clearpart:
         config += [clearpart]
+
+    reboot = make_reboot(options)
+    if reboot:
+        config += [reboot]
 
     target = os.path.join(tree, path)
     base = os.path.dirname(target)

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -55,8 +55,6 @@ from osbuild.testutil.imports import import_module_from_path
      'sshkey --username someusr "ssh-rsa not-really-a-real-key"'
      ),
     ({"zerombr": "true"}, "zerombr"),
-    # no clearpart for an empty dict (will not do anything with options anyway)
-    ({"clearpart": {}}, ""),
     ({"clearpart": {"all": True}}, "clearpart --all"),
     ({"clearpart": {"drives": ["hda", "hdb"]}}, "clearpart --drives=hda,hdb",),
     ({"clearpart": {"drives": ["hda"]}}, "clearpart --drives=hda"),
@@ -120,6 +118,7 @@ def test_kickstart(tmp_path, test_input, expected):
 @pytest.mark.parametrize("test_data,expected_err", [
     # BAD pattern, ensure some obvious ways to write arbitrary
     # kickstart files will not work
+    ({"clearpart": {}}, "{} is not valid "),
     ({"clearpart": {"disklabel": r"\n%pre\necho p0wnd"}}, r"p0wnd' does not match"),
     ({"clearpart": {"drives": [" --spaces-dashes-not-allowed"]}}, "' --spaces-dashes-not-allowed' does not match"),
     ({"clearpart": {"drives": ["\n%pre not allowed"]}}, "not allowed' does not match"),


### PR DESCRIPTION
This commit implements the `reboot` option for kickstart files.

Note that there are two ways this can be enabled via the json.
Either via a boolean or by passing a dict with options.
```
{"reboot": true}
{"reboot": {"eject": true, "kexec": true}
```

Passing the empty dict
```
{"reboot": {}}
```
is not allowed by the schema.