### PR TITLE
stage/test: add anaconda test

### DIFF
--- a/osbuild/testutil/__init__.py
+++ b/osbuild/testutil/__init__.py
@@ -1,3 +1,8 @@
 """
 Test related utilities
 """
+import shutil
+
+
+def has_executable(executable: str) -> bool:
+    return shutil.which(executable) is not None

--- a/stages/test/test_anaconda.py
+++ b/stages/test/test_anaconda.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+
+import os.path
+
+import pytest
+
+import osbuild.meta
+
+
+@pytest.mark.parametrize(
+    "test_data,expected_err",
+    [
+        # BAD patterns that should not work
+        ({"kickstart-modules": []}, "[] is too short"),
+        ({"activatable-modules": []}, "[] is too short"),
+        ({"forbidden-modules": []}, "[] is too short"),
+        ({"optional-modules": []}, "[] is too short"),
+        # GOOD patterns that should work, starting with a fully empty one
+        ({}, ""),
+        ({"kickstart-modules": ["test"]}, ""),
+        ({"activatable-modules": ["test"]}, ""),
+        ({"forbidden-modules": ["test"]}, ""),
+        ({"optional-modules": ["test"]}, ""),
+    ],
+)
+def test_schema_validation_smoke(test_data, expected_err):
+    name = "org.osbuild.anaconda"
+    root = os.path.join(os.path.dirname(__file__), "../..")
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
+    schema = osbuild.meta.Schema(mod_info.get_schema(), name)
+
+    test_input = {
+        "name": name,
+        "options": {},
+    }
+    test_input["options"].update(test_data)
+    res = schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True
+    else:
+        # assert res.valid is False
+        # assert len(res.errors) == 1
+        err_msgs = [e.as_dict()["message"] for e in res.errors]
+        assert expected_err in err_msgs[0]

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -6,90 +6,100 @@ import subprocess
 import pytest
 
 import osbuild.meta
+from osbuild.testutil import has_executable
 from osbuild.testutil.imports import import_module_from_path
 
-
-@pytest.mark.parametrize("test_input,expected", [
+TEST_INPUT = [
     ({"lang": "en_US.UTF-8"}, "lang en_US.UTF-8"),
     ({"keyboard": "us"}, "keyboard us"),
     ({"timezone": "UTC"}, "timezone UTC"),
-    ({"lang": "en_US.UTF-8",
-      "keyboard": "us",
-      "timezone": "UTC",
-      },
-     "lang en_US.UTF-8\nkeyboard us\ntimezone UTC"),
-    ({"ostree":
-      {
-          "osname": "some-osname",
-          "url": "http://some-ostree-url.com/foo",
-          "ref": "some-ref",
-          "remote": "some-remote",
-          "gpg": True,
-      },
-      "liveimg": {
-          "url": "some-liveimg-url",
-      },
-      "groups": {
-          "somegrp": {
-              "gid": 2337,
-          },
-      },
-      "users": {
-          "someusr": {
-              "uid": 1337,
-              "gid": 1337,
-              "groups": [
-                  "grp1",
-                  "grp2",
-              ],
-              "home": "/other/home/someusr",
-              "shell": "/bin/ksh",
-              "password": "$1$notreally",
-              "key": "ssh-rsa not-really-a-real-key",
-          },
-      },
-      },
-     "ostreesetup --osname=some-osname --url=http://some-ostree-url.com/foo --ref=some-ref --remote=some-remote\n" +
-     "liveimg --url some-liveimg-url\ngroup --name somegrp --gid 2337\n" +
-     "user --name someusr --password $1$notreally --iscrypted --shell /bin/ksh --uid 1337 --gid 1337 --groups grp1,grp2 --homedir /other/home/someusr\n" +
-     'sshkey --username someusr "ssh-rsa not-really-a-real-key"'
-     ),
+    (
+        {
+            "lang": "en_US.UTF-8",
+            "keyboard": "us",
+            "timezone": "UTC",
+        },
+        "lang en_US.UTF-8\nkeyboard us\ntimezone UTC",
+    ),
+    (
+        {
+            "ostree": {
+                "osname": "some-osname",
+                "url": "http://some-ostree-url.com/foo",
+                "ref": "some-ref",
+                "remote": "some-remote",
+                "gpg": True,
+            },
+            "liveimg": {
+                "url": "some-liveimg-url",
+            },
+            "groups": {
+                "somegrp": {
+                    "gid": 2337,
+                },
+            },
+            "users": {
+                "someusr": {
+                    "uid": 1337,
+                    "gid": 1337,
+                    "groups": [
+                        "grp1",
+                        "grp2",
+                    ],
+                    "home": "/other/home/someusr",
+                    "shell": "/bin/ksh",
+                    "password": "$1$notreally",
+                    "key": "ssh-rsa not-really-a-real-key",
+                },
+            },
+        },
+        "ostreesetup --osname=some-osname --url=http://some-ostree-url.com/foo --ref=some-ref --remote=some-remote\n"
+        + "liveimg --url some-liveimg-url\ngroup --name somegrp --gid 2337\n"
+        + "user --name someusr --password $1$notreally --iscrypted --shell /bin/ksh --uid 1337 --gid 1337 --groups grp1,grp2 --homedir /other/home/someusr\n"
+        + 'sshkey --username someusr "ssh-rsa not-really-a-real-key"',
+    ),
     ({"zerombr": "true"}, "zerombr"),
     ({"clearpart": {}}, "clearpart"),
     ({"clearpart": {"all": True}}, "clearpart --all"),
-    ({"clearpart": {"drives": ["hda", "hdb"]}}, "clearpart --drives=hda,hdb",),
+    (
+        {"clearpart": {"drives": ["hda", "hdb"]}},
+        "clearpart --drives=hda,hdb",
+    ),
     ({"clearpart": {"drives": ["hda"]}}, "clearpart --drives=hda"),
     ({"clearpart": {"list": ["sda2", "sda3"]}}, "clearpart --list=sda2,sda3"),
     ({"clearpart": {"list": ["sda2"]}}, "clearpart --list=sda2"),
-    ({"clearpart": {"disklabel": "some-label"}},
-     "clearpart --disklabel=some-label",
-     ),
+    (
+        {"clearpart": {"disklabel": "some-label"}},
+        "clearpart --disklabel=some-label",
+    ),
     ({"clearpart": {"linux": True}}, "clearpart --linux"),
-    ({"clearpart": {
-        "all": True,
-        "drives": ["hda", "hdb"],
-        "list": ["sda2", "sda3"],
-        "disklabel": "some-label",
-        "linux": True,
-    },
-    },
-        "clearpart --all --drives=hda,hdb --list=sda2,sda3 --disklabel=some-label --linux"),
-    ({"lang": "en_US.UTF-8",
-              "keyboard": "us",
-              "timezone": "UTC",
-              "zerombr": True,
-              "clearpart": {
-                  "all": True,
-                  "drives": [
-                      "sd*|hd*|vda",
-                      "/dev/vdc"
-                  ]
-              }
-      },
+    (
+        {
+            "clearpart": {
+                "all": True,
+                "drives": ["hda", "hdb"],
+                "list": ["sda2", "sda3"],
+                "disklabel": "some-label",
+                "linux": True,
+            },
+        },
+        "clearpart --all --drives=hda,hdb --list=sda2,sda3 --disklabel=some-label --linux",
+    ),
+    (
+        {
+            "lang": "en_US.UTF-8",
+            "keyboard": "us",
+            "timezone": "UTC",
+            "zerombr": True,
+            "clearpart": {"all": True, "drives": ["sd*|hd*|vda", "/dev/vdc"]},
+        },
         "lang en_US.UTF-8\nkeyboard us\ntimezone UTC\nzerombr\nclearpart --all --drives=sd*|hd*|vda,/dev/vdc",
-     ),
-])
-def test_kickstart(tmp_path, test_input, expected):
+    ),
+]
+
+
+@pytest.mark.parametrize("test_input,expected", TEST_INPUT)
+def test_kickstart_write(tmp_path, test_input, expected):
     ks_stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.kickstart")
     ks_stage = import_module_from_path("ks_stage", ks_stage_path)
 
@@ -104,25 +114,43 @@ def test_kickstart(tmp_path, test_input, expected):
         ks_content = fp.read()
     assert ks_content == expected + "\n"
 
-    # double check with pykickstart if the file looks valid
+
+@pytest.mark.skipif(not has_executable("ksvalidator"), reason="`ksvalidator` is required")
+@pytest.mark.parametrize("test_input,expected", TEST_INPUT)
+def test_kickstart_valid(tmp_path, test_input, expected):  # pylint: disable=unused-argument
+    ks_stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.kickstart")
+    ks_stage = import_module_from_path("ks_stage", ks_stage_path)
+
+    ks_path = "kickstart/kfs.cfg"
+    options = {"path": ks_path}
+    options.update(test_input)
+
+    ks_stage.main(tmp_path, options)
+
+    ks_path = os.path.join(tmp_path, ks_path)
+
+    # check with pykickstart if the file looks valid
     subprocess.check_call(["ksvalidator", ks_path])
 
 
-@pytest.mark.parametrize("test_data,expected_err", [
-    # BAD pattern, ensure some obvious ways to write arbitrary
-    # kickstart files will not work
-    ({"clearpart": {"disklabel": r"\n%pre\necho p0wnd"}}, r"p0wnd' does not match"),
-    ({"clearpart": {"drives": [" --spaces-dashes-not-allowed"]}}, "' --spaces-dashes-not-allowed' does not match"),
-    ({"clearpart": {"drives": ["\n%pre not allowed"]}}, "not allowed' does not match"),
-    ({"clearpart": {"drives": ["no,comma"]}}, "no,comma' does not match"),
-    ({"clearpart": {"list": ["\n%pre not allowed"]}}, "not allowed' does not match"),
-    ({"clearpart": {"list": ["no,comma"]}}, "no,comma' does not match"),
-    ({"clearpart": {"disklabel": "\n%pre not allowed"}}, "not allowed' does not match"),
-    # GOOD pattern we want to keep working
-    ({"clearpart": {"drives": ["sd*|hd*|vda", "/dev/vdc"]}}, ""),
-    ({"clearpart": {"drives": ["disk/by-id/scsi-58095BEC5510947BE8C0360F604351918"]}}, ""),
-    ({"clearpart": {"list": ["sda2", "sda3", "sdb1"]}}, ""),
-])
+@pytest.mark.parametrize(
+    "test_data,expected_err",
+    [
+        # BAD pattern, ensure some obvious ways to write arbitrary
+        # kickstart files will not work
+        ({"clearpart": {"disklabel": r"\n%pre\necho p0wnd"}}, r"p0wnd' does not match"),
+        ({"clearpart": {"drives": [" --spaces-dashes-not-allowed"]}}, "' --spaces-dashes-not-allowed' does not match"),
+        ({"clearpart": {"drives": ["\n%pre not allowed"]}}, "not allowed' does not match"),
+        ({"clearpart": {"drives": ["no,comma"]}}, "no,comma' does not match"),
+        ({"clearpart": {"list": ["\n%pre not allowed"]}}, "not allowed' does not match"),
+        ({"clearpart": {"list": ["no,comma"]}}, "no,comma' does not match"),
+        ({"clearpart": {"disklabel": "\n%pre not allowed"}}, "not allowed' does not match"),
+        # GOOD pattern we want to keep working
+        ({"clearpart": {"drives": ["sd*|hd*|vda", "/dev/vdc"]}}, ""),
+        ({"clearpart": {"drives": ["disk/by-id/scsi-58095BEC5510947BE8C0360F604351918"]}}, ""),
+        ({"clearpart": {"list": ["sda2", "sda3", "sdb1"]}}, ""),
+    ],
+)
 def test_schema_validation_smoke(test_data, expected_err):
     name = "org.osbuild.kickstart"
     root = os.path.join(os.path.dirname(__file__), "../..")
@@ -133,7 +161,7 @@ def test_schema_validation_smoke(test_data, expected_err):
         "name": "org.osbuild.kickstart",
         "options": {
             "path": "some-path",
-        }
+        },
     }
     test_input["options"].update(test_data)
     res = schema.validate(test_input)

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -158,7 +158,7 @@ def test_schema_validation_smoke(test_data, expected_err):
     schema = osbuild.meta.Schema(mod_info.get_schema(), name)
 
     test_input = {
-        "name": "org.osbuild.kickstart",
+        "name": name,
         "options": {
             "path": "some-path",
         },


### PR DESCRIPTION
This adds a quick Anaconda schema test in the format introduced by @mvo5. This is not ready to be merged and for now serves as a way to find out what we can move into `osbuild.testutil`, it is also based on top of #1438.

# TODO

- [ ] Implement write test for configuration.
- [ ] Figure out if Anaconda has a configuration validator.