### PR TITLE
stages(kickstart): ensure test inputs pass schema validation

### DIFF
--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -58,13 +58,17 @@ TEST_INPUT = [
         + "user --name someusr --password $1$notreally --iscrypted --shell /bin/ksh --uid 1337 --gid 1337 --groups grp1,grp2 --homedir /other/home/someusr\n"
         + 'sshkey --username someusr "ssh-rsa not-really-a-real-key"',
     ),
-    ({"zerombr": "true"}, "zerombr"),
+    ({"zerombr": True}, "zerombr"),
     ({"clearpart": {"all": True}}, "clearpart --all"),
     (
-        {"clearpart": {"drives": ["hda", "hdb"]}},
-        "clearpart --drives=hda,hdb",
+        {"clearpart": {"drives": ["sd*|hd*|vda", "/dev/vdc"]}},
+        "clearpart --drives=sd*|hd*|vda,/dev/vdc",
     ),
     ({"clearpart": {"drives": ["hda"]}}, "clearpart --drives=hda"),
+    (
+        {"clearpart": {"drives": ["disk/by-id/scsi-58095BEC5510947BE8C0360F604351918"]}},
+        "clearpart --drives=disk/by-id/scsi-58095BEC5510947BE8C0360F604351918"
+    ),
     ({"clearpart": {"list": ["sda2", "sda3"]}}, "clearpart --list=sda2,sda3"),
     ({"clearpart": {"list": ["sda2"]}}, "clearpart --list=sda2"),
     (
@@ -102,6 +106,28 @@ TEST_INPUT = [
     ({"reboot": {"kexec": True}}, "reboot --kexec"),
     ({"reboot": {"eject": True, "kexec": True}}, "reboot --eject --kexec"),
 ]
+
+
+def schema_validate_kickstart_stage(test_data):
+    name = "org.osbuild.kickstart"
+    root = os.path.join(os.path.dirname(__file__), "../..")
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
+    schema = osbuild.meta.Schema(mod_info.get_schema(), name)
+    test_input = {
+        "name": "org.osbuild.kickstart",
+        "options": {
+            "path": "some-path",
+        }
+    }
+    test_input["options"].update(test_data)
+    return schema.validate(test_input)
+
+
+@pytest.mark.parametrize("test_input,expected", TEST_INPUT)
+def test_kickstart_test_cases_valid(test_input, expected):  # pylint: disable=unused-argument
+    """ ensure all test inputs are valid """
+    res = schema_validate_kickstart_stage(test_input)
+    assert res.valid is True, f"input: {test_input}\nerr: {[e.as_dict() for e in res.errors]}"
 
 
 @pytest.mark.parametrize("test_input,expected", TEST_INPUT)
@@ -156,33 +182,12 @@ def test_kickstart_valid(tmp_path, test_input, expected):  # pylint: disable=unu
         ({"reboot": {}}, "{} is not valid under any of the given schemas"),
         ({"reboot": "random-string"}, "'random-string' is not valid "),
         ({"reboot": {"random": "option"}}, "{'random': 'option'} is not valid "),
-        # GOOD pattern we want to keep working
-        ({"clearpart": {"drives": ["sd*|hd*|vda", "/dev/vdc"]}}, ""),
-        ({"clearpart": {"drives": ["disk/by-id/scsi-58095BEC5510947BE8C0360F604351918"]}}, ""),
-        ({"clearpart": {"list": ["sda2", "sda3", "sdb1"]}}, ""),
-        ({"reboot": True}, ""),
-        ({"reboot": {"kexec": False}}, ""),
     ],
 )
-def test_schema_validation_smoke(test_data, expected_err):
-    name = "org.osbuild.kickstart"
-    root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
-    schema = osbuild.meta.Schema(mod_info.get_schema(), name)
+def test_schema_validation_bad_apples(test_data, expected_err):
+    res = schema_validate_kickstart_stage(test_data)
 
-    test_input = {
-        "name": "org.osbuild.kickstart",
-        "options": {
-            "path": "some-path",
-        },
-    }
-    test_input["options"].update(test_data)
-    res = schema.validate(test_input)
-
-    if expected_err == "":
-        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
-    else:
-        assert res.valid is False
-        assert len(res.errors) == 1
-        err_msgs = [e.as_dict()["message"] for e in res.errors]
-        assert expected_err in err_msgs[0]
+    assert res.valid is False
+    assert len(res.errors) == 1
+    err_msgs = [e.as_dict()["message"] for e in res.errors]
+    assert expected_err in err_msgs[0]


### PR DESCRIPTION
Now that inputs can be relatively easily validated against the schema this should also be used for all the "good" test inputs to ensure that all tests test against valid inputs.