### PR TITLE
stages(kickstart): implement "display_mode" option and tiny test addition

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -198,6 +198,10 @@ SCHEMA = r"""
         }
       }
     }]
+  },
+  "display_mode": {
+    "description": "Perform the Kickstart installation in the given display mode",
+    "enum": ["text", "graphical", "cmdline"]
   }
 }
 """
@@ -342,6 +346,9 @@ def main(tree, options):
     clearpart = make_clearpart(options)
     if clearpart:
         config += [clearpart]
+    display_mode = options.get("display_mode")
+    if display_mode:
+        config += [display_mode]
 
     reboot = make_reboot(options)
     if reboot:

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -98,13 +98,15 @@ TEST_INPUT = [
         },
         "lang en_US.UTF-8\nkeyboard us\ntimezone UTC\nzerombr\nclearpart --all --drives=sd*|hd*|vda,/dev/vdc",
     ),
-    # no reboot for an empty dict
     ({"reboot": True}, "reboot"),
     ({"reboot": {"eject": False}}, "reboot"),
     ({"reboot": {"eject": True}}, "reboot --eject"),
     ({"reboot": {"kexec": False}}, "reboot"),
     ({"reboot": {"kexec": True}}, "reboot --kexec"),
     ({"reboot": {"eject": True, "kexec": True}}, "reboot --eject --kexec"),
+    ({"display_mode": "text"}, "text"),
+    ({"display_mode": "graphical"}, "graphical"),
+    ({"display_mode": "cmdline"}, "cmdline"),
 ]
 
 
@@ -183,6 +185,7 @@ def test_kickstart_valid(tmp_path, test_input, expected):  # pylint: disable=unu
         ({"reboot": {}}, "{} is not valid under any of the given schemas"),
         ({"reboot": "random-string"}, "'random-string' is not valid "),
         ({"reboot": {"random": "option"}}, "{'random': 'option'} is not valid "),
+        ({"display_mode": "invalid-mode"}, "'invalid-mode' is not one of "),
     ],
 )
 def test_schema_validation_bad_apples(test_data, expected_err):

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -178,6 +178,7 @@ def test_kickstart_valid(tmp_path, test_input, expected):  # pylint: disable=unu
         ({"clearpart": {"list": ["\n%pre not allowed"]}}, "not allowed' does not match"),
         ({"clearpart": {"list": ["no,comma"]}}, "no,comma' does not match"),
         ({"clearpart": {"disklabel": "\n%pre not allowed"}}, "not allowed' does not match"),
+        ({"clearpart": {"random": "option"}}, "is not valid "),
         # schema ensures reboot has at least one option set
         ({"reboot": {}}, "{} is not valid under any of the given schemas"),
         ({"reboot": "random-string"}, "'random-string' is not valid "),


### PR DESCRIPTION
Tiny PR to add "text" to kickstart and also adds a missing testcase for clearpart (ensure no extra properties are allowed there).