### PR TITLE
tools: add "tools" dir to LINTABLES and fix issues

### DIFF
--- a/tools/check-runners
+++ b/tools/check-runners
@@ -5,6 +5,7 @@ and a list of Schutzfile entries not used by runners."""
 
 import json
 import sys
+
 import yaml
 
 

--- a/tools/check-snapshots
+++ b/tools/check-snapshots
@@ -5,16 +5,17 @@ against the current snapshot list"""
 import argparse
 import json
 import os
-import sys
 import subprocess
+import sys
 import time
 from urllib.parse import urlparse
 
 import requests
 
-SNAPSHOTS_URL="https://rpmrepo.osbuild.org/v2/enumerate"
+SNAPSHOTS_URL = "https://rpmrepo.osbuild.org/v2/enumerate"
 SNAPSHOTS_TIMEOUT = 2 * 60
 SNAPSHOT_GREP = ["grep", "--color=never", "-or", r"http.*rpmrepo.osbuild.org.*-20[0-9]\+"]
+
 
 def fetch_snapshots_api(url, timeout=SNAPSHOTS_TIMEOUT):
     """Get the list of snapshots from the rpmrepo API"""
@@ -22,7 +23,7 @@ def fetch_snapshots_api(url, timeout=SNAPSHOTS_TIMEOUT):
     start = time.time()
     try:
         r = requests.get(url, timeout=timeout)
-    except:
+    except BaseException:
         return None
     elapsed = time.time() - start
     if r.status_code != 200:
@@ -143,7 +144,7 @@ def check_snapshot_urls(urls, snapshots, skip=["test/data/manifests", "test/data
 
 # parse cmdline args
 def parse_args():
-    parser =argparse.ArgumentParser(description="Check snapshot urls")
+    parser = argparse.ArgumentParser(description="Check snapshot urls")
     parser.add_argument("--verbose")
     parser.add_argument("--timeout", type=int, default=SNAPSHOTS_TIMEOUT,
                         help="How long to wait for rpmrepo snapshot list")
@@ -155,6 +156,7 @@ def parse_args():
     parser.add_argument("directory")
     return parser.parse_args()
 
+
 def main():
     args = parse_args()
     urls = find_snapshot_urls(args.directory)
@@ -164,7 +166,7 @@ def main():
         try:
             with open(args.cache, encoding="utf8") as f:
                 snapshots = json.load(f)
-        except:
+        except BaseException:
             print(f"No snapshots cache found at {args.cache}")
             sys.exit(1)
     else:
@@ -176,5 +178,5 @@ def main():
     return check_snapshot_urls(urls, snapshots, errors_only=args.errors_only)
 
 
-if __name__=='__main__':
+if __name__ == '__main__':
     sys.exit(main())

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -364,8 +364,7 @@ import hawkey
 import rpm
 import yaml
 
-from osbuild.util import containers
-from osbuild.util import ostree
+from osbuild.util import containers, ostree
 from osbuild.util.rhsm import Subscriptions
 
 # We need to resolve an image name to a resolved image manifest digest
@@ -1314,6 +1313,7 @@ class ManifestFile:
     def _process_ostree(self, _stage):
         raise NotImplementedError()
 
+
 class ManifestFileV1(ManifestFile):
     def __init__(self, path, overrides, default_vars, data, searchdirs):
         super().__init__(path, overrides, default_vars, data, searchdirs, 1)
@@ -1547,11 +1547,11 @@ class ManifestFileV2(ManifestFile):
 
     def _process_container(self, stage):
         if stage.get("type", "") not in \
-            ["org.osbuild.skopeo", "org.osbuild.ostree.deploy.container"]:
+                ["org.osbuild.skopeo", "org.osbuild.ostree.deploy.container"]:
             return
 
         inputs = element_enter(stage, "inputs", {})
- 
+
         inputs_images = element_enter(inputs, "images", {})
 
         if inputs_images.get("type", "") != "org.osbuild.containers":
@@ -1622,7 +1622,7 @@ class ManifestFileV2(ManifestFile):
 
     def _process_ostree_commits(self, stage):
         if stage.get("type", "") not in \
-            ["org.osbuild.ostree.pull", "org.osbuild.ostree.deploy"]:
+                ["org.osbuild.ostree.pull", "org.osbuild.ostree.deploy"]:
             return
 
         # The ostree.deploy stage accepts both containers or
@@ -1665,8 +1665,8 @@ class ManifestFileV2(ManifestFile):
                 # This is a temporary repo so we'll just use a random name
                 remote_name = "tmpremote"
                 ostree.setup_remote(tmprepo, remote_name, remote)
-                ostree.cli( "pull", "--commit-metadata-only",
-                            "--mirror", remote_name, ref, repo=tmprepo)
+                ostree.cli("pull", "--commit-metadata-only",
+                           "--mirror", remote_name, ref, repo=tmprepo)
                 checksum = ostree.rev_parse(tmprepo, ref)
                 items[checksum] = {
                     "remote": remote

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     requests
 
 setenv =
-    LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/* stages/*.* stages/test/*.py
+    LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/* stages/*.* stages/test/*.py tools/
     TYPEABLES = osbuild
 
 passenv =


### PR DESCRIPTION
The `./tools` dir was not part of the LINTABLES in the `tox.ini` which meant that pep8/pylint etc checks were not run on the tools there.

This commit adds it and fixes the issues that `make lint` found.