### PR TITLE
Add stages to sign ostree commits

### DIFF
--- a/stages/org.osbuild.ostree.genkey
+++ b/stages/org.osbuild.ostree.genkey
@@ -1,0 +1,96 @@
+#!/usr/bin/python3
+"""Generate ed25519 public/private keypair in format used by `ostree sign`.
+
+This is used with the org.osbuild.ostree.sign stage, and these can be
+used with composefs to tie an initrd and ostree commit together. See
+https://ostreedev.github.io/ostree/composefs/#signatures for details
+of how this works.
+
+Notes:
+  - Requires 'openssl' in the buildroot.
+"""
+
+import base64
+import os
+import subprocess
+import sys
+import tempfile
+
+import osbuild.api
+
+SCHEMA_2 = r"""
+"options": {
+  "additionalProperties": false,
+  "required": ["publickey", "secretkey"],
+  "properties": {
+    "publickey": {
+      "description": "Path of generated public key",
+      "type": "string",
+      "pattern": "^\\/(?!\\.\\.)((?!\\/\\.\\.\\/).)+$"
+    },
+    "secretkey": {
+      "description": "Path of generated secret key",
+      "type": "string",
+      "pattern": "^\\/(?!\\.\\.)((?!\\/\\.\\.\\/).)+$"
+    }
+  }
+}
+"""
+
+
+def openssl(*args):
+    args = list(args)
+    print("openssl " + " ".join(args), file=sys.stderr)
+    subprocess.run(["openssl"] + args,
+                   encoding="utf8",
+                   stdout=sys.stderr,
+                   input=None,
+                   check=True)
+
+
+def openssl_stdout(*args):
+    args = list(args)
+    print("openssl " + " ".join(args), file=sys.stderr)
+    res = subprocess.run(["openssl"] + args,
+                         stdout=subprocess.PIPE,
+                         input=None,
+                         check=True)
+
+    return res.stdout
+
+# Based on gen_ed25519_keys() in https://github.com/ostreedev/ostree/blob/main/tests/libtest.sh
+
+
+def main(args, options):
+    tree = args["tree"]
+    pubkeyfile = os.path.join(tree, options["publickey"].lstrip("/"))
+    seckeyfile = os.path.join(tree, options["secretkey"].lstrip("/"))
+
+    with tempfile.TemporaryDirectory(dir=tree) as tmpdir:
+        # Generate key
+        pemfile = os.path.join(tmpdir, "key.pem")
+        openssl("genpkey", "-algorithm", "ed25519", "-outform", "PEM", "-out", pemfile)
+
+        # Extract the seed/public parts from generated key (last 32 byte in PEM file)
+        pubkey = openssl_stdout("pkey", "-outform", "DER", "-pubout", "-in", pemfile)[-32:]
+        seed = openssl_stdout("pkey", "-outform", "DER", "-in", pemfile)[-32:]
+
+        # Private key is seed and public key joined
+        seckey = seed + pubkey
+
+        # Ostree stores keys in base64
+        pubkey_b64 = base64.b64encode(pubkey).decode("utf8")
+        seckey_b64 = base64.b64encode(seckey).decode("utf8")
+
+        with open(pubkeyfile, "w", encoding="utf8") as f:
+            f.write(pubkey_b64)
+
+        with open(seckeyfile, "w", encoding="utf8") as f:
+            f.write(seckey_b64)
+
+
+if __name__ == '__main__':
+    stage_args = osbuild.api.arguments()
+    r = main(stage_args,
+             stage_args["options"])
+    sys.exit(r)

--- a/stages/org.osbuild.ostree.sign
+++ b/stages/org.osbuild.ostree.sign
@@ -1,0 +1,55 @@
+#!/usr/bin/python3
+"""Sign a commit in an ostree repo
+
+Given an ostree commit (referenced by a ref) in a repo and an ed25519
+secret key this adds a signature to the commit detached metadata.
+This commit can then be used to validate the commit, during ostree
+pull, during boot, or at any other time.
+
+"""
+
+import os
+import sys
+
+from osbuild import api
+from osbuild.util import ostree
+
+SCHEMA_2 = r"""
+"options": {
+  "additionalProperties": false,
+  "required": ["repo", "ref", "key"],
+  "properties": {
+    "repo": {
+      "description": "Location of the OSTree repo.",
+      "type": "string"
+    },
+    "ref": {
+      "description": "OSTree branch name or commit to sign",
+      "type": "string",
+      "default": ""
+    },
+    "key": {
+      "description": "Path to the secret key",
+      "type": "string",
+      "pattern": "^\\/(?!\\.\\.)((?!\\/\\.\\.\\/).)+$"
+    }
+  }
+}
+"""
+
+
+def main(tree, options):
+    repo = os.path.join(tree, options["repo"].lstrip("/"))
+    ref = options["ref"]
+    keyfile = os.path.join(tree, options["key"].lstrip("/"))
+
+    ostree.cli("sign", ref, **{"repo": repo, "keys-file": keyfile})
+
+
+if __name__ == '__main__':
+    stage_args = api.arguments()
+
+    r = main(stage_args["tree"],
+             stage_args["options"])
+
+    sys.exit(r)


### PR DESCRIPTION
This is the `org.osbuild.ostree.sign/genkey stages from https://github.com/osbuild/osbuild/pull/1343 separated out so we can land them before the rest of the outstanding issues are fixed.