### PR TITLE
Consolidate functions used by runners

### DIFF
--- a/osbuild/util/runners.py
+++ b/osbuild/util/runners.py
@@ -1,0 +1,82 @@
+import os.path
+import platform
+import shutil
+import subprocess
+import sys
+
+
+def ldconfig(*dirs):
+    # ld.so.conf must exist, or `ldconfig` throws a warning
+    subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
+
+    if len(dirs) > 0:
+        with open("/etc/ld.so.conf", "w", encoding="utf8") as f:
+            for d in dirs:
+                f.write(f"{d}\n")
+            f.flush()
+
+    subprocess.run(["ldconfig"], check=True)
+
+
+def sysusers():
+    try:
+        subprocess.run(
+            ["systemd-sysusers"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=True,
+        )
+    except subprocess.CalledProcessError as error:
+        sys.stderr.write(error.stdout)
+        sys.exit(1)
+
+
+def tmpfiles():
+    # Allow systemd-tmpfiles to return non-0. Some packages want to create
+    # directories owned by users that are not set up with systemd-sysusers.
+    subprocess.run(["systemd-tmpfiles", "--create"], check=False)
+
+
+def nsswitch():
+    # the default behavior is fine, but using nss-resolve does not
+    # necessarily work in a non-booted container, so make sure that
+    # is not configured.
+    try:
+        os.remove("/etc/nsswitch.conf")
+    except FileNotFoundError:
+        pass
+
+
+def python_alternatives():
+    """/usr/bin/python3 is a symlink to /etc/alternatives/python3, which points
+    to /usr/bin/python3.6 by default. Recreate the link in /etc, so that
+    shebang lines in stages and assemblers work.
+    """
+    os.makedirs("/etc/alternatives", exist_ok=True)
+    try:
+        os.symlink("/usr/bin/python3.6", "/etc/alternatives/python3")
+    except FileExistsError:
+        pass
+
+
+def sequoia():
+    # This provides a default set of crypto-policies which is important for
+    # re-enabling SHA1 support with rpm (so we can cross-build CentOS-Stream-9
+    # images).
+    os.makedirs("/etc/crypto-policies", exist_ok=True)
+    shutil.copytree(
+        "/usr/share/crypto-policies/back-ends/DEFAULT", "/etc/crypto-policies/back-ends"
+    )
+
+
+def quirks():
+    # Platform specific quirks
+    env = os.environ.copy()
+
+    if platform.machine() == "aarch64":
+        # Work around a bug in qemu-img on aarch64 that can lead to qemu-img
+        # hangs when more then one coroutine is use (which is the default)
+        # See https://bugs.launchpad.net/qemu/+bug/1805256
+        env["OSBUILD_QEMU_IMG_COROUTINES"] = "1"
+
+    return env

--- a/runners/org.osbuild.centos9
+++ b/runners/org.osbuild.centos9
@@ -1,48 +1,18 @@
 #!/usr/bin/python3
 
-import os
 import subprocess
 import sys
 
-import osbuild.api
-
-
-def ldconfig():
-    # ld.so.conf must exist, or `ldconfig` throws a warning
-    subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
-    subprocess.run(["ldconfig"], check=True)
-
-
-def sysusers():
-    try:
-        subprocess.run(["systemd-sysusers"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
-    except subprocess.CalledProcessError as error:
-        sys.stderr.write(error.stdout)
-        sys.exit(1)
-
-
-def tmpfiles():
-    # Allow systemd-tmpfiles to return non-0. Some packages want to create
-    # directories owned by users that are not set up with systemd-sysusers.
-    subprocess.run(["systemd-tmpfiles", "--create"], check=False)
-
-
-def nsswitch():
-    # the default behavior is fine, but using nss-resolve does not
-    # necessarily work in a non-booted container, so make sure that
-    # is not configured.
-    try:
-        os.remove("/etc/nsswitch.conf")
-    except FileNotFoundError:
-        pass
-
+from osbuild import api
+from osbuild.util import runners
 
 if __name__ == "__main__":
-    with osbuild.api.exception_handler():
-        ldconfig()
-        sysusers()
-        tmpfiles()
-        nsswitch()
+    with api.exception_handler():
+        runners.ldconfig()
+        runners.sysusers()
+        runners.tmpfiles()
+        runners.nsswitch()
 
         r = subprocess.run(sys.argv[1:], check=False)
+
         sys.exit(r.returncode)

--- a/runners/org.osbuild.fedora30
+++ b/runners/org.osbuild.fedora30
@@ -1,48 +1,18 @@
 #!/usr/bin/python3
 
-import os
 import subprocess
 import sys
 
-import osbuild.api
-
-
-def ldconfig():
-    # ld.so.conf must exist, or `ldconfig` throws a warning
-    subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
-    subprocess.run(["ldconfig"], check=True)
-
-
-def sysusers():
-    try:
-        subprocess.run(["systemd-sysusers"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
-    except subprocess.CalledProcessError as error:
-        sys.stderr.write(error.stdout)
-        sys.exit(1)
-
-
-def tmpfiles():
-    # Allow systemd-tmpfiles to return non-0. Some packages want to create
-    # directories owned by users that are not set up with systemd-sysusers.
-    subprocess.run(["systemd-tmpfiles", "--create"], check=False)
-
-
-def nsswitch():
-    # the default behavior is fine, but using nss-resolve does not
-    # necessarily work in a non-booted container, so make sure that
-    # is not configured.
-    try:
-        os.remove("/etc/nsswitch.conf")
-    except FileNotFoundError:
-        pass
-
+from osbuild import api
+from osbuild.util import runners
 
 if __name__ == "__main__":
-    with osbuild.api.exception_handler():
-        ldconfig()
-        sysusers()
-        tmpfiles()
-        nsswitch()
+    with api.exception_handler():
+        runners.ldconfig()
+        runners.sysusers()
+        runners.tmpfiles()
+        runners.nsswitch()
 
         r = subprocess.run(sys.argv[1:], check=False)
+
         sys.exit(r.returncode)

--- a/runners/org.osbuild.fedora38
+++ b/runners/org.osbuild.fedora38
@@ -1,60 +1,18 @@
 #!/usr/bin/python3
 
-import os
-import shutil
 import subprocess
 import sys
 
-import osbuild.api
-
-
-def ldconfig():
-    # ld.so.conf must exist, or `ldconfig` throws a warning
-    subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
-    subprocess.run(["ldconfig"], check=True)
-
-
-def sysusers():
-    try:
-        subprocess.run(["systemd-sysusers"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
-    except subprocess.CalledProcessError as error:
-        sys.stderr.write(error.stdout)
-        sys.exit(1)
-
-
-def tmpfiles():
-    # Allow systemd-tmpfiles to return non-0. Some packages want to create
-    # directories owned by users that are not set up with systemd-sysusers.
-    subprocess.run(["systemd-tmpfiles", "--create"], check=False)
-
-
-def nsswitch():
-    # the default behavior is fine, but using nss-resolve does not
-    # necessarily work in a non-booted container, so make sure that
-    # is not configured.
-    try:
-        os.remove("/etc/nsswitch.conf")
-    except FileNotFoundError:
-        pass
-
-
-def sequoia():
-    # This provides a default set of crypto-policies which is important for
-    # re-enabling SHA1 support with rpm (so we can cross-build CentOS-Stream-9
-    # images).
-    os.makedirs("/etc/crypto-policies", exist_ok=True)
-    shutil.copytree(
-        "/usr/share/crypto-policies/back-ends/DEFAULT", "/etc/crypto-policies/back-ends"
-    )
-
+from osbuild import api
+from osbuild.util import runners
 
 if __name__ == "__main__":
-    with osbuild.api.exception_handler():
-        ldconfig()
-        sysusers()
-        tmpfiles()
-        nsswitch()
-        sequoia()
+    with api.exception_handler():
+        runners.ldconfig()
+        runners.sysusers()
+        runners.tmpfiles()
+        runners.nsswitch()
+        runners.sequoia()
 
         r = subprocess.run(sys.argv[1:], check=False)
         sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel7
+++ b/runners/org.osbuild.rhel7
@@ -1,35 +1,15 @@
 #!/usr/bin/python3
 
-import os
 import subprocess
 import sys
 
-import osbuild.api
-
-
-def ldconfig():
-    # ld.so.conf must exist, or `ldconfig` throws a warning
-    with open("/etc/ld.so.conf", "w", encoding="utf8") as f:
-        # qemu-img needs `libiscsi`, which is located in /usr/lib64/iscsi
-        f.write("/usr/lib64/iscsi\n")
-        f.flush()
-    subprocess.run(["ldconfig"], check=True)
-
-
-def nsswitch():
-    # the default behavior is fine, but using nss-resolve does not
-    # necessarily work in a non-booted container, so make sure that
-    # is not configured.
-    try:
-        os.remove("/etc/nsswitch.conf")
-    except FileNotFoundError:
-        pass
-
+from osbuild import api
+from osbuild.util import runners
 
 if __name__ == "__main__":
-    with osbuild.api.exception_handler():
-        ldconfig()
-        nsswitch()
+    with api.exception_handler():
+        runners.ldconfig("/usr/lib64/iscsi")
+        runners.nsswitch()
 
         r = subprocess.run(sys.argv[1:], check=False)
         sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel81
+++ b/runners/org.osbuild.rhel81
@@ -4,37 +4,8 @@ import os
 import subprocess
 import sys
 
-import osbuild.api
-
-
-def ldconfig():
-    # ld.so.conf must exist, or `ldconfig` throws a warning
-    subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
-    subprocess.run(["ldconfig"], check=True)
-
-
-def sysusers():
-    try:
-        subprocess.run(["systemd-sysusers"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
-    except subprocess.CalledProcessError as error:
-        sys.stderr.write(error.stdout)
-        sys.exit(1)
-
-
-def tmpfiles():
-    # Allow systemd-tmpfiles to return non-0. Some packages want to create
-    # directories owned by users that are not set up with systemd-sysusers.
-    subprocess.run(["systemd-tmpfiles", "--create"], check=False)
-
-
-def nsswitch():
-    # the default behavior is fine, but using nss-resolve does not
-    # necessarily work in a non-booted container, so make sure that
-    # is not configured.
-    try:
-        os.remove("/etc/nsswitch.conf")
-    except FileNotFoundError:
-        pass
+from osbuild import api
+from osbuild.util import runners
 
 
 def os_release():
@@ -60,26 +31,14 @@ def os_release():
         f.write('BUG_REPORT_URL="https://bugzilla.redhat.com/"\n')
 
 
-def python_alternatives():
-    """/usr/bin/python3 is a symlink to /etc/alternatives/python3, which points
-    to /usr/bin/python3.6 by default. Recreate the link in /etc, so that
-    shebang lines in stages and assemblers work.
-    """
-    os.makedirs("/etc/alternatives", exist_ok=True)
-    try:
-        os.symlink("/usr/bin/python3.6", "/etc/alternatives/python3")
-    except FileExistsError:
-        pass
-
-
 if __name__ == "__main__":
-    with osbuild.api.exception_handler():
-        ldconfig()
-        sysusers()
-        tmpfiles()
-        nsswitch()
+    with api.exception_handler():
+        runners.ldconfig()
+        runners.sysusers()
+        runners.tmpfiles()
+        runners.nsswitch()
         os_release()
-        python_alternatives()
+        runners.python_alternatives()
 
         r = subprocess.run(sys.argv[1:], check=False)
         sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel82
+++ b/runners/org.osbuild.rhel82
@@ -1,83 +1,21 @@
 #!/usr/libexec/platform-python
 
-import os
-import platform
 import subprocess
 import sys
 
-import osbuild.api
-
-
-def quirks():
-    # Platform specific quirks
-    env = os.environ.copy()
-
-    if platform.machine() == "aarch64":
-        # Work around a bug in qemu-img on aarch64 that can lead to qemu-img
-        # hangs when more then one coroutine is use (which is the default)
-        # See https://bugs.launchpad.net/qemu/+bug/1805256
-        env["OSBUILD_QEMU_IMG_COROUTINES"] = "1"
-
-    return env
-
-
-def ldconfig():
-    # ld.so.conf must exist, or `ldconfig` throws a warning
-    subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
-    subprocess.run(["ldconfig"], check=True)
-
-
-def sysusers():
-    try:
-        subprocess.run(["systemd-sysusers"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
-    except subprocess.CalledProcessError as error:
-        sys.stderr.write(error.stdout)
-        sys.exit(1)
-
-
-def tmpfiles():
-    # Allow systemd-tmpfiles to return non-0. Some packages want to create
-    # directories owned by users that are not set up with systemd-sysusers.
-    subprocess.run(["systemd-tmpfiles", "--create"], check=False)
-
-
-def nsswitch():
-    # the default behavior is fine, but using nss-resolve does not
-    # necessarily work in a non-booted container, so make sure that
-    # is not configured.
-    try:
-        os.remove("/etc/nsswitch.conf")
-    except FileNotFoundError:
-        pass
-
-
-def python_alternatives():
-    """/usr/bin/python3 is a symlink to /etc/alternatives/python3, which points
-    to /usr/bin/python3.6 by default. Recreate the link in /etc, so that
-    shebang lines in stages and assemblers work.
-    """
-    os.makedirs("/etc/alternatives", exist_ok=True)
-    try:
-        os.symlink("/usr/bin/python3.6", "/etc/alternatives/python3")
-    except FileExistsError:
-        pass
-
-
-def main():
-    with osbuild.api.exception_handler():
-        ldconfig()
-        sysusers()
-        tmpfiles()
-        nsswitch()
-        python_alternatives()
-
-        env = quirks()
-
-        r = subprocess.run(sys.argv[1:],
-                           env=env,
-                           check=False)
-        sys.exit(r.returncode)
-
+from osbuild import api
+from osbuild.util import runners
 
 if __name__ == "__main__":
-    main()
+    with api.exception_handler():
+        runners.ldconfig()
+        runners.sysusers()
+        runners.tmpfiles()
+        runners.nsswitch()
+        runners.python_alternatives()
+
+        env = runners.quirks()
+
+        r = subprocess.run(sys.argv[1:], env=env, check=False)
+
+        sys.exit(r.returncode)

--- a/runners/org.osbuild.ubuntu1804
+++ b/runners/org.osbuild.ubuntu1804
@@ -1,48 +1,18 @@
 #!/usr/bin/python3
 
-import os
 import subprocess
 import sys
 
-import osbuild.api
-
-
-def ldconfig():
-    # ld.so.conf must exist, or `ldconfig` throws a warning
-    subprocess.run(["touch", "/etc/ld.so.conf"], check=True)
-    subprocess.run(["ldconfig"], check=True)
-
-
-def sysusers():
-    try:
-        subprocess.run(["systemd-sysusers"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
-    except subprocess.CalledProcessError as error:
-        sys.stderr.write(error.stdout)
-        sys.exit(1)
-
-
-def tmpfiles():
-    # Allow systemd-tmpfiles to return non-0. Some packages want to create
-    # directories owned by users that are not set up with systemd-sysusers.
-    subprocess.run(["systemd-tmpfiles", "--create"], check=False)
-
-
-def nsswitch():
-    # the default behavior is fine, but using nss-resolve does not
-    # necessarily work in a non-booted container, so make sure that
-    # is not configured.
-    try:
-        os.remove("/etc/nsswitch.conf")
-    except FileNotFoundError:
-        pass
-
+from osbuild import api
+from osbuild.util import runners
 
 if __name__ == "__main__":
-    with osbuild.api.exception_handler():
-        ldconfig()
-        sysusers()
-        tmpfiles()
-        nsswitch()
+    with api.exception_handler():
+        runners.ldconfig()
+        runners.sysusers()
+        runners.tmpfiles()
+        runners.nsswitch()
 
         r = subprocess.run(sys.argv[1:], check=False)
+
         sys.exit(r.returncode)


### PR DESCRIPTION
- Consolidate runners functions into a sigle file
- Create fake machine id within the runner to avoid `Failed to resolve specifiers in '/var/log/journal/%m': No such file or directory` errors
- Remove tmpfiles once the command has been executed by the runner
