### PR TITLE
tools: tweak `gen-stage-test-diff` to fix defaults for max-size and allow running from a git checkout

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -374,7 +374,7 @@ class OSBuild(contextlib.AbstractContextManager):
                 output_dir_context = tempfile.TemporaryDirectory(dir="/var/tmp")
                 output_dir = cm.enter_context(output_dir_context)
 
-            cmd_args = ["python3", "-m", "osbuild"]
+            cmd_args = [sys.executable, "-m", "osbuild"]
 
             cmd_args += ["--json"]
             cmd_args += ["--libdir", "."]

--- a/tools/gen-stage-test-diff
+++ b/tools/gen-stage-test-diff
@@ -3,12 +3,13 @@ import argparse
 import contextlib
 import os
 import subprocess
+import sys
 import tempfile
 
 
 def run_osbuild(output_directory, store, cache_max_size, libdir, manifest):
     args = [
-        "python3", "-m", "osbuild",
+        sys.executable, "-m", "osbuild",
         "--export",
         "tree",
         "--output-directory",

--- a/tools/gen-stage-test-diff
+++ b/tools/gen-stage-test-diff
@@ -8,7 +8,7 @@ import tempfile
 
 def run_osbuild(output_directory, store, cache_max_size, libdir, manifest):
     args = [
-        "osbuild",
+        "python3", "-m", "osbuild",
         "--export",
         "tree",
         "--output-directory",

--- a/tools/gen-stage-test-diff
+++ b/tools/gen-stage-test-diff
@@ -62,10 +62,10 @@ def main():
         "--store",
         type=str,
         help="Specify the osbuild store",
-        default=1024 * 1024 * 1024,
     )
     parser.add_argument(
-        "--cache-max-size", type=int, help="Specify the osbuild max cache size"
+        "--cache-max-size", type=int, help="Specify the osbuild max cache size",
+        default=1024 * 1024 * 1024,
     )
     parser.add_argument("--libdir", type=str, help="Specify the osbuild max cache size")
     parser.add_argument("stage_test", type=str, help="Specify the stage test")


### PR DESCRIPTION
While working on PR #1441 I had to run `./gen-stage-test-diff` multiple times and noticed two small issues:
1. The default for the cache-max-size seems to be on the wrong parser argument
2. Running it directly from git without having osbuild installed seems to not work

Both are fixed with this PR. For (2) it uses the same approach as in `test/test.py` to just run it as a python module.