### PR TITLE
RPM stage: link /proc/self/fd to /dev/fd

### DIFF
--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -320,6 +320,8 @@ def main(tree, inputs, options):
         os.makedirs(target, exist_ok=True)
         mount(source, target, ro=False)
 
+    os.symlink("/proc/self/fd", f"{tree}/dev/fd")
+
     machine_id_created = create_machine_id_if_needed(tree)
 
     ostree_booted = None


### PR DESCRIPTION
Link **/proc/self/fd** to **/dev/fd** within the tree to avoid **"'/dev/fd/63': No such file or directory"** errors

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
