### PR TITLE
tox: move to pylint 3.0.2 for py312 support

### DIFF
--- a/osbuild/util/rmrf.py
+++ b/osbuild/util/rmrf.py
@@ -106,4 +106,5 @@ def rmtree(path: str):
         else:
             raise e
 
-    shutil.rmtree(path, onerror=on_error)
+    # "onerror" can be replaced with "onexc" once we move to python 3.12
+    shutil.rmtree(path, onerror=on_error)  # pylint: disable=deprecated-argument

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
 
 [testenv:pylint]
 deps =
-    pylint==2.17.3
+    pylint==3.0.2
 
 commands =
     bash -c 'python -m pylint {env:LINTABLES}'


### PR DESCRIPTION
When running with python 3.12 on the host (like fc39) `make lint`
fails with some unexpected errors. This PR addresses the first
part of that:

With python 3.12 our pylint version breaks because of
https://github.com/pylint-dev/astroid/issues/2201

This is fixed in 3.0.0a6 but it seems sensible to move
to 3.0.2.


The `shutil.rmtree(onerror=...)` kwarg got deprecated with py3.12.
We still need to support older version of python all the way
back to 3.6 so just ignore this pylint error for a while.

There is still a autopep8 issue with py312 https://github.com/hhatto/autopep8/issues/712 