### PR TITLE
stages(kickstart): add `network` support to kickstart

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -45,7 +45,8 @@ SCHEMA = r"""
       },
       "ip": {
         "description": "IP address of the device",
-        "type": "string"
+        "type": "string",
+        "pattern": "^(((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}|auto)$"
       },
       "ipv6": {
         "description": "IPv6 address of the device, in the form of address[/prefix length]",
@@ -53,7 +54,8 @@ SCHEMA = r"""
       },
       "gateway": {
         "description": "Default gateway as a single IPv4 address",
-        "type": "string"
+        "type": "string",
+        "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$"
       },
       "ipv6gateway": {
         "description": "Default gateway as a single IPv6 address",
@@ -64,7 +66,8 @@ SCHEMA = r"""
         "type": "array",
         "minSize": 1,
         "items": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$"
         }
       },
       "netmask": {

--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -37,7 +37,8 @@ SCHEMA = r"""
       },
       "device": {
         "description": "Specifies the device to be configured",
-        "type": "string"
+        "type": "string",
+        "pattern": "^([a-zA-Z0-9]{2,16}|(([a-fA-F0-9]{2}:){5}[a-fA-F0-9A]{2}))$"
       },
       "onboot": {
         "description": "Whether or not to enable the device at boot time",

--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -17,6 +17,75 @@ from typing import Dict, List
 import osbuild.api
 
 SCHEMA = r"""
+"definitions": {
+  "ksboolean-from-pykickstart-ref": {
+    "enum": ["yes", "on", "true", "1", 1, "off", "no", "false", "0", 0]
+  },
+  "network-options-ref": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Configures network information for the target system and activates network devices in the installation environment",
+    "required": ["device"],
+    "properties": {
+      "activate": {
+        "description": "Activate (or reactivate) the device. When set to false prevents the device from automatically activating on boot",
+        "type": "boolean"
+      },
+      "bootproto": {
+        "description": "Boot protocol selection",
+        "enum": ["dhcp", "bootp", "ibft", "static"]
+      },
+      "device": {
+        "description": "Specifies the device to be configured",
+        "type": "string"
+      },
+      "onboot": {
+        "description": "Whether or not to enable the device at boot time",
+        "$ref": "#/definitions/ksboolean-from-pykickstart-ref"
+      },
+      "ip": {
+        "description": "IP address of the device",
+        "type": "string"
+      },
+      "ipv6": {
+        "description": "IPv6 address of the device, in the form of address[/prefix length]",
+        "type": "string"
+      },
+      "gateway": {
+        "description": "Default gateway as a single IPv4 address",
+        "type": "string"
+      },
+      "ipv6gateway": {
+        "description": "Default gateway as a single IPv6 address",
+        "type": "string"
+      },
+      "nameservers": {
+        "description": "DNS name servesr, a list of IP addresses",
+        "type": "array",
+        "minSize": 1,
+        "items": {
+          "type": "string"
+        }
+      },
+      "netmask": {
+        "description": "Network mask for the installed system",
+        "type": "string"
+      },
+      "hostname": {
+        "description": "Host name for the installed system",
+        "type": "string"
+      },
+      "essid": {
+        "description": "The network ID for wireless networks",
+        "type": "string"
+      },
+      "wpakey": {
+        "description": "The WPA encryption key for wireless networks",
+        "type": "string"
+      }
+    }
+  }
+},
 "additionalProperties": false,
 "required": ["path"],
 "properties": {
@@ -262,6 +331,13 @@ SCHEMA = r"""
         "type": "integer"
       }
     }
+  },
+  "network": {
+    "type": "array",
+    "minItems": 1,
+    "items": {
+      "$ref": "#/definitions/network-options-ref"
+    }
   }
 }
 """
@@ -382,6 +458,38 @@ def make_autopart(options: Dict) -> str:
     return cmd
 
 
+def make_network(options: Dict) -> List[str]:
+    networks = options.get("network")
+    if networks is None:
+        return []
+    res = []
+    for net in networks:
+        cmd = "network"
+        # simple string options
+        for key in [
+                "device", "bootproto", "onboot", "ip", "ipv6", "gateway",
+                "ipv6gateway", "netmask", "hostname", "essid", "wpakey",
+        ]:
+            if key not in net:
+                continue
+            val = net.get(key)
+            cmd += f" --{key}={val}"
+        # nameservers is a list
+        nameservers = net.get("nameservers")
+        if nameservers:
+            nss = " ".join([f"--nameserver={ns}" for ns in nameservers])
+            cmd += f" {nss}"
+        # activate can be true/false/unset
+        activate = net.get("activate")
+        if isinstance(activate, bool):
+            if activate:
+                cmd += " --activate"
+            else:
+                cmd += " --no-activate"
+        res += [cmd]
+    return res
+
+
 def main(tree, options):  # pylint: disable=too-many-branches
     path = options["path"].lstrip("/")
     ostree = options.get("ostree")
@@ -433,6 +541,7 @@ def main(tree, options):  # pylint: disable=too-many-branches
     reboot = make_reboot(options)
     if reboot:
         config += [reboot]
+    config += make_network(options)
 
     target = os.path.join(tree, path)
     base = os.path.dirname(target)

--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -77,7 +77,8 @@ SCHEMA = r"""
       },
       "hostname": {
         "description": "Host name for the installed system",
-        "type": "string"
+        "type": "string",
+        "pattern": "(?=^.{1,253}$)^[a-zA-Z0-9][a-zA-Z0-9-]{0,62}((\\.[a-zA-Z0-9][a-zA-Z0-9-]{0,62})+)?$"
       },
       "essid": {
         "description": "The network ID for wireless networks",

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -157,6 +157,27 @@ TEST_INPUT = [
         " --backuppassphrase --cipher=twofish-cbc --luks-version=2" +
         " --pbkdf=scrypt --pbkdf-memory=256 --pbkdf-time=512"
     ),
+    # network is always a list
+    ({"network": [{"device": "foo", "activate": False}, {"device": "bar", "bootproto": "dhcp"}]},
+     "network --device=foo --no-activate\nnetwork --device=bar --bootproto=dhcp"),
+    ({"network": [{"device": "foo", "activate": True}]}, "network --device=foo --activate"),
+    ({"network": [{"device": "foo", "activate": False}]}, "network --device=foo --no-activate"),
+    ({"network": [{"device": "foo", "bootproto": "dhcp"}]}, "network --device=foo --bootproto=dhcp"),
+    ({"network": [{"device": "foo", "onboot": "on"}]}, "network --device=foo --onboot=on"),
+    ({"network": [{"device": "foo", "ip": "10.0.0.2"}]}, "network --device=foo --ip=10.0.0.2"),
+    ({"network": [{"device": "foo", "ip": "auto"}]}, "network --device=foo --ip=auto"),
+    ({"network": [{"device": "foo", "ipv6": "3ffe:ffff:0:1::1/128"}]},
+     "network --device=foo --ipv6=3ffe:ffff:0:1::1/128"),
+    ({"network": [{"device": "foo", "ipv6": "dhcp"}]}, "network --device=foo --ipv6=dhcp"),
+    ({"network": [{"device": "foo", "gateway": "10.0.0.1"}]}, "network --device=foo --gateway=10.0.0.1"),
+    ({"network": [{"device": "foo", "ipv6gateway": "FE80::1"}]}, "network --device=foo --ipv6gateway=FE80::1"),
+    ({"network": [{"device": "foo", "nameservers": ["1.1.1.1"]}]}, "network --device=foo --nameserver=1.1.1.1"),
+    ({"network": [{"device": "foo", "nameservers": ["1.1.1.1", "8.8.8.8"]}]},
+     "network --device=foo --nameserver=1.1.1.1 --nameserver=8.8.8.8"),
+    ({"network": [{"device": "foo", "netmask": "255.255.0.0"}]}, "network --device=foo --netmask=255.255.0.0"),
+    ({"network": [{"device": "foo", "hostname": "meep"}]}, "network --device=foo --hostname=meep"),
+    ({"network": [{"device": "foo", "essid": "wlan-123"}]}, "network --device=foo --essid=wlan-123"),
+    ({"network": [{"device": "foo", "wpakey": "secret"}]}, "network --device=foo --wpakey=secret"),
 ]
 
 
@@ -240,6 +261,11 @@ def test_kickstart_valid(tmp_path, test_input, expected):  # pylint: disable=unu
         ({"autopart": {"type": "not-valid"}}, "'not-valid' is not one of ["),
         # Only one of --pbkdf-{time,iterations} can be specified at the same time
         ({"autopart": {"pbkdf-time": 1, "pbkdf-iterations": 2}}, " should not be valid under "),
+        # network is always a list
+        ({"network": {"device": "foo"}}, " is not of type 'array'"),
+        ({"network": [{"device": "foo", "activate": "string"}]}, " is not of type 'boolean'"),
+        ({"network": [{"device": "foo", "random": "option"}]}, "Additional properties are not allowed "),
+        ({"network": [{"device": "foo", "bootproto": "invalid"}]}, " is not one of ["),
     ],
 )
 def test_schema_validation_bad_apples(test_data, expected_err):

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -266,6 +266,18 @@ def test_kickstart_valid(tmp_path, test_input, expected):  # pylint: disable=unu
         ({"network": [{"device": "foo", "activate": "string"}]}, " is not of type 'boolean'"),
         ({"network": [{"device": "foo", "random": "option"}]}, "Additional properties are not allowed "),
         ({"network": [{"device": "foo", "bootproto": "invalid"}]}, " is not one of ["),
+        ({"network": [{"device": "foo", "ip": "invalid"}]}, " does not match "),
+        ({"network": [{"device": "foo", "ip": "256.1.1.1"}]}, " does not match "),
+        ({"network": [{"device": "foo", "ip": "1.256.1.1"}]}, " does not match "),
+        ({"network": [{"device": "foo", "ip": "1.1.256.1"}]}, " does not match "),
+        ({"network": [{"device": "foo", "ip": "1.1.1.256"}]}, " does not match "),
+        # kernel will accept this (and make it 127.0.0.1) but it's
+        # technically not valid. if this becomes a problem we may need to
+        # relax (or remove) the ipv4 validation regex. Also
+        # 127.256 will be accepted and overflows into "127.0.1.0".
+        ({"network": [{"device": "foo", "ip": "127.1"}]}, " does not match "),
+        ({"network": [{"device": "foo", "gateway": "invalid"}]}, " does not match "),
+        ({"network": [{"device": "foo", "nameservers": ["invalid"]}]}, " does not match "),
     ],
 )
 def test_schema_validation_bad_apples(test_data, expected_err):

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -178,6 +178,13 @@ TEST_INPUT = [
     ({"network": [{"device": "foo", "hostname": "meep"}]}, "network --device=foo --hostname=meep"),
     ({"network": [{"device": "foo", "essid": "wlan-123"}]}, "network --device=foo --essid=wlan-123"),
     ({"network": [{"device": "foo", "wpakey": "secret"}]}, "network --device=foo --wpakey=secret"),
+    # device= can be written in multiple forms, see
+    # https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#network
+    ({"network": [{"device": "1234567890123456"}]}, "network --device=1234567890123456"),
+    ({"network": [{"device": "em1"}]}, "network --device=em1"),
+    ({"network": [{"device": "01:23:45:67:89:ab"}]}, "network --device=01:23:45:67:89:ab"),
+    ({"network": [{"device": "link"}]}, "network --device=link"),
+    ({"network": [{"device": "bootif"}]}, "network --device=bootif"),
 ]
 
 
@@ -278,6 +285,18 @@ def test_kickstart_valid(tmp_path, test_input, expected):  # pylint: disable=unu
         ({"network": [{"device": "foo", "ip": "127.1"}]}, " does not match "),
         ({"network": [{"device": "foo", "gateway": "invalid"}]}, " does not match "),
         ({"network": [{"device": "foo", "nameservers": ["invalid"]}]}, " does not match "),
+        # schema says at least 2 chars (this is arbitrary)
+        ({"network": [{"device": "f"}]}, " does not match "),
+        # device name can be max 16 chars (see IFNAMSIZ in the kernel source)
+        # but otherwise are very free from, see
+        # https://elixir.bootlin.com/linux/v6.6.1/source/net/core/dev.c#L1038
+        ({"network": [{"device": "12345678901234567"}]}, " does not match "),
+        # when specificed via MAC address it 17 chars (12 chars plus 5 ":")
+        # and look like a mac address
+        ({"network": [{"device": "00:01"}]}, " does not match "),
+        ({"network": [{"device": "00:XX"}]}, " does not match "),
+        ({"network": [{"device": "foo/bar"}]}, " does not match "),
+        ({"network": [{"device": "foo?"}]}, " does not match "),
     ],
 )
 def test_schema_validation_bad_apples(test_data, expected_err):


### PR DESCRIPTION
This PR adds `network`support to the kickstart stage [0].

It is incomplete, i.e. it does not implement all options of [0]. However it is implementing all the pieces that are used in https://github.com/RedHatInsights/edge-api/blob/main/templates/templateKickstart.ks#L6 and everything that looks common.

The network options for kickstart are quite long, so I the following subset:
- bindto
- nodefroute
- nodns
- ethtool
- wepkey
- dhcpclass
- bond{opts,slaves}
- vlanid
- interfacename
- team{slaves,config}
- bridge{slave,opts}

Please let me know (especially people with deep kickstart knowledge like @bcl) if that list is sensible. It it easy enough to add more in future and also easy enough to just add them all.


[0] https://docs.fedoraproject.org/en-US/fedora/f36/install-guide/appendixes/Kickstart_Syntax_Reference/#sect-kickstart-commands-network