### PR TITLE
osbuild/util/fscache: calculate actual size of files

### DIFF
--- a/osbuild/util/fscache.py
+++ b/osbuild/util/fscache.py
@@ -288,7 +288,7 @@ class FsCache(contextlib.AbstractContextManager, os.PathLike):
         return sum(
             os.lstat(
                 os.path.join(path, f)
-            ).st_size for path, dirs, files in os.walk(
+            ).st_blocks * 512 for path, dirs, files in os.walk(
                 path_target
             ) for f in files
         )


### PR DESCRIPTION
In OSBuild we'll often be operating on sparse files. Let's make the tabulation of the size of files on disk used when determining cache size for pruning consider the actual size of the file usage on disk rather than the size the file reports to be.

This means using os.lstat().st_blocks * 512 versus os.lstat().st_size.

See https://stackoverflow.com/a/55203604