### PR TITLE
stage(kickstart): implement sudo support for `users` setting

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -11,6 +11,7 @@ commands are supported here.
 """
 
 import os
+import shlex
 import sys
 from typing import Dict, List
 
@@ -115,6 +116,17 @@ SCHEMA = r"""
           "key": {
             "description": "SSH Public Key to add to ~/.ssh/authorized_keys",
             "type": "string"
+          },
+          "sudo": {
+            "description": "Configure sudo for the given user",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "nopasswd": {
+                "description": "Allow use of sudo without a password",
+                "type": "boolean"
+              }
+            }
           }
         }
       }
@@ -324,6 +336,15 @@ def make_users(users: Dict) -> List[str]:
         key = opts.get("key")
         if key:
             res.append(f'sshkey --username {name} "{key}"')
+
+        sudo = opts.get("sudo")
+        if sudo is not None:
+            # the schema makes this unnecessary but paranoia++
+            if shlex.quote(name) != name:
+                raise ValueError(f"invalid username '{name}': requires shell quoting")
+            nopasswd = "\\tNOPASSWD:" if sudo.get("nopasswd", False) else ""
+            # not using "echo" as it's semantic depends on the shell
+            res.append(f'%post\nprintf "{name}\\tALL=(ALL){nopasswd} ALL\\n" >> /etc/sudoers.d/{name}-ks\n%end')
 
     return res
 


### PR DESCRIPTION
This commit adds support in the kickstart stage to have options like:
```json
{"users": {"foo": {"sudo": {}}}}
{"users": {"foo": {"sudo": {"nopasswd": true}}}}
```
Users with "sudo" will get added to the users that can run sudo via the `/etc/sudoers.d/{user}-ks` snippet. Kickstart does not have native support for sudo so this is implemented via a targeted `%post` script.

Opening as draft for now as I have a few questions and would like early feedback:
1. I'm not too happy with `sudo: {}` triggering the creation of the user (i.e. that the empty object is enough). However for users we already do something similar, i.e. `{"users": {"foo": {}}}` also creates a user.  What is the usual pattern here?
2. Instead of moving this into "users" this could also be a separate top-level item, e.g. `{"sudo": {"foo": {"nopasswd": true}}}`. It feels more integrated with the current approach but I did hear talk about a "org.osbuild.sudo" stage and if that is a plan we probably want to make the kickstart sudo support as similar as possible 
3. I assume we want to mirror the changes we make here into the "org.osbuild.users" stage?

[edit: adding ideas from Brian]
Alternative idea (thanks to @bcl, hope I got his suggestion correct):
```json
{
  "kickstart": {
    "post": {
      "sudo": {
        "foo": {"nopasswd": true}
      }
   }
}
```
We would not allow an empty object for this because just adding the user to the "wheel" group is sufficient to get "normal" sudo support.


