### PR TITLE
Create fake `machine-id` and cleanup before exiting

### DIFF
--- a/osbuild/util/runners.py
+++ b/osbuild/util/runners.py
@@ -62,6 +62,10 @@ def tmpfiles():
     subprocess.run(["systemd-tmpfiles", "--create"], check=False)
 
 
+def remove_tmpfiles():
+    subprocess.run(["systemd-tmpfiles", "--clean", "--remove"], check=False)
+
+
 def nsswitch():
     # the default behavior is fine, but using nss-resolve does not
     # necessarily work in a non-booted container, so make sure that
@@ -90,7 +94,8 @@ def sequoia():
     # images).
     os.makedirs("/etc/crypto-policies", exist_ok=True)
     shutil.copytree(
-        "/usr/share/crypto-policies/back-ends/DEFAULT", "/etc/crypto-policies/back-ends"
+        "/usr/share/crypto-policies/back-ends/DEFAULT",
+        "/etc/crypto-policies/back-ends"
     )
 
 

--- a/runners/org.osbuild.centos9
+++ b/runners/org.osbuild.centos9
@@ -10,9 +10,9 @@ if __name__ == "__main__":
     with api.exception_handler():
         runners.ldconfig()
         runners.sysusers()
-        runners.tmpfiles()
-        runners.nsswitch()
-
-        r = subprocess.run(sys.argv[1:], check=False)
+        with runners.create_machine_id_if_needed():
+            runners.tmpfiles()
+            runners.nsswitch()
+            r = subprocess.run(sys.argv[1:], check=False)
 
         sys.exit(r.returncode)

--- a/runners/org.osbuild.centos9
+++ b/runners/org.osbuild.centos9
@@ -14,5 +14,6 @@ if __name__ == "__main__":
             runners.tmpfiles()
             runners.nsswitch()
             r = subprocess.run(sys.argv[1:], check=False)
+            runners.remove_tmpfiles()
 
         sys.exit(r.returncode)

--- a/runners/org.osbuild.fedora30
+++ b/runners/org.osbuild.fedora30
@@ -10,9 +10,9 @@ if __name__ == "__main__":
     with api.exception_handler():
         runners.ldconfig()
         runners.sysusers()
-        runners.tmpfiles()
-        runners.nsswitch()
-
-        r = subprocess.run(sys.argv[1:], check=False)
+        with runners.create_machine_id_if_needed():
+            runners.tmpfiles()
+            runners.nsswitch()
+            r = subprocess.run(sys.argv[1:], check=False)
 
         sys.exit(r.returncode)

--- a/runners/org.osbuild.fedora30
+++ b/runners/org.osbuild.fedora30
@@ -14,5 +14,6 @@ if __name__ == "__main__":
             runners.tmpfiles()
             runners.nsswitch()
             r = subprocess.run(sys.argv[1:], check=False)
+            runners.remove_tmpfiles()
 
         sys.exit(r.returncode)

--- a/runners/org.osbuild.fedora38
+++ b/runners/org.osbuild.fedora38
@@ -10,9 +10,10 @@ if __name__ == "__main__":
     with api.exception_handler():
         runners.ldconfig()
         runners.sysusers()
-        runners.tmpfiles()
-        runners.nsswitch()
-        runners.sequoia()
+        with runners.create_machine_id_if_needed():
+            runners.tmpfiles()
+            runners.nsswitch()
+            runners.sequoia()
+            r = subprocess.run(sys.argv[1:], check=False)
 
-        r = subprocess.run(sys.argv[1:], check=False)
         sys.exit(r.returncode)

--- a/runners/org.osbuild.fedora38
+++ b/runners/org.osbuild.fedora38
@@ -15,5 +15,6 @@ if __name__ == "__main__":
             runners.nsswitch()
             runners.sequoia()
             r = subprocess.run(sys.argv[1:], check=False)
+            runners.remove_tmpfiles()
 
         sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel81
+++ b/runners/org.osbuild.rhel81
@@ -35,10 +35,11 @@ if __name__ == "__main__":
     with api.exception_handler():
         runners.ldconfig()
         runners.sysusers()
-        runners.tmpfiles()
-        runners.nsswitch()
-        os_release()
-        runners.python_alternatives()
+        with runners.create_machine_id_if_needed():
+            runners.tmpfiles()
+            runners.nsswitch()
+            os_release()
+            runners.python_alternatives()
+            r = subprocess.run(sys.argv[1:], check=False)
 
-        r = subprocess.run(sys.argv[1:], check=False)
         sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel81
+++ b/runners/org.osbuild.rhel81
@@ -41,5 +41,6 @@ if __name__ == "__main__":
             os_release()
             runners.python_alternatives()
             r = subprocess.run(sys.argv[1:], check=False)
+            runners.remove_tmpfiles()
 
         sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel82
+++ b/runners/org.osbuild.rhel82
@@ -16,5 +16,6 @@ if __name__ == "__main__":
             runners.python_alternatives()
             env = runners.quirks()
             r = subprocess.run(sys.argv[1:], env=env, check=False)
+            runners.remove_tmpfiles()
 
         sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel82
+++ b/runners/org.osbuild.rhel82
@@ -10,12 +10,11 @@ if __name__ == "__main__":
     with api.exception_handler():
         runners.ldconfig()
         runners.sysusers()
-        runners.tmpfiles()
-        runners.nsswitch()
-        runners.python_alternatives()
-
-        env = runners.quirks()
-
-        r = subprocess.run(sys.argv[1:], env=env, check=False)
+        with runners.create_machine_id_if_needed():
+            runners.tmpfiles()
+            runners.nsswitch()
+            runners.python_alternatives()
+            env = runners.quirks()
+            r = subprocess.run(sys.argv[1:], env=env, check=False)
 
         sys.exit(r.returncode)

--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -35,7 +35,6 @@ This stage will return the following metadata via the osbuild API:
 import contextlib
 import json
 import os
-import pathlib
 import subprocess
 import sys
 import tempfile
@@ -43,6 +42,7 @@ from operator import itemgetter
 
 from osbuild import api
 from osbuild.util.mnt import mount
+from osbuild.util.runners import create_machine_id_if_needed
 
 SCHEMA = """
 "additionalProperties": false,
@@ -263,21 +263,6 @@ def parse_input(inputs):
     return path, files
 
 
-def create_machine_id_if_needed(tree):
-    """Create a machine-id with a fake machine id if it does not exist"""
-    path = f"{tree}/etc/machine-id"
-    if os.path.exists(path):
-        return False
-
-    os.makedirs(f"{tree}/etc", exist_ok=True)
-    with open(path, "w", encoding="utf8") as f:
-        # create a fake machine ID to improve reproducibility
-        f.write("ffffffffffffffffffffffffffffffff\n")
-        os.fchmod(f.fileno(), 0o400)
-
-    return True
-
-
 # pylint: disable=too-many-branches
 def main(tree, inputs, options):
     pkgpath, packages = parse_input(inputs)
@@ -322,69 +307,61 @@ def main(tree, inputs, options):
 
     os.symlink("/proc/self/fd", f"{tree}/dev/fd")
 
-    machine_id_created = create_machine_id_if_needed(tree)
+    with create_machine_id_if_needed(tree, keep_empty=True):
+        ostree_booted = None
+        if options.get("ostree_booted", False):
+            os.makedirs(f"{tree}/run", exist_ok=True)
+            ostree_booted = f"{tree}/{OSTREE_BOOTED_MARKER}"
+            with open(ostree_booted, "w", encoding="utf8") as f:
+                f.write("")
 
-    ostree_booted = None
-    if options.get("ostree_booted", False):
-        os.makedirs(f"{tree}/run", exist_ok=True)
-        ostree_booted = f"{tree}/{OSTREE_BOOTED_MARKER}"
-        with open(ostree_booted, "w", encoding="utf8") as f:
-            f.write("")
+        extra_args = []
+        if options.get("exclude", {}).get("docs"):
+            extra_args += ["--excludedocs"]
 
-    extra_args = []
-    if options.get("exclude", {}).get("docs"):
-        extra_args += ["--excludedocs"]
+        # prevent dracut from running, if enabled
+        no_dracut = options.get("disable_dracut", False)
+        if no_dracut:
+            masked_files = disable_dracut(tree)
 
-    # prevent dracut from running, if enabled
-    no_dracut = options.get("disable_dracut", False)
-    if no_dracut:
-        masked_files = disable_dracut(tree)
+        langs = options.get("install_langs")
+        if langs:
+            macro = "%_install_langs " + ":".join(langs)
+            print(f"using '{macro}'")
+            extra_args += [
+                "--define", macro,
+            ]
 
-    langs = options.get("install_langs")
-    if langs:
-        macro = "%_install_langs " + ":".join(langs)
-        print(f"using '{macro}'")
-        extra_args += [
-            "--define", macro,
-        ]
+        with tempfile.NamedTemporaryFile(prefix="manifest.", mode='w') as manifest:
+            manifest.writelines(c + '\n' for c in packages)
+            manifest.flush()
+            subprocess.run([
+                "rpm",
+                "--verbose",
+                *rpm_args,
+                "--root", tree,
+                *extra_args,
+                # All digests and signatures of the rpms has been verified,
+                # default to not verifying package or header signatures when
+                # reading.
+                "--nosignature",
+                "--install", manifest.name
+            ], cwd=pkgpath, check=True)
 
-    with tempfile.NamedTemporaryFile(prefix="manifest.", mode='w') as manifest:
-        manifest.writelines(c + '\n' for c in packages)
-        manifest.flush()
-        subprocess.run([
-            "rpm",
-            "--verbose",
-            *rpm_args,
-            "--root", tree,
-            *extra_args,
-            # All digests and signatures of the rpms has been verified,
-            # default to not verifying package or header signatures when
-            # reading.
-            "--nosignature",
-            "--install", manifest.name
-        ], cwd=pkgpath, check=True)
+        for key in options.get("gpgkeys.fromtree", []):
+            path = os.path.join(tree, key.lstrip("/"))
+            subprocess.run([
+                "rpmkeys",
+                *rpm_args,
+                "--root", tree,
+                "--import", path
+            ], check=True)
+            print(f"imported gpg keys from '{key}'")
 
-    for key in options.get("gpgkeys.fromtree", []):
-        path = os.path.join(tree, key.lstrip("/"))
-        subprocess.run([
-            "rpmkeys",
-            *rpm_args,
-            "--root", tree,
-            "--import", path
-        ], check=True)
-        print(f"imported gpg keys from '{key}'")
-
-    # re-enabled dracut
-    if no_dracut:
-        enable_dracut(masked_files)
-        remove_unowned_etc_kernel(tree, rpm_args)
-
-    # remove temporary machine ID if it was created by us
-    if machine_id_created:
-        print("deleting the fake machine id")
-        machine_id_file = pathlib.Path(f"{tree}/etc/machine-id")
-        machine_id_file.unlink()
-        machine_id_file.touch(mode=0o444)
+        # re-enabled dracut
+        if no_dracut:
+            enable_dracut(masked_files)
+            remove_unowned_etc_kernel(tree, rpm_args)
 
     if ostree_booted:
         os.unlink(ostree_booted)


### PR DESCRIPTION
- runners: create fake machine id when needed
- runners: clean up temp files before exiting the runner
