### PR TITLE
enhance support for creating 4k native disk images

### DIFF
--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -82,6 +82,7 @@ class LoopbackService(devices.DeviceService):
                                   setup=self.setup_loop,
                                   offset=offset,
                                   sizelimit=sizelimit,
+                                  blocksize=self.sector_size,
                                   partscan=False,
                                   autoclear=True)
 

--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -385,7 +385,7 @@ class Loop:
         info = self._config_info(self.get_status(), offset, sizelimit, autoclear, partscan)
         fcntl.ioctl(self.fd, self.LOOP_SET_STATUS64, info)
 
-    def configure(self, fd: int, offset=None, sizelimit=None, autoclear=None, partscan=None):
+    def configure(self, fd: int, offset=None, sizelimit=None, blocksize=0, autoclear=None, partscan=None):
         """
         Configure the loopback device
         Bind and configure in a single operation a file descriptor to the
@@ -427,6 +427,8 @@ class Loop:
         sizelimit : int, optional
             The max size in bytes to make the loopback device, or None
             to leave unchanged (default is None)
+        blocksize : int, optional
+            Set the logical blocksize of the loopback device. Default is 0.
         autoclear : bool, optional
             Whether or not to enable autoclear, or None to leave unchanged
             (default is None)
@@ -437,9 +439,7 @@ class Loop:
         #  pylint: disable=attribute-defined-outside-init
         config = LoopConfig()
         config.fd = fd
-        # Previous implementation was not configuring the block size.
-        # Keep same behavior here by setting the value to 0.
-        config.block_size = 0
+        config.block_size = int(blocksize)
         config.info = self._config_info(LoopInfo(), offset, sizelimit, autoclear, partscan)
         try:
             fcntl.ioctl(self.fd, self.LOOP_CONFIGURE, config)

--- a/test/cases/ostree-images
+++ b/test/cases/ostree-images
@@ -100,6 +100,9 @@ def run_tests(args, tmpdir):
                 },
                 "metal": {
                     "artifact": "metal.raw"
+                },
+                "metal4k": {
+                    "artifact": "metal4k.raw"
                 }
             },
         }

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -567,24 +567,28 @@
                 "size": 2048,
                 "type": "21686148-6449-6E6F-744E-656564454649",
                 "bootable": true,
+                "name": "BIOS-BOOT",
                 "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
               },
               {
                 "start": 4096,
                 "size": 260096,
                 "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "name": "EFI-SYSTEM",
                 "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
               },
               {
                 "start": 264192,
                 "size": 786432,
                 "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "name": "boot",
                 "uuid": "61B2905B-DF3E-4FB3-80FA-49D1E773AA32"
               },
               {
                 "start": 1050624,
                 "size": 4194304,
                 "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "name": "root",
                 "uuid": "CA7D7CCB-63ED-4C53-861C-1742536059CC"
               }
             ]
@@ -762,24 +766,28 @@
                 "size": 256,
                 "type": "21686148-6449-6E6F-744E-656564454649",
                 "bootable": true,
+                "name": "BIOS-BOOT",
                 "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
               },
               {
                 "start": 512,
                 "size": 32512,
                 "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "name": "EFI-SYSTEM",
                 "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
               },
               {
                 "start": 33024,
                 "size": 98304,
                 "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "name": "boot",
                 "uuid": "61B2905B-DF3E-4FB3-80FA-49D1E773AA32"
               },
               {
                 "start": 131328,
                 "size": 524288,
                 "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "name": "root",
                 "uuid": "CA7D7CCB-63ED-4C53-861C-1742536059CC"
               }
             ]

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -732,6 +732,188 @@
       ]
     },
     {
+      "name": "raw-4k-image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "disk.img",
+            "size": "10737418240"
+          }
+        },
+        {
+          "type": "org.osbuild.sfdisk",
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "sector-size": 4096
+              }
+            }
+          },
+          "options": {
+            "uuid": "00000000-0000-4000-a000-000000000001",
+            "label": "gpt",
+            "partitions": [
+              {
+                "start": 256,
+                "size": 256,
+                "type": "21686148-6449-6E6F-744E-656564454649",
+                "bootable": true,
+                "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+              },
+              {
+                "start": 512,
+                "size": 32512,
+                "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+              },
+              {
+                "start": 33024,
+                "size": 98304,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "61B2905B-DF3E-4FB3-80FA-49D1E773AA32"
+              },
+              {
+                "start": 131328,
+                "size": 524288,
+                "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                "uuid": "CA7D7CCB-63ED-4C53-861C-1742536059CC"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.fat",
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 512,
+                "size": 32512,
+                "lock": true,
+                "sector-size": 4096
+              }
+            }
+          },
+          "options": {
+            "label": "EFI-SYSTEM",
+            "volid": "7B7795E7"
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.ext4",
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 33024,
+                "size": 98304,
+                "lock": true,
+                "sector-size": 4096
+              }
+            }
+          },
+          "options": {
+            "uuid": "96d15588-3596-4b3c-adca-a2ff7279ea63",
+            "label": "boot"
+          }
+        },
+        {
+          "type": "org.osbuild.mkfs.xfs",
+          "devices": {
+            "device": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 131328,
+                "size": 524288,
+                "lock": true,
+                "sector-size": 4096
+              }
+            }
+          },
+          "options": {
+            "uuid": "910678ff-f77e-4a7d-8d53-86f2ac47a823",
+            "label": "root"
+          }
+        },
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:tree"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/",
+                "to": "mount://root/"
+              }
+            ]
+          },
+          "devices": {
+            "efi": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 512,
+                "size": 32512,
+                "sector-size": 4096
+              }
+            },
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 33024,
+                "size": 98304,
+                "sector-size": 4096
+              }
+            },
+            "root": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 131328,
+                "size": 524288,
+                "sector-size": 4096
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "root",
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.ext4",
+              "source": "boot",
+              "target": "/boot"
+            },
+            {
+              "name": "efi",
+              "type": "org.osbuild.fat",
+              "source": "efi",
+              "target": "/boot/efi"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "raw-metal-image",
       "build": "name:build",
       "stages": [
@@ -770,6 +952,60 @@
                 "filename": "disk.img",
                 "start": 264192,
                 "size": 786432
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "boot",
+              "type": "org.osbuild.ext4",
+              "source": "boot",
+              "target": "/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "raw-metal4k-image",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:raw-4k-image"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/disk.img",
+                "to": "tree:///disk.img"
+              }
+            ]
+          }
+        },
+        {
+          "type": "org.osbuild.kernel-cmdline.bls-append",
+          "options": {
+            "bootpath": "mount:///",
+            "kernel_opts": [
+              "ignition.platform.id=metal"
+            ]
+          },
+          "devices": {
+            "boot": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "start": 33024,
+                "size": 98304,
+                "sector-size": 4096
               }
             }
           },
@@ -859,6 +1095,32 @@
               {
                 "from": "input://tree/disk.img",
                 "to": "tree:///metal.raw"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "metal4k",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.copy",
+          "inputs": {
+            "tree": {
+              "type": "org.osbuild.tree",
+              "origin": "org.osbuild.pipeline",
+              "references": [
+                "name:raw-metal4k-image"
+              ]
+            }
+          },
+          "options": {
+            "paths": [
+              {
+                "from": "input://tree/disk.img",
+                "to": "tree:///metal4k.raw"
               }
             ]
           }

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -6,35 +6,35 @@ mpp-vars:
   boot_size_mb: 384
   root_size_mb: 2048
   sector_size: 512
-mpp-define-image:
-  id: image
-  size:
-    mpp-format-string: "{disk_size_gb * 1024 * 1024 * 1024}"
-  table:
-    uuid: 00000000-0000-4000-a000-000000000001
-    label: gpt
-    partitions:
-      - id: BIOS-BOOT
-        type: 21686148-6449-6E6F-744E-656564454649
-        bootable: true
-        uuid: FAC7F1FB-3E8D-4137-A512-961DE09A5549
-        size:
-          mpp-format-int: "{bios_boot_size_mb * 1024 * 1024 / sector_size}"
-      - id: EFI-SYSTEM
-        type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
-        uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
-        size:
-          mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / sector_size}"
-      - id: boot
-        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
-        uuid: 61B2905B-DF3E-4FB3-80FA-49D1E773AA32
-        size:
-          mpp-format-int: "{boot_size_mb * 1024 * 1024 / sector_size}"
-      - id: root
-        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
-        uuid: CA7D7CCB-63ED-4C53-861C-1742536059CC
-        size:
-          mpp-format-int: "{root_size_mb * 1024 * 1024 / sector_size}"
+mpp-define-images:
+  - id: image
+    size:
+      mpp-format-string: "{disk_size_gb * 1024 * 1024 * 1024}"
+    table:
+      uuid: 00000000-0000-4000-a000-000000000001
+      label: gpt
+      partitions:
+        - id: BIOS-BOOT
+          type: 21686148-6449-6E6F-744E-656564454649
+          bootable: true
+          uuid: FAC7F1FB-3E8D-4137-A512-961DE09A5549
+          size:
+            mpp-format-int: "{bios_boot_size_mb * 1024 * 1024 / sector_size}"
+        - id: EFI-SYSTEM
+          type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+          uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
+          size:
+            mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / sector_size}"
+        - id: boot
+          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          uuid: 61B2905B-DF3E-4FB3-80FA-49D1E773AA32
+          size:
+            mpp-format-int: "{boot_size_mb * 1024 * 1024 / sector_size}"
+        - id: root
+          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          uuid: CA7D7CCB-63ED-4C53-861C-1742536059CC
+          size:
+            mpp-format-int: "{root_size_mb * 1024 * 1024 / sector_size}"
 pipelines:
   - mpp-import-pipelines:
       path: fedora-vars.ipp.yaml

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -6,6 +6,7 @@ mpp-vars:
   boot_size_mb: 384
   root_size_mb: 2048
   sector_size: 512
+  four_k_sector_size: 4096
 mpp-define-images:
   - id: image
     size:
@@ -35,6 +36,36 @@ mpp-define-images:
           uuid: CA7D7CCB-63ED-4C53-861C-1742536059CC
           size:
             mpp-format-int: "{root_size_mb * 1024 * 1024 / sector_size}"
+  - id: image4k
+    sector_size:
+        mpp-format-int: "{four_k_sector_size}"
+    size:
+      mpp-format-string: "{disk_size_gb * 1024 * 1024 * 1024}"
+    table:
+      uuid: 00000000-0000-4000-a000-000000000001
+      label: gpt
+      partitions:
+        - id: BIOS-BOOT
+          type: 21686148-6449-6E6F-744E-656564454649
+          bootable: true
+          uuid: FAC7F1FB-3E8D-4137-A512-961DE09A5549
+          size:
+            mpp-format-int: "{bios_boot_size_mb * 1024 * 1024 / four_k_sector_size}"
+        - id: EFI-SYSTEM
+          type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+          uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
+          size:
+            mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / four_k_sector_size}"
+        - id: boot
+          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          uuid: 61B2905B-DF3E-4FB3-80FA-49D1E773AA32
+          size:
+            mpp-format-int: "{boot_size_mb * 1024 * 1024 / four_k_sector_size}"
+        - id: root
+          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          uuid: CA7D7CCB-63ED-4C53-861C-1742536059CC
+          size:
+            mpp-format-int: "{root_size_mb * 1024 * 1024 / four_k_sector_size}"
 pipelines:
   - mpp-import-pipelines:
       path: fedora-vars.ipp.yaml
@@ -224,6 +255,127 @@ pipelines:
             number:
               mpp-format-int: '{image.layout[''boot''].index}'
             path: /grub2
+  - name: raw-4k-image
+    build: name:build
+    stages:
+      - type: org.osbuild.truncate
+        options:
+          filename: disk.img
+          size:
+            mpp-format-string: '{image4k.size}'
+      - type: org.osbuild.sfdisk
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        options:
+          mpp-format-json: '{image4k.layout}'
+      - type: org.osbuild.mkfs.fat
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].start}'
+              size:
+                mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].size}'
+              lock: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        options:
+          label: EFI-SYSTEM
+          volid: 7B7795E7
+      - type: org.osbuild.mkfs.ext4
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image4k.layout[''boot''].start}'
+              size:
+                mpp-format-int: '{image4k.layout[''boot''].size}'
+              lock: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        options:
+          uuid: 96d15588-3596-4b3c-adca-a2ff7279ea63
+          label: boot
+      - type: org.osbuild.mkfs.xfs
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image4k.layout[''root''].start}'
+              size:
+                mpp-format-int: '{image4k.layout[''root''].size}'
+              lock: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        options:
+          uuid: 910678ff-f77e-4a7d-8d53-86f2ac47a823
+          label: root
+      - type: org.osbuild.copy
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:tree
+        options:
+          paths:
+            - from: input://tree/
+              to: mount://root/
+        devices:
+          efi:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].start}'
+              size:
+                mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].size}'
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image4k.layout[''boot''].start}'
+              size:
+                mpp-format-int: '{image4k.layout[''boot''].size}'
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+          root:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image4k.layout[''root''].start}'
+              size:
+                mpp-format-int: '{image4k.layout[''root''].size}'
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: root
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: boot
+            target: /boot
+          - name: efi
+            type: org.osbuild.fat
+            source: efi
+            target: /boot/efi
   - name: raw-metal-image
     build: name:build
     stages:
@@ -252,6 +404,41 @@ pipelines:
                 mpp-format-int: '{image.layout[''boot''].start}'
               size:
                 mpp-format-int: '{image.layout[''boot''].size}'
+        mounts:
+          - name: boot
+            type: org.osbuild.ext4
+            source: boot
+            target: /
+  - name: raw-metal4k-image
+    build: name:build
+    stages:
+      - type: org.osbuild.copy
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:raw-4k-image
+        options:
+          paths:
+            - from: input://tree/disk.img
+              to: tree:///disk.img
+      - type: org.osbuild.kernel-cmdline.bls-append
+        options:
+          bootpath: mount:///
+          kernel_opts:
+            - ignition.platform.id=metal
+        devices:
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image4k.layout[''boot''].start}'
+              size:
+                mpp-format-int: '{image4k.layout[''boot''].size}'
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
         mounts:
           - name: boot
             type: org.osbuild.ext4
@@ -306,6 +493,20 @@ pipelines:
           paths:
             - from: input://tree/disk.img
               to: tree:///metal.raw
+  - name: metal4k
+    build: name:build
+    stages:
+      - type: org.osbuild.copy
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:raw-metal4k-image
+        options:
+          paths:
+            - from: input://tree/disk.img
+              to: tree:///metal4k.raw
   - name: qemu
     build: name:build
     stages:

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -15,23 +15,23 @@ mpp-define-images:
       uuid: 00000000-0000-4000-a000-000000000001
       label: gpt
       partitions:
-        - id: BIOS-BOOT
+        - name: BIOS-BOOT
           type: 21686148-6449-6E6F-744E-656564454649
           bootable: true
           uuid: FAC7F1FB-3E8D-4137-A512-961DE09A5549
           size:
             mpp-format-int: "{bios_boot_size_mb * 1024 * 1024 / sector_size}"
-        - id: EFI-SYSTEM
+        - name: EFI-SYSTEM
           type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
           uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
           size:
             mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / sector_size}"
-        - id: boot
+        - name: boot
           type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
           uuid: 61B2905B-DF3E-4FB3-80FA-49D1E773AA32
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / sector_size}"
-        - id: root
+        - name: root
           type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
           uuid: CA7D7CCB-63ED-4C53-861C-1742536059CC
           size:
@@ -45,23 +45,23 @@ mpp-define-images:
       uuid: 00000000-0000-4000-a000-000000000001
       label: gpt
       partitions:
-        - id: BIOS-BOOT
+        - name: BIOS-BOOT
           type: 21686148-6449-6E6F-744E-656564454649
           bootable: true
           uuid: FAC7F1FB-3E8D-4137-A512-961DE09A5549
           size:
             mpp-format-int: "{bios_boot_size_mb * 1024 * 1024 / four_k_sector_size}"
-        - id: EFI-SYSTEM
+        - name: EFI-SYSTEM
           type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
           uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
           size:
             mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / four_k_sector_size}"
-        - id: boot
+        - name: boot
           type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
           uuid: 61B2905B-DF3E-4FB3-80FA-49D1E773AA32
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / four_k_sector_size}"
-        - id: root
+        - name: root
           type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
           uuid: CA7D7CCB-63ED-4C53-861C-1742536059CC
           size:

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -1,30 +1,40 @@
 version: '2'
+mpp-vars:
+  disk_size_gb: 10
+  bios_boot_size_mb: 1
+  efi_system_size_mb: 127
+  boot_size_mb: 384
+  root_size_mb: 2048
+  sector_size: 512
 mpp-define-image:
   id: image
-  #10G
-  size: '10737418240'
+  size:
+    mpp-format-string: "{disk_size_gb * 1024 * 1024 * 1024}"
   table:
     uuid: 00000000-0000-4000-a000-000000000001
     label: gpt
     partitions:
       - id: BIOS-BOOT
-        size: 2048
         type: 21686148-6449-6E6F-744E-656564454649
         bootable: true
         uuid: FAC7F1FB-3E8D-4137-A512-961DE09A5549
+        size:
+          mpp-format-int: "{bios_boot_size_mb * 1024 * 1024 / sector_size}"
       - id: EFI-SYSTEM
-        size: 260096
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
+        size:
+          mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / sector_size}"
       - id: boot
-        size: 786432
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         uuid: 61B2905B-DF3E-4FB3-80FA-49D1E773AA32
+        size:
+          mpp-format-int: "{boot_size_mb * 1024 * 1024 / sector_size}"
       - id: root
-        # XXX: Dynamically set this size in the future
-        size: 4194304
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         uuid: CA7D7CCB-63ED-4C53-861C-1742536059CC
+        size:
+          mpp-format-int: "{root_size_mb * 1024 * 1024 / sector_size}"
 pipelines:
   - mpp-import-pipelines:
       path: fedora-vars.ipp.yaml

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -283,6 +283,7 @@ Example:
           "partitions": [
             {
               "id": "bios-boot",
+              "name": "BIOS-BOOT",
               "start": 2048,
               "size": 2048,
               "type": "21686148-6449-6E6F-744E-656564454649",
@@ -820,7 +821,8 @@ class Partition:
                  name: str = None,
                  uuid: str = None,
                  attrs: List[int] = None):
-        self.id = uid
+        # if no id provided, use the part-label (name) as the id
+        self.id = uid or name
         self.type = pttype
         self.start = start
         self.size = size

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -974,13 +974,19 @@ class Image:
     def from_dict(cls, js):
         size = js["size"]
         data = js["table"]
+        sector_size = js.get('sector_size', 512)
 
         with tempfile.TemporaryDirectory() as tmp:
             image = os.path.join(tmp, "disk.img")
             subprocess.run(["truncate", "--size", size, image], check=True)
-
-            table = PartitionTable.from_dict(data)
-            table.write_to(image)
+            cp = subprocess.run(["losetup", "--find", "--show", f"--sector-size={sector_size}", image],
+                                stdout=subprocess.PIPE, check=True)
+            loopimage = cp.stdout.rstrip()
+            try:
+                table = PartitionTable.from_dict(data)
+                table.write_to(loopimage)
+            finally:
+                subprocess.run(["losetup", "-d", loopimage])
 
         return cls(size, table)
 

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -263,8 +263,8 @@ Example:
 
 Defining partition layouts for disk images:
 
-It is possbile to define a partition layout via `mpp-define-image`. The defined layout
-is actually written to a temporary sparse file and read back via `sfdisk`, so that all
+It is possbile to define partition layouts via `mpp-define-images`. The defined layouts
+are actually written to a temporary sparse file and read back via `sfdisk`, so that all
 partition data like `size` and `start` include actual padding and such. The `image`
 variable will be defined with `size` and `layout` keys, the latter containing the
 partition layout data. It can be accessed via the "String expansion" explained above.
@@ -273,23 +273,28 @@ Example:
 
 ```
 ...
-    "mpp-define-image": {
-      "size": "10737418240",
-      "table": {
-      "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-      "label": "gpt",
-      "partitions": [
-        {
-          "id": "bios-boot",
-          "start": 2048,
-          "size": 2048,
-          "type": "21686148-6449-6E6F-744E-656564454649",
-          "bootable": true,
-          "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
-          "attrs": [ 60 ]
-        },
-        ...
-    }
+    "mpp-define-images": [
+      {
+        "id": "image",
+        "size": "10737418240",
+        "table": {
+          "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+          "label": "gpt",
+          "partitions": [
+            {
+              "id": "bios-boot",
+              "start": 2048,
+              "size": 2048,
+              "type": "21686148-6449-6E6F-744E-656564454649",
+              "bootable": true,
+              "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549",
+              "attrs": [ 60 ]
+            },
+            ...
+          ]
+        }
+      }
+    ]
 ...
 ```
 
@@ -1016,7 +1021,7 @@ class ManifestFile:
             raise ValueError(f"Unknown manfest version {version}")
 
         m.process_imports()
-        m.process_partition()
+        m.process_partitions()
 
         return m
 
@@ -1285,16 +1290,23 @@ class ManifestFile:
     def process_format(self):
         self._process_format(self.root)
 
-    def process_partition(self):
-        desc = self.get_mpp_node(self.root, "define-image")
+    def process_partitions(self):
+        images = self.get_mpp_node(self.root, "define-images") or []
 
-        if not desc:
+        # Backwards compat for mpp-define-image (no list)
+        image = self.get_mpp_node(self.root, "define-image")
+        if image:
+            if id not in image:
+                image['id'] = "image"
+            images.append(image)
+
+        if len(images) == 0:
             return
 
-        self._process_format(desc)
-
-        name = desc.get("id", "image")
-        self.vars[name] = Image.from_dict(desc)
+        for image in images:
+            self._process_format(image)
+            name = image["id"]
+            self.vars[name] = Image.from_dict(image)
 
     # pylint: disable=no-self-use
     def get_pipeline_name(self, node):

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -1241,6 +1241,11 @@ class ManifestFile:
             res = eval(f'f\'\'\'{format_string}\'\'\'', dict(local_vars))
 
             if res_type == "int":
+                # If the value ends with '.0' it could be because of
+                # some math that ended up converting the value to a
+                # float. Just trim it off in that case.
+                if res.endswith('.0'):
+                    res = res.strip('.0')
                 res = int(res)
             elif res_type == "json":
                 res = json.loads(res)


### PR DESCRIPTION
i.e. physical disks with logical/physical sector sizes of 4096 bytes. 

Support for this was originally discussed/added for CoreOS in:

- https://github.com/coreos/fedora-coreos-tracker/issues/385
- https://github.com/coreos/coreos-assembler/pull/1130
