### PR TITLE
osbuild. add comment why AST is used and not importlib

### DIFF
--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -429,6 +429,8 @@ class ModuleInfo:
         except FileNotFoundError:
             return None
 
+        # using AST here and not importlib because we can read/parse
+        # even if some python imports that the module may need are missing
         tree = ast.parse(data, name)
 
         docstring = ast.get_docstring(tree)


### PR DESCRIPTION
Add comment why the `ModuleInfo.load()` code uses open()/ast.parse() instead of just using `importlib`.

The reason is that while `importlib` is more convenient and much shorter it would require that all python modules of the osbuild modules are actually installed on the system just to inspect the schema/documentation of the stage.

Added this because I was originally a bit puzzled why not using importlib (which is much simpler :)