### PR TITLE
tests: remove custom tmpdir() fixtures and use tmp_path

### DIFF
--- a/test/run/test_devices.py
+++ b/test/run/test_devices.py
@@ -14,21 +14,15 @@ from osbuild import devices, host, loop, meta
 from ..test import TestBase
 
 
-@pytest.fixture(name="tmpdir")
-def tmpdir_fixture():
-    with tempfile.TemporaryDirectory(prefix="test-devices-") as tmp:
-        yield tmp
-
-
 @pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")
-def test_loopback_basic(tmpdir):
+def test_loopback_basic(tmp_path):
     index = meta.Index(os.curdir)
     info = index.get_module_info("Device", "org.osbuild.loopback")
 
-    tree = os.path.join(tmpdir, "tree")
+    tree = os.path.join(tmp_path, "tree")
     os.makedirs(tree)
 
-    devpath = os.path.join(tmpdir, "dev")
+    devpath = os.path.join(tmp_path, "dev")
     os.makedirs(devpath)
 
     size = 1024 * 1024
@@ -37,7 +31,7 @@ def test_loopback_basic(tmpdir):
         f.truncate(size)
         sb = os.fstat(f.fileno())
 
-    testfile = os.path.join(tmpdir, "test.img")
+    testfile = os.path.join(tmp_path, "test.img")
 
     options = {
         "filename": "image.img",

--- a/test/run/test_noop.py
+++ b/test/run/test_noop.py
@@ -37,12 +37,6 @@ def jsondata_fixture():
     })
 
 
-@pytest.fixture(name="tmpdir", scope="module")
-def tmpdir_fixture():
-    with tempfile.TemporaryDirectory() as tmp:
-        yield tmp
-
-
 @pytest.fixture(name="osb", scope="module")
 def osbuild_fixture():
     with test.OSBuild() as osb:
@@ -69,5 +63,5 @@ def test_noop2(osb):
 
 
 @pytest.mark.skipif(not test.TestBase.can_bind_mount(), reason="root-only")
-def test_noop_v2(osb, tmpdir, jsondata):
-    osb.compile(jsondata, output_dir=tmpdir, exports=["noop"])
+def test_noop_v2(osb, tmp_path, jsondata):
+    osb.compile(jsondata, output_dir=tmp_path, exports=["noop"])

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -114,15 +114,9 @@ def check_case(source, case, store, libdir):
             raise ValueError(f"invalid expectation: {expects}")
 
 
-@pytest.fixture(name="tmpdir")
-def tmpdir_fixture():
-    with tempfile.TemporaryDirectory() as tmp:
-        yield tmp
-
-
 @pytest.mark.skipif(not can_setup_netns(), reason="network namespace setup failed")
 @pytest.mark.parametrize("source,case", make_test_cases())
-def test_sources(source, case, tmpdir):
+def test_sources(source, case, tmp_path):
     index = osbuild.meta.Index(os.curdir)
     sources = os.path.join(test.TestBase.locate_test_data(), "sources")
 
@@ -136,7 +130,7 @@ def test_sources(source, case, tmpdir):
 
     src = osbuild.sources.Source(info, items, options)
 
-    with osbuild.objectstore.ObjectStore(tmpdir) as store, \
+    with osbuild.objectstore.ObjectStore(tmp_path) as store, \
             fileServer(test.TestBase.locate_test_data()):
         check_case(src, case_options, store, index.path)
         check_case(src, case_options, store, index.path)


### PR DESCRIPTION
This commit removes some unnecessary custom tmpdir() fixtures and uses the pytest buildin tmp_path instead.

Some custom tmpdir fixtures are left in place as they configure the tmp location to be under `/var/tmp` which is not trivial to do with pytests `tmp_path`. Not sure or not if the is a deep reason there for using /var/tmp. I assume it's to ensure that the tests run on a real FS not on a potential tmpfs but I don't have the full background so didn't want to change anything.

If someone know if there is a deep reason I will update the PR to add a comment in the relevant places :)