### PR TITLE
osbuild: fix missing initialization of fd in osbuild.loop.Loop

### DIFF
--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -120,6 +120,7 @@ class Loop:
         self.devname = f"loop{minor}"
         self.minor = minor
         self.on_close = None
+        self.fd = -1
 
         with contextlib.ExitStack() as stack:
             if not dir_fd:

--- a/test/mod/test_loop.py
+++ b/test/mod/test_loop.py
@@ -253,3 +253,8 @@ def test_on_close(tempdir):
             lo.close()
 
         ctl.close()
+
+
+def test_loop_handles_error_in_init():
+    with pytest.raises(FileNotFoundError):
+        lopo = loop.Loop("non-existing")


### PR DESCRIPTION
When osbuild.loop.Loop calls `__init__()` it assigns the `self.fd` on open. However if that open call fails for whatever reason (not found, permissions) the cleanup in `__del__` will fail in confusing ways because `self.fd` is not initialized yet. It also prevents the correct error from getting reported. A tiny test is added to ensure this does not regress.