### PR TITLE
test: stage tests -> stage integration tests

### DIFF
--- a/test/data/stages/README.md
+++ b/test/data/stages/README.md
@@ -1,6 +1,6 @@
-# Making tests for stages
+# Making integration tests for stages
 
-The stage tests are automatically run by the GitHub CI; in order to create a
+The stage integration tests are automatically run by the GitHub CI; in order to create a
 new test-bed for your new stage do the following:
 
 1. Create a folder with the name of your stage.


### PR DESCRIPTION
Quick rename to have our wording be in-line with the new differences between stage unit tests and stage integration tests; also being applied to the guides.