### PR TITLE
test: fix broken oscap remediation tests

### DIFF
--- a/test/data/stages/oscap.remediation-extra/diff.json
+++ b/test/data/stages/oscap.remediation-extra/diff.json
@@ -4,8 +4,6 @@
   ],
   "added_files": [
     "/boot/grub2/grubenv",
-    "/dev/null",
-    "/dev/shm",
     "/etc/authselect/custom/hardening",
     "/etc/authselect/custom/hardening/README",
     "/etc/authselect/custom/hardening/REQUIREMENTS",
@@ -45,7 +43,8 @@
     "/root/oscap_eval_xccdf_results.xml.xz",
     "/root/oscap_remediation.bash",
     "/root/report.html",
-    "/root/results_arf.xml.xz"
+    "/root/results_arf.xml.xz",
+    "/run/mount"
   ],
   "deleted_files": [],
   "differences": {

--- a/test/data/stages/oscap.remediation/diff.json
+++ b/test/data/stages/oscap.remediation/diff.json
@@ -5,8 +5,6 @@
   ],
   "added_files": [
     "/boot/grub2/grubenv",
-    "/dev/null",
-    "/dev/shm",
     "/etc/authselect/custom/hardening",
     "/etc/authselect/custom/hardening/dconf-db",
     "/etc/authselect/custom/hardening/dconf-locks",
@@ -35,6 +33,7 @@
     "/etc/selinux/config",
     "/etc/systemd/system/debug-shell.service",
     "/etc/systemd/system/systemd-coredump.socket",
+    "/run/mount",
     "/var/tmp/oscap_eval_xccdf_results.xml",
     "/var/tmp/oscap_remediation.bash"
   ],


### PR DESCRIPTION
The oscap remediation tests broke with 810a48d. This commit adds the fixes to get the GitHub actions to go green again.