### PR TITLE
osbuild: add "mypy-strict" check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ test-all:
 
 .PHONY: lint
 lint:
-	tox run-parallel -e ruff,pylint,autopep8,isort,mypy
+	tox run-parallel -e ruff,pylint,autopep8,isort,mypy,mypy-strict
 
 #
 # Building packages

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -10,16 +10,20 @@ import argparse
 import json
 import os
 import sys
+import typing
+from typing import List
 
 import osbuild
 import osbuild.meta
 import osbuild.monitor
+from osbuild.meta import ValidationResult
 from osbuild.objectstore import ObjectStore
+from osbuild.pipeline import Manifest
 from osbuild.util.parsing import parse_size
 from osbuild.util.term import fmt as vt
 
 
-def parse_manifest(path):
+def parse_manifest(path: str) -> dict:
     if path == "-":
         manifest = json.load(sys.stdin)
     else:
@@ -29,7 +33,7 @@ def parse_manifest(path):
     return manifest
 
 
-def show_validation(result, name):
+def show_validation(result: ValidationResult, name: str) -> None:
     if name == "-":
         name = "<stdin>"
 
@@ -47,7 +51,7 @@ def show_validation(result, name):
         print(f"  {error.message}\n")
 
 
-def export(name_or_id, output_directory, store, manifest):
+def export(name_or_id: str, output_directory: str, store: ObjectStore, manifest: Manifest) -> None:
     pipeline = manifest[name_or_id]
     obj = store.get(pipeline.id)
     dest = os.path.join(output_directory, name_or_id)
@@ -58,7 +62,8 @@ def export(name_or_id, output_directory, store, manifest):
     obj.export(dest, skip_preserve_owner=skip_preserve_owner)
 
 
-def parse_arguments(sys_argv):
+@typing.no_type_check  # see https://github.com/python/typeshed/issues/3107
+def parse_arguments(sys_argv: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="osbuild",
                                      description="Build operating system images")
 
@@ -103,7 +108,7 @@ def parse_arguments(sys_argv):
 
 
 # pylint: disable=too-many-branches,too-many-return-statements,too-many-statements
-def osbuild_cli():
+def osbuild_cli() -> int:
     args = parse_arguments(sys.argv)
     desc = parse_manifest(args.manifest_path)
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ env_list =
 labels =
     test = py{36,37,38,39,310,311}
     lint = ruff, isort, autopep8, pylint
-    type = mypy
+    type = mypy,mypy-strict
 
 [testenv]
 description = "run osbuild unit tests"
@@ -26,6 +26,7 @@ deps =
 setenv =
     LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/* stages/*.* stages/test/*.py test/ tools/
     TYPEABLES = osbuild
+    TYPEABLES_STRICT = ./osbuild/main_cli.py
 
 passenv =
     TEST_CATEGORY
@@ -71,3 +72,10 @@ deps =
 
 commands =
     bash -c 'python -m mypy {env:TYPEABLES}'
+
+[testenv:mypy-strict]
+deps =
+    mypy==1.2.0
+
+commands =
+    bash -c 'python -m mypy --follow-imports=skip --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs {env:TYPEABLES_STRICT}'


### PR DESCRIPTION
We have mypy right now which is super nice. However there are quite a few place where it's not used fully right now and where we lack type information. This PR start by adding a new `mypy-strict` tox filter that gradually builds up more and more files to be fully strict. I already see this uncovering potentially real issues in other files that should probably be addressed. But with this simple and humble start we can start addressing more and more of them.