### PR TITLE
Packit: make COPR builds for new releases in a dedicated project

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,6 +43,11 @@ jobs:
   branch: main
   owner: "@osbuild" # copr repo namespace
   project: osbuild  # copr repo name so you can consume the builds
+- <<: *copr
+  trigger: release
+  branch: main
+  owner: "@osbuild" # copr repo namespace
+  project: osbuild-stable  # copr repo name so you can consume the builds
 - job: propose_downstream
   trigger: release
   dist_git_branches:


### PR DESCRIPTION
Add a new Packit "copr_build" job, which will build new upstream releases in a dedicated COPR project "osbuild-stable". This will allow people to consume stable builds of osbuild ASAP (including some sub-packages on CS which are not part of the official distro builds).

The stable builds will end up in https://copr.fedorainfracloud.org/coprs/g/osbuild/osbuild-stable/