### PR TITLE
stages/oscap.remediation: Workaround for /proc/filesystems

### DIFF
--- a/stages/org.osbuild.oscap.remediation
+++ b/stages/org.osbuild.oscap.remediation
@@ -127,6 +127,16 @@ def main(tree, options):
     data_dir = data_dir.lstrip('/')
     os.makedirs(f"{tree}/{data_dir}", exist_ok=True)
 
+    # prepare a projection of kernel filesystems for the build tree
+    for source in ("/dev", "/proc"):
+        target = os.path.join(tree, source.lstrip("/"))
+        os.makedirs(target, exist_ok=True)
+        mount(source, target, ro=False)
+    # remediations need that for bash process substitution
+    os.symlink("/proc/self/fd", f"{tree}/dev/fd")
+    # remediations need to know available filesystem types
+    os.symlink("/proc/filesystems", f"{tree}/proc/filesystems")
+
     # build common data stream-related args list
     ds_args = ["--profile", profile_id]
     if ds_id is not None:
@@ -206,12 +216,6 @@ def main(tree, options):
         "/usr/bin/bash",
         f"{data_dir}/{REMEDIATION_SCRIPT}"
     ]
-
-    for source in ("/dev", "/proc"):
-        target = os.path.join(tree, source.lstrip("/"))
-        os.makedirs(target, exist_ok=True)
-        mount(source, target, ro=False)
-    os.symlink("/proc/self/fd", f"{tree}/dev/fd")
 
     log = None
     if verbose_log is not None:


### PR DESCRIPTION
Some of the remediations in CaC require this file for proper functioning. There is no harm in linking it from the host system.