### PR TITLE
utils.mnt: tweak/unify the {,u}mount helpers

### DIFF
--- a/osbuild/util/mnt.py
+++ b/osbuild/util/mnt.py
@@ -57,7 +57,16 @@ class MountGuard(contextlib.AbstractContextManager):
         if options:
             args += ["-o", ",".join(options)]
 
-        subprocess.run(["mount"] + args + [source, target], check=True)
+        r = subprocess.run(["mount"] + args + [source, target],
+                           stderr=subprocess.STDOUT,
+                           stdout=subprocess.PIPE,
+                           encoding="utf-8",
+                           check=False)
+        if r.returncode != 0:
+            code = r.returncode
+            msg = r.stdout.strip()
+            raise RuntimeError(f"{msg} (code: {code})")
+
         self.mounts += [{"source": source, "target": target}]
 
     def umount(self):

--- a/osbuild/util/mnt.py
+++ b/osbuild/util/mnt.py
@@ -6,16 +6,16 @@ import subprocess
 
 
 def _run_mount(source, target, args):
-    r = subprocess.run(["mount"] + args + [source, target],
+    try:
+        subprocess.run(["mount"] + args + [source, target],
                        stderr=subprocess.STDOUT,
                        stdout=subprocess.PIPE,
                        encoding="utf-8",
-                       check=False)
-
-    if r.returncode != 0:
-        code = r.returncode
-        msg = r.stdout.strip()
-        raise RuntimeError(f"{msg} (code: {code})")
+                       check=True)
+    except subprocess.CalledProcessError as e:
+        code = e.returncode
+        msg = e.stdout.strip()
+        raise RuntimeError(f"{msg} (code: {code})") from e
 
 
 def mount(source, target, bind=True, ro=True, private=True, mode="0755"):

--- a/osbuild/util/mnt.py
+++ b/osbuild/util/mnt.py
@@ -18,7 +18,7 @@ def _run_mount(source, target, args):
         raise RuntimeError(f"{msg} (code: {code})") from e
 
 
-def mount(source, target, bind=True, ro=True, private=True, mode="0755"):
+def mount(source, target, rbind=True, ro=True, rprivate=True, mode="0755"):
     options = []
     if ro:
         options += ["ro"]
@@ -26,9 +26,9 @@ def mount(source, target, bind=True, ro=True, private=True, mode="0755"):
         options += [mode]
 
     args = []
-    if bind:
+    if rbind:
         args += ["--rbind"]
-    if private:
+    if rprivate:
         args += ["--make-rprivate"]
     if options:
         args += ["-o", ",".join(options)]

--- a/test/mod/test_util_mnt.py
+++ b/test/mod/test_util_mnt.py
@@ -1,9 +1,10 @@
 import os
 import subprocess
+from unittest.mock import call, MagicMock, patch
 
 import pytest
 
-from osbuild.util.mnt import mount, MountGuard
+from osbuild.util.mnt import mount, MountGuard, umount
 
 
 @pytest.mark.skipif(os.getuid() != 0, reason="root only")
@@ -20,3 +21,47 @@ def test_mount_guard_failure_msg(tmp_path):
             mg.mount("/dev/invalid-src", tmp_path)
     assert "special device /dev/invalid-src does not exist" in str(e.value)
 
+
+@pytest.fixture(name="mock_completed_process")
+def mock_completed_process_fixture():
+    mock_completed_process = MagicMock()
+    mock_completed_process.returncode = 0
+    return mock_completed_process
+
+
+@patch("subprocess.run")
+def test_util_mnt_mount_defaults(mock_run, mock_completed_process):
+    mock_run.return_value = mock_completed_process
+
+    mount("src", "dst")
+    assert len(mock_run.call_args_list) == 1
+    assert mock_run.call_args == call(
+        ["mount", "--rbind", "--make-rprivate", "-o", "ro,0755", "src", "dst"],
+        stderr=subprocess.STDOUT, stdout=subprocess.PIPE, encoding="utf-8",
+        check=False)
+
+
+@patch("subprocess.run")
+def test_util_mnt_umount_defaults(mock_run, mock_completed_process):
+    mock_run.return_value = mock_completed_process
+
+    umount("target")
+    assert mock_run.call_args_list == [
+        call(["sync", "-f", "target"], check=True),
+        call(["umount", "-R", "target"], check=True),
+    ]
+
+
+@patch("subprocess.run")
+def test_util_mnt_mount_guard_defaults(mock_run, mock_completed_process):
+    mock_run.return_value = mock_completed_process
+
+    with MountGuard() as mg:
+        mg.mount("src", "dst")
+    assert mock_run.call_args_list == [
+        call(["mount", "--make-private", "-o", "bind,0755", "src", "dst"],
+             stderr=subprocess.STDOUT, stdout=subprocess.PIPE, encoding="utf-8",
+             check=False),
+        call(["sync", "-f", "dst"], check=True),
+        call(["umount", "dst"], check=True),
+    ]

--- a/test/mod/test_util_mnt.py
+++ b/test/mod/test_util_mnt.py
@@ -38,7 +38,7 @@ def test_util_mnt_mount_defaults(mock_run, mock_completed_process):
     assert mock_run.call_args == call(
         ["mount", "--rbind", "--make-rprivate", "-o", "ro,0755", "src", "dst"],
         stderr=subprocess.STDOUT, stdout=subprocess.PIPE, encoding="utf-8",
-        check=False)
+        check=True)
 
 
 @patch("subprocess.run")
@@ -61,7 +61,7 @@ def test_util_mnt_mount_guard_defaults(mock_run, mock_completed_process):
     assert mock_run.call_args_list == [
         call(["mount", "--make-private", "-o", "bind,0755", "src", "dst"],
              stderr=subprocess.STDOUT, stdout=subprocess.PIPE, encoding="utf-8",
-             check=False),
+             check=True),
         call(["sync", "-f", "dst"], check=True),
         call(["umount", "dst"], check=True),
     ]

--- a/test/mod/test_util_mnt.py
+++ b/test/mod/test_util_mnt.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+
+import pytest
+
+from osbuild.util.mnt import mount, MountGuard
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="root only")
+def test_mount_failure_msg(tmp_path):
+    with pytest.raises(RuntimeError) as e:
+        mount("/dev/invalid-src", tmp_path)
+    assert "special device /dev/invalid-src does not exist" in str(e.value)
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="root only")
+def test_mount_guard_failure_msg(tmp_path):
+    with pytest.raises(RuntimeError) as e:
+        with MountGuard() as mg:
+            mg.mount("/dev/invalid-src", tmp_path)
+    assert "special device /dev/invalid-src does not exist" in str(e.value)
+


### PR DESCRIPTION
The {,u}mount helpers are a bit different right now, one has an "bind" argument that uses rbind, same for private, they call mount in slightly different ways that caused issues with mount output visibility. This is a first attempt to unify them a bit more (maybe worth doing more).