### PR TITLE
osbuild: include std{out,err} in FileSystemMountService.mount() errors

### DIFF
--- a/osbuild/mounts.py
+++ b/osbuild/mounts.py
@@ -161,13 +161,20 @@ class FileSystemMountService(MountService):
         os.makedirs(mountpoint, exist_ok=True)
         self.mountpoint = mountpoint
 
-        subprocess.run(
-            ["mount"] +
-            options + [
-                "--source", source,
-                "--target", mountpoint
-            ],
-            check=True)
+        try:
+            subprocess.run(
+                ["mount"] +
+                options + [
+                    "--source", source,
+                    "--target", mountpoint
+                ],
+                stderr=subprocess.STDOUT,
+                stdout=subprocess.PIPE,
+                check=True)
+        except subprocess.CalledProcessError as e:
+            code = e.returncode
+            msg = e.stdout.strip()
+            raise RuntimeError(f"{msg} (code: {code})") from e
 
         self.check = True
         return mountpoint

--- a/test/mod/test_util_mnt.py
+++ b/test/mod/test_util_mnt.py
@@ -3,6 +3,7 @@ import subprocess
 
 import pytest
 
+from osbuild.mounts import FileSystemMountService
 from osbuild.util.mnt import mount, MountGuard
 
 
@@ -18,5 +19,30 @@ def test_mount_guard_failure_msg(tmp_path):
     with pytest.raises(RuntimeError) as e:
         with MountGuard() as mg:
             mg.mount("/dev/invalid-src", tmp_path)
+    assert "special device /dev/invalid-src does not exist" in str(e.value)
+
+
+# This needs a proper refactor so that FileSystemMountService just uses
+# a common mount helper.
+class TestFileSystemMountService(FileSystemMountService):
+    def __init__(self, args=None):
+        # override __init__ to make it testable
+        pass
+    def translate_options(self, options):
+        return options
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="root only")
+def test_osbuild_mount_failure_msg(tmp_path):
+    mnt_service = TestFileSystemMountService()
+    # yes, we have a third way of mounting things
+    with pytest.raises(RuntimeError) as e:
+        args = {
+            "source": "/dev/invalid-src",
+            "target": os.fspath(tmp_path),
+            "root": "/",
+            "options": [],
+        }
+        mnt_service.mount(args)
     assert "special device /dev/invalid-src does not exist" in str(e.value)
 


### PR DESCRIPTION
This commit adds mount output to the error raised by FileSystemMountService.mount(). This is useful when running into mount failures during osbuild runs.

The issue was discovered while debugging a mount failure for osbuild-composer PR#3820. Initially osbuild PR#1490 was meant to fix it but it turned out there is a third mount helper in the code that was originally overlooked (sorry for that!).

This is a quick (and hopefully uncontroversial) fix - I plan to address this also in https://github.com/osbuild/osbuild/pull/1491 (sorry that I overlooked this earlier).