### PR TITLE
osbuild: pytoml is deprecated, replace with toml

### DIFF
--- a/stages/test/test_containers_storage_conf.py
+++ b/stages/test/test_containers_storage_conf.py
@@ -3,7 +3,11 @@
 import os.path
 
 import pytest
-import pytoml
+
+try:
+    import toml
+except ModuleNotFoundError:
+    import pytoml as toml
 
 import osbuild.meta
 from osbuild.testutil import assert_dict_has
@@ -45,8 +49,8 @@ def test_containers_storage_conf_integration(tmp_path, test_filename, test_stora
     assert os.path.exists(confpath)
 
     conf = None
-    with open(confpath, 'rb') as f:
-        conf = pytoml.load(f)
+    with open(confpath, 'r', encoding="utf-8") as f:
+        conf = toml.load(f)
 
     assert conf is not None
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     mako
     iniparse
     pyyaml
-    pytoml
+    toml
     pykickstart
     # required by pykickstart but not pulled in automatically :/
     requests


### PR DESCRIPTION
Pytoml is no longer being maintained: https://github.com/avakar/pytoml The author suggest switching to toml.

We already use the 
```
try:
    import toml
except ModuleNotFoundError:
    import pytoml as toml
```
pattern in stages/org.osbuild.containers.storage.conf so use it in the tests too to prefer "toml" instead of pytoml.