### PR TITLE
start partition indexing at 1

### DIFF
--- a/stages/org.osbuild.grub2.inst
+++ b/stages/org.osbuild.grub2.inst
@@ -90,7 +90,7 @@ SCHEMA = r"""
         "enum": ["gpt", "dos"]
       },
       "number": {
-        "description": "The partition number, starting at zero",
+        "description": "The partition number, starting at one",
         "type": "number"
       },
       "path": {
@@ -252,7 +252,6 @@ def prefix_partition(options: Dict):
     pt_label = options["partlabel"]
     path = options["path"]
 
-    number += 1
     path = path.lstrip("/")
 
     label = grub2_partition_id(pt_label)

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -730,7 +730,7 @@
             "prefix": {
               "type": "partition",
               "partlabel": "gpt",
-              "number": 2,
+              "number": 3,
               "path": "/grub2"
             }
           }

--- a/test/data/manifests/fedora-ostree-image.json
+++ b/test/data/manifests/fedora-ostree-image.json
@@ -1448,7 +1448,7 @@
             "prefix": {
               "type": "partition",
               "partlabel": "gpt",
-              "number": 2,
+              "number": 3,
               "path": "/grub2"
             }
           }

--- a/test/data/manifests/rhel/el7-qcow2.json
+++ b/test/data/manifests/rhel/el7-qcow2.json
@@ -922,7 +922,7 @@
             "prefix": {
               "type": "partition",
               "partlabel": "gpt",
-              "number": 1,
+              "number": 2,
               "path": "/grub2"
             }
           }

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -935,7 +935,7 @@ class PartitionTable:
 
         assert len(disk_parts) == len(self.partitions)
         for i, part in enumerate(self.partitions):
-            part.index = i
+            part.index = i + 1
             part.start = disk_parts[i]["start"]
             part.size = disk_parts[i]["size"]
             part.type = disk_parts[i].get("type")


### PR DESCRIPTION
We typically think of partitions in terms of partition 1, 2, 3, etc. Let's start the index at 1 instead of 0. This also allows us to unwind the kind of confusing partition number field in the org.osbuild.grub2.inst stage where it asks for a partition number but then just adds 1 to it.

Alternatively here we could add a new `number` field to the osbuild-mpp partition table partitions that would just be index+1, but let me see how people like this first.