### PR TITLE
mounts: support mounting partitions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf install -y \
     lsof \
     make \
     packit \
+    parted \
     qemu-img \
     qemu-system-x86 \
     osbuild \

--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "global": {
     "dependencies": {
       "manifest-db": {
-        "commit": "4dda6c10c775d5810ea1aa1442d646f903dbedaf"
+        "commit": "3bb2cb6ec1c037dfc6a6dd57f65e245c0b3e79ae"
       }
     }
   },

--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -19,7 +19,9 @@ documentation for `osbuil.util.udev.UdevInhibitor`.
 
 import argparse
 import errno
+import glob
 import os
+import stat
 import sys
 from typing import Dict
 
@@ -34,6 +36,10 @@ SCHEMA = """
   "filename": {
     "type": "string",
     "description": "File to associate with the loopback device"
+  },
+  "partscan": {
+    "type": "boolean",
+    "description": "Perform partition scanning after device creation"
   },
   "start": {
     "type": "number",
@@ -71,10 +77,9 @@ class LoopbackService(devices.DeviceService):
         lock = UdevInhibitor.for_device(lo.LOOP_MAJOR, lo.minor)
         lo.on_close = lambda _l: lock.release()
 
-    def make_loop(self, fd: int, offset, sizelimit, lock):
+    def make_loop(self, fd: int, offset, sizelimit, lock, partscan):
         if not sizelimit:
-            stat = os.fstat(fd)
-            sizelimit = stat.st_size - offset
+            sizelimit = os.fstat(fd).st_size - offset
         else:
             sizelimit *= self.sector_size
 
@@ -83,7 +88,7 @@ class LoopbackService(devices.DeviceService):
                                   offset=offset,
                                   sizelimit=sizelimit,
                                   blocksize=self.sector_size,
-                                  partscan=False,
+                                  partscan=partscan,
                                   autoclear=True)
 
         return lo
@@ -94,12 +99,13 @@ class LoopbackService(devices.DeviceService):
         start = options.get("start", 0) * self.sector_size
         size = options.get("size")
         lock = options.get("lock", False)
+        partscan = options.get("partscan", False)
 
         path = os.path.join(tree, filename.lstrip("/"))
 
         self.fd = os.open(path, os.O_RDWR | os.O_CLOEXEC)
         try:
-            self.lo = self.make_loop(self.fd, start, size, lock)
+            self.lo = self.make_loop(self.fd, start, size, lock, partscan)
         except Exception as error:  # pylint: disable: broad-except
             self.close()
             raise error from None
@@ -111,6 +117,15 @@ class LoopbackService(devices.DeviceService):
             dir_fd = os.open(devpath, os.O_CLOEXEC | os.O_PATH)
             with ctx.suppress_oserror(errno.EEXIST):
                 self.lo.mknod(dir_fd)
+            # If partscan was enabled let's find any partition
+            # based devices that were added (i.e. loop0p1) and
+            # copy them into our custom /dev/ directory:
+            if partscan:
+                for device in glob.glob(os.path.join("/dev/", f"{self.lo.devname}p*")):
+                    os.mknod(os.path.basename(device),
+                             mode=(0o600 | stat.S_IFBLK),
+                             device=os.stat(device).st_rdev,
+                             dir_fd=dir_fd)
         finally:
             if dir_fd > -1:
                 os.close(dir_fd)

--- a/mounts/org.osbuild.btrfs
+++ b/mounts/org.osbuild.btrfs
@@ -21,6 +21,10 @@ SCHEMA_2 = """
   "source": {
     "type": "string"
   },
+  "partition": {
+    "description": "If the source device has partitions, the partition number, starting at one",
+    "type": "number"
+  },
   "target": {
     "type": "string"
   },

--- a/mounts/org.osbuild.ext4
+++ b/mounts/org.osbuild.ext4
@@ -21,6 +21,10 @@ SCHEMA_2 = """
   "source": {
     "type": "string"
   },
+  "partition": {
+    "description": "If the source device has partitions, the partition number, starting at one",
+    "type": "number"
+  },
   "target": {
     "type": "string"
   },

--- a/mounts/org.osbuild.fat
+++ b/mounts/org.osbuild.fat
@@ -24,6 +24,10 @@ SCHEMA_2 = """
   "target": {
     "type": "string"
   },
+  "partition": {
+    "description": "If the source device has partitions, the partition number, starting at one",
+    "type": "number"
+  },
   "options": {
     "type": "object",
     "additionalProperties": false,

--- a/mounts/org.osbuild.noop
+++ b/mounts/org.osbuild.noop
@@ -21,6 +21,9 @@ SCHEMA_2 = """
   "source": {
     "type": "string"
   },
+  "partition": {
+    "type": "number"
+  },
   "target": {
     "type": "string"
   },

--- a/mounts/org.osbuild.xfs
+++ b/mounts/org.osbuild.xfs
@@ -24,6 +24,10 @@ SCHEMA_2 = """
   "target": {
     "type": "string"
   },
+  "partition": {
+    "description": "If the source device has partitions, the partition number, starting at one",
+    "type": "number"
+  },
   "options": {
     "type": "object",
     "additionalProperties": false,

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -286,6 +286,7 @@ def load_mount(description: Dict, index: Index, stage: Stage):
         raise ValueError(f"Duplicated mount '{name}'")
 
     source = description.get("source")
+    partition = description.get("partition")
     target = description.get("target")
 
     options = description.get("options", {})
@@ -296,7 +297,7 @@ def load_mount(description: Dict, index: Index, stage: Stage):
         if not device:
             raise ValueError(f"Unknown device '{source}' for mount '{name}'")
 
-    stage.add_mount(name, info, device, target, options)
+    stage.add_mount(name, info, device, partition, target, options)
 
 
 def load_stage(description: Dict, index: Index, pipeline: Pipeline, manifest: Manifest, source_refs):

--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -84,9 +84,10 @@ def describe(manifest: Manifest, *, with_id=False) -> Dict:
 
         if mnt.device:
             desc["source"] = mnt.device.name
-
         if mnt.options:
             desc["options"] = mnt.options
+        if mnt.partition:
+            desc["partition"] = mnt.partition
         return desc
 
     def describe_mounts(mounts: Dict):

--- a/osbuild/mounts.py
+++ b/osbuild/mounts.py
@@ -23,10 +23,11 @@ class Mount:
     A single mount with its corresponding options
     """
 
-    def __init__(self, name, info, device, target, options: Dict):
+    def __init__(self, name, info, device, partition, target, options: Dict):
         self.name = name
         self.info = info
         self.device = device
+        self.partition = partition
         self.target = target
         self.options = options
         self.id = self.calc_id()
@@ -70,6 +71,11 @@ class MountManager:
         relpath = self.devices.device_relpath(mount.device)
         if relpath and os.path.exists(os.path.join('/dev', relpath)):
             source = os.path.join('/dev', relpath)
+
+        # If the user specified a partition then the filesystem to
+        # mount is actually on a partition of the disk.
+        if source and mount.partition:
+            source = f"{source}p{mount.partition}"
 
         root = os.fspath(self.root)
 

--- a/osbuild/mounts.py
+++ b/osbuild/mounts.py
@@ -37,6 +37,8 @@ class Mount:
         m.update(json.dumps(self.info.name, sort_keys=True).encode())
         if self.device:
             m.update(json.dumps(self.device.id, sort_keys=True).encode())
+        if self.partition:
+            m.update(json.dumps(self.partition, sort_keys=True).encode())
         if self.target:
             m.update(json.dumps(self.target, sort_keys=True).encode())
         m.update(json.dumps(self.options, sort_keys=True).encode())

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -111,8 +111,8 @@ class Stage:
         self.devices[name] = dev
         return dev
 
-    def add_mount(self, name, info, device, target, options):
-        mount = Mount(name, info, device, target, options)
+    def add_mount(self, name, info, device, partition, target, options):
+        mount = Mount(name, info, device, partition, target, options)
         self.mounts[name] = mount
         return mount
 

--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -82,6 +82,9 @@
         "target": {
           "type": "string"
         },
+        "partition": {
+          "type": "number"
+        },
         "options": {
           "type": "object",
           "additionalProperties": true

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -682,28 +682,11 @@
             ]
           },
           "devices": {
-            "efi": {
+            "disk": {
               "type": "org.osbuild.loopback",
               "options": {
                 "filename": "disk.img",
-                "start": 4096,
-                "size": 260096
-              }
-            },
-            "boot": {
-              "type": "org.osbuild.loopback",
-              "options": {
-                "filename": "disk.img",
-                "start": 264192,
-                "size": 786432
-              }
-            },
-            "root": {
-              "type": "org.osbuild.loopback",
-              "options": {
-                "filename": "disk.img",
-                "start": 1050624,
-                "size": 4194304
+                "partscan": true
               }
             }
           },
@@ -711,19 +694,22 @@
             {
               "name": "root",
               "type": "org.osbuild.xfs",
-              "source": "root",
+              "source": "disk",
+              "partition": 4,
               "target": "/"
             },
             {
               "name": "boot",
               "type": "org.osbuild.ext4",
-              "source": "boot",
+              "source": "disk",
+              "partition": 3,
               "target": "/boot"
             },
             {
               "name": "efi",
               "type": "org.osbuild.fat",
-              "source": "efi",
+              "source": "disk",
+              "partition": 2,
               "target": "/boot/efi"
             }
           ]
@@ -884,30 +870,11 @@
             ]
           },
           "devices": {
-            "efi": {
+            "disk": {
               "type": "org.osbuild.loopback",
               "options": {
                 "filename": "disk.img",
-                "start": 512,
-                "size": 32512,
-                "sector-size": 4096
-              }
-            },
-            "boot": {
-              "type": "org.osbuild.loopback",
-              "options": {
-                "filename": "disk.img",
-                "start": 33024,
-                "size": 98304,
-                "sector-size": 4096
-              }
-            },
-            "root": {
-              "type": "org.osbuild.loopback",
-              "options": {
-                "filename": "disk.img",
-                "start": 131328,
-                "size": 524288,
+                "partscan": true,
                 "sector-size": 4096
               }
             }
@@ -916,19 +883,22 @@
             {
               "name": "root",
               "type": "org.osbuild.xfs",
-              "source": "root",
+              "source": "disk",
+              "partition": 4,
               "target": "/"
             },
             {
               "name": "boot",
               "type": "org.osbuild.ext4",
-              "source": "boot",
+              "source": "disk",
+              "partition": 3,
               "target": "/boot"
             },
             {
               "name": "efi",
               "type": "org.osbuild.fat",
-              "source": "efi",
+              "source": "disk",
+              "partition": 2,
               "target": "/boot/efi"
             }
           ]

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -207,42 +207,29 @@ pipelines:
             - from: input://tree/
               to: mount://root/
         devices:
-          efi:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''EFI-SYSTEM''].start}'
-              size:
-                mpp-format-int: '{image.layout[''EFI-SYSTEM''].size}'
-          boot:
-            type: org.osbuild.loopback
-            options:
-              filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image.layout[''boot''].size}'
-          root:
-            type: org.osbuild.loopback
-            options:
-              filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''root''].start}'
-              size:
-                mpp-format-int: '{image.layout[''root''].size}'
+              partscan: true
         mounts:
           - name: root
             type: org.osbuild.xfs
-            source: root
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''root''].partnum}'
             target: /
           - name: boot
             type: org.osbuild.ext4
-            source: boot
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''boot''].partnum}'
             target: /boot
           - name: efi
             type: org.osbuild.fat
-            source: efi
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''EFI-SYSTEM''].partnum}'
             target: /boot/efi
       - type: org.osbuild.grub2.inst
         options:
@@ -339,48 +326,31 @@ pipelines:
             - from: input://tree/
               to: mount://root/
         devices:
-          efi:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].start}'
-              size:
-                mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].size}'
-              sector-size:
-                  mpp-format-int: "{four_k_sector_size}"
-          boot:
-            type: org.osbuild.loopback
-            options:
-              filename: disk.img
-              start:
-                mpp-format-int: '{image4k.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image4k.layout[''boot''].size}'
-              sector-size:
-                  mpp-format-int: "{four_k_sector_size}"
-          root:
-            type: org.osbuild.loopback
-            options:
-              filename: disk.img
-              start:
-                mpp-format-int: '{image4k.layout[''root''].start}'
-              size:
-                mpp-format-int: '{image4k.layout[''root''].size}'
+              partscan: true
               sector-size:
                   mpp-format-int: "{four_k_sector_size}"
         mounts:
           - name: root
             type: org.osbuild.xfs
-            source: root
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''root''].partnum}'
             target: /
           - name: boot
             type: org.osbuild.ext4
-            source: boot
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''boot''].partnum}'
             target: /boot
           - name: efi
             type: org.osbuild.fat
-            source: efi
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].partnum}'
             target: /boot/efi
   - name: raw-metal-image
     build: name:build

--- a/test/mod/test_fmt_v2.py
+++ b/test/mod/test_fmt_v2.py
@@ -80,6 +80,13 @@ BASIC_PIPELINE = {
                                 "filename": "empty.img"
                             }
                         },
+                        "var": {
+                            "type": "org.osbuild.loopback",
+                            "options": {
+                                "filename": "empty.img",
+                                "partscan": True,
+                            },
+                        },
                     },
                     "mounts": [
                         {
@@ -93,6 +100,13 @@ BASIC_PIPELINE = {
                             "type": "org.osbuild.noop",
                             "source": "boot",
                             "target": "/boot",
+                        },
+                        {
+                            "name": "var",
+                            "type": "org.osbuild.noop",
+                            "source": "var",
+                            "target": "/var",
+                            "partition": 1,
                         }
                     ]
                 }

--- a/test/mod/test_mounts.py
+++ b/test/mod/test_mounts.py
@@ -1,0 +1,22 @@
+from unittest.mock import Mock
+
+import pytest
+
+from osbuild.mounts import Mount
+from osbuild.meta import ModuleInfo
+
+
+def test_mount_calc_id_is_stable():
+    info = Mock(spec=ModuleInfo)
+    info.name = "some-name"
+    device = Mock(spec=ModuleInfo)
+    device.id = "some-id"
+    partition = 1
+    target = "/"
+    opts = {"opt1": 1}
+    # make sure to update Mount.calc_id and this test when adding
+    # parameters here
+    mount1 = Mount("name", info, device, partition, target, opts)
+    assert mount1.id == "15066da9ff760a60f1d1a360de2ad584cc0c97d6f6034e3258b3275ba3da6bb2"
+    mount2 = Mount("name", info, device, partition, target, opts)
+    assert mount1.id == mount2.id

--- a/test/run/test_mount.py
+++ b/test/run/test_mount.py
@@ -107,6 +107,7 @@ def mount(mgr, devpath, tree, size, mountpoint, options):
             lpath,
             index.get_module_info("Mount", "org.osbuild.fat"),
             dev,
+            None,
             "/",
             options
         )

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -831,6 +831,7 @@ class Partition:
         self.uuid = uuid
         self.attrs = attrs
         self.index = None
+        self.partnum = None
 
     @property
     def start_in_bytes(self):
@@ -936,6 +937,7 @@ class PartitionTable:
         assert len(disk_parts) == len(self.partitions)
         for i, part in enumerate(self.partitions):
             part.index = i
+            part.partnum = i + 1
             part.start = disk_parts[i]["start"]
             part.size = disk_parts[i]["size"]
             part.type = disk_parts[i].get("type")


### PR DESCRIPTION
This allows us to map in a whole disk as a loopback device with partition
scanning rather than slicing up the disk and creating several loopback
devices.

This depends on https://github.com/osbuild/osbuild/pull/1493 merging first.

Fixes https://github.com/osbuild/osbuild/issues/1495