### PR TITLE
HMS-3235: Skopeo source storage location

### DIFF
--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -60,6 +60,10 @@ SCHEMA = """
                 "enum": ["docker", "containers-storage" ],
                 "description": "The containers transport from which to copy the container",
                 "default": "docker"
+              },
+              "storage-location": {
+                "type": "string",
+                "description": "The location of the local containers storage"
               }
             }
           }
@@ -103,13 +107,19 @@ class SkopeoSource(sources.SourceService):
         digest = image["digest"]
         tls_verify = image.get("tls-verify", True)
         transport = image.get("containers-transport", DOCKER_TRANSPORT)
+        location = image.get("storage-location", "")
 
         with tempfile.TemporaryDirectory(prefix="tmp-download-", dir=self.cache) as tmpdir:
             archive_dir = os.path.join(tmpdir, "container-archive")
             os.makedirs(archive_dir)
             os.chmod(archive_dir, 0o755)
 
-            reference = f"{imagename}@{digest}"
+            # Skopeo will read the default storage path from the
+            # /etc/containers/storage.conf unless storage-location
+            # is provided. See:
+            # https://github.com/containers/storage/blob/acbb93bb802702bc171b9987a47a9b713c280d38/types/options.go#L53
+            specifier = location if location == "" else f"[overlay@{location}]"
+            reference = f"{specifier}{imagename}@{digest}"
             source = self.get_source(transport, reference)
 
             # We use the dir format because it is the most powerful in terms of feature support and is the closest to a

--- a/sources/org.osbuild.skopeo-index
+++ b/sources/org.osbuild.skopeo-index
@@ -47,6 +47,10 @@ SCHEMA = """
                 "enum": ["docker", "containers-storage" ],
                 "description": "The containers transport from which to copy the container",
                 "default": "docker"
+              },
+              "storage-location": {
+                "type": "string",
+                "description": "The location of the local containers storage"
               }
             }
           }
@@ -87,13 +91,19 @@ class SkopeoIndexSource(sources.SourceService):
         imagename = image["name"]
         tls_verify = image.get("tls-verify", True)
         transport = image.get("containers-transport", DOCKER_TRANSPORT)
+        location = image.get("storage-location", "")
 
         with tempfile.TemporaryDirectory(prefix="tmp-download-", dir=self.cache) as tmpdir:
             archive_dir = os.path.join(tmpdir, "index")
             os.makedirs(archive_dir)
             os.chmod(archive_dir, 0o755)
 
-            reference = f"{imagename}@{digest}"
+            # Skopeo will read the default storage path from the
+            # /etc/containers/storage.conf unless storage-location
+            # is provided. See:
+            # https://github.com/containers/storage/blob/acbb93bb802702bc171b9987a47a9b713c280d38/types/options.go#L53
+            specifier = location if location == "" else f"[overlay@{location}]"
+            reference = f"{specifier}{imagename}@{digest}"
             source = self.get_source(transport, reference)
 
             destination = f"dir:{archive_dir}"


### PR DESCRIPTION
For local images copied from an image store other than the default, we need to be able to specify the `storage-location`. This commit enables this functionality.

Jira: https://issues.redhat.com/browse/HMS-3235