### PR TITLE
org.osbuild.systemd: Support masking generators

### DIFF
--- a/stages/org.osbuild.systemd
+++ b/stages/org.osbuild.systemd
@@ -24,6 +24,7 @@ the following subset of options:
     - 'Environment' option
 """
 
+import os
 import subprocess
 import sys
 
@@ -47,6 +48,11 @@ SCHEMA = r"""
     "items": { "type": "string" },
     "description": "Array of systemd unit names to be masked"
   },
+  "masked_generators": {
+    "type": "array",
+    "items": { "type": "string" },
+    "description": "Array of systemd generators to be masked"
+  },
   "default_target": {
     "type": "string",
     "description": "The default target to boot into"
@@ -59,6 +65,7 @@ def main(tree, options):
     enabled_services = options.get("enabled_services", [])
     disabled_services = options.get("disabled_services", [])
     masked_services = options.get("masked_services", [])
+    masked_generators = options.get("masked_generators", [])
     default_target = options.get("default_target")
 
     for service in enabled_services:
@@ -69,6 +76,14 @@ def main(tree, options):
 
     for service in masked_services:
         subprocess.run(["systemctl", "--root", tree, "mask", service], check=True)
+
+    if masked_generators:
+        # systemctl can't mask generators, so manually create the mask
+        generator_dir = f"{tree}/etc/systemd/system-generators"
+        os.makedirs(generator_dir, exist_ok=True)
+        for generator in masked_generators:
+            target = os.path.join(generator_dir, generator)
+            os.symlink("/dev/null", target)
 
     if default_target:
         subprocess.run(["systemctl", "--root", tree, "set-default", default_target], check=True)

--- a/stages/test/test_systemd.py
+++ b/stages/test/test_systemd.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+
+import os
+import os.path
+
+from osbuild.testutil.imports import import_module_from_path
+
+
+def test_systemd_masked_generators(tmp_path):
+    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.systemd")
+    stage = import_module_from_path("stage", stage_path)
+
+    options = {"masked_generators": ["fake-generator"]}
+
+    stage.main(tmp_path, options)
+
+    masked_generator_path = os.path.join(tmp_path, "etc/systemd/system-generators/fake-generator")
+    assert os.path.lexists(masked_generator_path)
+    assert os.readlink(masked_generator_path) == "/dev/null"

--- a/test/data/stages/systemd/b.json
+++ b/test/data/stages/systemd/b.json
@@ -649,6 +649,9 @@
             "masked_services": [
               "ldconfig"
             ],
+            "masked_generators": [
+              "systemd-sysv-generator"
+            ],
             "disabled_services": [
               "sshd"
             ]

--- a/test/data/stages/systemd/b.mpp.yaml
+++ b/test/data/stages/systemd/b.mpp.yaml
@@ -35,5 +35,7 @@ pipelines:
             - nftables
           masked_services:
             - ldconfig
+          masked_generators:
+            - systemd-sysv-generator
           disabled_services:
             - sshd

--- a/test/data/stages/systemd/diff.json
+++ b/test/data/stages/systemd/diff.json
@@ -1,7 +1,9 @@
 {
   "added_files": [
     "/etc/systemd/system/ldconfig.service",
-    "/etc/systemd/system/multi-user.target.wants/nftables.service"
+    "/etc/systemd/system/multi-user.target.wants/nftables.service",
+    "/etc/systemd/system-generators",
+    "/etc/systemd/system-generators/systemd-sysv-generator"
   ],
   "deleted_files": [
     "/etc/systemd/system/multi-user.target.wants/sshd.service"


### PR DESCRIPTION
This adds a new key masked_generators, similar to masked_services, which masks systemd generators from running at boot, by creating symlinks to /dev/null in /etc/systemd/systemd-generators, as described in:
 https://www.freedesktop.org/software/systemd/man/latest/systemd.generator.html#Description

This will be useful for the automotive project, as it allows disabling of unsupported things like sysv or rc.local legacy support, while improving boot performance.