### PR TITLE
Add glob support to org.osbuild.copy from path

### DIFF
--- a/stages/org.osbuild.copy
+++ b/stages/org.osbuild.copy
@@ -19,6 +19,7 @@ with a file, you need to set the `remove_destination` option to
 symlinks to directories.
 """
 
+import glob
 import os
 import subprocess
 import sys
@@ -137,7 +138,10 @@ def main(args, options):
     items = options["paths"]
 
     for path in items:
-        src = parse_location(path["from"], args)
+        configured_src = parse_location(path["from"], args)
+        expanded_src = glob.glob(configured_src)
+        assert len(expanded_src) == 1
+        src = expanded_src[0]
         dst = parse_location(path["to"], args)
         remove_destination = path.get("remove_destination", False)
 


### PR DESCRIPTION
This expand glob pattern for the from path in
the org.osbuild.copy stage but asserts that it's
only one file.

This can be useful when you want to copy for example the kernel in /boot/vmlinuz-5.14.42-33 but don't want to hardcode the version number and instead put
/boot/vmlinuz-* in the from path.