### PR TITLE
stages: add new `org.osbuild.container-deploy` stage

### DIFF
--- a/osbuild/testutil/__init__.py
+++ b/osbuild/testutil/__init__.py
@@ -2,6 +2,7 @@
 Test related utilities
 """
 import os
+import pathlib
 import shutil
 
 
@@ -16,7 +17,7 @@ def assert_dict_has(v, keys, expected_value):
     assert v == expected_value
 
 
-def make_fake_tree(basedir, fake_content: dict):
+def make_fake_tree(basedir: pathlib.Path, fake_content: dict):
     """Create a directory tree of files with content.
 
     Call it with:
@@ -31,7 +32,7 @@ def make_fake_tree(basedir, fake_content: dict):
             fp.write(content)
 
 
-def make_fake_input_tree(tmpdir, fake_content: dict) -> str:
+def make_fake_input_tree(tmpdir: pathlib.Path, fake_content: dict) -> str:
     """
     Wrapper around make_fake_tree for "input trees"
     """

--- a/osbuild/testutil/__init__.py
+++ b/osbuild/testutil/__init__.py
@@ -16,7 +16,7 @@ def assert_dict_has(v, keys, expected_value):
     assert v == expected_value
 
 
-def make_fake_input_tree(tmpdir, fake_content: dict) -> str:
+def make_fake_tree(basedir, fake_content: dict):
     """Create a directory tree of files with content.
 
     Call it with:
@@ -24,10 +24,17 @@ def make_fake_input_tree(tmpdir, fake_content: dict) -> str:
 
     filename paths will have their parents created as needed, under tmpdir.
     """
-    basedir = os.path.join(tmpdir, "tree")
     for path, content in fake_content.items():
         dirp, name = os.path.split(os.path.join(basedir, path.lstrip("/")))
         os.makedirs(dirp, exist_ok=True)
         with open(os.path.join(dirp, name), "w", encoding="utf-8") as fp:
             fp.write(content)
-    return basedir
+
+
+def make_fake_input_tree(tmpdir, fake_content: dict) -> str:
+    """
+    Wrapper around make_fake_tree for "input trees"
+    """
+    basedir = tmpdir / "tree"
+    make_fake_tree(basedir, fake_content)
+    return os.fspath(basedir)

--- a/stages/org.osbuild.container-deploy
+++ b/stages/org.osbuild.container-deploy
@@ -2,12 +2,13 @@
 """
 Deploy a container.
 
-Buildhost commands used: podman
+Buildhost commands used: podman skopeo
 """
 import contextlib
+import random
+import string
 import subprocess
 import sys
-import tempfile
 
 import osbuild.api
 from osbuild.util import containers
@@ -31,20 +32,19 @@ SCHEMA_2 = r"""
 
 
 @contextlib.contextmanager
-def mount_container(store, image):
+def mount_container(image_tag):
     try:
         result = subprocess.run(
-            ["podman", "--imagestore", store, "image", "mount", image],
+            ["podman", "image", "mount", image_tag],
             capture_output=True,
             encoding="utf-8",
             check=True,
         )
-
         yield result.stdout.strip()
 
     finally:
         subprocess.run(
-            ["podman", "--imagestore", store, "image", "umount", image],
+            ["podman", "image", "umount", image_tag],
             check=True,
         )
 
@@ -54,13 +54,20 @@ def main(inputs, output):
     assert len(images) == 1
     image = list(images.values())[0]
 
-    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp_storage:
+    # We cannot use a tmpdir as storage here because of
+    # https://github.com/containers/storage/issues/1779 so instead
+    # just pick a random suffix. This runs inside bwrap which gives a
+    # tmp /var so it does not really matter much.
+    image_tag = "tmp-container-deploy-" + "".join(random.choices(string.digits, k=14))
+    with contextlib.ExitStack() as cm:
+        cm.callback(subprocess.run, ["podman", "rmi", image_tag], check=True)
         with containers.container_source(image) as (_, source):
             subprocess.run(
-                ["skopeo", "copy", source, f"containers-storage:[overlay@{tmp_storage}]image"],
+                ["skopeo", "copy", source,
+                 f"containers-storage:{image_tag}"],
                 check=True,
             )
-        with mount_container(tmp_storage, "image") as img:
+        with mount_container(image_tag) as img:
             subprocess.run(["cp", "-a", f"{img}/.", f"{output}/"], check=True)
 
 

--- a/stages/org.osbuild.container-deploy
+++ b/stages/org.osbuild.container-deploy
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+"""
+Deploy a container.
+
+Buildhost commands used: podman
+"""
+import contextlib
+import subprocess
+import sys
+import tempfile
+
+import osbuild.api
+from osbuild.util import containers
+
+SCHEMA_2 = r"""
+"inputs": {
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["images"],
+  "properties": {
+    "images": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+},
+"options": {
+  "additionalProperties": false
+}
+"""
+
+
+@contextlib.contextmanager
+def mount_container(store, image):
+    try:
+        result = subprocess.run(
+            ["podman", "--imagestore", store, "image", "mount", image],
+            capture_output=True,
+            encoding="utf-8",
+            check=True,
+        )
+
+        yield result.stdout.strip()
+
+    finally:
+        subprocess.run(
+            ["podman", "--imagestore", store, "image", "umount", image],
+            check=True,
+        )
+
+
+def main(inputs, output):
+    images = containers.parse_containers_input(inputs)
+    assert len(images) == 1
+    image = list(images.values())[0]
+
+    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+        with containers.container_source(image) as (_, source):
+            subprocess.run(
+                ["skopeo", "copy", source, f"containers-storage:[overlay@{tmp}]image"],
+                check=True,
+            )
+
+        with mount_container(tmp, "image") as img:
+            subprocess.run(["cp", "-a", f"{img}/.", f"{output}/"], check=True)
+
+
+if __name__ == "__main__":
+    args = osbuild.api.arguments()
+    r = main(args["inputs"], args["tree"])
+    sys.exit(r)

--- a/stages/org.osbuild.container-deploy
+++ b/stages/org.osbuild.container-deploy
@@ -54,14 +54,13 @@ def main(inputs, output):
     assert len(images) == 1
     image = list(images.values())[0]
 
-    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp_storage:
         with containers.container_source(image) as (_, source):
             subprocess.run(
-                ["skopeo", "copy", source, f"containers-storage:[overlay@{tmp}]image"],
+                ["skopeo", "copy", source, f"containers-storage:[overlay@{tmp_storage}]image"],
                 check=True,
             )
-
-        with mount_container(tmp, "image") as img:
+        with mount_container(tmp_storage, "image") as img:
             subprocess.run(["cp", "-a", f"{img}/.", f"{output}/"], check=True)
 
 

--- a/stages/test/test_container_deploy.py
+++ b/stages/test/test_container_deploy.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python3
+
+import os
+import os.path
+import random
+import string
+import subprocess
+
+import pytest
+
+from osbuild.testutil import has_executable, make_fake_tree
+from osbuild.testutil.imports import import_module_from_path
+
+
+def make_container(tmp_path, tag, fake_content, base="scratch"):
+    fake_container_src = tmp_path / "fake-container-src"
+    make_fake_tree(fake_container_src, fake_content)
+    fake_containerfile_path = fake_container_src / "Containerfile"
+    container_file_content = f"""
+    FROM {base}
+    COPY . .
+    """
+    fake_containerfile_path.write_text(container_file_content, encoding="utf8")
+    subprocess.check_call([
+        "podman", "build",
+        "--no-cache",
+        "-f", os.fspath(fake_containerfile_path),
+        "-t", tag,
+    ])
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="needs root")
+@pytest.mark.skipif(not has_executable("podman"), reason="no podman executable")
+def test_container_deploy_integration(tmp_path):
+    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.container-deploy")
+    stage = import_module_from_path("stage", stage_path)
+
+    # build two containers and overlay files to test for
+    # https://github.com/containers/storage/issues/1779
+    base_tag = "cont-base-" + "".join(random.choices(string.digits, k=12))
+    make_container(tmp_path, base_tag, {"file1": "file1 from base"})
+    cont_tag = "cont" + "".join(random.choices(string.digits, k=12))
+    make_container(tmp_path, cont_tag, {"file1": "file1 from final layer"}, base_tag)
+    # export for the container-deploy stage
+    fake_container_dst = tmp_path / "fake-container"
+    subprocess.check_call([
+        "podman", "save",
+        "--format=oci-archive",
+        f"--output={fake_container_dst}",
+        cont_tag,
+    ])
+    # and remove from podman
+    subprocess.check_call(["podman", "rmi", cont_tag, base_tag])
+
+    inputs = {
+        "images": {
+            # seems to be unused with fake_container_path?
+            "path": fake_container_dst,
+            "data": {
+                "archives": {
+                    fake_container_dst: {
+                        "format": "oci-archive",
+                        "name": cont_tag,
+                    },
+                },
+            },
+        },
+    }
+    output_dir = tmp_path / "output"
+
+    stage.main(inputs, output_dir)
+
+    assert output_dir.exists()
+    assert (output_dir / "file1").read_bytes() == b"file1 from final layer"

--- a/test/mod/test_testutil_fake_tree.py
+++ b/test/mod/test_testutil_fake_tree.py
@@ -3,16 +3,30 @@
 #
 import os.path
 
-from osbuild.testutil import make_fake_input_tree
+from osbuild.testutil import make_fake_input_tree, make_fake_tree
+
+TEST_INPUT_TREE = {
+    "/fake-file-one": "Some content",
+    "/second/fake-file-two": "Second content",
+}
 
 
-def test_make_fake_tree(tmp_path):  # pylint: disable=unused-argument
-    fake_input_tree = make_fake_input_tree(tmp_path, {
-        "/fake-file-one": "Some content",
-        "/second/fake-file-two": "Second content",
-    })
+def validate_test_input_tree(fake_input_tree):
     assert os.path.isdir(fake_input_tree)
     assert os.path.exists(os.path.join(fake_input_tree, "fake-file-one"))
     assert open(os.path.join(fake_input_tree, "fake-file-one"), encoding="utf8").read() == "Some content"
     assert os.path.exists(os.path.join(fake_input_tree, "second/fake-file-two"))
-    assert open(os.path.join(fake_input_tree, "second/fake-file-two"), encoding="utf").read() == "Second content"
+    assert open(os.path.join(fake_input_tree, "second/fake-file-two"), encoding="utf8").read() == "Second content"
+
+
+def test_make_fake_tree(tmp_path):
+    make_fake_tree(tmp_path, TEST_INPUT_TREE)
+    validate_test_input_tree(tmp_path)
+
+
+def test_make_fake_input_tree(tmp_path):
+    # make_fake_input_tree is a convinience wrapper around make_fake_tree
+    # for the osbuild input trees
+    fake_input_tree = make_fake_input_tree(tmp_path, TEST_INPUT_TREE)
+    assert fake_input_tree.endswith("/tree")
+    validate_test_input_tree(fake_input_tree)

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -1602,7 +1602,7 @@ class ManifestFileV2(ManifestFile):
 
     def _process_container(self, stage):
         if stage.get("type", "") not in \
-                ["org.osbuild.skopeo", "org.osbuild.ostree.deploy.container"]:
+                ["org.osbuild.skopeo", "org.osbuild.ostree.deploy.container", "org.osbuild.container-deploy"]:
             return
 
         inputs = element_enter(stage, "inputs", {})


### PR DESCRIPTION
This implements a new stage `org.osbuild.container-deploy` so that we can use containers to deploy e.g. a build-root. Kudos to @ondrejbudai. 

This is a split out of https://github.com/ondrejbudai/osbuild/commits/bootc/.