### PR TITLE
osbuild: allow to export a tree without preserving the ownership (less tests)

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -52,8 +52,10 @@ def export(name_or_id, output_directory, store, manifest):
     obj = store.get(pipeline.id)
     dest = os.path.join(output_directory, name_or_id)
 
+    skip_preserve_owner = \
+        os.getenv("OSBUILD_EXPORT_FORCE_NO_PRESERVE_OWNER") == "1"
     os.makedirs(dest, exist_ok=True)
-    obj.export(dest)
+    obj.export(dest, skip_preserve_owner=skip_preserve_owner)
 
 
 def parse_arguments(sys_argv):

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -244,18 +244,20 @@ class Object:
         if self.mode != want:
             raise ValueError(f"Wrong object mode: {self.mode}, want {want}")
 
-    def export(self, to_directory: PathLike):
+    def export(self, to_directory: PathLike, skip_preserve_owner=False):
         """Copy object into an external directory"""
-        subprocess.run(
-            [
-                "cp",
-                "--reflink=auto",
-                "-a",
-                os.fspath(self.tree) + "/.",
-                os.fspath(to_directory),
-            ],
-            check=True,
-        )
+        cp_cmd = [
+            "cp",
+            "--reflink=auto",
+            "-a",
+        ]
+        if skip_preserve_owner:
+            cp_cmd += ["--no-preserve=ownership"]
+        cp_cmd += [
+            os.fspath(self.tree) + "/.",
+            os.fspath(to_directory),
+        ]
+        subprocess.run(cp_cmd, check=True)
 
     def __fspath__(self):
         return self.tree


### PR DESCRIPTION
This commit allows to exclude preserving ownership from an object
export. This is required to fix the issue that on macOS the an
podman based workflow cannot export objects with preserving
ownerships.

Originally this was a no_preserve: Optional[List[str]] = None)
to be super flexible in what we pass to cp but then I felt like
YAGNI - if we need more we can trivially change this (internal)
API again :)

A version of https://github.com/osbuild/osbuild/pull/1511/ without the crazy^Wcontroversial parts.