### PR TITLE
github: run tests on merge queue

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 name: Checks
 
-on: [pull_request, push]
+on: [pull_request, merge_group]
 
 permissions:
   contents: read

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,6 +1,6 @@
 name: Generate
 
-on: [pull_request, push]
+on: [pull_request, push, merge_group]
 
 jobs:
   generate_documentation:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [pull_request, push]
+on: [pull_request, merge_group]
 
 jobs:
   test_suite:


### PR DESCRIPTION
LET'S USE MERGE QUEUES :tada: 

Add the `merge_group` trigger to all checks so they run on the merge queue.
Don't run checks on push to main since the tip of the merge queue will be the same.