### PR TITLE
github: run tests on push again

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 name: Checks
 
-on: [pull_request, merge_group]
+on: [pull_request, push]
 
 permissions:
   contents: read

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,6 +1,6 @@
 name: Generate
 
-on: [pull_request, push, merge_group]
+on: [pull_request, push]
 
 jobs:
   generate_documentation:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [pull_request, merge_group]
+on: [pull_request, push]
 
 jobs:
   test_suite:


### PR DESCRIPTION
We've temporarily disabled the merge queue because our tests often require retries to go all-green and this isn't possible to do on the queue, meaning that it's close to impossible to get a PR merged. Run tests on push so that they run in main when a PR is merged.

This reverts commit 63feab7d864743b69ea61255b1509a5d749b9e3a.