### PR TITLE
create org.osbuild.bootupd stage

### DIFF
--- a/stages/org.osbuild.bootupd
+++ b/stages/org.osbuild.bootupd
@@ -1,0 +1,127 @@
+#!/usr/bin/python3
+"""
+Install GRUB on both BIOS and UEFI systems,
+ensuring that your bootloader stays up-to-date.
+
+Bootupd supports updating GRUB and shim for
+UEFI firmware on x86_64 and aarch64,
+and GRUB for BIOS firmware on x86_64.
+The project is deployed in Fedora CoreOS and derivatives
+"""
+
+import os
+import subprocess
+import sys
+
+import osbuild.api
+from osbuild.util import ostree
+
+SCHEMA_2 = r"""
+"devices": {
+  "type": "object",
+  "additionalProperties": true
+},
+"mounts": {
+  "type": "array"
+},
+"options": {
+  "additionalProperties": false,
+  "properties": {
+    "deployment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["osname", "ref"],
+      "properties": {
+        "osname": {
+          "description": "Name of the stateroot to be used in the deployment",
+          "type": "string"
+        },
+        "ref": {
+          "description": "OStree ref to create and use for deployment",
+          "type": "string"
+        },
+        "serial": {
+          "description": "The deployment serial (usually '0')",
+          "type": "number",
+          "default": 0
+        }
+      }
+    },
+    "static-configs": {
+      "description": "Install the grub configs defined for Fedora CoreOS",
+      "type": "boolean"
+    },
+    "bios": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": ["device"],
+      "properties": {
+        "device": {
+            "description": "Name of stage device to install GRUB for BIOS-based systems.",
+            "type": "string"
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def main(args, options):
+    deployment = options.get("deployment", None)
+    static_configs = options.get("static-configs", False)
+    bios = options.get("bios", {})
+    device = bios.get("device", "")
+
+    # Get the path where the filesystems are mounted
+    mounts = args["paths"]["mounts"]
+
+    # Get the deployment root. For non-OSTree this is simply
+    # the root location of the mount points. For OSTree systems
+    # we'll call ostree.deployment_path() helper to find it for us.
+    root = mounts
+    if deployment:
+        osname = deployment["osname"]
+        ref = deployment["ref"]
+        serial = deployment.get("serial", 0)
+        root = ostree.deployment_path(mounts, osname, ref, serial)
+
+    bootupd_args = []
+    if device:
+        # The value passed by the user is the name of the device
+        # as specified in the devices array (also passed in by the
+        # user). Let's map that name to the actual loopback device
+        # that now backs it.
+        target = args["devices"][device]["path"]
+        bootupd_args.append(f"--device={target}")
+    if static_configs:
+        bootupd_args.append("--with-static-configs")
+
+    # We want to run the bootupctl command from the target (i.e. we
+    # want to make sure the version used matches the target and not
+    # risk any inconsistencies with the build root). Let's set up
+    # and chroot to run the bootupctl command from the target.
+    submounts = ['dev', 'proc', 'sys', 'run', 'var', 'tmp']
+    for mnt in submounts:
+        subprocess.run(['mount', '--rbind',
+                       os.path.join("/", mnt),
+                       os.path.join(root, mnt)],
+                       check=True)
+    try:
+        cmd = ['chroot', root, '/usr/bin/bootupctl', 'backend', 'install']
+        cmd.extend(bootupd_args)
+        cmd.append(mounts)
+        subprocess.run(cmd, check=True)
+    finally:
+        for mnt in submounts:
+            subprocess.run(['umount', '--recursive',
+                           os.path.join(root, mnt)],
+                           check=False)
+
+    return 0
+
+
+if __name__ == '__main__':
+    _args = osbuild.api.arguments()
+    r = main(_args, _args["options"])
+    sys.exit(r)

--- a/stages/org.osbuild.bootupd
+++ b/stages/org.osbuild.bootupd
@@ -10,6 +10,7 @@ The project is deployed in Fedora CoreOS and derivatives
 """
 
 import contextlib
+import json
 import os
 import subprocess
 import sys
@@ -60,6 +61,10 @@ SCHEMA_2 = r"""
         "device": {
             "description": "Name of stage device to install GRUB for BIOS-based systems.",
             "type": "string"
+        },
+        "partition": {
+            "description": "The partition on the stage device to install to, if installing to a partition",
+            "type": "number"
         }
       }
     }
@@ -86,6 +91,7 @@ def main(args, options):
     static_configs = options.get("static-configs", False)
     bios = options.get("bios", {})
     device = bios.get("device", "")
+    partition = bios.get("partition", None)
 
     # Get the path where the filesystems are mounted
     mounts = args["paths"]["mounts"]
@@ -107,6 +113,19 @@ def main(args, options):
         # user). Let's map that name to the actual loopback device
         # that now backs it.
         target = args["devices"][device]["path"]
+        # If we are targeting a partition on the device rather than
+        # the whole device itself (i.e. MBR) then let's find that
+        # partition's device.
+        if partition:
+            cp = subprocess.run(["sfdisk", "--json", target],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                encoding='utf8',
+                                check=True)
+            disk_table = json.loads(cp.stdout)["partitiontable"]
+            disk_parts = disk_table["partitions"]
+            index = partition - 1  # partition index starts at 0
+            target = disk_parts[index]["node"]
         bootupd_args.append(f"--device={target}")
     if static_configs:
         bootupd_args.append("--with-static-configs")

--- a/stages/org.osbuild.bootupd
+++ b/stages/org.osbuild.bootupd
@@ -9,6 +9,7 @@ and GRUB for BIOS firmware on x86_64.
 The project is deployed in Fedora CoreOS and derivatives
 """
 
+import contextlib
 import os
 import subprocess
 import sys
@@ -67,6 +68,19 @@ SCHEMA_2 = r"""
 """
 
 
+@contextlib.contextmanager
+def bind_mounts(sources, dest_root):
+    for src in sources:
+        dst = os.path.join(dest_root, src.lstrip("/"))
+        subprocess.run(["mount", "--rbind", src, dst], check=True)
+    try:
+        yield
+    finally:
+        for src in sources:
+            dst = os.path.join(dest_root, src.lstrip("/"))
+            subprocess.run(["umount", "--recursive", dst], check=False)
+
+
 def main(args, options):
     deployment = options.get("deployment", None)
     static_configs = options.get("static-configs", False)
@@ -101,22 +115,11 @@ def main(args, options):
     # want to make sure the version used matches the target and not
     # risk any inconsistencies with the build root). Let's set up
     # and chroot to run the bootupctl command from the target.
-    submounts = ['dev', 'proc', 'sys', 'run', 'var', 'tmp']
-    for mnt in submounts:
-        subprocess.run(['mount', '--rbind',
-                       os.path.join("/", mnt),
-                       os.path.join(root, mnt)],
-                       check=True)
-    try:
+    with bind_mounts(['/dev', '/proc', '/sys', '/run', '/var', '/tmp'], root):
         cmd = ['chroot', root, '/usr/bin/bootupctl', 'backend', 'install']
         cmd.extend(bootupd_args)
         cmd.append(mounts)
         subprocess.run(cmd, check=True)
-    finally:
-        for mnt in submounts:
-            subprocess.run(['umount', '--recursive',
-                           os.path.join(root, mnt)],
-                           check=False)
 
     return 0
 

--- a/stages/org.osbuild.bootupd
+++ b/stages/org.osbuild.bootupd
@@ -76,7 +76,7 @@ def bind_mounts(sources, dest_root):
     try:
         yield
     finally:
-        for src in sources:
+        for src in reversed(sources):
             dst = os.path.join(dest_root, src.lstrip("/"))
             subprocess.run(["umount", "--recursive", dst], check=False)
 

--- a/stages/test/test_bootupd.py
+++ b/stages/test/test_bootupd.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+
+import os.path
+import subprocess
+from unittest import mock
+
+import pytest
+
+import osbuild.meta
+from osbuild.testutil import has_executable, make_fake_input_tree
+from osbuild.testutil.imports import import_module_from_path
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # bad
+    ({"deployment": "totally"}, "'totally' is not of type 'object'"),
+    ({"deployment": {"osname": "some-os"}}, "'ref' is a required property"),
+    ({"deployment": {"ref": "some-ref"}}, "'osname' is a required property"),
+    ({"deployment": {"osname": "some-os", "ref": "some-ref", "serial": "yo"}}, "'yo' is not of type 'number'"),
+    ({"random": "property"}, "Additional properties are not allowed"),
+    ({"bios": {}}, "'device' is a required property"),
+    ({"bios": "yes"}, "'yes' is not of type 'object'"),
+    # good
+    ({}, ""),
+    ({"deployment": {
+          "osname": "some-os",
+          "ref": "some-ref",
+          "serial": 1,
+      },
+      "static-configs": True,
+      "bios": {
+          "device": "/dev/sda",
+      }}, "")
+
+])
+def test_schema_validation_bootupd(test_data, expected_err):
+    name = "org.osbuild.bootupd"
+    root = os.path.join(os.path.dirname(__file__), "../..")
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
+    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), name)
+
+    test_input = {
+        "type": "org.osbuild.bootupd",
+        "options": {
+        }
+    }
+    test_input["options"].update(test_data)
+    res = schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        assert len(res.errors) == 1, [e.as_dict() for e in res.errors]
+        err_msgs = [e.as_dict()["message"] for e in res.errors]
+        assert expected_err in err_msgs[0]

--- a/stages/test/test_bootupd.py
+++ b/stages/test/test_bootupd.py
@@ -1,39 +1,42 @@
 #!/usr/bin/python3
 
 import os.path
-import subprocess
-from unittest import mock
+from unittest.mock import call, patch
 
 import pytest
 
 import osbuild.meta
-from osbuild.testutil import has_executable, make_fake_input_tree
 from osbuild.testutil.imports import import_module_from_path
 
 
 @pytest.mark.parametrize("test_data,expected_err", [
     # bad
-    ({"deployment": "totally"}, "'totally' is not of type 'object'"),
+    ({"deployment": "must-be-object"}, "'must-be-object' is not of type 'object'"),
     ({"deployment": {"osname": "some-os"}}, "'ref' is a required property"),
     ({"deployment": {"ref": "some-ref"}}, "'osname' is a required property"),
-    ({"deployment": {"osname": "some-os", "ref": "some-ref", "serial": "yo"}}, "'yo' is not of type 'number'"),
+    ({"deployment": {"osname": "some-os", "ref": "some-ref", "serial": "must-be-number"}},
+     "'must-be-number' is not of type 'number'"),
     ({"random": "property"}, "Additional properties are not allowed"),
     ({"bios": {}}, "'device' is a required property"),
-    ({"bios": "yes"}, "'yes' is not of type 'object'"),
+    ({"bios": "must-be-object"}, "'must-be-object' is not of type 'object'"),
     # good
     ({}, ""),
-    ({"deployment": {
-          "osname": "some-os",
-          "ref": "some-ref",
-          "serial": 1,
-      },
-      "static-configs": True,
-      "bios": {
-          "device": "/dev/sda",
-      }}, "")
+    ({
+        "deployment":
+        {
+            "osname": "some-os",
+            "ref": "some-ref",
+            "serial": 1,
+        },
+        "static-configs": True,
+        "bios":
+        {
+            "device": "/dev/sda",
+        },
+    }, "")
 
 ])
-def test_schema_validation_bootupd(test_data, expected_err):
+def test_bootupd_schema_validation(test_data, expected_err):
     name = "org.osbuild.bootupd"
     root = os.path.join(os.path.dirname(__file__), "../..")
     mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
@@ -54,3 +57,33 @@ def test_schema_validation_bootupd(test_data, expected_err):
         assert len(res.errors) == 1, [e.as_dict() for e in res.errors]
         err_msgs = [e.as_dict()["message"] for e in res.errors]
         assert expected_err in err_msgs[0]
+
+
+@patch("subprocess.run")
+def test_bootupd_defaults(mocked_run):
+    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.bootupd")
+    stage = import_module_from_path("bootupd_stage", stage_path)
+
+    args = {
+        "paths": {
+            "mounts": "/run/osbuild/mounts",
+        },
+    }
+    options = {}
+    stage.main(args, options)
+
+    assert mocked_run.call_args_list == [
+        call(["mount", "--rbind", "/dev", "/run/osbuild/mounts/dev"], check=True),
+        call(["mount", "--rbind", "/proc", "/run/osbuild/mounts/proc"], check=True),
+        call(["mount", "--rbind", "/sys", "/run/osbuild/mounts/sys"], check=True),
+        call(["mount", "--rbind", "/run", "/run/osbuild/mounts/run"], check=True),
+        call(["mount", "--rbind", "/var", "/run/osbuild/mounts/var"], check=True),
+        call(["mount", "--rbind", "/tmp", "/run/osbuild/mounts/tmp"], check=True),
+        call(["chroot", "/run/osbuild/mounts", "/usr/bin/bootupctl", "backend", "install", "/run/osbuild/mounts"], check=True),
+        call(["umount", "--recursive", "/run/osbuild/mounts/dev"], check=False),
+        call(["umount", "--recursive", "/run/osbuild/mounts/proc"], check=False),
+        call(["umount", "--recursive", "/run/osbuild/mounts/sys"], check=False),
+        call(["umount", "--recursive", "/run/osbuild/mounts/run"], check=False),
+        call(["umount", "--recursive", "/run/osbuild/mounts/var"], check=False),
+        call(["umount", "--recursive", "/run/osbuild/mounts/tmp"], check=False),
+    ]

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -504,8 +504,8 @@
               "type": "org.osbuild.containers",
               "origin": "org.osbuild.source",
               "references": {
-                "sha256:3bdf633fb6c027a01688aecf1d3f33bbecf8975b138c1861cb89ae20f3e3e7db": {
-                  "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/images/fedora-coreos:stable"
+                "sha256:66d1012cb68ea1ec0c38a830499feadb2c9e015162a5acb818f65afb6f25d0e5": {
+                  "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/images/fedora-coreos:testing"
                 }
               }
             }
@@ -1612,10 +1612,10 @@
     },
     "org.osbuild.skopeo": {
       "items": {
-        "sha256:3bdf633fb6c027a01688aecf1d3f33bbecf8975b138c1861cb89ae20f3e3e7db": {
+        "sha256:66d1012cb68ea1ec0c38a830499feadb2c9e015162a5acb818f65afb6f25d0e5": {
           "image": {
             "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/images/fedora-coreos",
-            "digest": "sha256:f0ebfc8bb813e45225a93e76780c44439fac11a24ba8fb83001ec96a61ebbb12"
+            "digest": "sha256:2ba8999ef74d45f39c601c20783d61a1c632636eb3e8ead9c020e29bfbbae8bf"
           }
         }
       }

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -529,25 +529,6 @@
               "ref": "ostree/1/1/0"
             }
           }
-        },
-        {
-          "type": "org.osbuild.grub2",
-          "options": {
-            "rootfs": {
-              "label": "root"
-            },
-            "bootfs": {
-              "label": "boot"
-            },
-            "uefi": {
-              "vendor": "fedora",
-              "install": true
-            },
-            "legacy": "i386-pc",
-            "write_defaults": false,
-            "greenboot": false,
-            "ignition": true
-          }
         }
       ]
     },
@@ -715,23 +696,49 @@
           ]
         },
         {
-          "type": "org.osbuild.grub2.inst",
+          "type": "org.osbuild.bootupd",
           "options": {
-            "platform": "i386-pc",
-            "filename": "disk.img",
-            "location": 2048,
-            "core": {
-              "type": "mkimage",
-              "partlabel": "gpt",
-              "filesystem": "ext4"
+            "bios": {
+              "device": "disk"
             },
-            "prefix": {
-              "type": "partition",
-              "partlabel": "gpt",
-              "number": 2,
-              "path": "/grub2"
+            "static-configs": true,
+            "deployment": {
+              "osname": "fedora-coreos",
+              "ref": "ostree/1/1/0"
             }
-          }
+          },
+          "devices": {
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "partscan": true
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "disk",
+              "partition": 4,
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.ext4",
+              "source": "disk",
+              "partition": 3,
+              "target": "/boot"
+            },
+            {
+              "name": "efi",
+              "type": "org.osbuild.fat",
+              "source": "disk",
+              "partition": 2,
+              "target": "/boot/efi"
+            }
+          ]
         }
       ]
     },
@@ -868,6 +875,49 @@
                 "to": "mount://root/"
               }
             ]
+          },
+          "devices": {
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "partscan": true,
+                "sector-size": 4096
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "disk",
+              "partition": 4,
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.ext4",
+              "source": "disk",
+              "partition": 3,
+              "target": "/boot"
+            },
+            {
+              "name": "efi",
+              "type": "org.osbuild.fat",
+              "source": "disk",
+              "partition": 2,
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.bootupd",
+          "options": {
+            "static-configs": true,
+            "deployment": {
+              "osname": "fedora-coreos",
+              "ref": "ostree/1/1/0"
+            }
           },
           "devices": {
             "disk": {

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -112,7 +112,7 @@ pipelines:
             mpp-resolve-images:
               images:
                 - source: registry.gitlab.com/redhat/services/products/image-builder/ci/images/fedora-coreos
-                  tag: stable
+                  tag: testing
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -124,19 +124,6 @@ pipelines:
           deployment:
             osname: fedora-coreos
             ref: ostree/1/1/0
-      - type: org.osbuild.grub2
-        options:
-          rootfs:
-            label: root
-          bootfs:
-            label: boot
-          uefi:
-            vendor: fedora
-            install: true
-          legacy: i386-pc
-          write_defaults: false
-          greenboot: false
-          ignition: true
   - name: raw-image
     build: name:build
     stages:
@@ -231,23 +218,39 @@ pipelines:
             partition:
               mpp-format-int: '{image.layout[''EFI-SYSTEM''].partnum}'
             target: /boot/efi
-      - type: org.osbuild.grub2.inst
+      - type: org.osbuild.bootupd
         options:
-          platform: i386-pc
-          filename: disk.img
-          location:
-            mpp-format-int: '{image.layout[''BIOS-BOOT''].start}'
-          core:
-            type: mkimage
-            partlabel: gpt
-            filesystem: ext4
-          prefix:
-            type: partition
-            partlabel:
-              mpp-format-string: '{image.layout.label}'
-            number:
-              mpp-format-int: '{image.layout[''boot''].index}'
-            path: /grub2
+          bios:
+            device: disk
+          static-configs: true
+          deployment:
+            osname: fedora-coreos
+            ref: ostree/1/1/0
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''root''].partnum}'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''boot''].partnum}'
+            target: /boot
+          - name: efi
+            type: org.osbuild.fat
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''EFI-SYSTEM''].partnum}'
+            target: /boot/efi
   - name: raw-4k-image
     build: name:build
     stages:
@@ -325,6 +328,39 @@ pipelines:
           paths:
             - from: input://tree/
               to: mount://root/
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''root''].partnum}'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''boot''].partnum}'
+            target: /boot
+          - name: efi
+            type: org.osbuild.fat
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].partnum}'
+            target: /boot/efi
+      - type: org.osbuild.bootupd
+        options:
+          static-configs: true
+          deployment:
+            osname: fedora-coreos
+            ref: ostree/1/1/0
         devices:
           disk:
             type: org.osbuild.loopback


### PR DESCRIPTION
Add the bootupd stage to install GRUB on both BIOS and UEFI systems,
ensuring that your bootloader stays up-to-date.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>               
