### PR TITLE
test: include tests in `make lint` and fix issues

### DIFF
--- a/test/mod/test_fmt_v1.py
+++ b/test/mod/test_fmt_v1.py
@@ -185,7 +185,7 @@ class TestFormatV1(unittest.TestCase):
         self.assertEqual(info.version, "1")
         self.assertEqual(info.module, fmt)
 
-    #pylint: disable=too-many-statements
+    # pylint: disable=too-many-statements
     @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
     def test_format_output(self):
         """Test that output formatting is as expected"""

--- a/test/mod/test_loop.py
+++ b/test/mod/test_loop.py
@@ -258,16 +258,16 @@ def test_on_close(tempdir):
 
 
 @patch("os.open", side_effect=FileNotFoundError)
-def test_loop_handles_error_in_init(mocked_open):
+def test_loop_handles_error_in_init(mocked_open):  # pylint: disable=unused-argument
     with pytest.raises(FileNotFoundError):
-        lopo = loop.Loop(999)
+        loop.Loop(999)
 
 
 @pytest.mark.skipif(os.getuid() != 0, reason="root only")
 def test_loop_create_mknod():
     # tmpdir must be /var/tmp because /tmp is usually mounted with "nodev"
     with TemporaryDirectory(dir="/var/tmp") as tmpdir:
-        with patch.object(loop, "DEV_PATH", new=tmpdir) as mocked_dev_path:
+        with patch.object(loop, "DEV_PATH", new=tmpdir):
             lopo = loop.Loop(1337)
             assert lopo.devname == "loop1337"
             assert pathlib.Path(f"{tmpdir}/loop1337").is_block_device()

--- a/test/mod/test_meta.py
+++ b/test/mod/test_meta.py
@@ -1,5 +1,4 @@
 import os
-from tempfile import TemporaryDirectory
 
 import pytest
 

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -33,7 +33,7 @@ class TapeMonitor(osbuild.monitor.BaseMonitor):
     def begin(self, pipeline: osbuild.Pipeline):
         self.counter["begin"] += 1
 
-    def finish(self, result):
+    def finish(self, results):
         self.counter["finish"] += 1
         self.output = self.logger.getvalue()
 

--- a/test/mod/test_mounts.py
+++ b/test/mod/test_mounts.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
-from osbuild.mounts import Mount
 from osbuild.meta import ModuleInfo
+from osbuild.mounts import Mount
 
 
 def test_mount_calc_id_is_stable():

--- a/test/mod/test_mounts.py
+++ b/test/mod/test_mounts.py
@@ -1,7 +1,5 @@
 from unittest.mock import Mock
 
-import pytest
-
 from osbuild.mounts import Mount
 from osbuild.meta import ModuleInfo
 

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -348,4 +348,3 @@ def test_object_export_preserves_override(tmp_path, object_store):
     assert expected_exported_path.exists()
     assert expected_exported_path.stat().st_uid == 0
     assert expected_exported_path.stat().st_gid == 0
-

--- a/test/mod/test_testutil_fake_tree.py
+++ b/test/mod/test_testutil_fake_tree.py
@@ -3,8 +3,6 @@
 #
 import os.path
 
-import pytest
-
 from osbuild.testutil import make_fake_input_tree
 
 
@@ -15,6 +13,6 @@ def test_make_fake_tree(tmp_path):  # pylint: disable=unused-argument
     })
     assert os.path.isdir(fake_input_tree)
     assert os.path.exists(os.path.join(fake_input_tree, "fake-file-one"))
-    assert open(os.path.join(fake_input_tree, "fake-file-one")).read() == "Some content"
+    assert open(os.path.join(fake_input_tree, "fake-file-one"), encoding="utf8").read() == "Some content"
     assert os.path.exists(os.path.join(fake_input_tree, "second/fake-file-two"))
-    assert open(os.path.join(fake_input_tree, "second/fake-file-two")).read() == "Second content"
+    assert open(os.path.join(fake_input_tree, "second/fake-file-two"), encoding="utf").read() == "Second content"

--- a/test/mod/test_testutil_imports.py
+++ b/test/mod/test_testutil_imports.py
@@ -1,10 +1,6 @@
 #
 # Tests for the 'osbuild.util.testutil' module.
 #
-import os.path
-import tempfile
-
-import pytest
 
 from osbuild.testutil.imports import import_module_from_path
 

--- a/test/mod/test_testutil_imports.py
+++ b/test/mod/test_testutil_imports.py
@@ -4,7 +4,6 @@
 
 from osbuild.testutil.imports import import_module_from_path
 
-
 canary = "import-went-okay"
 
 

--- a/test/mod/test_util_fscache.py
+++ b/test/mod/test_util_fscache.py
@@ -66,9 +66,9 @@ def test_calculate_space(tmpdir):
     os.makedirs(os.path.join(test_dir, "dir"))
     assert fscache.FsCache._calculate_space(test_dir) == du(test_dir)
 
-    with open(os.path.join(test_dir, "sparse-file"), "w") as f:
+    with open(os.path.join(test_dir, "sparse-file"), "wb") as f:
         f.truncate(10*1024*1024)
-        f.write("I'm not an empty file")
+        f.write(b"I'm not an empty file")
     assert fscache.FsCache._calculate_space(test_dir) == du(test_dir)
 
 
@@ -429,9 +429,9 @@ def test_cache_load_updates_last_used(tmpdir):
     cache = fscache.FsCache("osbuild-test-appid", tmpdir)
     with cache:
         cache.info = cache.info._replace(maximum_size=1024*1024)
-        with cache.store("foo") as rpath:
+        with cache.store("foo"):
             pass
-        with cache.load("foo") as rpath:
+        with cache.load("foo"):
             pass
         load_time1 = cache._last_used("foo")
         # would be nice to have a helper for this in cache
@@ -440,7 +440,7 @@ def test_cache_load_updates_last_used(tmpdir):
         mtime1 = os.stat(cache._path(obj_lock_path)).st_mtime
         assert load_time1 > 0
         sleep_for_fs()
-        with cache.load("foo") as rpath:
+        with cache.load("foo"):
             pass
         # load time is updated
         load_time2 = cache._last_used("foo")

--- a/test/mod/test_util_fscache.py
+++ b/test/mod/test_util_fscache.py
@@ -49,7 +49,7 @@ def test_calculate_space(tmpdir):
         env = os.environ.copy()
         env["POSIXLY_CORRECT"] = "1"
         output = subprocess.check_output(["du", "-s", path_target], env=env, encoding="utf8")
-        return int(output.split()[0].strip())*512
+        return int(output.split()[0].strip()) * 512
 
     test_dir = os.path.join(tmpdir, "dir")
     os.mkdir(test_dir)
@@ -67,7 +67,7 @@ def test_calculate_space(tmpdir):
     assert fscache.FsCache._calculate_space(test_dir) == du(test_dir)
 
     with open(os.path.join(test_dir, "sparse-file"), "wb") as f:
-        f.truncate(10*1024*1024)
+        f.truncate(10 * 1024 * 1024)
         f.write(b"I'm not an empty file")
     assert fscache.FsCache._calculate_space(test_dir) == du(test_dir)
 
@@ -383,7 +383,7 @@ def test_basic(tmpdir):
 
     cache = fscache.FsCache("osbuild-test-appid", tmpdir)
     with cache:
-        cache.info = cache.info._replace(maximum_size=1024*1024)
+        cache.info = cache.info._replace(maximum_size=1024 * 1024)
 
         with cache.stage() as rpath:
             with open(os.path.join(tmpdir, rpath, "bar"), "x", encoding="utf8") as f:
@@ -418,6 +418,7 @@ def test_size_discard(tmpdir):
             with cache.load("foo") as rpath:
                 pass
 
+
 def test_cache_last_used_noent(tmpdir):
     cache = fscache.FsCache("osbuild-test-appid", tmpdir)
     with pytest.raises(fscache.FsCache.MissError):
@@ -428,7 +429,7 @@ def test_cache_last_used_noent(tmpdir):
 def test_cache_load_updates_last_used(tmpdir):
     cache = fscache.FsCache("osbuild-test-appid", tmpdir)
     with cache:
-        cache.info = cache.info._replace(maximum_size=1024*1024)
+        cache.info = cache.info._replace(maximum_size=1024 * 1024)
         with cache.store("foo"):
             pass
         with cache.load("foo"):
@@ -473,7 +474,7 @@ def test_cache_full_behavior(tmp_path):
         with cache.store("o1") as rpath:
             rpath_f1 = os.path.join(tmp_path, rpath, "f1")
             with open(rpath_f1, "wb") as fp:
-                fp.write(b'a'*64*1024)
+                fp.write(b'a' * 64 * 1024)
         assert cache._calculate_space(tmp_path) > 64 * 1024
         assert cache._calculate_space(tmp_path) < 128 * 1024
         with cache.load("o1") as o:
@@ -482,7 +483,7 @@ def test_cache_full_behavior(tmp_path):
         with cache.store("o2") as rpath:
             rpath_f2 = os.path.join(tmp_path, rpath, "f2")
             with open(rpath_f2, "wb") as fp:
-                fp.write(b'b'*64*1024)
+                fp.write(b'b' * 64 * 1024)
         assert cache._calculate_space(tmp_path) > 128 * 1024
         assert cache._calculate_space(tmp_path) < 192 * 1024
         with cache.load("o2") as o:
@@ -491,7 +492,7 @@ def test_cache_full_behavior(tmp_path):
         with cache.store("o3") as rpath:
             rpath_f3 = os.path.join(tmp_path, rpath, "f3")
             with open(rpath_f3, "wb") as fp:
-                fp.write(b'b'*128*1024)
+                fp.write(b'b' * 128 * 1024)
         assert cache._calculate_space(tmp_path) > 128 * 1024
         assert cache._calculate_space(tmp_path) < 192 * 1024
         with pytest.raises(fscache.FsCache.MissError):

--- a/test/mod/test_util_fscache_coherency.py
+++ b/test/mod/test_util_fscache_coherency.py
@@ -274,4 +274,4 @@ def test_atomics_nfs(nfsmnts):
     # NFS mounts with no shared caches. Unfortunately, this keeps
     # triggering kernel-oopses, so we disable the tests for now:
 
-    #_test_atomics_with(nfsmnts[0], nfsmnts[1])
+    # _test_atomics_with(nfsmnts[0], nfsmnts[1])

--- a/test/mod/test_util_linux.py
+++ b/test/mod/test_util_linux.py
@@ -252,10 +252,10 @@ def test_libc_futimens_errcheck():
 def test_libc_futimes_works(tmpdir):
     libc = linux.Libc.default()
     stamp_file = os.path.join(tmpdir, "foo")
-    with open(stamp_file, "w") as fp:
-        fp.write("meep")
+    with open(stamp_file, "wb") as fp:
+        fp.write(b"meep")
     mtime1 = os.stat(stamp_file).st_mtime
-    with open(stamp_file, "w") as fp:
+    with open(stamp_file, "wb") as fp:
         libc.futimens(fp.fileno(), ctypes.byref(linux.c_timespec_times2(
             atime=linux.c_timespec(tv_sec=3, tv_nsec=300*1000*1000),
             mtime=linux.c_timespec(tv_sec=0, tv_nsec=libc.UTIME_OMIT),

--- a/test/mod/test_util_linux.py
+++ b/test/mod/test_util_linux.py
@@ -257,7 +257,7 @@ def test_libc_futimes_works(tmpdir):
     mtime1 = os.stat(stamp_file).st_mtime
     with open(stamp_file, "wb") as fp:
         libc.futimens(fp.fileno(), ctypes.byref(linux.c_timespec_times2(
-            atime=linux.c_timespec(tv_sec=3, tv_nsec=300*1000*1000),
+            atime=linux.c_timespec(tv_sec=3, tv_nsec=300 * 1000 * 1000),
             mtime=linux.c_timespec(tv_sec=0, tv_nsec=libc.UTIME_OMIT),
         )))
     assert os.stat(stamp_file).st_atime == 3.3

--- a/test/mod/test_util_mnt.py
+++ b/test/mod/test_util_mnt.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from osbuild.mounts import FileSystemMountService
-from osbuild.util.mnt import mount, MountGuard
+from osbuild.util.mnt import MountGuard, mount
 
 
 @pytest.mark.skipif(os.getuid() != 0, reason="root only")

--- a/test/mod/test_util_mnt.py
+++ b/test/mod/test_util_mnt.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 
 import pytest
 
@@ -25,7 +24,7 @@ def test_mount_guard_failure_msg(tmp_path):
 # This needs a proper refactor so that FileSystemMountService just uses
 # a common mount helper.
 class FakeFileSystemMountService(FileSystemMountService):
-    def __init__(self, args=None):
+    def __init__(self, args=None):  # pylint: disable=super-init-not-called
         # override __init__ to make it testable
         pass
     def translate_options(self, options):
@@ -45,4 +44,3 @@ def test_osbuild_mount_failure_msg(tmp_path):
         }
         mnt_service.mount(args)
     assert "special device /dev/invalid-src does not exist" in str(e.value)
-

--- a/test/mod/test_util_mnt.py
+++ b/test/mod/test_util_mnt.py
@@ -27,6 +27,7 @@ class FakeFileSystemMountService(FileSystemMountService):
     def __init__(self, args=None):  # pylint: disable=super-init-not-called
         # override __init__ to make it testable
         pass
+
     def translate_options(self, options):
         return options
 

--- a/test/mod/test_util_ostree.py
+++ b/test/mod/test_util_ostree.py
@@ -159,7 +159,7 @@ class TestPasswdLike(unittest.TestCase):
             with open(os.path.join(tmpdir, "result"), "r", encoding="utf8") as f:
                 self.assertEqual(sorted(f.readlines()), sorted(result_file_lines))
 
-    #pylint: disable=no-self-use
+    # pylint: disable=no-self-use
     def test_subids_cfg(self):
         with tempfile.TemporaryDirectory() as tmpdir:
 

--- a/test/run/test_devices.py
+++ b/test/run/test_devices.py
@@ -5,7 +5,6 @@
 #
 
 import os
-import tempfile
 
 import pytest
 

--- a/test/run/test_mount.py
+++ b/test/run/test_mount.py
@@ -212,10 +212,10 @@ def test_mount_with_partition(tmp_path):
             opts = {}
             # mount both partitions
             for i in range(1,3):
-                mount = mounts.Mount(
+                mount_opts = mounts.Mount(
                     name=f"name-{i}", info=ext4_mod_info, device=dev,
                     partition=i, target=f"/mnt-{i}", options=opts)
-                mntmgr.mount(mount)
+                mntmgr.mount(mount_opts)
 
             # check that the both mounts actually happend
             output = subprocess.check_output(
@@ -227,4 +227,3 @@ def test_mount_with_partition(tmp_path):
             chld = lsblk_info["blockdevices"][0]["children"]
             assert chld[0]["mountpoints"] == [f"{mnt_base}/mnt-1"]
             assert chld[1]["mountpoints"] == [f"{mnt_base}/mnt-2"]
-

--- a/test/run/test_mount.py
+++ b/test/run/test_mount.py
@@ -173,7 +173,7 @@ def create_image_with_partitions(tmp_path):
     tree.mkdir()
     img = tree / "disk.img"
     with img.open("w") as fp:
-        fp.truncate(20*1024*1024)
+        fp.truncate(20 * 1024 * 1024)
     for cmd in [
         ["parted", "--script", img, "mklabel", "msdos"],
         ["parted", "--script", img, "mkpart", "primary", "ext4", "1MiB", "10Mib"],
@@ -210,7 +210,7 @@ def test_mount_with_partition(tmp_path):
             mntmgr = mounts.MountManager(devmgr, mnt_base)
             opts = {}
             # mount both partitions
-            for i in range(1,3):
+            for i in range(1, 3):
                 mount_opts = mounts.Mount(
                     name=f"name-{i}", info=ext4_mod_info, device=dev,
                     partition=i, target=f"/mnt-{i}", options=opts)

--- a/test/run/test_mount.py
+++ b/test/run/test_mount.py
@@ -15,8 +15,7 @@ from contextlib import contextmanager
 
 import pytest
 
-from osbuild import devices, host, meta, mounts
-from osbuild import testutil
+from osbuild import devices, host, meta, mounts, testutil
 
 from ..test import TestBase
 

--- a/test/run/test_noop.py
+++ b/test/run/test_noop.py
@@ -3,7 +3,6 @@
 #
 
 import json
-import tempfile
 
 import pytest
 

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -9,7 +9,6 @@ import json
 import os
 import socketserver
 import subprocess
-import tempfile
 import threading
 
 import pytest
@@ -66,7 +65,7 @@ def can_setup_netns() -> bool:
     try:
         with netns():
             return True
-    except BaseException:  # pylint: disable=bare-except
+    except BaseException:  # pylint: disable=broad-exception-caught
         return False
 
 

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -17,11 +17,11 @@ import xml
 from collections.abc import Mapping
 from typing import Callable, Dict, List, Optional
 
-from osbuild.util import checksum, selinux
 from osbuild.testutil import has_executable
-from .test_assemblers import mount
+from osbuild.util import checksum, selinux
 
 from .. import initrd, test
+from .test_assemblers import mount
 
 
 def have_sfdisk_with_json():

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -173,7 +173,7 @@ class TestStages(test.TestBase):
             raise_assertion('length of differences different')
 
         for (file1, differences1), (file2, differences2) in \
-            zip(tree_diff1['differences'].items(), tree_diff2['differences'].items()):
+                zip(tree_diff1['differences'].items(), tree_diff2['differences'].items()):
 
             if file1 != file2:
                 raise_assertion(f"filename different: {file1}, {file2}")
@@ -182,18 +182,18 @@ class TestStages(test.TestBase):
                 raise_assertion("length of file differences different")
 
             for (difference1_kind, difference1_values), (difference2_kind, difference2_values) in \
-                zip(differences1.items(), differences2.items()):
+                    zip(differences1.items(), differences2.items()):
                 if difference1_kind != difference2_kind:
                     raise_assertion(f"different difference kinds: {difference1_kind}, {difference2_kind}")
 
                 if difference1_values[0] is not None \
-                    and difference2_values[0] is not None \
-                    and difference1_values[0] != difference2_values[0]:
+                        and difference2_values[0] is not None \
+                        and difference1_values[0] != difference2_values[0]:
                     raise_assertion(f"before values are different: {difference1_values[0]}, {difference2_values[0]}")
 
                 if difference1_values[1] is not None \
-                    and difference2_values[1] is not None \
-                    and difference1_values[1] != difference2_values[1]:
+                        and difference2_values[1] is not None \
+                        and difference1_values[1] != difference2_values[1]:
                     raise_assertion(f"after values are different: {difference1_values[1]}, {difference2_values[1]}")
 
     @classmethod

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -4,7 +4,6 @@
 
 import contextlib
 import difflib
-import functools
 import glob
 import json
 import os

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     requests
 
 setenv =
-    LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/* stages/*.* stages/test/*.py tools/
+    LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/* stages/*.* stages/test/*.py test/ tools/
     TYPEABLES = osbuild
 
 passenv =


### PR DESCRIPTION
While doing something unrelated I noticed that the tests are not part of the linting. This PR fixes this and also tweaks the test to pass the lint checks. I tried to keep the changes as minimal as possible. It's also split into the linters for easier review, the pylint one is the most "invasive".