### PR TITLE
stages,util: add org.osbuild.selinux tests and small functional tweaks

### DIFF
--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -56,11 +56,9 @@ SCHEMA = """
 
 
 def main(tree, options):
-    file_contexts = os.path.join(f"{tree}", options["file_contexts"])
+    selinux.setfiles(options["file_contexts"], os.fspath(tree), "")
+
     labels = options.get("labels", {})
-
-    subprocess.run(["setfiles", "-F", "-r", f"{tree}", f"{file_contexts}", f"{tree}"], check=True)
-
     for path, label in labels.items():
         fullpath = os.path.join(tree, path.lstrip("/"))
         selinux.setfilecon(fullpath, label)

--- a/stages/test/test_selinux.py
+++ b/stages/test/test_selinux.py
@@ -56,8 +56,8 @@ def test_schema_validation_selinux_file_context_required():
     assert "'file_contexts' is a required property" in err_msgs[0]
 
 
-@patch("subprocess.run")
-def test_selinux_file_contexts(mocked_run, tmp_path):
+@patch("osbuild.util.selinux.setfiles")
+def test_selinux_file_contexts(mocked_setfiles, tmp_path):
     stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.selinux")
     stage = import_module_from_path("stage", stage_path)
 
@@ -66,17 +66,15 @@ def test_selinux_file_contexts(mocked_run, tmp_path):
     }
     stage.main(tmp_path, options)
 
-    assert len(mocked_run.call_args_list) == 1
-    assert mocked_run.call_args_list == [
-        call(
-            ["setfiles", "-F", "-r", os.fspath(tmp_path),
-             "/etc/selinux/thing", os.fspath(tmp_path)], check=True),
+    assert len(mocked_setfiles.call_args_list) == 1
+    assert mocked_setfiles.call_args_list == [
+        call("/etc/selinux/thing", os.fspath(tmp_path), "")
     ]
 
 
 @patch("osbuild.util.selinux.setfilecon")
-@patch("subprocess.run")
-def test_selinux_labels(mocked_run, mocked_setfilecon, tmp_path):
+@patch("osbuild.util.selinux.setfiles")
+def test_selinux_labels(mocked_setfiles, mocked_setfilecon, tmp_path):
     stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.selinux")
     stage = import_module_from_path("stage", stage_path)
 
@@ -92,15 +90,15 @@ def test_selinux_labels(mocked_run, mocked_setfilecon, tmp_path):
     }
     stage.main(tmp_path, options)
 
-    assert len(mocked_run.call_args_list) == 1
+    assert len(mocked_setfiles.call_args_list) == 1
     assert len(mocked_setfilecon.call_args_list) == 1
     assert mocked_setfilecon.call_args_list == [
         call(f"{tmp_path}/tree/usr/bin/bootc", "system_u:object_r:install_exec_t:s0"),
     ]
 
 
-@patch("subprocess.run")
-def test_selinux_force_autorelabel(mocked_run, tmp_path):  # pylint: disable=unused-argument
+@patch("osbuild.util.selinux.setfiles")
+def test_selinux_force_autorelabel(mocked_setfiles, tmp_path):  # pylint: disable=unused-argument
     stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.selinux")
     stage = import_module_from_path("stage", stage_path)
 

--- a/stages/test/test_selinux.py
+++ b/stages/test/test_selinux.py
@@ -1,0 +1,114 @@
+#!/usr/bin/python3
+
+import os.path
+from unittest.mock import call, patch
+
+import pytest
+
+import osbuild.meta
+import osbuild.testutil
+from osbuild.testutil.imports import import_module_from_path
+
+
+def schema_validation_selinux(test_data, implicit_file_contexts=True):
+    name = "org.osbuild.selinux"
+    root = os.path.join(os.path.dirname(__file__), "../..")
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
+    schema = osbuild.meta.Schema(mod_info.get_schema(version="1"), name)
+
+    test_input = {
+        "name": "org.osbuild.selinux",
+        "options": {}
+    }
+    if implicit_file_contexts:
+        test_input["options"]["file_contexts"] = "some-context"
+
+    test_input["options"].update(test_data)
+    return schema.validate(test_input)
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # good
+    ({"labels": {"/usr/bin/cp": "system_u:object_r:install_exec_t:s0"}}, ""),
+    ({"force_autorelabel": True}, ""),
+    # bad
+    ({"file_contexts": 1234}, "1234 is not of type 'string'"),
+    ({"labels": "xxx"}, "'xxx' is not of type 'object'"),
+    ({"force_autorelabel": "foo"}, "'foo' is not of type 'boolean'"),
+])
+def test_schema_validation_selinux(test_data, expected_err):
+    res = schema_validation_selinux(test_data)
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        assert len(res.errors) == 1, [e.as_dict() for e in res.errors]
+        err_msgs = [e.as_dict()["message"] for e in res.errors]
+        assert expected_err in err_msgs[0]
+
+
+def test_schema_validation_selinux_file_context_required():
+    test_data = {}
+    res = schema_validation_selinux(test_data, implicit_file_contexts=False)
+    assert res.valid is False
+    assert len(res.errors) == 1, [e.as_dict() for e in res.errors]
+    err_msgs = [e.as_dict()["message"] for e in res.errors]
+    assert "'file_contexts' is a required property" in err_msgs[0]
+
+
+@patch("subprocess.run")
+def test_selinux_file_contexts(mocked_run, tmp_path):
+    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.selinux")
+    stage = import_module_from_path("stage", stage_path)
+
+    options = {
+        "file_contexts": "/etc/selinux/thing",
+    }
+    stage.main(tmp_path, options)
+
+    assert len(mocked_run.call_args_list) == 1
+    assert mocked_run.call_args_list == [
+        call(
+            ["setfiles", "-F", "-r", os.fspath(tmp_path),
+             "/etc/selinux/thing", os.fspath(tmp_path)], check=True),
+    ]
+
+
+@patch("osbuild.util.selinux.setfilecon")
+@patch("subprocess.run")
+def test_selinux_labels(mocked_run, mocked_setfilecon, tmp_path):
+    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.selinux")
+    stage = import_module_from_path("stage", stage_path)
+
+    osbuild.testutil.make_fake_input_tree(tmp_path, {
+        "/usr/bin/bootc": "I'm only an imposter",
+    })
+
+    options = {
+        "file_contexts": "/etc/selinux/thing",
+        "labels": {
+            "/tree/usr/bin/bootc": "system_u:object_r:install_exec_t:s0",
+        }
+    }
+    stage.main(tmp_path, options)
+
+    assert len(mocked_run.call_args_list) == 1
+    assert len(mocked_setfilecon.call_args_list) == 1
+    assert mocked_setfilecon.call_args_list == [
+        call(f"{tmp_path}/tree/usr/bin/bootc", "system_u:object_r:install_exec_t:s0"),
+    ]
+
+
+@patch("subprocess.run")
+def test_selinux_force_autorelabel(mocked_run, tmp_path):  # pylint: disable=unused-argument
+    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.selinux")
+    stage = import_module_from_path("stage", stage_path)
+
+    for enable_autorelabel in [False, True]:
+        options = {
+            "file_contexts": "/etc/selinux/thing",
+            "force_autorelabel": enable_autorelabel,
+        }
+        stage.main(tmp_path, options)
+
+        assert (tmp_path / ".autorelabel").exists() == enable_autorelabel

--- a/test/mod/test_util_selinux.py
+++ b/test/mod/test_util_selinux.py
@@ -4,6 +4,7 @@
 
 import errno
 import io
+import os
 from unittest import mock
 
 from osbuild.util import selinux
@@ -58,3 +59,18 @@ def test_setfilecon():
             setxattr.side_effect = raise_error
 
             selinux.setfilecon("path", "context")
+
+
+@mock.patch("subprocess.run")
+def test_selinux_setfiles(mocked_run, tmp_path):
+    selinux.setfiles("/etc/selinux/thing", os.fspath(tmp_path), "/", "/boot")
+
+    assert len(mocked_run.call_args_list) == 2
+    assert mocked_run.call_args_list == [
+        mock.call(
+            ["setfiles", "-F", "-r", os.fspath(tmp_path),
+             "/etc/selinux/thing", os.fspath(tmp_path)+"/"], check=True),
+        mock.call(
+            ["setfiles", "-F", "-r", os.fspath(tmp_path),
+             "/etc/selinux/thing", os.fspath(tmp_path)+"/boot"], check=True),
+    ]


### PR DESCRIPTION
This was originally started  because of work Ondrej did in https://github.com/ondrejbudai/osbuild/commit/dbf2ab49334929c186ee6035a0e1a9e992f431e7#diff-b009fdb01bdd4ed236a5c8df69d8b5d19360c70fe37fdde4beb5e222f723377fL36 when working on the containers-as-buildroots stage.

I started with the test and wanted to make file_contexts no longer required. But after further discussion/investigation it seems we don't need this particular change but having the tests is probably still useful and while writing it I noticed a small cleanup opportunity: instead of calling `setfiles` directly we can use the library function in `utils.selinux`. 

Easiest to read is probably commit by commit.