### PR TITLE
osbuild/util/ostree: optimize deployment_path()

### DIFF
--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -1,5 +1,6 @@
 import collections
 import contextlib
+import glob
 import json
 import os
 import subprocess
@@ -214,8 +215,16 @@ def parse_input_commits(commits):
     return commits["path"], data["refs"]
 
 
-def deployment_path(root: PathLike, osname: str, ref: str, serial: int):
+def deployment_path(root: PathLike, osname: str = "", ref: str = "", serial: int = None):
     """Return the path to a deployment given the parameters"""
+
+    if osname == "" and ref == "" and serial is None:
+        filenames = glob.glob(os.path.join(root, 'ostree/deploy/*/deploy/*.0'), recursive=True)
+        if len(filenames) < 1:
+            raise ValueError("Could not find deployment")
+        if len(filenames) > 1:
+            raise ValueError("More than one deployment found")
+        return filenames[0]
 
     base = os.path.join(root, "ostree")
 

--- a/stages/org.osbuild.bootupd
+++ b/stages/org.osbuild.bootupd
@@ -1,0 +1,125 @@
+#!/usr/bin/python3
+"""
+Install GRUB on both BIOS and UEFI systems,
+ensuring that your bootloader stays up-to-date.
+
+Bootupd supports updating GRUB and shim for
+UEFI firmware on x86_64 and aarch64,
+and GRUB for BIOS firmware on x86_64.
+The project is deployed in Fedora CoreOS and derivatives
+"""
+
+import os
+import subprocess
+import sys
+
+import osbuild.api
+from osbuild.util import ostree
+
+SCHEMA_2 = r"""
+"devices": {
+  "type": "object",
+  "additionalProperties": true
+},
+"mounts": {
+  "type": "array"
+},
+"options": {
+"additionalProperties": true,
+"properties": {
+  "deployment": {
+    "additionalProperties": false,
+    "required": ["osname", "ref"],
+    "properties": {
+      "osname": {
+        "description": "Name of the stateroot to be used in the deployment",
+        "type": "string"
+      },
+      "ref": {
+        "description": "OStree ref to create and use for deployment",
+        "type": "string"
+      },
+      "serial": {
+        "description": "The deployment serial (usually '0')",
+        "type": "number",
+        "default": 0
+      }
+    }
+  },
+  "static-configs": {
+    "description": "Install the grub configs defined for Fedora CoreOS",
+    "type": "boolean"
+  },
+  "bios": {
+    "additionalProperties": false,
+    "required": ["disk"],
+    "properties": {
+      "disk": {
+          "description": "Disk to install GRUB for BIOS-based systems",
+          "type": "string"
+      }
+    }
+  }
+}
+}
+"""
+
+
+def main(args, options):
+    deployment = options.get("deployment", None)
+    static_configs = options.get("static-configs", False)
+    bios = options.get("bios", {})
+    disk = bios.get("disk", "")
+
+    # Get the path where the filesystems are mounted
+    mounts = args["paths"]["mounts"]
+
+    # Get the deployment root. For non-OSTree this is simply
+    # the root location of the mount points. For OSTree systems
+    # we'll call ostree.deployment_path() helper to find it for us.
+    root = mounts
+    if deployment:
+        osname = deployment["osname"]
+        ref = deployment["ref"]
+        serial = deployment.get("serial", 0)
+        root = ostree.deployment_path(mounts, osname, ref, serial)
+
+    bootupd_args = []
+    if disk:
+        # The value passed by the user is the name of the device
+        # as specified in the devices array (also passed in by the
+        # user). Let's map that name to the actual loopback device
+        # that now backs it.
+        dev = args["devices"][disk]["path"]
+        bootupd_args.append(f"--device={dev}")
+    if static_configs:
+        bootupd_args.append("--with-static-configs")
+
+    # We want to run the bootupctl command from the target (i.e. we
+    # want to make sure the version used matches the target and not
+    # risk any inconsistencies with the build root). Let's set up
+    # and chroot to run the bootupctl command from the target.
+    submounts = ['dev', 'proc', 'sys', 'run', 'var', 'tmp']
+    for mnt in submounts:
+        subprocess.run(['mount', '--rbind',
+                       os.path.join("/", mnt),
+                       os.path.join(root, mnt)],
+                       check=True)
+    try:
+        cmd = ['chroot', root, '/usr/bin/bootupctl', 'backend', 'install']
+        cmd.extend(bootupd_args)
+        cmd.append(mounts)
+        subprocess.run(cmd, check=True)
+    finally:
+        for mnt in submounts:
+            subprocess.run(['umount', '--recursive',
+                           os.path.join(root, mnt)],
+                           check=False)
+
+    return 0
+
+
+if __name__ == '__main__':
+    _args = osbuild.api.arguments()
+    r = main(_args, _args["options"])
+    sys.exit(r)

--- a/stages/org.osbuild.bootupd
+++ b/stages/org.osbuild.bootupd
@@ -27,25 +27,6 @@ SCHEMA_2 = r"""
 "options": {
 "additionalProperties": true,
 "properties": {
-  "deployment": {
-    "additionalProperties": false,
-    "required": ["osname", "ref"],
-    "properties": {
-      "osname": {
-        "description": "Name of the stateroot to be used in the deployment",
-        "type": "string"
-      },
-      "ref": {
-        "description": "OStree ref to create and use for deployment",
-        "type": "string"
-      },
-      "serial": {
-        "description": "The deployment serial (usually '0')",
-        "type": "number",
-        "default": 0
-      }
-    }
-  },
   "static-configs": {
     "description": "Install the grub configs defined for Fedora CoreOS",
     "type": "boolean"
@@ -66,7 +47,6 @@ SCHEMA_2 = r"""
 
 
 def main(args, options):
-    deployment = options.get("deployment", None)
     static_configs = options.get("static-configs", False)
     bios = options.get("bios", {})
     disk = bios.get("disk", "")
@@ -77,12 +57,9 @@ def main(args, options):
     # Get the deployment root. For non-OSTree this is simply
     # the root location of the mount points. For OSTree systems
     # we'll call ostree.deployment_path() helper to find it for us.
-    root = mounts
-    if deployment:
-        osname = deployment["osname"]
-        ref = deployment["ref"]
-        serial = deployment.get("serial", 0)
-        root = ostree.deployment_path(mounts, osname, ref, serial)
+    deployment = mounts
+    if os.path.isdir(os.path.join(mounts, "ostree")):
+        deployment = ostree.deployment_path(mounts)
 
     bootupd_args = []
     if disk:
@@ -103,17 +80,17 @@ def main(args, options):
     for mnt in submounts:
         subprocess.run(['mount', '--rbind',
                        os.path.join("/", mnt),
-                       os.path.join(root, mnt)],
+                       os.path.join(deployment, mnt)],
                        check=True)
     try:
-        cmd = ['chroot', root, '/usr/bin/bootupctl', 'backend', 'install']
+        cmd = ['chroot', deployment, '/usr/bin/bootupctl', 'backend', 'install']
         cmd.extend(bootupd_args)
         cmd.append(mounts)
         subprocess.run(cmd, check=True)
     finally:
         for mnt in submounts:
             subprocess.run(['umount', '--recursive',
-                           os.path.join(root, mnt)],
+                           os.path.join(deployment, mnt)],
                            check=False)
 
     return 0

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -529,25 +529,6 @@
               "ref": "ostree/1/1/0"
             }
           }
-        },
-        {
-          "type": "org.osbuild.grub2",
-          "options": {
-            "rootfs": {
-              "label": "root"
-            },
-            "bootfs": {
-              "label": "boot"
-            },
-            "uefi": {
-              "vendor": "fedora",
-              "install": true
-            },
-            "legacy": "i386-pc",
-            "write_defaults": false,
-            "greenboot": false,
-            "ignition": true
-          }
         }
       ]
     },
@@ -715,23 +696,49 @@
           ]
         },
         {
-          "type": "org.osbuild.grub2.inst",
+          "type": "org.osbuild.bootupd",
           "options": {
-            "platform": "i386-pc",
-            "filename": "disk.img",
-            "location": 2048,
-            "core": {
-              "type": "mkimage",
-              "partlabel": "gpt",
-              "filesystem": "ext4"
+            "bios": {
+              "disk": "disk"
             },
-            "prefix": {
-              "type": "partition",
-              "partlabel": "gpt",
-              "number": 2,
-              "path": "/grub2"
+            "static-configs": true,
+            "deployment": {
+              "osname": "fedora-coreos",
+              "ref": "ostree/1/1/0"
             }
-          }
+          },
+          "devices": {
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "partscan": true
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "disk",
+              "partition": 4,
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.ext4",
+              "source": "disk",
+              "partition": 3,
+              "target": "/boot"
+            },
+            {
+              "name": "efi",
+              "type": "org.osbuild.fat",
+              "source": "disk",
+              "partition": 2,
+              "target": "/boot/efi"
+            }
+          ]
         }
       ]
     },
@@ -868,6 +875,49 @@
                 "to": "mount://root/"
               }
             ]
+          },
+          "devices": {
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "partscan": true,
+                "sector-size": 4096
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "disk",
+              "partition": 4,
+              "target": "/"
+            },
+            {
+              "name": "boot",
+              "type": "org.osbuild.ext4",
+              "source": "disk",
+              "partition": 3,
+              "target": "/boot"
+            },
+            {
+              "name": "efi",
+              "type": "org.osbuild.fat",
+              "source": "disk",
+              "partition": 2,
+              "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.bootupd",
+          "options": {
+            "static-configs": true,
+            "deployment": {
+              "osname": "fedora-coreos",
+              "ref": "ostree/1/1/0"
+            }
           },
           "devices": {
             "disk": {

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -701,11 +701,7 @@
             "bios": {
               "disk": "disk"
             },
-            "static-configs": true,
-            "deployment": {
-              "osname": "fedora-coreos",
-              "ref": "ostree/1/1/0"
-            }
+            "static-configs": true
           },
           "devices": {
             "disk": {
@@ -913,11 +909,7 @@
         {
           "type": "org.osbuild.bootupd",
           "options": {
-            "static-configs": true,
-            "deployment": {
-              "osname": "fedora-coreos",
-              "ref": "ostree/1/1/0"
-            }
+            "static-configs": true
           },
           "devices": {
             "disk": {

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -504,8 +504,8 @@
               "type": "org.osbuild.containers",
               "origin": "org.osbuild.source",
               "references": {
-                "sha256:3bdf633fb6c027a01688aecf1d3f33bbecf8975b138c1861cb89ae20f3e3e7db": {
-                  "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/images/fedora-coreos:stable"
+                "sha256:48749a61060accd9ec7127f08807b80476e5b2fe63bf69b8492025ee82094175": {
+                  "name": "quay.io/fedora/fedora-coreos:testing-devel"
                 }
               }
             }
@@ -1612,10 +1612,10 @@
     },
     "org.osbuild.skopeo": {
       "items": {
-        "sha256:3bdf633fb6c027a01688aecf1d3f33bbecf8975b138c1861cb89ae20f3e3e7db": {
+        "sha256:48749a61060accd9ec7127f08807b80476e5b2fe63bf69b8492025ee82094175": {
           "image": {
-            "name": "registry.gitlab.com/redhat/services/products/image-builder/ci/images/fedora-coreos",
-            "digest": "sha256:f0ebfc8bb813e45225a93e76780c44439fac11a24ba8fb83001ec96a61ebbb12"
+            "name": "quay.io/fedora/fedora-coreos",
+            "digest": "sha256:fffe3e15c89548e8604ed03878be82e04e862b7d26da572a7a8c8356657092a1"
           }
         }
       }

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -223,9 +223,6 @@ pipelines:
           bios:
             disk: disk
           static-configs: true
-          deployment:
-            osname: fedora-coreos
-            ref: ostree/1/1/0
         devices:
           disk:
             type: org.osbuild.loopback
@@ -358,9 +355,6 @@ pipelines:
       - type: org.osbuild.bootupd
         options:
           static-configs: true
-          deployment:
-            osname: fedora-coreos
-            ref: ostree/1/1/0
         devices:
           disk:
             type: org.osbuild.loopback

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -111,8 +111,8 @@ pipelines:
             origin: org.osbuild.source
             mpp-resolve-images:
               images:
-                - source: registry.gitlab.com/redhat/services/products/image-builder/ci/images/fedora-coreos
-                  tag: stable
+                - source: quay.io/fedora/fedora-coreos
+                  tag: testing-devel
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -124,19 +124,6 @@ pipelines:
           deployment:
             osname: fedora-coreos
             ref: ostree/1/1/0
-      - type: org.osbuild.grub2
-        options:
-          rootfs:
-            label: root
-          bootfs:
-            label: boot
-          uefi:
-            vendor: fedora
-            install: true
-          legacy: i386-pc
-          write_defaults: false
-          greenboot: false
-          ignition: true
   - name: raw-image
     build: name:build
     stages:
@@ -231,23 +218,39 @@ pipelines:
             partition:
               mpp-format-int: '{image.layout[''EFI-SYSTEM''].partnum}'
             target: /boot/efi
-      - type: org.osbuild.grub2.inst
+      - type: org.osbuild.bootupd
         options:
-          platform: i386-pc
-          filename: disk.img
-          location:
-            mpp-format-int: '{image.layout[''BIOS-BOOT''].start}'
-          core:
-            type: mkimage
-            partlabel: gpt
-            filesystem: ext4
-          prefix:
-            type: partition
-            partlabel:
-              mpp-format-string: '{image.layout.label}'
-            number:
-              mpp-format-int: '{image.layout[''boot''].index}'
-            path: /grub2
+          bios:
+            disk: disk
+          static-configs: true
+          deployment:
+            osname: fedora-coreos
+            ref: ostree/1/1/0
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''root''].partnum}'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''boot''].partnum}'
+            target: /boot
+          - name: efi
+            type: org.osbuild.fat
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''EFI-SYSTEM''].partnum}'
+            target: /boot/efi
   - name: raw-4k-image
     build: name:build
     stages:
@@ -325,6 +328,39 @@ pipelines:
           paths:
             - from: input://tree/
               to: mount://root/
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''root''].partnum}'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''boot''].partnum}'
+            target: /boot
+          - name: efi
+            type: org.osbuild.fat
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].partnum}'
+            target: /boot/efi
+      - type: org.osbuild.bootupd
+        options:
+          static-configs: true
+          deployment:
+            osname: fedora-coreos
+            ref: ostree/1/1/0
         devices:
           disk:
             type: org.osbuild.loopback


### PR DESCRIPTION
When provisioning disk images there should really not be more than
one deployment on a system. We don't really need any of the parameters
here so let's make them optional and just find the deployment anyway.

Co-authored-by: Luke Yang <luyang@redhat.com>                          
