### PR TITLE
tools/osbuild-mpp: run _process_format() for mpp-embed dict

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -1545,6 +1545,7 @@ class ManifestFileV2(ManifestFile):
                 return self.checksum
 
         def embed_data(ip, mpp):
+            self._process_format(mpp)
             uid = mpp["id"]
             path = mpp.get("path")
             url = mpp.get("url")


### PR DESCRIPTION
So we can use something like mpp-format-string inside of mpp-embed. An example would be below where we want to substitute the ociarchive var in using `mpp-format-string: 'file://{ociarchive}'`.

```
version: '2'
mpp-vars:
  ociarchive: /path/to/fedora-coreos-39.20240104.dev.2-ostree.x86_64.ociarchive
pipelines:
  - name: oci-archive
    stages:
      - type: org.osbuild.copy
        inputs:
          inlinefile:
            type: org.osbuild.files
            origin: org.osbuild.source
            mpp-embed:
              id: fcos.ociarchive
              url:
                mpp-format-string: 'file://{ociarchive}'
        options:
          paths:
            - from:
                mpp-format-string: input://inlinefile/{embedded['fcos.ociarchive']}
              to: tree:///fcos.ociarchive
```