### PR TITLE
stages(container-deploy): ensure `/var/tmp` is available

### DIFF
--- a/stages/org.osbuild.container-deploy
+++ b/stages/org.osbuild.container-deploy
@@ -5,6 +5,7 @@ Deploy a container.
 Buildhost commands used: podman skopeo
 """
 import contextlib
+import os
 import random
 import string
 import subprocess
@@ -54,6 +55,8 @@ def main(inputs, output):
     assert len(images) == 1
     image = list(images.values())[0]
 
+    # skopeo needs /var/tmp but the bwrap env is minimal and may not have it
+    os.makedirs("/var/tmp", mode=0o1777, exist_ok=True)
     # We cannot use a tmpdir as storage here because of
     # https://github.com/containers/storage/issues/1779 so instead
     # just pick a random suffix. This runs inside bwrap which gives a

--- a/stages/test/test_container_deploy.py
+++ b/stages/test/test_container_deploy.py
@@ -5,6 +5,7 @@ import os.path
 import random
 import string
 import subprocess
+from unittest.mock import call, patch
 
 import pytest
 
@@ -68,7 +69,10 @@ def test_container_deploy_integration(tmp_path):
     }
     output_dir = tmp_path / "output"
 
-    stage.main(inputs, output_dir)
+    with patch("os.makedirs", wraps=os.makedirs) as mocked_makedirs:
+        stage.main(inputs, output_dir)
 
     assert output_dir.exists()
     assert (output_dir / "file1").read_bytes() == b"file1 from final layer"
+
+    assert mocked_makedirs.call_args_list == [call("/var/tmp", mode=0o1777, exist_ok=True)]


### PR DESCRIPTION
This commit ensures that `/var/tmp` is available. Skopeo expects this dir but the bwrap environment starts with a very minimal `/var` so `/var/tmp` may not be available.