### PR TITLE
add --break for requesting a debug shell

### DIFF
--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -57,6 +57,8 @@ is not listed here, **osbuild** will deny startup and exit with an error.
 --monitor-fd=NUM                file-descriptor to be used for the monitor
 --stage-timeout                 set the maximal time (in seconds) each stage is
                                 allowed to run
+--break, --break=ID             open debug shell when executing stages; accepts
+                                stage name or id (from --inspect) or * (for all)
 
 NB: If neither ``--output-directory`` nor ``--checkpoint`` is specified, no
 attempt to build the manifest will be made.

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -70,7 +70,7 @@ class ProcOverrides:
         self.overrides.add("cmdline")
 
 
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes,too-many-branches
 class BuildRoot(contextlib.AbstractContextManager):
     """Build Root
 
@@ -177,7 +177,7 @@ class BuildRoot(contextlib.AbstractContextManager):
         if self._exitstack:
             self._exitstack.enter_context(api)
 
-    def run(self, argv, monitor, timeout=None, binds=None, readonly_binds=None, extra_env=None):
+    def run(self, argv, monitor, timeout=None, binds=None, readonly_binds=None, extra_env=None, debug_shell=False):
         """Runs a command in the buildroot.
 
         Takes the command and arguments, as well as bind mounts to mirror
@@ -289,6 +289,7 @@ class BuildRoot(contextlib.AbstractContextManager):
         cmd += self.build_capabilities_args()
 
         cmd += mounts
+        debug_shell_cmd = cmd + ["--", "/bin/bash"]  # used for debugging if requested
         cmd += ["--", runner]
         cmd += argv
 
@@ -303,6 +304,11 @@ class BuildRoot(contextlib.AbstractContextManager):
         }
         if extra_env:
             env.update(extra_env)
+
+        # If the user requested it then break into a shell here
+        # for debugging.
+        if debug_shell:
+            subprocess.run(debug_shell_cmd, check=True)
 
         proc = subprocess.Popen(cmd,
                                 bufsize=0,

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -95,6 +95,9 @@ def parse_arguments(sys_argv):
     parser.add_argument("--version", action="version",
                         help="return the version of osbuild",
                         version="%(prog)s " + osbuild.__version__)
+    # nargs='?' const='*' means `--break` is equivalent to `--break=*`
+    parser.add_argument("--break", dest='debug_break', type=str, nargs='?', const='*',
+                        help="open debug shell when executing stage. Accepts stage name or id or * (for all)")
 
     return parser.parse_args(sys_argv[1:])
 
@@ -163,6 +166,7 @@ def osbuild_cli():
                 object_store.maximum_size = args.cache_max_size
 
             stage_timeout = args.stage_timeout
+            debug_break = args.debug_break
 
             pipelines = manifest.depsolve(object_store, exports)
 
@@ -173,6 +177,7 @@ def osbuild_cli():
                 pipelines,
                 monitor,
                 args.libdir,
+                debug_break,
                 stage_timeout=stage_timeout
             )
 


### PR DESCRIPTION
Similar to rd.break for dracut this allows a user to specify:

- `--break` or `--break=*`
    - to get a shell before each stage is run
- `--break=stage.name`
    - to get a shell each time the stage with that name is run
    - example: `--break=org.osbuild.copy`
- `--break=stage.id`
    - to get a shell each time the stage with that ID is run
    - get the ID for the stages for your manifest by running osbuild on the manifest with `--inspect`
    - example: `--break=dc6e3a66fef3ebe7c815eb24d348215b9e5e2ed0cd808c15ebbe85fc73181a86`

and get a bash shell where they can inspect the environment to debug and develop OSBuild stages.
