### PR TITLE
stages/org.osbuild.ostree.config: support bls-append-except-default

### DIFF
--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -42,6 +42,10 @@ SCHEMA = """
           "readonly": {
             "description": "Read only sysroot and boot",
             "type": "boolean"
+          },
+          "bls-append-except-default": {
+            "description": "Set value for bls-append-except-default",
+            "type": "string"
           }
         }
       }
@@ -63,6 +67,10 @@ def main(tree, options):
     if readonly is not None:  # can be False, which we would want to set
         ro = "true" if readonly else "false"
         ostree.cli("config", "set", "sysroot.readonly", ro, repo=repo)
+
+    bls_append_except_default = sysroot_options.get("bls-append-except-default")
+    if bls_append_except_default:
+        ostree.cli("config", "set", "sysroot.bls-append-except-default", bls_append_except_default, repo=repo)
 
 
 if __name__ == '__main__':

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -466,7 +466,8 @@
             "config": {
               "sysroot": {
                 "readonly": false,
-                "bootloader": "none"
+                "bootloader": "none",
+                "bls-append-except-default": "grub_users=\"\""
               }
             }
           }

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -89,6 +89,7 @@ pipelines:
             sysroot:
               readonly: false
               bootloader: none
+              bls-append-except-default: grub_users=""
       - type: org.osbuild.mkdir
         options:
           paths:


### PR DESCRIPTION
Support setting the sysroot.bls-append-except-default value in the OSTree config. This is used by CoreOS to support configuration used for GRUB password support https://github.com/coreos/fedora-coreos-tracker/issues/1333