### PR TITLE
Add chattr stage; support stacked ostree.deployment mounts

### DIFF
--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -98,32 +98,37 @@ class OSTreeDeploymentMount(mounts.MountService):
         ref = deployment["ref"]
         serial = deployment.get("serial", 0)
 
-        # create a private mountpoint for the tree, which is needed
-        # in order to be able to move the `root` mountpoint, which
-        # is contained inside tree, since "moving a mount residing
-        # under a shared mount is invalid and unsupported."
+        # The target path where we want the deployment to be mounted
+        # is the root of the tree.
+        target = tree
+
+        # create a private mountpoint for the target path, which is
+        # needed in order to be able to move the deployment `root`
+        # mountpoint here, which is contained inside tree, since
+        # "moving a mount residing under a shared mount is invalid
+        # and unsupported."
         #                                              - `mount(8)`
-        self.bind_mount(tree, tree)
+        self.bind_mount(target, target)
 
-        deploy_root = ostree.deployment_path(tree, osname, ref, serial)
+        deploy_root = ostree.deployment_path(target, osname, ref, serial)
 
-        print(f"Deployment root at '{os.path.relpath(deploy_root, tree)}'")
+        print(f"Deployment root at '{os.path.relpath(deploy_root, target)}'")
 
-        var = os.path.join(tree, "ostree", "deploy", osname, "var")
-        boot = os.path.join(tree, "boot")
+        var = os.path.join(target, "ostree", "deploy", osname, "var")
+        boot = os.path.join(target, "boot")
 
         self.mountpoint = deploy_root
         self.bind_mount(deploy_root, deploy_root)  # prepare to move it later
 
-        self.bind_mount(tree, os.path.join(deploy_root, "sysroot"))
+        self.bind_mount(target, os.path.join(deploy_root, "sysroot"))
         self.bind_mount(var, os.path.join(deploy_root, "var"))
         self.bind_mount(boot, os.path.join(deploy_root, "boot"))
 
         subprocess.run([
-            "mount", "--move", deploy_root, tree,
+            "mount", "--move", deploy_root, target,
         ], check=True)
 
-        self.mountpoint = tree
+        self.mountpoint = target
         self.check = True
 
     def umount(self):

--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -63,7 +63,6 @@ class OSTreeDeploymentMount(mounts.MountService):
     def __init__(self, args):
         super().__init__(args)
 
-        self.tree = None
         self.mountpoint = None
         self.check = False
 
@@ -72,7 +71,22 @@ class OSTreeDeploymentMount(mounts.MountService):
         subprocess.run([
             "mount", "--bind", "--make-private", source, target,
         ], check=True)
-        return target
+
+    def is_mounted(self):
+        # Use `mountpoint` command here to determine if the mountpoint is mounted.
+        # We would use os.path.ismount() here but that only works if a device is
+        # mounted (i.e. it doesn't use the mountinfo file in the heuristic and
+        # thus things like `mount --move` wouldn't show up). The exit codes from
+        # `mountpoint` are:
+        #
+        #  0 success; the directory is a mountpoint, or device is block device on --devno
+        #  1 failure; incorrect invocation, permissions or system error
+        #  32 failure; the directory is not a mountpoint, or device is not a block device on --devno
+        #
+        cp = subprocess.run(["mountpoint", "-q", self.mountpoint], check=False)
+        if cp.returncode not in [0, 32]:
+            cp.check_returncode()  # will raise error
+        return cp.returncode == 0
 
     def mount(self, args: Dict):
 
@@ -89,7 +103,7 @@ class OSTreeDeploymentMount(mounts.MountService):
         # is contained inside tree, since "moving a mount residing
         # under a shared mount is invalid and unsupported."
         #                                              - `mount(8)`
-        self.tree = self.bind_mount(tree, tree)
+        self.bind_mount(tree, tree)
 
         root = ostree.deployment_path(tree, osname, ref, serial)
 
@@ -116,15 +130,25 @@ class OSTreeDeploymentMount(mounts.MountService):
         if self.mountpoint:
             subprocess.run(["sync", "-f", self.mountpoint],
                            check=self.check)
-
-            subprocess.run(["umount", "-R", self.mountpoint],
+            subprocess.run(["umount", "-v", "-R", self.mountpoint],
                            check=self.check)
+
+            # Handle bug in older util-linux mount where the
+            # mountinfo/utab wouldn't have updated information
+            # when mount --move is performed, which means that
+            # umount -R wouldn't unmount all overmounted mounts
+            # on the target because it was operating on outdated
+            # information. The umount -R behavior is fixed in v2.39
+            # of util-linux most likely by [1] or [2] or both. This
+            # loop can be removed when all hosts we care about have
+            # moved to v2.39+.
+            # [1] https://github.com/karelzak/util-linux/commit/a04149fbb7c1952da1194d1514e298ff07dbc7ca
+            # [2] https://github.com/karelzak/util-linux/commit/8cf6c5075780598fe3b30e7a7753d8323d093e22
+            while self.is_mounted():
+                print(f"extra unmount {self.mountpoint}")
+                subprocess.run(["umount", "-v", self.mountpoint],
+                               check=self.check)
             self.mountpoint = None
-
-        if self.tree:
-            subprocess.run(["umount", "-R", self.tree],
-                           check=self.check)
-            self.tree = None
 
 
 def main():

--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -32,6 +32,12 @@ SCHEMA_2 = """
     "type": "object",
     "required": ["deployment"],
     "properties": {
+      "source": {
+        "type": "string",
+        "pattern": "^(mount|tree)$",
+        "default": "tree",
+        "description": "The source of the OSTree filesystem tree. If 'mount', there should be a preceding mount defined that's mounted at /."
+      },
       "deployment": {
         "type": "object",
         "additionalProperties": false,
@@ -91,16 +97,21 @@ class OSTreeDeploymentMount(mounts.MountService):
     def mount(self, args: Dict):
 
         tree = args["tree"]
+        mountroot = args["root"]
         options = args["options"]
 
+        source = options.get("source", "tree")
         deployment = options["deployment"]
         osname = deployment["osname"]
         ref = deployment["ref"]
         serial = deployment.get("serial", 0)
 
-        # The target path where we want the deployment to be mounted
-        # is the root of the tree.
-        target = tree
+        # The user could specify either the tree or mountroot as the
+        # place where we want the deployment to be mounted.
+        if source == "mount":
+            target = mountroot
+        else:
+            target = tree
 
         # create a private mountpoint for the target path, which is
         # needed in order to be able to move the deployment `root`
@@ -113,6 +124,7 @@ class OSTreeDeploymentMount(mounts.MountService):
         deploy_root = ostree.deployment_path(target, osname, ref, serial)
 
         print(f"Deployment root at '{os.path.relpath(deploy_root, target)}'")
+        print(f"mounting {deploy_root} -> {target}")
 
         var = os.path.join(target, "ostree", "deploy", osname, "var")
         boot = os.path.join(target, "boot")

--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -105,22 +105,22 @@ class OSTreeDeploymentMount(mounts.MountService):
         #                                              - `mount(8)`
         self.bind_mount(tree, tree)
 
-        root = ostree.deployment_path(tree, osname, ref, serial)
+        deploy_root = ostree.deployment_path(tree, osname, ref, serial)
 
-        print(f"Deployment root at '{os.path.relpath(root, tree)}'")
+        print(f"Deployment root at '{os.path.relpath(deploy_root, tree)}'")
 
         var = os.path.join(tree, "ostree", "deploy", osname, "var")
         boot = os.path.join(tree, "boot")
 
-        self.mountpoint = root
-        self.bind_mount(root, root)  # prepare to move it later
+        self.mountpoint = deploy_root
+        self.bind_mount(deploy_root, deploy_root)  # prepare to move it later
 
-        self.bind_mount(tree, os.path.join(root, "sysroot"))
-        self.bind_mount(var, os.path.join(root, "var"))
-        self.bind_mount(boot, os.path.join(root, "boot"))
+        self.bind_mount(tree, os.path.join(deploy_root, "sysroot"))
+        self.bind_mount(var, os.path.join(deploy_root, "var"))
+        self.bind_mount(boot, os.path.join(deploy_root, "boot"))
 
         subprocess.run([
-            "mount", "--move", root, tree,
+            "mount", "--move", deploy_root, tree,
         ], check=True)
 
         self.mountpoint = tree

--- a/stages/org.osbuild.chattr
+++ b/stages/org.osbuild.chattr
@@ -1,0 +1,95 @@
+#!/usr/bin/python3
+"""
+Runs `chattr` to set file/directory attributes.
+"""
+
+import os
+import subprocess
+import sys
+from typing import Dict
+from urllib.parse import ParseResult, urlparse
+
+import osbuild.api
+
+SCHEMA_2 = r"""
+"options": {
+  "additionalProperties": false,
+  "properties": {
+    "items": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^mount:\/\/[^\/]+\/|^tree:\/\/\/": {
+          "type": "object",
+          "required": ["immutable"],
+          "properties": {
+            "immutable": {
+              "type": "boolean",
+              "description": "Make the file/directory immutable",
+              "default": true
+            }
+          }
+        }
+      }
+    }
+  }
+},
+"devices": {
+  "type": "object",
+  "additionalProperties": true
+},
+"mounts": {
+  "type": "array"
+}
+"""
+
+
+def parse_mount(url: ParseResult, args: Dict):
+    name = url.netloc
+    if name:
+        root = args["mounts"].get(name, {}).get("path")
+        if not root:
+            raise ValueError(f"Unknown mount '{name}'")
+    else:
+        root = args["paths"]["mounts"]
+
+    return root
+
+
+def parse_location(location, args):
+    url = urlparse(location)
+
+    scheme = url.scheme
+    if scheme == "tree":
+        root = args["tree"]
+    elif scheme == "mount":
+        root = parse_mount(url, args)
+    else:
+        raise ValueError(f"Unsupported scheme '{scheme}'")
+
+    assert url.path.startswith("/")
+
+    path = os.path.relpath(url.path, "/")
+    path = os.path.join(root, path)
+    path = os.path.normpath(path)
+
+    if url.path.endswith("/"):
+        path = os.path.join(path, ".")
+
+    return path
+
+
+def main(args, options):
+    for path, cmdargs in options["items"].items():
+        immutable = cmdargs["immutable"]
+        dst = parse_location(path, args)
+        op = '+' if immutable else '-'
+        subprocess.run(["chattr", f"{op}i", dst], check=True)
+
+    return 0
+
+
+if __name__ == '__main__':
+    _args = osbuild.api.arguments()
+    r = main(_args, _args["options"])
+    sys.exit(r)

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -736,6 +736,45 @@
               "target": "/boot/efi"
             }
           ]
+        },
+        {
+          "type": "org.osbuild.chattr",
+          "options": {
+            "items": {
+              "mount://root/": {
+                "immutable": true
+              }
+            }
+          },
+          "devices": {
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "partscan": true
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "disk",
+              "partition": 4,
+              "target": "/"
+            },
+            {
+              "name": "ostree.deployment",
+              "type": "org.osbuild.ostree.deployment",
+              "options": {
+                "source": "mount",
+                "deployment": {
+                  "ref": "ostree/1/1/0",
+                  "osname": "fedora-coreos"
+                }
+              }
+            }
+          ]
         }
       ]
     },
@@ -943,6 +982,46 @@
               "source": "disk",
               "partition": 2,
               "target": "/boot/efi"
+            }
+          ]
+        },
+        {
+          "type": "org.osbuild.chattr",
+          "options": {
+            "items": {
+              "mount://root/": {
+                "immutable": true
+              }
+            }
+          },
+          "devices": {
+            "disk": {
+              "type": "org.osbuild.loopback",
+              "options": {
+                "filename": "disk.img",
+                "partscan": true,
+                "sector-size": 4096
+              }
+            }
+          },
+          "mounts": [
+            {
+              "name": "root",
+              "type": "org.osbuild.xfs",
+              "source": "disk",
+              "partition": 4,
+              "target": "/"
+            },
+            {
+              "name": "ostree.deployment",
+              "type": "org.osbuild.ostree.deployment",
+              "options": {
+                "source": "mount",
+                "deployment": {
+                  "ref": "ostree/1/1/0",
+                  "osname": "fedora-coreos"
+                }
+              }
             }
           ]
         }

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -265,6 +265,32 @@ pipelines:
             partition:
               mpp-format-int: '{image.layout[''EFI-SYSTEM''].partnum}'
             target: /boot/efi
+      - type: org.osbuild.chattr
+        options:
+          items:
+            mount://root/:
+              immutable: true
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''root''].partnum}'
+            target: /
+          - name: ostree.deployment
+            type: org.osbuild.ostree.deployment
+            options:
+              source: mount
+              deployment:
+                ref: ostree/1/1/0
+                osname:
+                  mpp-format-string: '{osname}'
   - name: raw-4k-image
     build: name:build
     stages:
@@ -407,6 +433,34 @@ pipelines:
             partition:
               mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].partnum}'
             target: /boot/efi
+      - type: org.osbuild.chattr
+        options:
+          items:
+            mount://root/:
+              immutable: true
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''root''].partnum}'
+            target: /
+          - name: ostree.deployment
+            type: org.osbuild.ostree.deployment
+            options:
+              source: mount
+              deployment:
+                ref: ostree/1/1/0
+                osname:
+                  mpp-format-string: '{osname}'
   - name: raw-metal-image
     build: name:build
     stages:


### PR DESCRIPTION
Here we add two main changes:

1. a chattr stage to set file/directory attributes
2. a rework of the ostree.deployment mount to support the OSTree musical chairs on mounted filesystems too.

The ostree.deployment rework is needed for the chattr stage to work (i.e. we lose the immutable bit when going through a `org.osbuild.copy` stage). 