### PR TITLE
test: fix new mount tests under rhel8

### DIFF
--- a/test/run/test_mount.py
+++ b/test/run/test_mount.py
@@ -178,8 +178,8 @@ def create_image_with_partitions(tmp_path):
         ["parted", "--script", img, "mklabel", "msdos"],
         ["parted", "--script", img, "mkpart", "primary", "ext4", "1MiB", "10Mib"],
         ["parted", "--script", img, "mkpart", "primary", "ext4", "10MiB", "19Mib"],
-        ["mkfs.ext4", "-E", f"offset={1*1024*1024}", img, "9M"],
-        ["mkfs.ext4", "-E", f"offset={10*1024*1024}", img, "9M"],
+        ["mkfs.ext4", "-F", "-E", f"offset={1*1024*1024}", img, "9M"],
+        ["mkfs.ext4", "-F", "-E", f"offset={10*1024*1024}", img, "9M"],
     ]:
         subprocess.check_call(cmd)
     return tree, img.name

--- a/test/run/test_mount.py
+++ b/test/run/test_mount.py
@@ -224,5 +224,10 @@ def test_mount_with_partition(tmp_path):
             lsblk_info = json.loads(output)
             assert len(lsblk_info["blockdevices"][0]["children"]) == 2
             chld = lsblk_info["blockdevices"][0]["children"]
-            assert chld[0]["mountpoints"] == [f"{mnt_base}/mnt-1"]
-            assert chld[1]["mountpoints"] == [f"{mnt_base}/mnt-2"]
+            # rhel8 lsblk only gives us a single mountpoint (no plural)
+            if "mountpoint" in chld[0]:
+                assert chld[0]["mountpoint"] == f"{mnt_base}/mnt-1"
+                assert chld[1]["mountpoint"] == f"{mnt_base}/mnt-2"
+            else:
+                assert chld[0]["mountpoints"] == [f"{mnt_base}/mnt-1"]
+                assert chld[1]["mountpoints"] == [f"{mnt_base}/mnt-2"]


### PR DESCRIPTION
The new `create_image_with_partitions()` helper fails under rhel8 currently. The reason is that `mkfs.ext4 -E offset=` will warn in older versions about a partition table and require user input.

This got fixed `e2fsprogs` 1.46.3 in Jul 2021 but RHEL8 still has 1.45.

[0] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=989612