### PR TITLE
stages/org.osbuild.mkfs.ext4: add ext4 options

### DIFF
--- a/stages/org.osbuild.mkfs.ext4
+++ b/stages/org.osbuild.mkfs.ext4
@@ -38,6 +38,14 @@ SCHEMA_2 = r"""
       "type": "string",
       "maxLength": 16
     },
+    "metadata_csum_seed": {
+      "description": "Enable metadata_csum_seed support",
+      "type": "boolean"
+    },
+    "orphan_file": {
+      "description": "Enable orphan_file support",
+      "type": "boolean"
+    },
     "verity": {
       "description": "Enable fs-verity support",
       "type": "boolean"
@@ -52,17 +60,18 @@ def main(devices, options):
 
     uuid = options["uuid"]
     label = options.get("label")
-    verity = options.get("verity")
     opts = []
 
     if label:
         opts = ["-L", label]
 
-    if verity is not None:
-        if verity:
-            opts += ["-O", "verity"]
-        else:
-            opts += ["-O", "^verity"]
+    for fsopt in ["verity", "orphan_file", "metadata_csum_seed"]:
+        val = options.get(fsopt)
+        if val is not None:
+            if val:
+                opts += ["-O", fsopt]
+            else:
+                opts += ["-O", f"^{fsopt}"]
 
     subprocess.run(["mkfs.ext4", "-U", uuid] + opts + [device],
                    encoding='utf8', check=True)

--- a/stages/test/test_mkfs_ext4.py
+++ b/stages/test/test_mkfs_ext4.py
@@ -82,6 +82,11 @@ def test_mkfs_ext4_integration(tmp_path):
     ({}, []),
     ({"verity": True}, ["-O", "verity"]),
     ({"verity": False}, ["-O", "^verity"]),
+    ({"orphan_file": True}, ["-O", "orphan_file"]),
+    ({"orphan_file": False}, ["-O", "^orphan_file"]),
+    ({"metadata_csum_seed": True}, ["-O", "metadata_csum_seed"]),
+    ({"metadata_csum_seed": False}, ["-O", "^metadata_csum_seed"]),
+    ({"verity": True, "orphan_file": True, "metadata_csum_seed": True}, ["-O", "verity", "-O", "orphan_file", "-O", "metadata_csum_seed"]),
 ])
 @mock.patch("subprocess.run")
 def test_mkfs_ext4_cmdline(mock_run, test_input, expected):


### PR DESCRIPTION
Add optional flags to the org.osbuild.mkfs.ext4 stage enabling/disabling the metadata_csum_seed and orphan_file features.