### PR TITLE
test: export schemas in testing_libdir_fixture

### DIFF
--- a/test/run/test_exports.py
+++ b/test/run/test_exports.py
@@ -58,7 +58,7 @@ def testing_libdir_fixture(tmpdir_factory):
     # in buildroot.py
     (fake_libdir_path / "osbuild").mkdir()
     # construct minimal viable libdir from current checkout
-    for d in ["stages", "runners", ]:
+    for d in ["stages", "runners", "schemas", "assemblers"]:
         subprocess.run(
             ["cp", "-a", os.fspath(project_path / d), f"{fake_libdir_path}"],
             check=True)


### PR DESCRIPTION
When constructing a minimal environment for osbuild the exported dirs lacked "schemas" so the test_exports.py test failed on RHEL8.

This commit adds it (and also "assemblers" for good measure). With that the test will pass.