### PR TITLE
move source parallelization into sources

### DIFF
--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -67,8 +67,8 @@ class SourceService(host.Service):
         """Performs the actual fetch of an element described by its checksum and its descriptor"""
 
     @abc.abstractmethod
-    def download(self, items: Dict) -> None:
-        """Download all sources."""
+    def fetch_all(self, items: Dict) -> None:
+        """Fetch all sources."""
 
     def exists(self, checksum, _desc) -> bool:
         """Returns True if the item to download is in cache. """
@@ -94,7 +94,7 @@ class SourceService(host.Service):
         if method == "download":
             self.setup(args)
             with tempfile.TemporaryDirectory(prefix=".unverified-", dir=self.cache) as self.tmpdir:
-                self.download(SourceService.load_items(fds))
+                self.fetch_all(SourceService.load_items(fds))
                 return None, None
 
         raise host.ProtocolError("Unknown method")

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -12,12 +12,13 @@ an internal cache. Multiple parallel connections are used to speed
 up the download.
 """
 
-
+import concurrent.futures
 import os
 import subprocess
 import sys
 import tempfile
 import urllib.parse
+from typing import Dict
 
 from osbuild import sources
 from osbuild.util.checksum import verify_file
@@ -115,6 +116,14 @@ class CurlSource(sources.SourceService):
         path = urllib.parse.quote(purl.path)
         quoted = purl._replace(path=path)
         return quoted.geturl()
+
+    def download(self, items: Dict) -> None:
+        filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
+        transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            for _ in executor.map(self.fetch_one, *zip(*transformed)):
+                pass
 
     def fetch_one(self, checksum, desc):
         secrets = desc.get("secrets")

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -117,7 +117,7 @@ class CurlSource(sources.SourceService):
         quoted = purl._replace(path=path)
         return quoted.geturl()
 
-    def download(self, items: Dict) -> None:
+    def fetch_all(self, items: Dict) -> None:
         filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
         transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
 

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -12,7 +12,6 @@ resource is decoded and written to the store.
 
 
 import base64
-import concurrent.futures
 import contextlib
 import os
 import sys
@@ -62,9 +61,8 @@ class InlineSource(sources.SourceService):
         filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
         transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            for _ in executor.map(self.fetch_one, *zip(*transformed)):
-                pass
+        for args in transformed:
+            self.fetch_one(*args)
 
     def fetch_one(self, checksum, desc):
         target = os.path.join(self.cache, checksum)

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -57,7 +57,7 @@ class InlineSource(sources.SourceService):
 
     content_type = "org.osbuild.files"
 
-    def download(self, items: Dict) -> None:
+    def fetch_all(self, items: Dict) -> None:
         filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
         transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
 

--- a/sources/org.osbuild.inline
+++ b/sources/org.osbuild.inline
@@ -12,9 +12,11 @@ resource is decoded and written to the store.
 
 
 import base64
+import concurrent.futures
 import contextlib
 import os
 import sys
+from typing import Dict
 
 from osbuild import sources
 from osbuild.util.checksum import verify_file
@@ -55,6 +57,14 @@ SCHEMA = """
 class InlineSource(sources.SourceService):
 
     content_type = "org.osbuild.files"
+
+    def download(self, items: Dict) -> None:
+        filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
+        transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            for _ in executor.map(self.fetch_one, *zip(*transformed)):
+                pass
 
     def fetch_one(self, checksum, desc):
         target = os.path.join(self.cache, checksum)

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -89,7 +89,7 @@ class OSTreeSource(sources.SourceService):
         super().__init__(*args, **kwargs)
         self.repo = None
 
-    def download(self, items: Dict) -> None:
+    def fetch_all(self, items: Dict) -> None:
         filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
         transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
 

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -7,9 +7,11 @@ gpg keys are provided via `gpgkeys`.
 """
 
 
+import concurrent.futures
 import os
 import sys
 import uuid
+from typing import Dict
 
 from osbuild import sources
 from osbuild.util import ostree
@@ -86,6 +88,14 @@ class OSTreeSource(sources.SourceService):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.repo = None
+
+    def download(self, items: Dict) -> None:
+        filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
+        transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            for _ in executor.map(self.fetch_one, *zip(*transformed)):
+                pass
 
     def fetch_one(self, checksum, desc):
         commit = checksum

--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -102,7 +102,7 @@ class SkopeoSource(sources.SourceService):
             return f"containers-storage:{reference}"
         raise RuntimeError("Unrecognized containers transport")
 
-    def download(self, items: Dict) -> None:
+    def fetch_all(self, items: Dict) -> None:
         filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
         transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
 

--- a/sources/org.osbuild.skopeo
+++ b/sources/org.osbuild.skopeo
@@ -14,12 +14,14 @@ retaining signatures and manifests.
 Buildhost commands used: `skopeo`.
 """
 
+import concurrent.futures
 import errno
 import hashlib
 import os
 import subprocess
 import sys
 import tempfile
+from typing import Dict
 
 from osbuild import sources
 from osbuild.util import ctx
@@ -99,6 +101,14 @@ class SkopeoSource(sources.SourceService):
         if transport == CONTAINERS_STORAGE_TRANSPORT:
             return f"containers-storage:{reference}"
         raise RuntimeError("Unrecognized containers transport")
+
+    def download(self, items: Dict) -> None:
+        filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
+        transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            for _ in executor.map(self.fetch_one, *zip(*transformed)):
+                pass
 
     def fetch_one(self, checksum, desc):
         image_id = checksum

--- a/sources/org.osbuild.skopeo-index
+++ b/sources/org.osbuild.skopeo-index
@@ -6,12 +6,14 @@ The manifest is stored as a single file indexed by its content hash.
 Buildhost commands used: `skopeo`.
 """
 
+import concurrent.futures
 import errno
 import json
 import os
 import subprocess
 import sys
 import tempfile
+from typing import Dict
 
 from osbuild import sources
 from osbuild.util import containers, ctx
@@ -84,6 +86,14 @@ class SkopeoIndexSource(sources.SourceService):
         if transport == CONTAINERS_STORAGE_TRANSPORT:
             return f"containers-storage:{reference}"
         raise RuntimeError("Unrecognized containers transport")
+
+    def download(self, items: Dict) -> None:
+        filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
+        transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            for _ in executor.map(self.fetch_one, *zip(*transformed)):
+                pass
 
     def fetch_one(self, checksum, desc):
         digest = checksum

--- a/sources/org.osbuild.skopeo-index
+++ b/sources/org.osbuild.skopeo-index
@@ -87,7 +87,7 @@ class SkopeoIndexSource(sources.SourceService):
             return f"containers-storage:{reference}"
         raise RuntimeError("Unrecognized containers transport")
 
-    def download(self, items: Dict) -> None:
+    def fetch_all(self, items: Dict) -> None:
         filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
         transformed = map(lambda i: self.transform(i[0], i[1]), filtered)  # prepare each item to be downloaded
 


### PR DESCRIPTION
We parallelize (with a threadpool) our sources, this currently happens in `osbuild.sources`. This PR moves that parallelization into the source implementations themselves.

Initially this leads to some duplicated code (only one stage has had its parallelization removed) but allows sources better control on *how* they want to parallelize their workload, and better control over output which is relevant for #1545.