### PR TITLE
osbuild-mpp: support user-defined partition numbers for GPT disks

### DIFF
--- a/stages/org.osbuild.sgdisk
+++ b/stages/org.osbuild.sgdisk
@@ -30,6 +30,10 @@ SCHEMA_2 = r"""
       "description": "UUID for the disk image's partition table",
       "type": "string"
     },
+    "label": {
+      "description": "The type of the partition table",
+      "type": "string"
+    },
     "quote_partition_name": {
       "description": "Quote partition names passed to sgdisk, so that they end up quoted in the partition table. This is old behavior kept for backward compatibility.",
       "type": "boolean",
@@ -49,6 +53,10 @@ SCHEMA_2 = r"""
           "name": {
             "description": "The partition name",
             "type": "string"
+          },
+          "partnum": {
+            "description": "The partition number",
+            "type": "integer"
           },
           "size": {
             "description": "The size of this partition",
@@ -88,6 +96,7 @@ SCHEMA_2 = r"""
 class Partition:
     def __init__(self,
                  pttype: str = None,
+                 partnum: int = None,
                  start: int = None,
                  size: int = None,
                  bootable: bool = False,
@@ -95,6 +104,7 @@ class Partition:
                  uuid: str = None,
                  attrs: int = None):
         self.type = pttype
+        self.partnum = partnum
         self.start = start
         self.size = size
         self.name = name
@@ -106,7 +116,8 @@ class Partition:
 
 
 class PartitionTable:
-    def __init__(self, uuid, partitions):
+    def __init__(self, label, uuid, partitions):
+        assert label == "gpt"
         self.uuid = uuid
         self.partitions = partitions or []
         self.sector_size = 512
@@ -129,7 +140,7 @@ class PartitionTable:
             command += ["-U", self.uuid]
 
         for i, part in enumerate(self.partitions):
-            idx = i + 1  # partitions are 1-indexed
+            idx = part.partnum if part.partnum else i + 1  # partitions are 1-indexed
 
             # format is 'partnum:start:end'
             size = "0"
@@ -173,6 +184,7 @@ class PartitionTable:
 
 def partition_from_json(js) -> Partition:
     p = Partition(pttype=js.get("type"),
+                  partnum=js.get("partnum"),
                   start=js.get("start"),
                   size=js.get("size"),
                   bootable=js.get("bootable"),
@@ -186,11 +198,12 @@ def main(devices, options):
     device = devices["device"]["path"]
 
     ptuuid = options["uuid"]
+    pttype = options["label"]
     quote_partition_name = options.get("quote_partition_name", True)
     partitions = options.get("partitions")
 
     parts = [partition_from_json(p) for p in partitions]
-    pt = PartitionTable(ptuuid, parts)
+    pt = PartitionTable(pttype, ptuuid, parts)
 
     pt.write_to(device, quote_partition_name)
 

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -357,6 +357,7 @@ import hashlib
 import json
 import os
 import pathlib
+import re
 import string
 import subprocess
 import sys
@@ -815,6 +816,7 @@ class Partition:
     def __init__(self,
                  uid: str = None,
                  pttype: str = None,
+                 partnum: int = None,
                  start: int = None,
                  size: int = None,
                  bootable: bool = False,
@@ -830,8 +832,8 @@ class Partition:
         self.name = name
         self.uuid = uuid
         self.attrs = attrs
-        self.index = None
-        self.partnum = None
+        self.index = partnum - 1 if partnum else None
+        self.partnum = partnum
 
     @property
     def start_in_bytes(self):
@@ -845,6 +847,7 @@ class Partition:
     def from_dict(cls, js):
         p = cls(uid=js.get("id"),
                 pttype=js.get("type"),
+                partnum=js.get("partnum"),
                 start=js.get("start"),
                 size=js.get("size"),
                 bootable=js.get("bootable"),
@@ -858,6 +861,8 @@ class Partition:
 
         if self.start:
             data["start"] = self.start
+        if self.partnum:
+            data["partnum"] = self.partnum
         if self.size:
             data["size"] = self.size
         if self.type:
@@ -891,6 +896,16 @@ class PartitionTable:
 
     def write_to(self, target, sync=True):
         """Write the partition table to disk"""
+        if self.label == "gpt":
+            self.sgdisk_write_to(target)
+        else:
+            self.sfdisk_write_to(target)
+
+        if sync:
+            self.update_from(target)
+
+    def sfdisk_write_to(self, target):
+        """Write the partition table to disk"""
         # generate the command for sfdisk to create the table
         command = f"label: {self.label}\nlabel-id: {self.uuid}"
         for partition in self.partitions:
@@ -922,8 +937,61 @@ class PartitionTable:
                        encoding='utf-8',
                        check=True)
 
-        if sync:
-            self.update_from(target)
+    def sgdisk_write_to(self, target):
+        """Write the partition table to disk"""
+        # generate the command for sgdisk to create the table
+
+        command = [
+            "sgdisk",
+            "-Z",  # erase the partition table
+            target,
+            "-g",  # needed for older sgdisk
+        ]
+
+        if self.uuid:
+            command += ["-U", self.uuid]
+
+        for i, part in enumerate(self.partitions):
+            idx = part.partnum if part.partnum else i + 1  # partitions are 1-indexed
+            start = part.start if part.start else 0
+
+            # format is 'partnum:start:end'
+            size = "0"
+            if part.size:
+                size_bytes = part.size
+                size = f"+{size_bytes}"
+
+            cmd = [
+                "-n", f"{idx}:{start}:{size}"
+
+            ]
+
+            if part.name:
+                cmd += [
+                    "-c", f"{idx}:{part.name}"
+                ]
+
+            if part.uuid:
+                cmd += [
+                    "-u", f"{idx}:{part.uuid}"
+                ]
+
+            if part.type:
+                cmd += [
+                    "-t", f"{idx}:{part.type}"
+                ]
+
+            if part.attrs:
+                for attr in sorted(part.attrs):
+                    cmd += [
+                        "-A", f"{idx}:set:{attr}"
+                    ]
+
+            command += cmd
+
+        subprocess.run(command,
+                       encoding='utf8',
+                       check=True)
 
     def update_from(self, target):
         """Update and fill in missing information from disk"""
@@ -936,8 +1004,9 @@ class PartitionTable:
 
         assert len(disk_parts) == len(self.partitions)
         for i, part in enumerate(self.partitions):
-            part.index = i
-            part.partnum = i + 1
+            node = re.findall(r'\d+', disk_parts[i]["node"])
+            part.partnum = int(node[-1])
+            part.index = part.partnum - 1
             part.start = disk_parts[i]["start"]
             part.size = disk_parts[i]["size"]
             part.type = disk_parts[i].get("type")


### PR DESCRIPTION
Partitions by default are indexed starting at 1, but in some cases, such as CoreOS for IBM Z, it may be usefull to set the 'partnum' for GPT disks explicitly, without creating dummy partitions.

Now user can define an image:

```
    mpp-define-images:
      - id: image
        size: 10737418240
        table:
          uuid: 00000000-0000-4000-a000-000000000001
          label: gpt
          partitions:
            - name: boot
              type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
	      partnum: 3
              size: 786432
            - name: root
              type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
	      partnum: 4
              size: 4194304
```

So target disk would look like:

```
    Disklabel type: gpt
    Disk identifier: 00000000-0000-4000-A000-000000000001
    Device        Start     End Sectors  Size Type
    /dev/loop0p3   2048  788479  786432  384M Linux filesystem
    /dev/loop0p4 788480 4982783 4194304    2G Linux filesystem
```