### PR TITLE
stages/org.osbuild.cloud-init: fix dump format of `datasource_list` key

### DIFF
--- a/stages/org.osbuild.cloud-init
+++ b/stages/org.osbuild.cloud-init
@@ -142,11 +142,33 @@ SCHEMA = r"""
 """
 
 
+# Class representing the 'datasource_list' configuration option,
+# allowing to define a custom YAML dumper for it.
+class DatasourceList(list):
+    pass
+
+
+# Dedicated YAML dumper for the `DatasourceList` class.
+# Make sure that the `DatasourceList` always uses flow style.
+# https://cloudinit.readthedocs.io/en/latest/reference/base_config_reference.html#datasource-list
+# Specifically, it says for the `datasource_list` key:
+# "This key is unique in that it uses a subset of YAML syntax.
+#  It requires that the key and its contents, a list,
+#  must share a single line - no newlines."
+def datasourcelist_presenter(dumper, data):
+    return dumper.represent_sequence("tag:yaml.org,2002:seq", data, flow_style=True)
+
+
 # Writes the passed `config` object as is into the configuration file in YAML format.
 # The validity of the `config` content is assured by the SCHEMA.
 def main(tree, options):
     filename = options.get("filename")
     config = options.get("config", {})
+
+    datasource_list = config.get("datasource_list")
+    if datasource_list:
+        config["datasource_list"] = DatasourceList(datasource_list)
+    yaml.add_representer(DatasourceList, datasourcelist_presenter)
 
     config_files_dir = f"{tree}/etc/cloud/cloud.cfg.d"
 

--- a/stages/test/conftest.py
+++ b/stages/test/conftest.py
@@ -4,6 +4,7 @@ from types import ModuleType
 
 import pytest
 
+import osbuild.meta
 from osbuild.testutil.imports import import_module_from_path
 
 
@@ -19,3 +20,26 @@ def stage_module(request: pytest.FixtureRequest) -> ModuleType:
     caller_dir = pathlib.Path(request.node.fspath).parent
     module_path = caller_dir.parent / stage_name
     return import_module_from_path("stage", os.fspath(module_path))
+
+
+@pytest.fixture
+def stage_schema(request: pytest.FixtureRequest) -> osbuild.meta.Schema:
+    """stage_schema is a fixture returns the schema for a stage module.
+
+    This fixture may be indirectly parametrized with the stage schema version.
+    If the schema version is not specified, the version "2" is assumed.
+    The stage name must be defined in STAGE_NAME in the test module.
+    """
+    if hasattr(request, "param") and not isinstance(request.param, str):
+        raise ValueError(
+            "stage_schema fixture may be indirectly parametrized only with the stage schema version string")
+
+    if not hasattr(request.module, "STAGE_NAME"):
+        raise ValueError("stage_schema fixture must be used in a test module that defines STAGE_NAME")
+
+    stage_name = request.module.STAGE_NAME
+    schema_version = request.param if hasattr(request, "param") else "2"
+    caller_dir = pathlib.Path(request.node.fspath).parent
+    root = caller_dir.parent.parent
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", stage_name)
+    return osbuild.meta.Schema(mod_info.get_schema(version=schema_version), stage_name)

--- a/stages/test/conftest.py
+++ b/stages/test/conftest.py
@@ -1,0 +1,21 @@
+import os
+import pathlib
+from types import ModuleType
+
+import pytest
+
+from osbuild.testutil.imports import import_module_from_path
+
+
+@pytest.fixture
+def stage_module(request: pytest.FixtureRequest) -> ModuleType:
+    """stage_module is a fixture that imports a stage module by its name
+    defined in STAGE_NAME in the test module.
+    """
+    if not hasattr(request.module, "STAGE_NAME"):
+        raise ValueError("stage_module fixture must be used in a test module that defines STAGE_NAME")
+
+    stage_name = request.module.STAGE_NAME
+    caller_dir = pathlib.Path(request.node.fspath).parent
+    module_path = caller_dir.parent / stage_name
+    return import_module_from_path("stage", os.fspath(module_path))

--- a/stages/test/test_bootupd.py
+++ b/stages/test/test_bootupd.py
@@ -1,11 +1,9 @@
 #!/usr/bin/python3
 
-import os.path
 from unittest.mock import call, patch
 
 import pytest
 
-import osbuild.meta
 from osbuild import testutil
 
 STAGE_NAME = "org.osbuild.bootupd"
@@ -38,18 +36,14 @@ STAGE_NAME = "org.osbuild.bootupd"
     }, "")
 
 ])
-def test_bootupd_schema_validation(test_data, expected_err):
-    root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), STAGE_NAME)
-
+def test_bootupd_schema_validation(stage_schema, test_data, expected_err):
     test_input = {
         "type": STAGE_NAME,
         "options": {
         }
     }
     test_input["options"].update(test_data)
-    res = schema.validate(test_input)
+    res = stage_schema.validate(test_input)
 
     if expected_err == "":
         assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"

--- a/stages/test/test_cloud-init.py
+++ b/stages/test/test_cloud-init.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+
+import os.path
+
+from osbuild.testutil.imports import import_module_from_path
+
+
+# Test that the 'datasource_list' option is dumped as a single line
+# in the configuration file.
+def test_cloud_init_datasource_list_single_line(tmp_path):
+    treedir = tmp_path / "tree"
+    confpath = treedir / "etc/cloud/cloud.cfg.d/datasource_list.cfg"
+    confpath.parent.mkdir(parents=True, exist_ok=True)
+
+    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.cloud-init")
+    stage = import_module_from_path("stage", stage_path)
+
+    options = {
+        "filename": confpath.name,
+        "config": {
+            "datasource_list": [
+                "Azure",
+            ]
+        }
+    }
+
+    stage.main(treedir, options)
+    assert os.path.exists(confpath)
+    assert confpath.read_text() == "datasource_list: [Azure]\n"

--- a/stages/test/test_cloud-init.py
+++ b/stages/test/test_cloud-init.py
@@ -2,18 +2,15 @@
 
 import os.path
 
-from osbuild.testutil.imports import import_module_from_path
+STAGE_NAME = "org.osbuild.cloud-init"
 
 
 # Test that the 'datasource_list' option is dumped as a single line
 # in the configuration file.
-def test_cloud_init_datasource_list_single_line(tmp_path):
+def test_cloud_init_datasource_list_single_line(tmp_path, stage_module):
     treedir = tmp_path / "tree"
     confpath = treedir / "etc/cloud/cloud.cfg.d/datasource_list.cfg"
     confpath.parent.mkdir(parents=True, exist_ok=True)
-
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.cloud-init")
-    stage = import_module_from_path("stage", stage_path)
 
     options = {
         "filename": confpath.name,
@@ -24,6 +21,6 @@ def test_cloud_init_datasource_list_single_line(tmp_path):
         }
     }
 
-    stage.main(treedir, options)
+    stage_module.main(treedir, options)
     assert os.path.exists(confpath)
     assert confpath.read_text() == "datasource_list: [Azure]\n"

--- a/stages/test/test_containers_storage_conf.py
+++ b/stages/test/test_containers_storage_conf.py
@@ -10,7 +10,6 @@ try:
 except ModuleNotFoundError:
     import pytoml as toml
 
-import osbuild.meta
 from osbuild import testutil
 
 TEST_INPUT = [
@@ -95,12 +94,7 @@ def test_containers_storage_conf_integration(tmp_path, stage_module, test_filena
         ({}, {"options": {"pull_options": {"use_hard_links": True}}}, "is not of type 'string'"),
     ],
 )
-def test_schema_validation_containers_storage_conf(test_data, storage_test_data, expected_err):
-    version = "2"
-    root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version=version), STAGE_NAME)
-
+def test_schema_validation_containers_storage_conf(stage_schema, test_data, storage_test_data, expected_err):
     test_input = {
         "type": STAGE_NAME,
         "options": {
@@ -113,7 +107,7 @@ def test_schema_validation_containers_storage_conf(test_data, storage_test_data,
 
     test_input["options"].update(test_data)
     test_input["options"]["config"]["storage"].update(storage_test_data)
-    res = schema.validate(test_input)
+    res = stage_schema.validate(test_input)
 
     if expected_err == "":
         assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"

--- a/stages/test/test_erofs.py
+++ b/stages/test/test_erofs.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 
-import osbuild.meta
 from osbuild import testutil
 from osbuild.testutil import has_executable, make_fake_input_tree
 
@@ -89,11 +88,7 @@ def test_erofs(mock_run, tmp_path, stage_module, test_options, expected):
     # good
     ({"compression": {"method": "lz4"}}, ""),
 ])
-def test_schema_validation_erofs(test_data, expected_err):
-    root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), STAGE_NAME)
-
+def test_schema_validation_erofs(stage_schema, test_data, expected_err):
     test_input = {
         "type": STAGE_NAME,
         "options": {
@@ -101,7 +96,7 @@ def test_schema_validation_erofs(test_data, expected_err):
         }
     }
     test_input["options"].update(test_data)
-    res = schema.validate(test_input)
+    res = stage_schema.validate(test_input)
 
     if expected_err == "":
         assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"

--- a/stages/test/test_grub2.py
+++ b/stages/test/test_grub2.py
@@ -1,15 +1,11 @@
 #!/usr/bin/python3
 
-import os.path
-
 from osbuild.testutil import make_fake_tree
-from osbuild.testutil.imports import import_module_from_path
+
+STAGE_NAME = "org.osbuild.grub2"
 
 
-def test_grub2_copy_efi_data(tmp_path):
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.grub2")
-    stage = import_module_from_path("stage", stage_path)
-
+def test_grub2_copy_efi_data(tmp_path, stage_module):
     fake_efi_src_dir = tmp_path / "fake-efi/EFI"
     make_fake_tree(fake_efi_src_dir, {
         "fedora/a.shim": "fake shim",
@@ -27,6 +23,6 @@ def test_grub2_copy_efi_data(tmp_path):
         },
     }
     fake_tree = tmp_path / "tree"
-    stage.main(fake_tree, test_options)
+    stage_module.main(fake_tree, test_options)
     assert (fake_tree / "boot/efi/EFI/fedora/a.shim").exists()
     assert (fake_tree / "boot/efi/EFI/BOOT/BOOTX64.EFI").exists()

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -8,7 +8,6 @@ import pytest
 import osbuild.meta
 from osbuild import testutil
 from osbuild.testutil import has_executable
-from osbuild.testutil.imports import import_module_from_path
 
 TEST_INPUT = [
     ({"lang": "en_US.UTF-8"}, "lang en_US.UTF-8"),
@@ -216,14 +215,16 @@ TEST_INPUT = [
 ]
 
 
+STAGE_NAME = "org.osbuild.kickstart"
+
+
 def schema_validate_kickstart_stage(test_data):
-    name = "org.osbuild.kickstart"
     version = "1"
     root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version=version), name)
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
+    schema = osbuild.meta.Schema(mod_info.get_schema(version=version), STAGE_NAME)
     test_input = {
-        "name": "org.osbuild.kickstart",
+        "name": STAGE_NAME,
         "options": {
             "path": "some-path",
         }
@@ -240,15 +241,12 @@ def test_kickstart_test_cases_valid(test_input, expected):  # pylint: disable=un
 
 
 @pytest.mark.parametrize("test_input,expected", TEST_INPUT)
-def test_kickstart_write(tmp_path, test_input, expected):
-    ks_stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.kickstart")
-    ks_stage = import_module_from_path("ks_stage", ks_stage_path)
-
+def test_kickstart_write(tmp_path, stage_module, test_input, expected):
     ks_path = "kickstart/kfs.cfg"
     options = {"path": ks_path}
     options.update(test_input)
 
-    ks_stage.main(tmp_path, options)
+    stage_module.main(tmp_path, options)
 
     ks_path = os.path.join(tmp_path, ks_path)
     with open(ks_path, encoding="utf-8") as fp:
@@ -258,15 +256,12 @@ def test_kickstart_write(tmp_path, test_input, expected):
 
 @pytest.mark.skipif(not has_executable("ksvalidator"), reason="`ksvalidator` is required")
 @pytest.mark.parametrize("test_input,expected", TEST_INPUT)
-def test_kickstart_valid(tmp_path, test_input, expected):  # pylint: disable=unused-argument
-    ks_stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.kickstart")
-    ks_stage = import_module_from_path("ks_stage", ks_stage_path)
-
+def test_kickstart_valid(tmp_path, stage_module, test_input, expected):  # pylint: disable=unused-argument
     ks_path = "kickstart/kfs.cfg"
     options = {"path": ks_path}
     options.update(test_input)
 
-    ks_stage.main(tmp_path, options)
+    stage_module.main(tmp_path, options)
 
     ks_path = os.path.join(tmp_path, ks_path)
 

--- a/stages/test/test_machine-id.py
+++ b/stages/test/test_machine-id.py
@@ -1,12 +1,10 @@
 #!/usr/bin/python3
 
 import os
-import pathlib
 import unittest.mock
 
 import pytest
 
-import osbuild.meta
 from osbuild import testutil
 
 STAGE_NAME = "org.osbuild.machine-id"
@@ -59,17 +57,14 @@ def test_machine_id_first_boot_preserve(
 @pytest.mark.parametrize("test_data,expected_err", [
     ({"first-boot": "invalid-option"}, "'invalid-option' is not one of "),
 ])
-def test_machine_id_schema_validation(test_data, expected_err):
-    root = pathlib.Path(__file__).parents[2]
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
-    schema = osbuild.meta.Schema(mod_info.get_schema(), STAGE_NAME)
-
+@pytest.mark.parametrize("stage_schema", ["1"], indirect=True)
+def test_machine_id_schema_validation(stage_schema, test_data, expected_err):
     test_input = {
         "name": STAGE_NAME,
         "options": {},
     }
     test_input["options"].update(test_data)
-    res = schema.validate(test_input)
+    res = stage_schema.validate(test_input)
 
     assert res.valid is False
     testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)

--- a/stages/test/test_mkfs_ext4.py
+++ b/stages/test/test_mkfs_ext4.py
@@ -7,7 +7,6 @@ from unittest import mock
 
 import pytest
 
-import osbuild.meta
 from osbuild import testutil
 from osbuild.testutil import has_executable
 
@@ -27,11 +26,7 @@ STAGE_NAME = "org.osbuild.mkfs.ext4"
     # uuid but our schema is not strict enough right now
     ({"uuid": "some-uuid"}, ""),
 ])
-def test_schema_validation_mkfs_ext4(test_data, expected_err):
-    root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), STAGE_NAME)
-
+def test_schema_validation_mkfs_ext4(stage_schema, test_data, expected_err):
     test_input = {
         "type": STAGE_NAME,
         "devices": {
@@ -43,7 +38,7 @@ def test_schema_validation_mkfs_ext4(test_data, expected_err):
         }
     }
     test_input["options"].update(test_data)
-    res = schema.validate(test_input)
+    res = stage_schema.validate(test_input)
 
     if expected_err == "":
         assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"

--- a/stages/test/test_ostree_post_copy.py
+++ b/stages/test/test_ostree_post_copy.py
@@ -7,17 +7,17 @@ import pytest
 
 import osbuild.meta
 from osbuild import testutil
-from osbuild.testutil.imports import import_module_from_path
+
+STAGE_NAME = "org.osbuild.ostree.post-copy"
 
 
 def schema_validate_stage_ostree_post_copy(test_data):
-    name = "org.osbuild.ostree.post-copy"
     version = "2"
     root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version=version), name)
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
+    schema = osbuild.meta.Schema(mod_info.get_schema(version=version), STAGE_NAME)
     test_input = {
-        "type": "org.osbuild.ostree.post-copy",
+        "type": STAGE_NAME,
         "options": {
             "sysroot": "/some/sysroot",
         },
@@ -27,17 +27,14 @@ def schema_validate_stage_ostree_post_copy(test_data):
 
 
 @patch("osbuild.util.ostree.cli")
-def test_ostree_post_copy_smoke(mock_ostree_cli):
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.ostree.post-copy")
-    stage = import_module_from_path("stage", stage_path)
-
+def test_ostree_post_copy_smoke(mock_ostree_cli, stage_module):
     paths = {
         "mounts": "/run/osbuild/mounts",
     }
     options = {
         "sysroot": "/some/sysroot",
     }
-    stage.main(paths, options)
+    stage_module.main(paths, options)
 
     assert mock_ostree_cli.call_args_list == [
         call("admin", "post-copy", sysroot="/run/osbuild/mounts/some/sysroot")]

--- a/stages/test/test_ostree_post_copy.py
+++ b/stages/test/test_ostree_post_copy.py
@@ -1,29 +1,12 @@
 #!/usr/bin/python3
 
-import os.path
 from unittest.mock import call, patch
 
 import pytest
 
-import osbuild.meta
 from osbuild import testutil
 
 STAGE_NAME = "org.osbuild.ostree.post-copy"
-
-
-def schema_validate_stage_ostree_post_copy(test_data):
-    version = "2"
-    root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version=version), STAGE_NAME)
-    test_input = {
-        "type": STAGE_NAME,
-        "options": {
-            "sysroot": "/some/sysroot",
-        },
-    }
-    test_input.update(test_data)
-    return schema.validate(test_input)
 
 
 @patch("osbuild.util.ostree.cli")
@@ -50,8 +33,15 @@ def test_ostree_post_copy_smoke(mock_ostree_cli, stage_module):
         ({"mounts": "must-be-array"}, " is not of type 'array'"),
     ],
 )
-def test_schema_validation_ostree_post_copy(test_data, expected_err):
-    res = schema_validate_stage_ostree_post_copy(test_data)
+def test_schema_validation_ostree_post_copy(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "options": {
+            "sysroot": "/some/sysroot",
+        },
+    }
+    test_input.update(test_data)
+    res = stage_schema.validate(test_input)
 
     assert res.valid is False
     testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)

--- a/stages/test/test_selinux.py
+++ b/stages/test/test_selinux.py
@@ -7,17 +7,17 @@ import pytest
 
 import osbuild.meta
 from osbuild import testutil
-from osbuild.testutil.imports import import_module_from_path
+
+STAGE_NAME = "org.osbuild.selinux"
 
 
 def schema_validation_selinux(test_data, implicit_file_contexts=True):
-    name = "org.osbuild.selinux"
     root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version="1"), name)
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
+    schema = osbuild.meta.Schema(mod_info.get_schema(version="1"), STAGE_NAME)
 
     test_input = {
-        "name": "org.osbuild.selinux",
+        "name": STAGE_NAME,
         "options": {}
     }
     if implicit_file_contexts:
@@ -54,14 +54,11 @@ def test_schema_validation_selinux_file_context_required():
 
 
 @patch("osbuild.util.selinux.setfiles")
-def test_selinux_file_contexts(mocked_setfiles, tmp_path):
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.selinux")
-    stage = import_module_from_path("stage", stage_path)
-
+def test_selinux_file_contexts(mocked_setfiles, tmp_path, stage_module):
     options = {
         "file_contexts": "etc/selinux/thing",
     }
-    stage.main(tmp_path, options)
+    stage_module.main(tmp_path, options)
 
     assert len(mocked_setfiles.call_args_list) == 1
     assert mocked_setfiles.call_args_list == [
@@ -71,10 +68,7 @@ def test_selinux_file_contexts(mocked_setfiles, tmp_path):
 
 @patch("osbuild.util.selinux.setfilecon")
 @patch("osbuild.util.selinux.setfiles")
-def test_selinux_labels(mocked_setfiles, mocked_setfilecon, tmp_path):
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.selinux")
-    stage = import_module_from_path("stage", stage_path)
-
+def test_selinux_labels(mocked_setfiles, mocked_setfilecon, tmp_path, stage_module):
     osbuild.testutil.make_fake_input_tree(tmp_path, {
         "/usr/bin/bootc": "I'm only an imposter",
     })
@@ -85,7 +79,7 @@ def test_selinux_labels(mocked_setfiles, mocked_setfilecon, tmp_path):
             "/tree/usr/bin/bootc": "system_u:object_r:install_exec_t:s0",
         }
     }
-    stage.main(tmp_path, options)
+    stage_module.main(tmp_path, options)
 
     assert len(mocked_setfiles.call_args_list) == 1
     assert len(mocked_setfilecon.call_args_list) == 1
@@ -95,15 +89,12 @@ def test_selinux_labels(mocked_setfiles, mocked_setfilecon, tmp_path):
 
 
 @patch("osbuild.util.selinux.setfiles")
-def test_selinux_force_autorelabel(mocked_setfiles, tmp_path):  # pylint: disable=unused-argument
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.selinux")
-    stage = import_module_from_path("stage", stage_path)
-
+def test_selinux_force_autorelabel(mocked_setfiles, tmp_path, stage_module):  # pylint: disable=unused-argument
     for enable_autorelabel in [False, True]:
         options = {
             "file_contexts": "etc/selinux/thing",
             "force_autorelabel": enable_autorelabel,
         }
-        stage.main(tmp_path, options)
+        stage_module.main(tmp_path, options)
 
         assert (tmp_path / ".autorelabel").exists() == enable_autorelabel

--- a/stages/test/test_skopeo.py
+++ b/stages/test/test_skopeo.py
@@ -7,6 +7,8 @@ import pytest
 import osbuild.meta
 from osbuild import testutil
 
+STAGE_NAME = "org.osbuild.skopeo"
+
 
 @pytest.mark.parametrize("test_data,expected_err", [
     # bad
@@ -22,13 +24,12 @@ from osbuild import testutil
     ({"destination": {"type": "containers-storage"}}, ""),
 ])
 def test_schema_validation_skopeo(test_data, expected_err):
-    name = "org.osbuild.skopeo"
     root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), name)
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
+    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), STAGE_NAME)
 
     test_input = {
-        "type": "org.osbuild.skopeo",
+        "type": STAGE_NAME,
         "options": {},
     }
     test_input["options"].update(test_data)

--- a/stages/test/test_skopeo.py
+++ b/stages/test/test_skopeo.py
@@ -1,10 +1,7 @@
 #!/usr/bin/python3
 
-import os.path
-
 import pytest
 
-import osbuild.meta
 from osbuild import testutil
 
 STAGE_NAME = "org.osbuild.skopeo"
@@ -23,17 +20,13 @@ STAGE_NAME = "org.osbuild.skopeo"
     # *inputs* and it'll be a no-op in the stage
     ({"destination": {"type": "containers-storage"}}, ""),
 ])
-def test_schema_validation_skopeo(test_data, expected_err):
-    root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), STAGE_NAME)
-
+def test_schema_validation_skopeo(stage_schema, test_data, expected_err):
     test_input = {
         "type": STAGE_NAME,
         "options": {},
     }
     test_input["options"].update(test_data)
-    res = schema.validate(test_input)
+    res = stage_schema.validate(test_input)
 
     if expected_err == "":
         assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"

--- a/stages/test/test_systemd.py
+++ b/stages/test/test_systemd.py
@@ -3,16 +3,13 @@
 import os
 import os.path
 
-from osbuild.testutil.imports import import_module_from_path
+STAGE_NAME = "org.osbuild.systemd"
 
 
-def test_systemd_masked_generators(tmp_path):
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.systemd")
-    stage = import_module_from_path("stage", stage_path)
-
+def test_systemd_masked_generators(tmp_path, stage_module):
     options = {"masked_generators": ["fake-generator"]}
 
-    stage.main(tmp_path, options)
+    stage_module.main(tmp_path, options)
 
     masked_generator_path = os.path.join(tmp_path, "etc/systemd/system-generators/fake-generator")
     assert os.path.lexists(masked_generator_path)

--- a/stages/test/test_xz.py
+++ b/stages/test/test_xz.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 
-import osbuild.meta
 from osbuild import testutil
 from osbuild.testutil import has_executable, make_fake_input_tree
 
@@ -19,18 +18,14 @@ STAGE_NAME = "org.osbuild.xz"
     # good
     ({"filename": "image.xz"}, ""),
 ])
-def test_schema_validation_xz(test_data, expected_err):
-    root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), STAGE_NAME)
-
+def test_schema_validation_xz(stage_schema, test_data, expected_err):
     test_input = {
         "type": STAGE_NAME,
         "options": {
         }
     }
     test_input["options"].update(test_data)
-    res = schema.validate(test_input)
+    res = stage_schema.validate(test_input)
 
     if expected_err == "":
         assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"

--- a/stages/test/test_xz.py
+++ b/stages/test/test_xz.py
@@ -9,7 +9,8 @@ import pytest
 import osbuild.meta
 from osbuild import testutil
 from osbuild.testutil import has_executable, make_fake_input_tree
-from osbuild.testutil.imports import import_module_from_path
+
+STAGE_NAME = "org.osbuild.xz"
 
 
 @pytest.mark.parametrize("test_data,expected_err", [
@@ -19,13 +20,12 @@ from osbuild.testutil.imports import import_module_from_path
     ({"filename": "image.xz"}, ""),
 ])
 def test_schema_validation_xz(test_data, expected_err):
-    name = "org.osbuild.xz"
     root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), name)
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
+    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), STAGE_NAME)
 
     test_input = {
-        "type": "org.osbuild.xz",
+        "type": STAGE_NAME,
         "options": {
         }
     }
@@ -58,14 +58,12 @@ def fake_input(tmp_path):
 
 
 @pytest.mark.skipif(not has_executable("xz"), reason="no xz executable")
-def test_xz_integration(tmp_path, fake_input_tree):  # pylint: disable=unused-argument
+def test_xz_integration(tmp_path, stage_module, fake_input_tree):  # pylint: disable=unused-argument
     inputs = fake_input_tree[1]
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.xz")
-    stage = import_module_from_path("xz_stage", stage_path)
     options = {
         "filename": "image.txt.xz",
     }
-    stage.main(inputs, tmp_path, options)
+    stage_module.main(inputs, tmp_path, options)
 
     img_path = os.path.join(tmp_path, "image.txt.xz")
     assert os.path.exists(img_path)
@@ -75,16 +73,14 @@ def test_xz_integration(tmp_path, fake_input_tree):  # pylint: disable=unused-ar
 
 
 @mock.patch("subprocess.run")
-def test_xz_cmdline(mock_run, tmp_path, fake_input_tree):
+def test_xz_cmdline(mock_run, tmp_path, stage_module, fake_input_tree):
     fake_input_path = fake_input_tree[0]
     inputs = fake_input_tree[1]
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.xz")
-    stage = import_module_from_path("xz_stage", stage_path)
     filename = "image.txt.xz"
     options = {
         "filename": filename,
     }
-    stage.main(inputs, tmp_path, options)
+    stage_module.main(inputs, tmp_path, options)
 
     expected = [
         "xz",

--- a/stages/test/test_zstd.py
+++ b/stages/test/test_zstd.py
@@ -9,7 +9,8 @@ import pytest
 import osbuild.meta
 from osbuild import testutil
 from osbuild.testutil import has_executable, make_fake_input_tree
-from osbuild.testutil.imports import import_module_from_path
+
+STAGE_NAME = "org.osbuild.zstd"
 
 
 @pytest.mark.parametrize("test_data,expected_err", [
@@ -19,13 +20,12 @@ from osbuild.testutil.imports import import_module_from_path
     ({"filename": "image.zst"}, ""),
 ])
 def test_schema_validation_zstd(test_data, expected_err):
-    name = "org.osbuild.zstd"
     root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", name)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), name)
+    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
+    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), STAGE_NAME)
 
     test_input = {
-        "type": "org.osbuild.zstd",
+        "type": STAGE_NAME,
         "options": {
         }
     }
@@ -58,14 +58,12 @@ def fake_input(tmp_path):
 
 
 @pytest.mark.skipif(not has_executable("zstd"), reason="no zstd executable")
-def test_zstd_integration(tmp_path, fake_input_tree):  # pylint: disable=unused-argument
+def test_zstd_integration(tmp_path, stage_module, fake_input_tree):  # pylint: disable=unused-argument
     inputs = fake_input_tree[1]
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.zstd")
-    stage = import_module_from_path("zstd_stage", stage_path)
     options = {
         "filename": "image.txt.zst",
     }
-    stage.main(inputs, tmp_path, options)
+    stage_module.main(inputs, tmp_path, options)
 
     img_path = os.path.join(tmp_path, "image.txt.zst")
     assert os.path.exists(img_path)
@@ -75,16 +73,14 @@ def test_zstd_integration(tmp_path, fake_input_tree):  # pylint: disable=unused-
 
 
 @mock.patch("subprocess.run")
-def test_zstd_cmdline(mock_run, tmp_path, fake_input_tree):
+def test_zstd_cmdline(mock_run, tmp_path, stage_module, fake_input_tree):
     fake_input_path = fake_input_tree[0]
     inputs = fake_input_tree[1]
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.zstd")
-    stage = import_module_from_path("zstd_stage", stage_path)
     filename = "image.txt.zst"
     options = {
         "filename": filename,
     }
-    stage.main(inputs, tmp_path, options)
+    stage_module.main(inputs, tmp_path, options)
 
     expected = [
         "zstd",

--- a/stages/test/test_zstd.py
+++ b/stages/test/test_zstd.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 
-import osbuild.meta
 from osbuild import testutil
 from osbuild.testutil import has_executable, make_fake_input_tree
 
@@ -19,18 +18,14 @@ STAGE_NAME = "org.osbuild.zstd"
     # good
     ({"filename": "image.zst"}, ""),
 ])
-def test_schema_validation_zstd(test_data, expected_err):
-    root = os.path.join(os.path.dirname(__file__), "../..")
-    mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", STAGE_NAME)
-    schema = osbuild.meta.Schema(mod_info.get_schema(version="2"), STAGE_NAME)
-
+def test_schema_validation_zstd(stage_schema, test_data, expected_err):
     test_input = {
         "type": STAGE_NAME,
         "options": {
         }
     }
     test_input["options"].update(test_data)
-    res = schema.validate(test_input)
+    res = stage_schema.validate(test_input)
 
     if expected_err == "":
         assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"


### PR DESCRIPTION
The `org.osbuild.cloud-init` would create an invalid cloud-init configuration file, if the `datasource_list` config key was specified in the stage options.

Specifically, the configuration file would contain the key dumped in the following format:

```yaml
datasource_list:
 - Azure
```

The cloud-init documentation for the `datasource_list` config key [explicitly mentions that](https://cloudinit.readthedocs.io/en/latest/reference/base_config_reference.html#datasource-list):
```
This key is unique in that it uses a subset of YAML syntax. It requires that the key and its contents, a list, must share a single line - no newlines.
```

Therefore, the dump format for the key is supposed to be the following:

```yaml
datasource_list: [Azure]
```

Fix the stage to dump the key in the "flow" format on a single line.
Add a simple unit test verifying the dump format of the `datasource_list` config key.

Note that this PR technically changes the behavior of the stage and will "fix" Azure image definitions in osbuild-composer as a result. I considered keeping the current behavior and gating the new dump format behind a new option, but I do not think it makes sense.

Fix #1554 