### PR TITLE
stages: add new `stagefixture` fixture

### DIFF
--- a/stages/test/stagefixture.py
+++ b/stages/test/stagefixture.py
@@ -1,0 +1,13 @@
+import os
+
+import pytest
+
+from osbuild.testutil.imports import import_module_from_path
+
+
+@pytest.fixture(name="stage")
+def stagefixture(request):
+    stage_name = request.module.STAGE
+    stage_path = os.path.join(os.path.dirname(__file__), f"../{stage_name}")
+    stage = import_module_from_path("xz_stage", stage_path)
+    return stage

--- a/stages/test/test_xz.py
+++ b/stages/test/test_xz.py
@@ -5,11 +5,14 @@ import subprocess
 from unittest import mock
 
 import pytest
+from stagefixture import stagefixture  # noqa, pylint: disable=unused-import
 
 import osbuild.meta
 from osbuild import testutil
 from osbuild.testutil import has_executable, make_fake_input_tree
-from osbuild.testutil.imports import import_module_from_path
+
+# read by the stagefixture to know what stage to test
+STAGE = "org.osbuild.xz"
 
 
 @pytest.mark.parametrize("test_data,expected_err", [
@@ -58,10 +61,8 @@ def fake_input(tmp_path):
 
 
 @pytest.mark.skipif(not has_executable("xz"), reason="no xz executable")
-def test_xz_integration(tmp_path, fake_input_tree):  # pylint: disable=unused-argument
+def test_xz_integration(tmp_path, stage, fake_input_tree):  # pylint: disable=unused-argument
     inputs = fake_input_tree[1]
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.xz")
-    stage = import_module_from_path("xz_stage", stage_path)
     options = {
         "filename": "image.txt.xz",
     }
@@ -75,11 +76,9 @@ def test_xz_integration(tmp_path, fake_input_tree):  # pylint: disable=unused-ar
 
 
 @mock.patch("subprocess.run")
-def test_xz_cmdline(mock_run, tmp_path, fake_input_tree):
+def test_xz_cmdline(mock_run, tmp_path, stage, fake_input_tree):
     fake_input_path = fake_input_tree[0]
     inputs = fake_input_tree[1]
-    stage_path = os.path.join(os.path.dirname(__file__), "../org.osbuild.xz")
-    stage = import_module_from_path("xz_stage", stage_path)
     filename = "image.txt.xz"
     options = {
         "filename": filename,


### PR DESCRIPTION
This new fixture automatically imports the right stage into the test-files.

DRAFT for now to see if people consider this is win or not - it might just be a bit too much magic for removing two lines per test. OTOH it's kinda nice. If others like it I will convert the entire codebase.