### PR TITLE
tox: use `pytest -rs` to see what tests are skipped

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ passenv =
     TEST_CATEGORY
 
 commands =
-    bash -c 'python -m pytest --pyargs --rootdir=. {env:TEST_CATEGORY} {env:TEST_WORKERS}'
+    bash -c 'python -m pytest --pyargs --rootdir=. {env:TEST_CATEGORY} {env:TEST_WORKERS} -rs'
 
 allowlist_externals =
     bash


### PR DESCRIPTION
Some PRs are failing right now because pytest has no unittest to run, e.g.
https://github.com/osbuild/osbuild/pull/1559
https://github.com/osbuild/osbuild/pull/1556

This is rather unexpected and this PR adds debug to see what is going on in GH