### PR TITLE
test: pin pytest to 7.4.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         - "test.run.test_noop"
         - "test.run.test_sources"
         - "test.run.test_stages"
+        # remove the "-k" when we move to "pytest 8.0.0"
         - "-k stages/test"
         environment:
         - "py36"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 jsonschema
-pytest
+pytest=7.4.4

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ labels =
 [testenv]
 description = "run osbuild unit tests"
 deps =
-    pytest
+    pytest==7.4.4
     pytest-xdist
     jsonschema
     mako


### PR DESCRIPTION
Tests started to fail recently and it looks like this is because pytest 8.0.0 changes the semantic of the `-k` option. We used to pass `-k stages/test` but that seems to no longer work. So pin pytest to the last good version until this is better understood.