### PR TITLE
test: drop `-k` from `-k stages/test` test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         - "test.run.test_noop"
         - "test.run.test_sources"
         - "test.run.test_stages"
-        - "-k stages/test"
+        - "stages/test"
         environment:
         - "py36"
         - "py39"


### PR DESCRIPTION
With pytest 8.0.0 (released 27.01.2024)  the `-k` option seem to have changed it's behavior. This makes our tests fail right now.

This commit drop `-k` therefore to make them work again.

Tests started to fail recently and it looks like this is because pytest 8.0.0 changes the semantic of the `-k` option. We used to pass `-k stages/test` but that seems to no longer work. So pin pytest to the last good version until this is better understood.


Alternative approach to https://github.com/osbuild/osbuild/pull/1563 - may fail with py3.6 which does not have pytest 8.0.0