### PR TITLE
stages(ostree.config): support setting sysroot.bootprefix

### DIFF
--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -39,6 +39,10 @@ SCHEMA = """
             "type": "string",
             "enum": ["none", "auto", "grub2", "syslinux", "uboot", "zipl", "aboot"]
           },
+          "bootprefix": {
+            "description": "If set to true, the bootloader entries generated will include /boot as a prefix.",
+            "type": "boolean"
+          },
           "readonly": {
             "description": "Read only sysroot and boot",
             "type": "boolean"
@@ -62,6 +66,11 @@ def main(tree, options):
     bootloader = sysroot_options.get("bootloader")
     if bootloader:
         ostree.cli("config", "set", "sysroot.bootloader", bootloader, repo=repo)
+
+    bootprefix = sysroot_options.get("bootprefix")
+    if bootprefix is not None:  # can be False, which we would want to set
+        bp = "true" if bootprefix else "false"
+        ostree.cli("config", "set", "sysroot.bootprefix", bp, repo=repo)
 
     readonly = sysroot_options.get("readonly")
     if readonly is not None:  # can be False, which we would want to set

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -467,7 +467,8 @@
               "sysroot": {
                 "readonly": true,
                 "bootloader": "none",
-                "bls-append-except-default": "grub_users=\"\""
+                "bls-append-except-default": "grub_users=\"\"",
+                "bootprefix": true
               }
             }
           }

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -94,6 +94,7 @@ pipelines:
               readonly: true
               bootloader: none
               bls-append-except-default: grub_users=""
+              bootprefix: true
       - type: org.osbuild.mkdir
         options:
           paths:


### PR DESCRIPTION
See https://github.com/ostreedev/ostree/pull/2705 and also https://github.com/osbuild/osbuild/issues/1566.