### PR TITLE
container-deploy: Output stderr on failure

### DIFF
--- a/stages/org.osbuild.container-deploy
+++ b/stages/org.osbuild.container-deploy
@@ -47,12 +47,16 @@ def mount_container(image_tag):
     try:
         result = subprocess.run(
             ["podman", "image", "mount", image_tag],
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             encoding="utf-8",
-            check=True,
+            check=False,
         )
+        if result.returncode != 0:
+            code = result.returncode
+            msg = result.stderr.strip()
+            raise RuntimeError(f"Failed to mount image ({code}): {msg}")
         yield result.stdout.strip()
-
     finally:
         subprocess.run(
             ["podman", "image", "umount", image_tag],


### PR DESCRIPTION
This stage was failing for me in bib, with this change I now get more useful information from podman's stderr, e.g.:

```
RuntimeError: Failed to mount image (125): time="2024-02-06T14:23:06Z" level=error msg="Unmounting /var/lib/containers/storage/overlay/06456126e7c06cf1b21de024e08e64eddead2b8d03779be213e63aeeea9dec94/merged: invalid argument"
Error: creating overlay mount (...snip...)
fuse: device not found, try 'modprobe fuse' first
fuse-overlayfs: cannot mount: No such file or directory
```