### PR TITLE
sources(curl): download multiple URLs with the same curl command

### DIFF
--- a/osbuild/testutil/net.py
+++ b/osbuild/testutil/net.py
@@ -34,6 +34,14 @@ class SilentHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     def log_message(self, *args, **kwargs):
         pass
 
+    def do_GET(self):
+        # silence errors when the other side "hangs up" unexpectedly
+        # (our tests will do that when downloading in parallel)
+        try:
+            super().do_GET()
+        except (ConnectionResetError, BrokenPipeError):
+            pass
+
 
 class DirHTTPServer(ThreadingHTTPServer):
     def __init__(self, *args, directory=None, simulate_failures=0, **kwargs):

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -19,6 +19,8 @@ up the download.
 """
 
 import concurrent.futures
+import contextlib
+import json
 import os
 import pathlib
 import platform
@@ -105,7 +107,7 @@ def curl_has_parallel_downloads():
     first_line = output.split("\n", maxsplit=1)[0]
     m = re.match(r'^curl (\d+\.\d+\.\d+)', first_line)
     if not m:
-        print(f"WARNING: cannot parse curl version from '{first_line}'")
+        print(f"WARNING: cannot parse curl version from '{first_line}'", file=sys.stderr)
         return False
     major, minor, _ = m.group(1).split(".")
     if int(major) > 7:
@@ -164,6 +166,82 @@ def gen_curl_download_config(config_path: pathlib.Path, chksum_desc_tuple: List[
             fp.write("\n")
 
 
+def try_parse_curl_json_line(line):
+    line = line.strip()
+    if line:
+        try:
+            return json.loads(line)
+        except json.decoder.JSONDecodeError:
+            print(f"WARNING: cannot decode {line}", file=sys.stderr)
+    return None
+
+
+def validate_and_move_to_targetdir(tmpdir, targetdir, checksum, origin):
+    """
+    Validate that the checksum of the file with the filename
+    "checksum" in tmpdir matches and move into target dir. The
+    "origin" parameter is purely information to generate better
+    errors.
+    """
+    if not verify_file(f"{tmpdir}/{checksum}", checksum):
+        raise RuntimeError(f"checksum mismatch: {checksum} {origin}")
+    # The checksum has been verified, move the file into place. in case we race
+    # another download of the same file, we simply ignore the error as their
+    # contents are guaranteed to be  the same.
+    with contextlib.suppress(FileExistsError):
+        os.rename(f"{tmpdir}/{checksum}", f"{targetdir}/{checksum}")
+
+
+def fetch_many_new_curl(tmpdir, targetdir, dl_pairs):
+    curl_config_path = f"{tmpdir}/curl-config.txt"
+    gen_curl_download_config(curl_config_path, dl_pairs)
+    curl_command = [
+        "curl",
+        "--config", curl_config_path,
+        # this adds a bunch of noise but might be nice for debug?
+        # "--show-error",
+        "--parallel",
+        # this will write out a json record for each finished download
+        "--write-out", "%{json}\n",
+    ]
+    with contextlib.ExitStack() as cm:
+        curl_p = subprocess.Popen(curl_command, encoding="utf-8", cwd=tmpdir, stdout=subprocess.PIPE)
+        # ensure that curl is killed even if an unexpected exit happens
+        cm.callback(curl_p.kill)
+        while True:
+            line = curl_p.stdout.readline()
+            # empty line means eof/process finished
+            if line == "":
+                break
+            dl_details = try_parse_curl_json_line(line)
+            if not dl_details:
+                continue
+            url = dl_details['url']
+            # ignore individual download errors, the overall exit status will
+            # reflect them and the caller can retry
+            if dl_details["exitcode"] != 0:
+                print(f"WARNING: failed to download {url}: {dl_details['errormsg']}", file=sys.stderr)
+                continue
+            # the way downloads are setup the filename is the expected hash
+            # so validate now and move into place
+            checksum = dl_details["filename_effective"]
+            validate_and_move_to_targetdir(tmpdir, targetdir, checksum, url)
+            # remove item from download list
+            for todo_chksum, desc in dl_pairs[:]:
+                if todo_chksum == checksum:
+                    dl_pairs.remove((checksum, desc))
+            # Workaround the lack of structured progress reporting from
+            # stages/sources. It generates messages of the form
+            #   "message": "source/org.osbuild.curl (org.osbuild.curl): Downloaded https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/fonts-srpm-macros-2.0.5-11.fc38.noarch.rpm\n
+            #
+            # Without it just a long pause with no progress while curl
+            # downloads.
+            print(f"Downloaded {url}")
+        # return overall download status (this will be an error if any
+        # transfer failed)
+        return curl_p.wait()
+
+
 class CurlSource(sources.SourceService):
 
     content_type = "org.osbuild.files"
@@ -203,6 +281,31 @@ class CurlSource(sources.SourceService):
         filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
         amended = map(lambda i: self.amend_secrets(i[0], i[1]), filtered)
 
+        if curl_has_parallel_downloads():
+            self._fetch_all_new_curl(amended)
+        else:
+            self._fetch_all_old_curl(amended)
+
+    def _fetch_all_new_curl(self, dl_pairs):
+        dl_pairs = list(dl_pairs)
+        if len(dl_pairs) == 0:
+            return
+
+        # Download to a temporary sub cache until we have verified the checksum. Use a
+        # subdirectory, so we avoid copying across block devices.
+        with tempfile.TemporaryDirectory(prefix="osbuild-unverified-file-", dir=self.cache) as tmpdir:
+            # some mirrors are sometimes broken. retry manually, because we could be
+            # redirected to a different, working, one on retry.
+            return_code = 0
+            for _ in range(10):
+                return_code = fetch_many_new_curl(tmpdir, self.cache, dl_pairs)
+                if return_code == 0:
+                    break
+            else:
+                failed_urls = ",".join([itm[1]["url"] for itm in dl_pairs])
+                raise RuntimeError(f"curl: error downloading {failed_urls}: error code {return_code}")
+
+    def _fetch_all_old_curl(self, amended):
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             for _ in executor.map(self.fetch_one, *zip(*amended)):
                 pass
@@ -227,16 +330,7 @@ class CurlSource(sources.SourceService):
             else:
                 raise RuntimeError(f"curl: error downloading {url}: error code {return_code}")
 
-            if not verify_file(f"{tmpdir}/{checksum}", checksum):
-                raise RuntimeError(f"checksum mismatch: {checksum} {url}")
-
-            # The checksum has been verified, move the file into place. in case we race
-            # another download of the same file, we simply ignore the error as their
-            # contents are guaranteed to be  the same.
-            try:
-                os.rename(f"{tmpdir}/{checksum}", f"{self.cache}/{checksum}")
-            except FileExistsError:
-                pass
+            validate_and_move_to_targetdir(tmpdir, self.cache, checksum, url)
             # Workaround the lack of structured progress reporting from
             # stages/sources. It generates messages of the form
             #   "message": "source/org.osbuild.curl (org.osbuild.curl): Downloaded https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/fonts-srpm-macros-2.0.5-11.fc38.noarch.rpm\n

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -20,12 +20,14 @@ up the download.
 
 import concurrent.futures
 import os
+import pathlib
 import platform
 import subprocess
 import sys
 import tempfile
+import textwrap
 import urllib.parse
-from typing import Dict
+from typing import Dict, List, Tuple
 
 from osbuild import sources
 from osbuild.util.checksum import verify_file
@@ -93,6 +95,52 @@ SCHEMA = """
 """
 
 
+def _quote_url(url: str) -> str:
+    purl = urllib.parse.urlparse(url)
+    path = urllib.parse.quote(purl.path)
+    quoted = purl._replace(path=path)
+    return quoted.geturl()
+
+
+def gen_curl_download_config(config_path: pathlib.Path, chksum_desc_tuple: List[Tuple[str, Dict]]):
+    with open(config_path, "w", encoding="utf8") as fp:
+        # global options
+        fp.write(textwrap.dedent(f"""\
+        user-agent = "osbuild (Linux.{platform.machine()}; https://osbuild.org/)"
+        silent
+        speed-limit = 1000
+        connect-timeout = 30
+        fail
+        location
+        """))
+        proxy = os.getenv("OSBUILD_SOURCES_CURL_PROXY")
+        if proxy:
+            fp.write(f'proxy = "{proxy}"\n')
+        fp.write("\n")
+        # per url options
+        for checksum, desc in chksum_desc_tuple:
+            url = _quote_url(desc.get("url"))
+            fp.write(f'url = "{url}"\n')
+            fp.write(f'output = "{checksum}"\n')
+            secrets = desc.get("secrets")
+            if secrets:
+                ssl_ca_cert = secrets.get('ssl_ca_cert')
+                if ssl_ca_cert:
+                    fp.write(f'cacert = "{ssl_ca_cert}"\n')
+                ssl_client_cert = secrets.get('ssl_client_cert')
+                if ssl_client_cert:
+                    fp.write(f'cert = "{ssl_client_cert}"\n')
+                ssl_client_key = secrets.get('ssl_client_key')
+                if ssl_client_key:
+                    fp.write(f'key = "{ssl_client_key}"\n')
+            insecure = desc.get("insecure")
+            if insecure:
+                fp.write('insecure\n')
+            else:
+                fp.write('no-insecure\n')
+            fp.write("\n")
+
+
 class CurlSource(sources.SourceService):
 
     content_type = "org.osbuild.files"
@@ -128,13 +176,6 @@ class CurlSource(sources.SourceService):
 
         return checksum, desc
 
-    @staticmethod
-    def _quote_url(url: str) -> str:
-        purl = urllib.parse.urlparse(url)
-        path = urllib.parse.quote(purl.path)
-        quoted = purl._replace(path=path)
-        return quoted.geturl()
-
     def fetch_all(self, items: Dict) -> None:
         filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
         amended = map(lambda i: self.amend_secrets(i[0], i[1]), filtered)
@@ -144,45 +185,19 @@ class CurlSource(sources.SourceService):
                 pass
 
     def fetch_one(self, checksum, desc):
-        secrets = desc.get("secrets")
-        insecure = desc.get("insecure")
-        url = self._quote_url(desc.get("url"))
-        proxy = os.getenv("OSBUILD_SOURCES_CURL_PROXY")
+        url = _quote_url(desc.get("url"))
         # Download to a temporary sub cache until we have verified the checksum. Use a
         # subdirectory, so we avoid copying across block devices.
         with tempfile.TemporaryDirectory(prefix="osbuild-unverified-file-", dir=self.cache) as tmpdir:
             # some mirrors are sometimes broken. retry manually, because we could be
             # redirected to a different, working, one on retry.
             return_code = 0
-            arch = platform.machine()
             for _ in range(10):
-                curl_command = [
-                    "curl",
-                    "--silent",
-                    "--speed-limit", "1000",
-                    "--connect-timeout", "30",
-                    "--fail",
-                    "--location",
-                    "--user-agent", f"osbuild (Linux.{arch}; https://osbuild.org/)",
-                    "--output", checksum,
-                ]
-                if proxy:
-                    curl_command.extend(["--proxy", proxy])
-                if secrets:
-                    if secrets.get('ssl_ca_cert'):
-                        curl_command.extend(["--cacert", secrets.get('ssl_ca_cert')])
-                    if secrets.get('ssl_client_cert'):
-                        curl_command.extend(["--cert", secrets.get('ssl_client_cert')])
-                    if secrets.get('ssl_client_key'):
-                        curl_command.extend(["--key", secrets.get('ssl_client_key')])
-
-                if insecure:
-                    curl_command.append("--insecure")
-
-                # url must follow options
-                curl_command.append(url)
-
-                curl = subprocess.run(curl_command, encoding="utf-8", cwd=tmpdir, check=False)
+                curl_config_path = f"{tmpdir}/curl-config.txt"
+                gen_curl_download_config(curl_config_path, [(checksum, desc)])
+                curl = subprocess.run(
+                    ["curl", "--config", curl_config_path],
+                    encoding="utf-8", cwd=tmpdir, check=False)
                 return_code = curl.returncode
                 if return_code == 0:
                     break

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -20,7 +20,6 @@ up the download.
 
 import concurrent.futures
 import contextlib
-import json
 import os
 import pathlib
 import platform
@@ -113,7 +112,6 @@ def curl_has_parallel_downloads():
     if int(major) > 7:
         return True
     # --parallel got added in 7.68
-    # --write-out "%{json}" was added in 7.70
     # --write-out "%{exitcode} is 7.75
     if int(major) == 7 and int(minor) >= 75:
         return True
@@ -166,14 +164,19 @@ def gen_curl_download_config(config_path: pathlib.Path, chksum_desc_tuple: List[
             fp.write("\n")
 
 
-def try_parse_curl_json_line(line):
+def try_parse_curl_line(line):
     line = line.strip()
-    if line:
-        try:
-            return json.loads(line)
-        except json.decoder.JSONDecodeError:
-            print(f"WARNING: cannot decode {line}", file=sys.stderr)
-    return None
+    print(line)
+    if not line.startswith("osbuild-dl\x1c"):
+        print(f"WARNING: unexpected prefix in {line}", file=sys.stderr)
+        return None
+    _, url, filename, exitcode, errormsg = line.split("\x1c")
+    return {
+        "url": url,
+        "filename_effective": filename,
+        "exitcode": int(exitcode),
+        "errormsg": errormsg,
+    }
 
 
 def validate_and_move_to_targetdir(tmpdir, targetdir, checksum, origin):
@@ -201,8 +204,10 @@ def fetch_many_new_curl(tmpdir, targetdir, dl_pairs):
         # this adds a bunch of noise but might be nice for debug?
         # "--show-error",
         "--parallel",
-        # this will write out a json record for each finished download
-        "--write-out", "%{json}\n",
+        # this will write out a "record" for each finished download
+        # Not using %{json} here because older curl (7.76) will write
+        # {"http_connect":000} which python cannot parse
+        "--write-out", "osbuild-dl\x1c%{url}\x1c%{filename_effective}\x1c%{exitcode}\x1cerror: %{errormsg}\n",
     ]
     with contextlib.ExitStack() as cm:
         curl_p = subprocess.Popen(curl_command, encoding="utf-8", cwd=tmpdir, stdout=subprocess.PIPE)
@@ -213,7 +218,7 @@ def fetch_many_new_curl(tmpdir, targetdir, dl_pairs):
             # empty line means eof/process finished
             if line == "":
                 break
-            dl_details = try_parse_curl_json_line(line)
+            dl_details = try_parse_curl_line(line)
             if not dl_details:
                 continue
             url = dl_details['url']

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -22,6 +22,7 @@ import concurrent.futures
 import os
 import pathlib
 import platform
+import re
 import subprocess
 import sys
 import tempfile
@@ -93,6 +94,28 @@ SCHEMA = """
   "required": ["urls"]
 }]
 """
+
+
+def curl_has_parallel_downloads():
+    """
+    Return true if curl has all the support we needed for parallel downloading
+    (this include --write-out "%{json}" too
+    """
+    output = subprocess.check_output(["curl", "--version"], universal_newlines=True)
+    first_line = output.split("\n", maxsplit=1)[0]
+    m = re.match(r'^curl (\d+\.\d+\.\d+)', first_line)
+    if not m:
+        print(f"WARNING: cannot parse curl version from '{first_line}'")
+        return False
+    major, minor, _ = m.group(1).split(".")
+    if int(major) > 7:
+        return True
+    # --parallel got added in 7.68
+    # --write-out "%{json}" was added in 7.70
+    # --write-out "%{exitcode} is 7.75
+    if int(major) == 7 and int(minor) >= 75:
+        return True
+    return False
 
 
 def _quote_url(url: str) -> str:

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -251,6 +251,7 @@ class CurlSource(sources.SourceService):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.subscriptions = None
+        self._curl_has_parallel_downloads = curl_has_parallel_downloads()
 
     def amend_secrets(self, checksum, desc_or_url):
         if not isinstance(desc_or_url, dict):
@@ -281,7 +282,7 @@ class CurlSource(sources.SourceService):
         filtered = filter(lambda i: not self.exists(i[0], i[1]), items.items())  # discards items already in cache
         amended = map(lambda i: self.amend_secrets(i[0], i[1]), filtered)
 
-        if curl_has_parallel_downloads():
+        if self._curl_has_parallel_downloads:
             self._fetch_all_new_curl(amended)
         else:
             self._fetch_all_old_curl(amended)

--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -5,6 +5,7 @@ import platform
 import re
 import shutil
 import textwrap
+from unittest.mock import patch
 
 import pytest
 
@@ -257,3 +258,29 @@ def test_curl_gen_download_config(tmp_path, sources_module):
     no-insecure
 
     """)
+
+
+# fc39
+NEW_CURL_OUTPUT = """\
+curl 8.2.1 (x86_64-redhat-linux-gnu) libcurl/8.2.1 OpenSSL/3.1.1 zlib/1.2.13 libidn2/2.3.7 nghttp2/1.55.1
+Release-Date: 2023-07-26
+Protocols: file ftp ftps http https
+Features: alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz SPNEGO SSL threadsafe UnixSockets
+"""
+
+# centos-stream8
+OLD_CURL_OUTPUT = """\
+curl 7.61.1 (x86_64-redhat-linux-gnu) libcurl/7.61.1 OpenSSL/1.1.1k zlib/1.2.11 nghttp2/1.33.0
+Release-Date: 2018-09-05
+Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
+Features: AsynchDNS IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP HTTP2 UnixSockets HTTPS-proxy
+"""
+
+
+@patch("subprocess.check_output")
+def test_curl_has_parallel_download(mocked_check_output, sources_module):
+    mocked_check_output.return_value = NEW_CURL_OUTPUT
+    assert sources_module.curl_has_parallel_downloads()
+
+    mocked_check_output.return_value = OLD_CURL_OUTPUT
+    assert not sources_module.curl_has_parallel_downloads()


### PR DESCRIPTION
This PR is based on the excellent work of @supakeen in https://github.com/osbuild/osbuild/pull/1549 and the findings in https://github.com/osbuild/osbuild/pull/1023

Simon found that curl has a lot of fork/exec overhead in the way we use it. The other issue with our current use of curl is that we do not reuse connections and the overhead of the connection setup (especially for https) is there. 

Newer versions of curl (7.68+) have a nice new feature called `--parallel` that will reuse connections and download 50 streams in parallel by default (this can be controlled via the --parallel-max option). Since we want some more features (like --write-out %{json}) we actually need curl 7.75+ to use --parallel in a nice way. But that is okay because RHEL9/Centos9 have 7.76 as their default (but of course I can bring it back if people feel strongly about this).

Note that this PR originally also parallelized the old forking() curl but I removed this because it seems like a lot of extra work just for RHEL8 which is (AIUI) in maintenance mode.

The numbers I see are relatively modest for me though, for me it's mostly I/O bound as my connections is not that fast maybe someone with a fast connection can also test this? I ran:
````
$ rm -rf .osbuild/ ; time python3 -m osbuild  --libdir . ./test/data/manifests/fedora-container.json 
...
real	0m28.433s
user	0m6.179s
sys	0m4.821s


[upstream/main at v117-13-gaf0e8490]
$ rm -rf .osbuild/ ; time python3 -m osbuild  --libdir . ./test/data/manifests/fedora-container.json 
...
real	0m32.849s
user	0m17.607s
sys	0m6.236s
`` 
and see broadly the same total time except that the "user" time is significantly lower.

[Build on top of https://github.com/osbuild/osbuild/pull/1767 - once that is merged this one will be a lot shorter]