### PR TITLE
stages/org.osbuild.qemu: make qcow2 compression optional

### DIFF
--- a/stages/org.osbuild.qemu
+++ b/stages/org.osbuild.qemu
@@ -31,6 +31,11 @@ SCHEMA_2 = r"""
         "type": "string",
         "enum": ["qcow2"]
       },
+      "compression": {
+        "description": "Enable/disable compression of the qcow2 image",
+        "type": "boolean",
+        "default": true
+      },
       "compat": {
         "description": "The qcow2-compatibility-version to use",
         "type": "string"
@@ -60,6 +65,11 @@ SCHEMA_2 = r"""
         "description": "The type of the format, here 'vmdk'",
         "type": "string",
         "enum": ["vmdk"]
+      },
+      "compression": {
+        "description": "Enable/disable compression of the vmdk image",
+        "type": "boolean",
+        "default": true
       },
       "subformat": {
         "description": "VMDK flat extent format",
@@ -140,8 +150,12 @@ SCHEMA_2 = r"""
 
 
 def qcow2_arguments(options):
-    argv = ["-c"]
+    argv = []
+    compression = options.get("compression", True)
     compat = options.get("compat")
+
+    if compression:
+        argv += ["-c"]
 
     if compat:
         argv += ["-o", f"compat={compat}"]
@@ -149,8 +163,13 @@ def qcow2_arguments(options):
 
 
 def vmdk_arguments(options):
-    argv = ["-c"]
+    argv = []
+    compression = options.get("compression", True)
     subformat = options.get("subformat")
+
+    if compression:
+        argv += ["-c"]
+
     if subformat:
         argv += ["-o", f"subformat={subformat}"]
     return argv

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -1271,6 +1271,7 @@
             "filename": "qemu.qcow2",
             "format": {
               "type": "qcow2",
+              "compression": false,
               "compat": "1.1"
             }
           }

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -612,4 +612,5 @@ pipelines:
           filename: qemu.qcow2
           format:
             type: qcow2
+            compression: false
             compat: '1.1'


### PR DESCRIPTION
Modify the stages/org.osbuild.qemu stage such that compression is optional. This resolves the image size differences between an image built with coreos assember vs osbuild, as discussed in: [coreos/fedora-coreos-tracker#1653 (comment)](https://github.com/coreos/fedora-coreos-tracker/issues/1653#issuecomment-1928342241)