### PR TITLE
stages,testutil: add test/tweak for podman mount errror handling

### DIFF
--- a/stages/org.osbuild.container-deploy
+++ b/stages/org.osbuild.container-deploy
@@ -44,18 +44,18 @@ SCHEMA_2 = r"""
 
 @contextlib.contextmanager
 def mount_container(image_tag):
+    result = subprocess.run(
+        ["podman", "image", "mount", image_tag],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+        check=False,
+    )
+    if result.returncode != 0:
+        code = result.returncode
+        msg = result.stderr.strip()
+        raise RuntimeError(f"Failed to mount image ({code}): {msg}")
     try:
-        result = subprocess.run(
-            ["podman", "image", "mount", image_tag],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            encoding="utf-8",
-            check=False,
-        )
-        if result.returncode != 0:
-            code = result.returncode
-            msg = result.stderr.strip()
-            raise RuntimeError(f"Failed to mount image ({code}): {msg}")
         yield result.stdout.strip()
     finally:
         subprocess.run(

--- a/test/mod/test_testutil_mock_command.py
+++ b/test/mod/test_testutil_mock_command.py
@@ -1,0 +1,29 @@
+#
+# Tests for the 'osbuild.util.testutil.mock_command' module.
+#
+import os
+import subprocess
+import textwrap
+
+from osbuild.testutil import mock_command
+
+
+def test_mock_command_integration():
+    output = subprocess.check_output(["echo", "hello"])
+    assert output == b"hello\n"
+    fake_echo = textwrap.dedent("""\
+    #!/bin/sh
+    echo i-am-not-echo
+    """)
+    with mock_command("echo", fake_echo):
+        output = subprocess.check_output(["echo", "hello"])
+        assert output == b"i-am-not-echo\n"
+    output = subprocess.check_output(["echo", "hello"])
+    assert output == b"hello\n"
+
+
+def test_mock_command_environ_is_modified_and_restored():
+    orig_path = os.environ["PATH"]
+    with mock_command("something", "#!/bin/sh\ntrue\n"):
+        assert os.environ["PATH"] != orig_path
+    assert os.environ["PATH"] == orig_path


### PR DESCRIPTION
I promised to write a small test for the podman mount error handling in https://github.com/osbuild/osbuild/pull/1571. This PR contains a new helper `testutil.mock_command` to create fake commands for things in PATH and a test that ensures that the error messages are handled correct from podman. This lead to a small tweak in deploy-container so that the code only `podman umounts` if the `podman mount` was successful.