### PR TITLE
[Draft] CI: Add Centos based testing to the upstream CI

### DIFF
--- a/.github/workflows/test-on-centos
+++ b/.github/workflows/test-on-centos
@@ -1,0 +1,22 @@
+name: Run tests in Centos container
+on: [pull_request, push]
+
+jobs:
+  test-on-c8s:
+    runs-on: ubuntu-latest
+    container: quay.io/osbuild/osbuild-ci-c8s
+    steps:
+    - name: "Clone Repository"
+      uses: actions/checkout@v3
+    - name: Run
+      run: uname -a
+      run: ls -al
+  test-on-c9s:
+    runs-on: ubuntu-latest
+    container: quay.io/osbuild/osbuild-ci-c9s
+    steps:
+    - name: "Clone Repository"
+      uses: actions/checkout@v3
+    - name: Run
+      run: uname -a
+      run: ls -al


### PR DESCRIPTION

When new upstream release tag is created automation will pick it up and push to centos stream. Both RHEL and CentOS environment is differeent than upstream Fedora which leads to test failures.

Having centos based CI should allow us detect such scenarios on the early stage - before they will be merged upstream.