### PR TITLE
mount/ostree.deployment: Fix ostree deployment call

### DIFF
--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -125,7 +125,6 @@ class OSTreeDeploymentMount(mounts.MountService):
         options = args["options"]
         source = options.get("source", "tree")
         deployment = options["deployment"]
-        osname, ref, serial = ostree.parse_deployment_option(tree, deployment)
 
         # The user could specify either the tree or mountroot as the
         # place where we want the deployment to be mounted.
@@ -133,6 +132,8 @@ class OSTreeDeploymentMount(mounts.MountService):
             target = mountroot
         else:
             target = tree
+
+        osname, ref, serial = ostree.parse_deployment_option(target, deployment)
 
         # create a private mountpoint for the target path, which is
         # needed in order to be able to move the deployment `root`

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -771,8 +771,7 @@
               "options": {
                 "source": "mount",
                 "deployment": {
-                  "ref": "ostree/1/1/0",
-                  "osname": "fedora-coreos"
+                  "default": true
                 }
               }
             }
@@ -1023,8 +1022,7 @@
               "options": {
                 "source": "mount",
                 "deployment": {
-                  "ref": "ostree/1/1/0",
-                  "osname": "fedora-coreos"
+                  "default": true
                 }
               }
             }

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -287,9 +287,7 @@ pipelines:
             options:
               source: mount
               deployment:
-                ref: ostree/1/1/0
-                osname:
-                  mpp-format-string: '{osname}'
+                default: true
   - name: raw-4k-image
     build: name:build
     stages:
@@ -455,9 +453,7 @@ pipelines:
             options:
               source: mount
               deployment:
-                ref: ostree/1/1/0
-                osname:
-                  mpp-format-string: '{osname}'
+                default: true
   - name: raw-metal-image
     build: name:build
     stages:


### PR DESCRIPTION
We need to pass in the root of the ostree deployment which can be the tree or the mount. Fixes e1cbf92