### PR TITLE
Revert "osbuild-depsolve-dnf: port weak dependencies"

### DIFF
--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -206,13 +206,11 @@ class Solver():
     def depsolve(self, transactions):
         last_transaction = []
 
-        for idx, transaction in enumerate(transactions):
+        for transaction in transactions:
             self.base.reset(goal=True)
             self.base.sack.reset_excludes()
 
-            # don't install weak-deps for transactions after the 1st transaction
-            if idx > 0:
-                self.base.conf.install_weak_deps = False
+            self.base.conf.install_weak_deps = transaction.get("install_weak_deps", False)
 
             # set the packages from the last transaction as installed
             for installed_pkg in last_transaction:


### PR DESCRIPTION
This reverts commit e023fdec1b641ca97e75b17b3759bb4aa2da6e34.

Ends up this was based on an older version of dnf-json, the correct behavior is to use the "install_weak_deps" bool.