### PR TITLE
stages/bootc.install-to-fs: fix root mount handling

### DIFF
--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -2,7 +2,9 @@
 """Run bootc install to-filesystem
 
 Note that this needs the disk.img in the inputs as one continous
-devices so that bootupd can install grub to the mbr.
+devices so that bootupd can install grub to the mbr. It also needs
+all relevant mount points for booting (e.g. /boot, /boot/efi) in
+mounted in the "mounts" path.
 
 Buildhost commands used: bootc
 """
@@ -40,23 +42,23 @@ SCHEMA_2 = r"""
 """
 
 
-def main(inputs, mounts):
+def main(inputs, paths):
     images = containers.parse_containers_input(inputs)
     assert len(images) == 1
     image = list(images.values())[0]
 
     with containers.container_source(image) as (_, source):
-        dst = mounts["root"]["path"]
+        dst = paths["mounts"]
         subprocess.run(
             ["bootc", "install", "to-filesystem",
              "--source-imgref", source,
              "--skip-fetch-check", "--generic-image",
              dst],
-            check=True
+            check=True,
         )
 
 
 if __name__ == "__main__":
     args = osbuild.api.arguments()
-    r = main(args["inputs"], args["mounts"])
+    r = main(args["inputs"], args["paths"])
     sys.exit(r)

--- a/stages/test/test_bootc_install_to_fs.py
+++ b/stages/test/test_bootc_install_to_fs.py
@@ -25,22 +25,20 @@ def test_bootc_install_to_fs(mock_run, tmp_path):
             },
         },
     }
-    mounts = {
-        "root": {
-            "path": "/path/to/root",
-        },
+    paths = {
+        "mounts": "/path/to/mounts",
     }
 
     @contextmanager
     def faked_tmp_dir():
         yield tmp_path
     with patch("tempfile.TemporaryDirectory", side_effect=faked_tmp_dir):
-        stage.main(inputs, mounts)
+        stage.main(inputs, paths)
 
     assert len(mock_run.call_args_list) == 1
     assert mock_run.call_args_list == [
         call(["bootc", "install", "to-filesystem",
               "--source-imgref", f"oci-archive:{tmp_path}/image",
               "--skip-fetch-check", "--generic-image",
-              "/path/to/root"], check=True)
+              "/path/to/mounts"], check=True)
     ]


### PR DESCRIPTION
The bootc.install-to-filesystem code needs to run against the root directory of a mounted tree, i.e. with /boot, /boot/efi mounted. So change the code so that the target dir is the the "mounts" paths. This is similar to how bootupd works and the caller need to arrange the right mount setup there.

This was discovered during the final end-to-end work of osbuild+images+bib