### PR TITLE
DO NOT MERGE: Test theory about reflink corruption in qcow2 images

### DIFF
--- a/stages/org.osbuild.qemu
+++ b/stages/org.osbuild.qemu
@@ -231,6 +231,17 @@ def main(inputs, output, options):
         cmd, check=True
     )
 
+    # Sanity check that the image is 100%
+    cmd = [
+        "qemu-img", "compare",
+        "-f", "raw",
+        "-F", fmt["type"],
+        source, target
+    ]
+    subprocess.run(
+        cmd, check=True
+    )
+
     return 0
 
 

--- a/stages/org.osbuild.qemu
+++ b/stages/org.osbuild.qemu
@@ -151,7 +151,7 @@ SCHEMA_2 = r"""
 
 def qcow2_arguments(options):
     argv = []
-    compression = options.get("compression", True)
+    compression = options.get("compression", False)
     compat = options.get("compat")
 
     if compression:


### PR DESCRIPTION
In CoreOS land we are seeing failures when we disabled internal compression when running `qemu-img convert` to create a `qcow2` out of a `raw` disk image.

The current theory is that there is some issue where internally the `qcow2` (target) and `raw` (source) files are using reflinks and sharing data and somehow that is getting corrupted. We switched our backing FS from `xfs` to `ext4` and are no longer able to see failures happen.

See https://github.com/coreos/coreos-assembler/issues/3728#issuecomment-1944956047

I'm opening this PR to see if we can reproduce this failure in CI where I'm sure some of the builders have XFS or BTRFS (filesystems that support reflinks) as the backing stores. 