### PR TITLE
tox,tools: add tools back to lintables

### DIFF
--- a/tools/check-snapshots
+++ b/tools/check-snapshots
@@ -24,6 +24,7 @@ def fetch_snapshots_api(url, timeout=SNAPSHOTS_TIMEOUT):
     try:
         r = requests.get(url, timeout=timeout)
     except BaseException as e:  # pylint: disable=broad-exception-caught
+        print(f"Problem downloading {url}: {e}")
         return None
     elapsed = time.time() - start
     if r.status_code != 200:

--- a/tools/check-snapshots
+++ b/tools/check-snapshots
@@ -23,7 +23,7 @@ def fetch_snapshots_api(url, timeout=SNAPSHOTS_TIMEOUT):
     start = time.time()
     try:
         r = requests.get(url, timeout=timeout)
-    except BaseException:  # pylint: disable=broad-exception-caught
+    except BaseException as e:  # pylint: disable=broad-exception-caught
         return None
     elapsed = time.time() - start
     if r.status_code != 200:
@@ -168,7 +168,7 @@ def main():
         try:
             with open(args.cache, encoding="utf8") as f:
                 snapshots = json.load(f)
-        except BaseException:  # pylint: disable=broad-exception-caught
+        except FileNotFoundError:
             print(f"No snapshots cache found at {args.cache}")
             sys.exit(1)
     else:

--- a/tools/check-snapshots
+++ b/tools/check-snapshots
@@ -23,7 +23,7 @@ def fetch_snapshots_api(url, timeout=SNAPSHOTS_TIMEOUT):
     start = time.time()
     try:
         r = requests.get(url, timeout=timeout)
-    except BaseException:
+    except BaseException:  # pylint: disable=broad-exception-caught
         return None
     elapsed = time.time() - start
     if r.status_code != 200:
@@ -90,7 +90,8 @@ def check_baseurl(repo, snapshots):
     return invalid, newer
 
 
-def check_snapshot_urls(urls, snapshots, skip=["test/data/assemblers", "test/data/manifests", "test/data/stages"],
+# pylint: disable=too-many-branches
+def check_snapshot_urls(urls, snapshots, skip=("test/data/assemblers", "test/data/manifests", "test/data/stages"),
                         errors_only=False):
     """check the urls against the current list of snapshots
 
@@ -133,11 +134,11 @@ def check_snapshot_urls(urls, snapshots, skip=["test/data/assemblers", "test/dat
                     messages[f] = {"newer": [newer], "invalid": []}
 
     # Print the messages for each file
-    for f in messages:
+    for f, msgs in messages.items():
         print(f"{f}:")
-        for msg in messages[f]["invalid"]:
+        for msg in msgs["invalid"]:
             print(f"    ERROR: {msg}")
-        for msg in messages[f]["newer"]:
+        for msg in msgs["newer"]:
             print(f"    NEWER: {msg}")
 
     return ret
@@ -167,7 +168,7 @@ def main():
         try:
             with open(args.cache, encoding="utf8") as f:
                 snapshots = json.load(f)
-        except BaseException:
+        except BaseException:  # pylint: disable=broad-exception-caught
             print(f"No snapshots cache found at {args.cache}")
             sys.exit(1)
     else:

--- a/tools/gen-stage-test-diff
+++ b/tools/gen-stage-test-diff
@@ -40,7 +40,7 @@ def run_osbuild(output_directory, store, cache_max_size, libdir, manifest):
     except subprocess.CalledProcessError as err:
         raise RuntimeError(
             f"osbuild crashed when building {manifest}:\n\nstdout:\n{err.stdout}\n\nstderr:\n{err.stderr}"
-        )
+        ) from err
 
 
 epilog = """

--- a/tools/osbuild-depsolve-dnf5
+++ b/tools/osbuild-depsolve-dnf5
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 import tempfile
+import traceback
 from datetime import datetime
 
 import libdnf5 as dnf5
@@ -20,7 +21,7 @@ from libdnf5.common import QueryCmp_EQ as EQ
 from libdnf5.common import QueryCmp_GLOB as GLOB
 
 
-# XXX - Temporarily lifted from dnf.rpm module
+# XXX - Temporarily lifted from dnf.rpm module  # pylint: disable=fixme
 def _invert(dct):
     return {v: k for k in dct for v in dct[k]}
 
@@ -140,7 +141,7 @@ class Solver():
 
             self.base.get_repo_sack().update_and_load_enabled_repos(load_system=False)
         except RuntimeError as e:
-            raise RepoError(e)
+            raise RepoError(e) from e
 
     # pylint: disable=too-many-branches
     def _dnfrepo(self, desc, exclude_pkgs=None):
@@ -420,8 +421,7 @@ def solve(request, cache_dir):
                 "kind": "RepoError",
                 "reason": f"There was a problem reading a repository: {e}"
             }
-        except Exception as e:
-            import traceback
+        except Exception as e:  # pylint: disable=broad-exception-caught
             printe("error traceback")
             return None, {
                 "kind": type(e).__name__,

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -692,7 +692,7 @@ class DepSolver:
             if not result.scheme:
                 path = basedir.joinpath(baseurl)
                 return path.resolve().as_uri()
-        except BaseException:  # pylint: disable=bare-except
+        except BaseException:  # pylint: disable=broad-exception-caught
             pass
 
         return baseurl
@@ -1008,7 +1008,7 @@ class Image:
                 try:
                     table.write_to(loopimage)
                 finally:
-                    subprocess.run(["losetup", "-d", loopimage])
+                    subprocess.run(["losetup", "-d", loopimage], check=True)
 
         return cls(size, table)
 
@@ -1215,7 +1215,7 @@ class ManifestFile:
             pipeline_name = self.get_pipeline_name(parent_node)
             self._process_stage(node, pipeline_name)
 
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,too-many-statements
     def _process_format(self, node):
         def _is_format(node):
             if not isinstance(node, dict):
@@ -1245,7 +1245,7 @@ class ManifestFile:
                 res = False
                 try:
                     res = eval(code, dict(local_vars))
-                except Exception as e:
+                except Exception as e:  # pylint: disable=broad-exception-caught
                     print(f"In {self.path}: Failed to evaluate mpp-if of:\n  {code}")
                     print(f"Error: {e}")
                     sys.exit(1)
@@ -1266,7 +1266,7 @@ class ManifestFile:
                 # Note, we copy local_vars here to avoid eval modifying it
                 try:
                     res = eval(code, dict(local_vars))
-                except Exception as e:
+                except Exception as e:  # pylint: disable=broad-exception-caught
                     print(f"In {self.path}: Failed to mpp-eval:\n  {code}")
                     print(f"Error: {e}")
                     sys.exit(1)
@@ -1286,7 +1286,7 @@ class ManifestFile:
             # Note, we copy local_vars here to avoid eval modifying it
             try:
                 res = eval(f'f\'\'\'{format_string}\'\'\'', dict(local_vars))
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-exception-caught
                 print(f"In {self.path}: Failed to format string:\n  {format_string}")
                 print(f"Error: {e}")
                 sys.exit(1)
@@ -1373,7 +1373,7 @@ class ManifestFile:
     def _process_container(self, _stage):
         raise NotImplementedError()
 
-    def _process_ostree(self, _stage):
+    def _process_ostree_commits(self, _stage):
         raise NotImplementedError()
 
 
@@ -1788,7 +1788,7 @@ def main():
     args = parser.parse_args(sys.argv[1:])
 
     defaults = {
-        "arch": rpm.expandMacro("%{_arch}")
+        "arch": rpm.expandMacro("%{_arch}")  # pylint: disable=no-member
     }
 
     # Override variables from the main of imported files

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,10 @@ deps =
     pykickstart
     # required by pykickstart but not pulled in automatically :/
     requests
+    tox-backticks
 
 setenv =
-    LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/* stages/*.* stages/test/*.py test/ tools/
+    LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/* stages/*.* stages/test/*.py test/ `find ./tools ! -name "*.sh" -type f`
     TYPEABLES = osbuild
     TYPEABLES_STRICT = ./osbuild/main_cli.py
 


### PR DESCRIPTION
During the review of https://github.com/osbuild/osbuild/pull/1598 we noticed that tools is not checked by pylint (and the other linters).

This PR adds it back and fixes the issues that pylint found.

For the non-obvious changes I added comments in the commit message and I'm happy (of course) to change/adjust the changes as needed.

One issue that this PR may have is that it uses "tox-backticks" in tox.ini. AFAIK this is only available via pip but not packaged. If this is a problem the way to re-enable pylint (and friends) needs to be re-evaluated.