### PR TITLE
Stages/grub2.legacy: make config options a subset of grub2 stage

### DIFF
--- a/stages/org.osbuild.grub2.legacy
+++ b/stages/org.osbuild.grub2.legacy
@@ -174,6 +174,11 @@ SCHEMA = """
         "description": "Additional kernel command line options",
         "type": "string"
       },
+      "default": {
+        "description": "Default boot entry",
+        "type": "string",
+        "default": "saved"
+      },
       "disable_recovery": {
         "type": "boolean",
         "default": true
@@ -355,6 +360,7 @@ class GrubConfig:
         self.bootfs = bootfs
         self.entries = []
         self.cmdline = ""
+        self.default_entry = "saved"
         self.disable_recovery = True
         self.disable_submenu = True
         self.distributor = ""
@@ -456,7 +462,7 @@ class GrubConfig:
             f"GRUB_DISABLE_SUBMENU={str(self.disable_submenu).lower()}\n"
             f"GRUB_DISABLE_RECOVERY={str(self.disable_recovery).lower()}\n"
             f"GRUB_TIMEOUT_STYLE={self.timeout_style}\n"
-            "GRUB_DEFAULT=saved\n"
+            f"GRUB_DEFAULT={self.default_entry}\n"
         )
 
         if self.distributor:
@@ -492,6 +498,7 @@ def main(tree, options):
     cfg = options.get("config", {})
     config = GrubConfig(bios, root_fs, boot_fs)
     config.cmdline = cfg.get("cmdline", "")
+    config.default_entry = cfg.get("default", "saved")
     config.disable_recovery = cfg.get("disable_recovery", True)
     config.disable_submenu = cfg.get("disable_submenu", True)
     config.distributor = cfg.get("distributor")

--- a/stages/test/test_grub2_legacy.py
+++ b/stages/test/test_grub2_legacy.py
@@ -19,6 +19,7 @@ GRUB_DEFAULT=saved
 """),
     # custom
     ({
+        "default": "0",
         "disable_submenu": False,
         "disable_recovery": False,
         "timeout": 10,
@@ -28,7 +29,7 @@ GRUB_CMDLINE_LINUX=""
 GRUB_DISABLE_SUBMENU=false
 GRUB_DISABLE_RECOVERY=false
 GRUB_TIMEOUT_STYLE=hidden
-GRUB_DEFAULT=saved
+GRUB_DEFAULT=0
 """),
     # custom (Azure)
     ({


### PR DESCRIPTION
While integrating the changes to grub2 config stage options in the `osbuild/images` repository, I noticed that the code for grub2.legacy is embedding the grub2 stage config options struct in its own config options struct [1]. However, the grub2 stage options contain also the `default` entry, while the grub2.legacy stage does not allow this option in its stage options.

This change fixes that and ensures that the grub2 stage options config section is a subset of the grub2.legacy stage options config section.

[1] https://github.com/osbuild/images/blob/d5644f311537df5965ac0ca0fdbcb2800b8cd8ed/pkg/osbuild/grub2_legacy_stage.go#L85