### PR TITLE
many: tweak `containers-storage` implementation

### DIFF
--- a/inputs/org.osbuild.containers-storage
+++ b/inputs/org.osbuild.containers-storage
@@ -84,20 +84,14 @@ SCHEMA = r"""
 """
 
 
-class ContainersInput(inputs.InputService):
+class ContainersStorageInput(inputs.InputService):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.mg = MountGuard()
-        self.storage_conf = None
+        self.storage_conf = containers.get_host_storage()
 
-    def map_storage_ref(self, _source, ref, target):
-        # we only want to read the host once and only for inputs that
-        # require it. If we do this for all inputs, reading the host
-        # may cause unexpected errors.
-        if self.storage_conf is None:
-            self.storage_conf = containers.get_host_storage()
-
+    def bind_mount_local_storage(self, target):
         source = self.storage_conf["storage"]["graphroot"]
         dest = os.path.join(target, "storage")
 
@@ -105,23 +99,17 @@ class ContainersInput(inputs.InputService):
         os.makedirs(dest, exist_ok=True)
         self.mg.mount(source, dest)
 
-        return ref, "containers-storage"
-
     def map(self, store, origin, refs, target, _options):
+        self.bind_mount_local_storage(target)
+
         images = {}
-
         for ref, data in refs.items():
-            source = "org.osbuild.containers-storage"
-            ref, container_format = self.map_storage_ref(source, ref, target)
-
             images[ref] = {
-                "format": container_format,
+                "format": "containers-storage",
                 "name": data["name"]
             }
             images[ref]["name"] = data["name"]
-
-            if container_format == "containers-storage" and self.storage_conf is not None:
-                images[ref]["storage"] = self.storage_conf["storage"]
+            images[ref]["storage"] = self.storage_conf["storage"]
 
         reply = {
             "path": target,
@@ -137,7 +125,7 @@ class ContainersInput(inputs.InputService):
 
 
 def main():
-    service = ContainersInput.from_args(sys.argv[1:])
+    service = ContainersStorageInput.from_args(sys.argv[1:])
     service.main()
 
 

--- a/inputs/test/conftest.py
+++ b/inputs/test/conftest.py
@@ -1,0 +1,21 @@
+import os
+import pathlib
+from types import ModuleType
+
+import pytest
+
+from osbuild.testutil.imports import import_module_from_path
+
+
+@pytest.fixture
+def inputs_module(request: pytest.FixtureRequest) -> ModuleType:
+    """inputs_module is a fixture that imports a stage module by its name
+    defined in INPUTS_NAME in the test module.
+    """
+    if not hasattr(request.module, "INPUTS_NAME"):
+        raise ValueError("inputs_module fixture must be used in a test module that defines INPUTS_NAME")
+
+    inputs_name = request.module.INPUTS_NAME
+    caller_dir = pathlib.Path(request.node.fspath).parent
+    module_path = caller_dir.parent / inputs_name
+    return import_module_from_path("inputs", os.fspath(module_path))

--- a/inputs/test/test_containers.py
+++ b/inputs/test/test_containers.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+
+import os
+import pathlib
+import random
+import socket
+import string
+import subprocess
+import tempfile
+
+import pytest
+
+from osbuild.testutil import has_executable, make_container
+
+INPUTS_NAME = "org.osbuild.containers-storage"
+
+
+class FakeStoreClient:
+    def __init__(self, fake_sources_base):
+        self.fake_sources_base = fake_sources_base
+        self.fake_sources_base.mkdir()
+
+    def source(self, name: str) -> str:
+        fake_source_path = self.fake_sources_base / f"path-for-{name}"
+        fake_source_path.mkdir(parents=True)
+        return fake_source_path
+
+
+def rmdir_only(path):
+    """
+    Remove all empty directories from the given target, errors for
+    non-empty dirs
+    """
+    for root, dirs, _ in os.walk(path):
+        for d in dirs:
+            os.rmdir(pathlib.Path(root) / d)
+    os.rmdir(path)
+
+
+@pytest.mark.skipif(not has_executable("podman"), reason="no podman executable")
+@pytest.mark.skipif(os.getuid() != 0, reason="root only")
+def test_containers_local_inputs_integration(tmp_path, inputs_module):
+    base_tag = "container-" + "".join(random.choices(string.digits, k=12))
+    with make_container(tmp_path, base_tag, {"file1": "file1 content"}):
+        image_id = subprocess.check_output(
+            ["podman", "inspect", "-f", "{{ .Id }}", base_tag],
+            universal_newlines=True).strip()
+        inputs = {
+            "type": INPUTS_NAME,
+            "origin": "org.osbuild.source",
+            "references": {
+                f"sha256:{image_id}": {
+                    "name": "localhost/some-name:latest",
+                }
+            }
+        }
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        cnt_inputs = inputs_module.ContainersInput.from_args(["--service-fd", str(sock.fileno())])
+        store = FakeStoreClient(tmp_path / "fake-sources")
+        # not using "tmp_path" here as it will "rm -rf" on cleanup and
+        # that is dangerous as during the tests we bind mount the
+        # system container storage read-write
+        target = pathlib.Path(tempfile.TemporaryDirectory("cnt-target").name)
+        options = None
+        try:
+            reply = cnt_inputs.map(store, inputs["origin"], inputs["references"], target, options)
+            assert reply["path"] == target
+            assert len(reply["data"]["archives"]) == 1
+            assert (target / "storage").exists()
+        finally:
+            cnt_inputs.unmap()
+            rmdir_only(target)

--- a/inputs/test/test_containers.py
+++ b/inputs/test/test_containers.py
@@ -55,7 +55,7 @@ def test_containers_local_inputs_integration(tmp_path, inputs_module):
             }
         }
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        cnt_inputs = inputs_module.ContainersInput.from_args(["--service-fd", str(sock.fileno())])
+        cnt_inputs = inputs_module.ContainersStorageInput.from_args(["--service-fd", str(sock.fileno())])
         store = FakeStoreClient(tmp_path / "fake-sources")
         # not using "tmp_path" here as it will "rm -rf" on cleanup and
         # that is dangerous as during the tests we bind mount the

--- a/osbuild/util/containers.py
+++ b/osbuild/util/containers.py
@@ -132,7 +132,9 @@ def containers_storage_source(image, image_filepath, container_format):
         if driver == "overlay":
             # NOTE: the overlay sub-directory isn't always released,
             # so we need to force unmount it
-            subprocess.run(["umount", "-f", "--lazy", os.path.join(storage_path, "overlay")], check=False)
+            ret = subprocess.run(["umount", "-f", "--lazy", os.path.join(storage_path, "overlay")], check=False)
+            if ret.returncode != 0:
+                print(f"WARNING: umount of overlay dir failed with an error: {ret}")
 
 
 @contextmanager

--- a/sources/org.osbuild.containers-storage
+++ b/sources/org.osbuild.containers-storage
@@ -4,9 +4,8 @@
 This stage differs from other sources in that the source checks to see if the
 container is available in the host's container storage. This puts a requirement
 on the user to ensure that the container is copied into local storage before
-trying to build an image. The starts by reading the host's
-`/etc/containers/storage.conf` file and then using the config to check if the
-container has been imported.
+trying to build an image. The starts by reading the host's `storage.conf`
+file and then using the config to check if the container has been imported.
 
 Unlike all other sources, this source relies on external storage not controlled
 by osbuild itself.

--- a/sources/org.osbuild.containers-storage
+++ b/sources/org.osbuild.containers-storage
@@ -81,10 +81,16 @@ class ContainersStorageSource(sources.SourceService):
         # fail early if the user hasn't imported the container into
         # containers-storage
         if res.returncode != 0:
-            raise RuntimeError(f"Container does not exist in local containers storage: {res.stderr}")
+            # string not matching not ideal - this is ErrNotAnImage
+            # which is unchanged since 2016 (added in ee99172905 in
+            # containers/storage)
+            if "identifier is not an image" in res.stderr:
+                return False
+            raise RuntimeError(f"unknown skopeo error: {res.stderr}")
 
         # NOTE: this is a bit redundant because we're checking the content digest of the thing we retrieved via its
         # id (which is the content digest), but let's keep it in case we change to retrieving local containers by name
+        # See also https://github.com/containers/skopeo/pull/2236
         local_id = "sha256:" + hashlib.sha256(res.stdout.encode()).hexdigest()
         if local_id != checksum:
             raise RuntimeError(

--- a/sources/test/test_container_storage_source.py
+++ b/sources/test/test_container_storage_source.py
@@ -26,3 +26,14 @@ def test_containers_storage_integration(tmp_path, sources_module):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(sock.fileno())])
         assert cnt_storage.exists(checksum, None)
+
+
+@pytest.mark.skipif(not has_executable("podman"), reason="no podman executable")
+@pytest.mark.skipif(os.getuid() != 0, reason="root only")
+def test_containers_storage_integration_missing(sources_module):
+    checksum = "sha256:1234567890123456789012345678901234567890909b14ffb032aa20fa23d9ad6"
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(sock.fileno())])
+    # this is not ideal, consider to just return "False" here
+    with pytest.raises(RuntimeError):
+        cnt_storage.exists(checksum, None)

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     tox-backticks
 
 setenv =
-    LINTABLES = osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/*.* stages/*.* stages/test/*.py sources/test/*.py test/ `find ./tools ! -name "*.sh" -type f`
+    LINTABLES = osbuild/ assemblers/* devices/* inputs/*.* mounts/* runners/* sources/*.* stages/*.* inputs/test/*.py stages/test/*.py sources/test/*.py test/ `find ./tools ! -name "*.sh" -type f`
     TYPEABLES = osbuild
     TYPEABLES_STRICT = ./osbuild/main_cli.py
 


### PR DESCRIPTION
This PR tweaks the excellent work from Gianluca in PR#1550 a
little bit. Now that the container inputs are their own input
type some of the code that used to be part of the original
`inputs/org.osbuild.containers` can be simplified.

It also contains some small misc tests, string/comment updates.
All in their own commits but I can break into multiple PRs for easier
reviews if desired. 