### PR TITLE
Sources/containers-storage: make the code Python 3.6 compliant

### DIFF
--- a/sources/org.osbuild.containers-storage
+++ b/sources/org.osbuild.containers-storage
@@ -77,7 +77,7 @@ class ContainersStorageSource(sources.SourceService):
         image_id = checksum.split(":")[1]
         source = self.local_image_name(image_id)
         res = sp.run(["skopeo", "inspect", "--raw", "--config", source],
-                     check=False, capture_output=True, universal_newlines=True)
+                     check=False, stdout=sp.PIPE, stderr=sp.PIPE, universal_newlines=True)
 
         # fail early if the user hasn't imported the container into
         # containers-storage


### PR DESCRIPTION
The source implementation used `subprocess.run()` argument `capture_output`, which was added in Python 3.7. Since the minimum supported Python version for osbuild on RHEL-8 is 3.6, the source fails with TypeError.

Example failure: https://artifacts.dev.testing-farm.io/c147b608-c40e-46ed-bf11-6b15ecf718dc/