### PR TITLE
tests: migrate manifest tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,12 +108,12 @@ Manifests:
           - aws/centos-stream-9-aarch64
       - PARALLEL_EXEC: ["1/4", "2/4", "3/4", "4/4"]
         RUNNER:
-          - aws/rhel-8.8-ga-x86_64
-          - aws/rhel-8.8-ga-aarch64
+          - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-8.9-ga-aarch64
           - aws/rhel-8.10-nightly-x86_64
           - aws/rhel-8.10-nightly-aarch64
-          - aws/rhel-9.2-ga-x86_64
-          - aws/rhel-9.2-ga-aarch64
+          - aws/rhel-9.3-ga-x86_64
+          - aws/rhel-9.3-ga-aarch64
           - aws/rhel-9.4-nightly-x86_64
           - aws/rhel-9.4-nightly-aarch64
         INTERNAL_NETWORK: "true"

--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "global": {
     "dependencies": {
       "manifest-db": {
-        "commit": "3bb2cb6ec1c037dfc6a6dd57f65e245c0b3e79ae"
+        "commit": "d143f8838ddcf596b7e02c0e0cdc664f39117e27"
       }
     }
   },

--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "global": {
     "dependencies": {
       "manifest-db": {
-        "commit": "d143f8838ddcf596b7e02c0e0cdc664f39117e27"
+        "commit": "c15cf3e456877fe4b54ebbfb192b78f89a29b448"
       }
     }
   },

--- a/schutzbot/manifest_tests.sh
+++ b/schutzbot/manifest_tests.sh
@@ -3,8 +3,7 @@ set -euxo pipefail
 # Get OS details.
 source /etc/os-release
 ARCH=$(uname -m)
-DISTRO_CODE="${DISTRO_CODE:-${ID}-${VERSION_ID//./}}"
-
+DISTRO_CODE="${DISTRO_CODE:-${ID}-${VERSION_ID}}"
 # get manifest-db at the version specified for this arch+distro
 MANIFEST_DB_COMMIT=$(cat Schutzfile | jq -r '.global.dependencies."manifest-db".commit')
 MANIFEST_DB_REPO="https://github.com/osbuild/manifest-db"


### PR DESCRIPTION
Migrate manifest tests to RHEL GA 8.9 and 9.3

Related ticket: [COMPOSER-2156](https://issues.redhat.com/browse/COMPOSER-2156?filter=-1)