### PR TITLE
workflow, osbuild-mpp: run with cache (HMS-3697)

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -36,9 +36,15 @@ jobs:
   generate_test_data:
     name: "Test Data"
     runs-on: ubuntu-latest
+    env:
+      OSBUILD_MPP_CACHEDIR: "/var/tmp/osbuild-mpp-cache"
     steps:
     - name: "Clone Repository"
       uses: actions/checkout@v3
+    - name: Cache metadata
+      uses: actions/cache@v4
+      with:
+        path: /var/tmp/osbuild-mpp-cache
     - name: "Regenerate Test Data"
       uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
       with:

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -1804,8 +1804,11 @@ def main():
 
     m = ManifestFile.load(args.src, overrides, defaults, args.searchdirs)
 
+    cachedir = args.cachedir
+    if cachedir is None:
+        cachedir = os.getenv("OSBUILD_MPP_CACHEDIR")
     with tempfile.TemporaryDirectory() as persistdir:
-        m.solver_factory = DepSolverFactory(args.cachedir, persistdir)
+        m.solver_factory = DepSolverFactory(cachedir, persistdir)
         m.process_format()
         m.solver_factory = None
 

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -681,6 +681,25 @@ class DepSolver:
         base.conf.install_weak_deps = not ignore_weak_deps
         base.conf.arch = arch
 
+        # We use the same cachedir for multiple architectures when
+        # OSBUILD_MPP_CACHEDIR is given. Unfortunately, this is something that
+        # doesn't work well in certain situations with zchunk:
+        # Imagine that we already have cache for arch1. Then, we use dnf
+        # to depsolve for arch2. If ZChunk is enabled and available (that's
+        # the case for Fedora), dnf will try to download only differences
+        # between arch1 and arch2 metadata. But, as these are completely
+        # different, dnf must basically redownload everything.
+        # For downloding deltas, zchunk uses HTTP range requests. Unfortunately,
+        # if the mirror doesn't support multi range requests, then zchunk will
+        # download one small segment per a request. Because we need to update
+        # the whole metadata (10s of MB), this can be extremely slow in some cases.
+        # Thus, let's just disable zchunk for now.
+
+        # Note that when OSBUILD_MPP_CACHEDIR is not given, this has basically
+        # no effect, because zchunk is only used when a persistent cachedir is
+        # used.
+        self.base.conf.zchunk = False
+
         self.base = base
         self.basedir = basedir
 


### PR DESCRIPTION
The `Test Data` action takes an incredibly long time to run (2h+).  This job generates all test manifests (mpp.yaml -> json) which involves a lot of depsolving, but it still shouldn't be taking this long.

To speed up the job:
1. ~~Run the generation in parallel (`make -j4`)~~ (Removed: No noticeable improvement)
2. Share the cache across runs
3. Disable zchunks in dnf which causes a lot of slowdowns when caches are shared across architectures


In the very near future we should remove the dnf depsolver from osbuild-mpp and use osbuild-depsolve-dnf instead.
