### PR TITLE
workflow: drop python3.11 from matrix (HMS-3697)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,9 @@ jobs:
         - "test.run.test_stages"
         - "stages/test"
         environment:
-        - "py36"
-        - "py39"
-        - "py311"
-        - "py312"
+        - "py36"    # RH8
+        - "py39"    # RH9
+        - "py312"   # latest fedora
     steps:
     - name: "Clone Repository"
       uses: actions/checkout@v3


### PR DESCRIPTION
With fedora moving to python3.12 we can stop testing on py311.

As a drive-by this commit also documents why we need to test on py36 and py39.