### PR TITLE
tests: improve the gitlab tests (HMS-3697)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,10 +64,25 @@ OSTree Images:
   extends: .terraform
   script:
     - schutzbot/deploy.sh
-    - sudo test/cases/ostree-images
+    - sudo test/cases/ostree-images --manifest "$MANIFEST" --export $EXPORT
+  variables:
+    RUNNER: aws/fedora-38-x86_64
   parallel:
     matrix:
-      - RUNNER: aws/fedora-38-x86_64
+      - MANIFEST: fedora-ostree-tarball.json
+        EXPORT: tarball/fedora-commit.tar
+      - MANIFEST: fedora-ostree-container.json
+        EXPORT: container/fedora-container.tar
+      - MANIFEST: fedora-ostree-native-container.json
+        EXPORT: container/ostree-container.tar
+      - MANIFEST: fedora-ostree-bootiso.json
+        EXPORT: bootiso/fedora-ostree-boot.iso
+      - MANIFEST: fedora-ostree-bootiso-xz.json
+        EXPORT: bootiso/fedora-ostree-boot.iso
+      - MANIFEST: fedora-ostree-image.json
+        EXPORT: qcow2/disk.qcow2
+      - MANIFEST: fedora-coreos-container.json
+        EXPORT: qemu/qemu.qcow2 metal/metal.raw metal4k/metal4k.raw
 
 Manifests:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,7 @@ Manifests:
       - manifest-db/generated-image-infos/
   parallel:
     matrix:
-      - PARALLEL_EXEC: ["1/4", "2/4", "3/4", "4/4"]
+      - PARALLEL_EXEC: ["1/8", "2/8", "3/8", "4/8", "5/8", "6/8", "7/8", "8/8"]
         RUNNER:
           - aws/fedora-37-x86_64
           - aws/fedora-37-aarch64
@@ -104,7 +104,7 @@ Manifests:
           - aws/centos-stream-8-aarch64
           - aws/centos-stream-9-x86_64
           - aws/centos-stream-9-aarch64
-      - PARALLEL_EXEC: ["1/4", "2/4", "3/4", "4/4"]
+      - PARALLEL_EXEC: ["1/8", "2/8", "3/8", "4/8", "5/8", "6/8", "7/8", "8/8"]
         RUNNER:
           - aws/rhel-8.8-ga-x86_64
           - aws/rhel-8.8-ga-aarch64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,6 @@ OSTree Images:
   parallel:
     matrix:
       - RUNNER: aws/fedora-38-x86_64
-        INTERNAL_NETWORK: "true"
 
 Manifests:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,13 +67,7 @@ OSTree Images:
     - sudo test/cases/ostree-images
   parallel:
     matrix:
-      - RUNNER:
-          - aws/fedora-37-x86_64
-          - aws/fedora-38-x86_64
-          - aws/rhel-8.8-ga-x86_64
-          - aws/rhel-9.2-ga-x86_64
-          - aws/rhel-8.10-nightly-x86_64
-          - aws/rhel-9.4-nightly-x86_64
+      - RUNNER: aws/fedora-38-x86_64
         INTERNAL_NETWORK: "true"
 
 Manifests:

--- a/test/cases/ostree-images
+++ b/test/cases/ostree-images
@@ -43,71 +43,6 @@ class OSBuild:
 
 
 def run_tests(args, tmpdir):
-    tests = {
-        "fedora-ostree-tarball": {
-            "manifest": "fedora-ostree-tarball.json",
-            "exports": {
-                "tarball": {
-                    "artifact": "fedora-commit.tar"
-                }
-            }
-        },
-        "fedora-ostree-container": {
-            "manifest": "fedora-ostree-container.json",
-            "exports": {
-                "container": {
-                    "artifact": "fedora-container.tar"
-                }
-            },
-        },
-        "fedora-ostree-native-container": {
-            "manifest": "fedora-ostree-native-container.json",
-            "exports": {
-                "container": {
-                    "artifact": "container.tar"
-                }
-            },
-        },
-        "fedora-ostree-bootiso": {
-            "manifest": "fedora-ostree-bootiso.json",
-            "exports": {
-                "bootiso": {
-                    "artifact": "fedora-ostree-boot.iso"
-                }
-            },
-        },
-        "fedora-ostree-bootiso-xz": {
-            "manifest": "fedora-ostree-bootiso-xz.json",
-            "exports": {
-                "bootiso": {
-                    "artifact": "fedora-ostree-boot-xz.iso"
-                }
-            },
-        },
-        "fedora-ostree-image": {
-            "manifest": "fedora-ostree-image.json",
-            "exports": {
-                "qcow2": {
-                    "artifact": "disk.qcow2"
-                }
-            },
-        },
-        "fedora-coreos-container": {
-            "manifest": "fedora-coreos-container.json",
-            "exports": {
-                "qemu": {
-                    "artifact": "qemu.qcow2"
-                },
-                "metal": {
-                    "artifact": "metal.raw"
-                },
-                "metal4k": {
-                    "artifact": "metal4k.raw"
-                }
-            },
-        }
-    }
-
     outdir, store = args.output_directory, args.store
 
     if not outdir:
@@ -129,37 +64,20 @@ def run_tests(args, tmpdir):
         "ostree-commit"
     ]
 
-    results = []
+    print(f"Testing {BOLD}{args.manifest}{RESET}", flush=True)
 
-    for testname, test in tests.items():
-        print(f"Testing {BOLD}{testname}{RESET}", flush=True)
-        manifest = test["manifest"]
+    path = os.path.join("test", "data", "manifests", args.manifest)
 
-        start = time.monotonic()
-        result = {
-            "test": manifest
-        }
-        path = os.path.join("test", "data", "manifests", manifest)
-        exports = test["exports"]
+    success = True
+    export_names = map(lambda p: p.split("/")[0], args.export)
+    osbuild.run(path, export_names)
+    for export in args.export:
+        path = os.path.join(outdir, export)
+        if not os.path.exists(path):
+            print(f"{RED}Error{RESET}: {path} does not exist")
+            success = False
 
-        try:
-            osbuild.run(path, exports.keys())
-            for name, data in exports.items():
-                artifact = data["artifact"]
-                path = os.path.join(outdir, name, artifact)
-                assert os.path.exists(path)
-                print(f"{GREEN}success{RESET}", flush=True)
-        except Exception as e:  # pylint: disable=broad-except
-            print(f"{RED}Error{RESET}: {e}")
-            result["error"] = str(e)
-
-        duration = time.monotonic() - start
-        result["duration"] = duration
-        print(f"Test duration: {duration}", flush=True)
-
-        results.append(result)
-
-    return results
+    return success
 
 
 def main():
@@ -176,6 +94,19 @@ def main():
         type=os.path.abspath,
         default=None,
         help="directory where result objects are stored")
+    parser.add_argument(
+        "--manifest",
+        metavar="FILE",
+        type=str,
+        required=True,
+        help="manifest to build")
+    parser.add_argument(
+        "--export",
+        metavar="ID",
+        type=str,
+        nargs="+",
+        required=True,
+        help="expected export filepaths (can be passed multiple times)")
     args = parser.parse_args()
 
     print(f"Running in {os.path.realpath(os.curdir)}")
@@ -183,16 +114,9 @@ def main():
     tmpdir = "/var/osbuild/tmp"
     os.makedirs(tmpdir, exist_ok=True)
     with tempfile.TemporaryDirectory(dir=tmpdir) as tmp:
-        results = run_tests(args, tmp)
+        success = run_tests(args, tmp)
 
-    n = len(results)
-    failed = len(list(filter(lambda x: x.get("error"), results)))
-    ok = n - failed
-
-    print("tests/ok/failed", end=": ")
-    print(f"{n}/{GREEN}{ok}{RESET}/{RED}{failed}{RESET}")
-
-    if failed:
+    if not success:
         sys.exit(1)
 
 


### PR DESCRIPTION
- Drop testing Fedora ostree artifacts on RHEL
- Run the ostree tests in parallel to make them faster
- Increase the "paralleliness" of the manifest tests to make them faster