### PR TITLE
test: use OSBUILD_TEST_STORE in test_assemblers.py and run in parallel (HMS-3697)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,9 @@ jobs:
         with:
           image: ghcr.io/osbuild/osbuild-ci:latest-202308241910
           run: |
+            # Using 4 workers is a bit arbitrary, "auto" is probably too
+            # aggressive.
+            export TEST_WORKERS="-n 4"
             export OSBUILD_TEST_STORE=/var/tmp/osbuild-test-store
             TEST_CATEGORY="test.run.test_assemblers" \
             tox -e "py36"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,5 +62,6 @@ jobs:
         with:
           image: ghcr.io/osbuild/osbuild-ci:latest-202308241910
           run: |
+            export OSBUILD_TEST_STORE=/var/tmp/osbuild-test-store
             TEST_CATEGORY="test.run.test_assemblers" \
             tox -e "py36"

--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -252,7 +252,8 @@ def loop_create_device(ctl, fd, offset=None, sizelimit=None):
         lo = ctl.loop_for_fd(fd,
                              offset=offset,
                              sizelimit=sizelimit,
-                             autoclear=True)
+                             autoclear=True,
+                             lock=True)
         yield lo
     finally:
         if lo:


### PR DESCRIPTION
Use the OSBUILD_TEST_STORE in the test_assemblers.py file too and re-use already downloaded sources.

This reduces the time from 46min to 16min now and adding the locking to the LoopControl in the assembler tests hopefully fixed the races we saw earlier.