### PR TITLE
test: use OSBUILD_TEST_STORE in test_assemblers.py too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,5 +62,6 @@ jobs:
         with:
           image: ghcr.io/osbuild/osbuild-ci:latest-202308241910
           run: |
+            export OSBUILD_TEST_STORE=/var/tmp/osbuild-test-store
             TEST_CATEGORY="test.run.test_assemblers" \
             tox -e "py36"


### PR DESCRIPTION
Use the OSBUILD_TEST_STORE in the test_assemblers.py file too and re-use already downloaded sources.

This seems to decrease the time in test_assemblers from 46min to 35min. Not super great but also not that bad.