### PR TITLE
tests: Report GitLab job failures globally (HMS-3697)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,6 @@ stages:
   after_script:
     - schutzbot/ci_details.sh > ci-details-after-run
     - schutzbot/unregister.sh
-    - schutzbot/update_github_status.sh update
   tags:
     - terraform
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,3 +114,13 @@ finish:
     - shell
   script:
     - schutzbot/update_github_status.sh finish
+
+fail:
+  stage: finish
+  tags:
+    - shell
+  script:
+    - schutzbot/update_github_status.sh fail
+    - exit 1  # make the pipeline fail so it doesn't look like success in gitlab
+  when:
+    on_failure

--- a/schutzbot/update_github_status.sh
+++ b/schutzbot/update_github_status.sh
@@ -16,6 +16,9 @@ elif [[ $1 == "update" ]]; then
   else
     exit 0
   fi
+elif [[ $1 == "fail" ]]; then
+    GITHUB_NEW_STATE="failure"
+    GITHUB_NEW_DESC="I'm sorry, something is odd about this commit."
 else
   echo "unknown command"
   exit 1


### PR DESCRIPTION
This is the same change we made in osbuild/images#369.

Never update the GitHub status at the end of a job. Instead, let the job retry and if another failure occurs, when everything is done, the fail job will run in the finish stage and update the status accordingly.

Then we can add retries for any unreliable jobs and avoid registering an early failure before the job is retried so we could then enable a merge-queue for the repository.