### PR TITLE
schutzbot: add manual caching to manifest_tests.sh (HMS-3697)

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -33,4 +33,5 @@ sudo dnf install -y osbuild \
                     osbuild-lvm2 \
                     osbuild-luks2 \
                     jq \
-                    python3
+                    python3 \
+		    unzip

--- a/schutzbot/manifest_tests.sh
+++ b/schutzbot/manifest_tests.sh
@@ -17,7 +17,7 @@ OSBUILD_LABEL=$(matchpathcon -n /usr/bin/osbuild)
 chcon $OSBUILD_LABEL tools/image-info
 
 # set the maximum cache size to unlimited
-echo "{}" | sudo osbuild --store /var/lib/osbuild/store --cache-max-size unlimited -
+echo "{}" | sudo osbuild --store /var/lib/osbuild/store --cache-max-size 20GB -
 
 IFS='/' read -r -a array <<< $1
 
@@ -34,8 +34,6 @@ AWS_ACCESS_KEY_ID="$V2_AWS_ACCESS_KEY_ID" \
 if [ -f  /tmp/osbuild-store.tgz ]; then
     (cd /var/lib/osbuild/store && sudo tar xf /tmp/osbuild-store.tgz)
 fi
-# debug
-ls -a /var/lib/osbuild/store
 
 # run the tests from the manifest-db for this arch+distro
 echo "Running the osbuild-image-test for arch $ARCH and ditribution $DISTRO_CODE"


### PR DESCRIPTION
This PR caches the osbuild store between manifest tests. This should speedup the runs.

There are two approaches that we both need to measure:
[x] no caching (baseline): https://gitlab.com/redhat/services/products/image-builder/ci/osbuild/-/jobs/6330199006 - 16 minutes 19 seconds 
[x] use `aws sync` and just sync the entire osbuild store dir (looks like sync takes a while https://gitlab.com/redhat/services/products/image-builder/ci/osbuild/-/jobs/6330557061 - 31min+)
[x] use `aws cp` and tar the osbuild store dir first: https://gitlab.com/redhat/services/products/image-builder/ci/osbuild/-/jobs/6332692061 (first run: 20 minutes 38 seconds  with cold cache, second run with created tar file https://gitlab.com/redhat/services/products/image-builder/ci/osbuild/-/jobs/6334331227 13min)

Depending how aws sync is implemented we may need the first or second option. The first option is great between we get deltas for free. But it also means many small files get transfered. The second is great because it's just one big upload/download. Only measuring it will determine which one is better.