### PR TITLE
lint: replace `isort` with `ruff` and provide `lint-quick` (HMS-3697)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,29 @@
 line-length = 120
 
-lint.ignore = [
-    "E741",  # ambiguous variable names
-    "E501",  # line too long
+[lint]
+# enabled the `isort` and `pylint` additional linters, see `ruff linter` output
+# or: https://docs.astral.sh/ruff/rules/
+extend-select = ["I", "PL"]
+
+# all of these ignores and their explanatiosn can be found at: https://docs.astral.sh/ruff/rules/
+# or the relevant linter documentation
+ignore = [
+    "E741",  # pycodestyle: ambiguous variable names
+    "E501",  # pycodestyle: line too long
+
+    "PLW0603", # pylint: global statement
+
+    "PLR0911", # pylint: too many return statements
+    "PLR0912", # pylint: too many branches
+    "PLR0913", # pylint: too many arguments in function definition
+    "PLR0915", # pylint: too many statements
+
+    "PLR2004", # pylint: constant used in comparison
+    "PLR0402", # pylint: import alias
+    "PLR5501", # pylint: use elif
+
+    "PLW2901", # pylint: redefined loop variable
 ]
+
+[format]
+quote-style = "preserve"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,6 @@
 line-length = 120
 
-ignore = [
+lint.ignore = [
     "E741",  # ambiguous variable names
     "E501",  # line too long
 ]

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ test-all:
 
 .PHONY: lint
 lint:
-	tox run-parallel -e ruff,pylint,autopep8,isort,mypy,mypy-strict
+	tox run-parallel -e ruff,pylint,autopep8,mypy,mypy-strict
 
 #
 # Building packages

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ help:
 	@echo "    help:               Print this usage information."
 	@echo "    man:                Generate all man-pages"
 	@echo
-	@echo "    lint:               Check the code with linter"
+	@echo "    lint:               Check the code with linter (tox)"
+	@echo "    lint-quick:         Check the code with fast linters only (local)"
 	@echo
 	@echo "    coverity-download:  Force a new download of the coverity tool"
 	@echo "    coverity-check:     Run the coverity test suite"
@@ -243,12 +244,24 @@ test-all:
 #
 # Linting the code
 #
-# Just run `make lint` and see if our linters like your code.
+# Just run `make lint` and see if our linters like your code. Linters run in an
+# environment created by tox.
 #
 
 .PHONY: lint
 lint:
 	tox run-parallel -e ruff,pylint,autopep8,mypy,mypy-strict
+
+
+#
+# Quick-linting the code
+#
+# Just run `make lint-quick` and see if our linters like your code. Linters run locally
+# and need to be installed. See also `lint`.
+#
+.PHONY: lint-quick
+lint-quick:
+	ruff check osbuild/ assemblers/* devices/* inputs/* mounts/* runners/* sources/*.* stages/*.* inputs/test/*.py stages/test/*.py sources/test/*.py test/
 
 #
 # Building packages

--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -29,8 +29,7 @@ import os
 import pkgutil
 import sys
 from collections import deque
-from typing import (Any, Deque, Dict, List, Optional, Sequence, Set, Tuple,
-                    Union)
+from typing import Any, Deque, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import jsonschema
 

--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import tempfile
 import typing
+
 # pylint doesn't understand the string-annotation below
 from typing import Any, Dict, List, Tuple  # pylint: disable=unused-import
 

--- a/tools/osbuild-dev
+++ b/tools/osbuild-dev
@@ -227,7 +227,7 @@ def pretty_diff(
 
             paths.append(path)
 
-        subprocess.run((["diff", "-u"] if simple else ["vimdiff"]) + paths)
+        subprocess.run((["diff", "-u"] if simple else ["vimdiff"]) + paths, check=True)
 
     return 0
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,10 +40,10 @@ allowlist_externals =
 
 [testenv:ruff]
 deps =
-    ruff==0.0.263
+    ruff==0.3.0
 
 commands =
-    bash -c 'python -m ruff {env:LINTABLES}'
+    bash -c 'python -m ruff check {env:LINTABLES}'
 
 [testenv:isort]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ env_list =
 
 labels =
     test = py{36,37,38,39,310,311}
-    lint = ruff, isort, autopep8, pylint
+    lint = ruff, autopep8, pylint
     type = mypy,mypy-strict
 
 [testenv]
@@ -44,13 +44,6 @@ deps =
 
 commands =
     bash -c 'python -m ruff check {env:LINTABLES}'
-
-[testenv:isort]
-deps =
-    isort==5.12.0
-
-commands =
-    bash -c 'python -m isort --check --diff {env:LINTABLES}'
 
 [testenv:autopep8]
 deps =


### PR DESCRIPTION
This PR aims to make some things faster, it now provides a `make lint-quick` Makefile target that can be used in local pre-commit checks that only checks:

1. Import sorting.
2. Most of pylint.

`make lint` takes about 45 seconds to run on my system, `make lint-quick` takes about 0.3 seconds on my system but does require one to `dnf install ruff`.

This PR might grow to also do formatting through `ruff` as `autopep8` is broken for Python >= 3.12.

Aside from providing the new `lint-quick` target this PR also removes `isort` as it can be done to the same effect with `ruff` everywhere.