### PR TITLE
tests: Cancel in-progress tests on PR updates (HMS-3697)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Tests
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_suite:
     name: "Unittest"


### PR DESCRIPTION
Before this commit GitHub Action runs that were triggered by a PR were not canceled when updates were made to the same PR. This lead to even more clogging of our pipelines and not enough runners being available.

This changes the behavior in a way that whenever a PR gets updated all still-in-progress runs get canceled and new runs get spawned.