### PR TITLE
tests: revert "workflow: run assembler tests in parallel" /o\

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,6 @@ jobs:
         with:
           image: ghcr.io/osbuild/osbuild-ci:latest-202308241910
           run: |
-            # Using 4 workers is a bit arbitrary, "auto" is probably too
-            # aggressive.
-            export TEST_WORKERS="-n 4"
             export OSBUILD_TEST_STORE=/var/tmp/osbuild-test-store
             TEST_CATEGORY="test.run.test_assemblers" \
             tox -e "py36"

--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -252,8 +252,7 @@ def loop_create_device(ctl, fd, offset=None, sizelimit=None):
         lo = ctl.loop_for_fd(fd,
                              offset=offset,
                              sizelimit=sizelimit,
-                             autoclear=True,
-                             lock=True)
+                             autoclear=True)
         yield lo
     finally:
         if lo:


### PR DESCRIPTION
This reverts commit ea36e25b09a3eb0bd2424361d9fd2f48ab3c3dfd.

It turns out that the assemblers test is (too) racy, I suspect that this is actually a real bug in our org.osbuild.qemu assembler and/or in remoteloop.py but given that we do not use assemblers anymore it's hard to justify spending too much time on this.

But I'm very sad about it.