### PR TITLE
tests/manifest: Don't retain image-info artifacts (HMS-3697)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,10 +89,6 @@ Manifests:
   script:
     - schutzbot/deploy.sh
     - schutzbot/manifest_tests.sh ${PARALLEL_EXEC}
-  artifacts:
-    when: always
-    paths:
-      - manifest-db/generated-image-infos/
   parallel:
     matrix:
       - PARALLEL_EXEC: ["1/8", "2/8", "3/8", "4/8", "5/8", "6/8", "7/8", "8/8"]


### PR DESCRIPTION
Nothing else seems to rely on the image-info generated by the manifest tests, so let's not retain those artifacts. This currently makes the `finish` stage take 6 minutes for no good reason.