### PR TITLE
test: fix test_assembler to support parallel runs and run in parallel (HMS-3697)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           image: ghcr.io/osbuild/osbuild-ci:latest-202308241910
           run: |
+            # Using 4 workers is a bit arbitrary, "auto" is probably too
+            # aggressive.
+            export TEST_WORKERS="-n 4"
             export OSBUILD_TEST_STORE=/var/tmp/osbuild-test-store
             TEST_CATEGORY="test.run.test_assemblers" \
             tox -e "py36"

--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import tempfile
+from uuid import uuid4
 
 import pytest
 
@@ -87,7 +88,7 @@ def test_rawfs(osbuild, fs_type):
         pytest.skip(f"The {fs_type} was explicitly marked as unsupported on this platform.")
     options = {
         "filename": "image.raw",
-        "root_fs_uuid": "016a1cda-5182-4ab3-bf97-426b00b74eb0",
+        "root_fs_uuid": str(uuid4()),
         "size": 1024 * MEBIBYTE,
         "fs_type": fs_type,
     }
@@ -165,8 +166,8 @@ def test_qemu(osbuild, fmt, fs_type):
         options = {
             "format": fmt,
             "filename": f"image.{fmt}",
-            "ptuuid": "b2c09a39-db93-44c5-846a-81e06b1dc162",
-            "root_fs_uuid": "aff010e9-df95-4f81-be6b-e22317251033",
+            "ptuuid": str(uuid4()),
+            "root_fs_uuid": str(uuid4()),
             "size": 1024 * MEBIBYTE,
             "root_fs_type": fs_type,
         }


### PR DESCRIPTION
The `test_assembler.py` hardcods some filesystem and partition UUIDs. This leads to hard to diagnose test failures when the test is run in parallel. The btrfs and xfs filesystem drivers will see the same uuid for multi created images and error sometimes with someting like:
```
Mar 06 10:22:54 top kernel: BTRFS error: device /dev/loop104 belongs to fsid aff010e9-df95-4f81-be6b-e22317251033, and the fs is already mounted, scanned by mount (123856)
```
Its a race that only happens when two images are checked at the same time.

This commit fixes the issue by just using a randomized UUID in the test_assemblers.py. It also re-enables running the test in parallel (which make it run a lot faster, from 34min to 14min).