### PR TITLE
Revert "osbuild: ensure loop.Loop() has the required device node"

### DIFF
--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -15,9 +15,6 @@ __all__ = [
     "UnexpectedDevice"
 ]
 
-# can be mocked in tests
-DEV_PATH = "/dev"
-
 
 class UnexpectedDevice(Exception):
     def __init__(self, expected_minor, rdev, mode):
@@ -127,14 +124,8 @@ class Loop:
 
         with contextlib.ExitStack() as stack:
             if not dir_fd:
-                dir_fd = os.open(DEV_PATH, os.O_DIRECTORY)
+                dir_fd = os.open("/dev", os.O_DIRECTORY)
                 stack.callback(lambda: os.close(dir_fd))
-            # ensure the device node is availale, in containers it may
-            # not get dynamically created
-            try:
-                self.mknod(dir_fd)
-            except FileExistsError:
-                pass
             self.fd = os.open(self.devname, os.O_RDWR, dir_fd=dir_fd)
 
         info = os.stat(self.fd)
@@ -543,7 +534,7 @@ class LoopControl:
 
         with contextlib.ExitStack() as stack:
             if not dir_fd:
-                dir_fd = os.open(DEV_PATH, os.O_DIRECTORY)
+                dir_fd = os.open("/dev", os.O_DIRECTORY)
                 stack.callback(lambda: os.close(dir_fd))
 
             self.fd = os.open("loop-control", os.O_RDWR, dir_fd=dir_fd)

--- a/test/mod/test_loop.py
+++ b/test/mod/test_loop.py
@@ -5,7 +5,6 @@
 import contextlib
 import fcntl
 import os
-import pathlib
 import threading
 import time
 from tempfile import TemporaryDirectory, TemporaryFile
@@ -261,13 +260,3 @@ def test_on_close(tempdir):
 def test_loop_handles_error_in_init(mocked_open):  # pylint: disable=unused-argument
     with pytest.raises(FileNotFoundError):
         loop.Loop(999)
-
-
-@pytest.mark.skipif(os.getuid() != 0, reason="root only")
-def test_loop_create_mknod():
-    # tmpdir must be /var/tmp because /tmp is usually mounted with "nodev"
-    with TemporaryDirectory(dir="/var/tmp") as tmpdir:
-        with patch.object(loop, "DEV_PATH", new=tmpdir):
-            lopo = loop.Loop(1337)
-            assert lopo.devname == "loop1337"
-            assert pathlib.Path(f"{tmpdir}/loop1337").is_block_device()


### PR DESCRIPTION
This reverts commit 158acaac785056132bffa777755d93e490e2e2d6.

With https://github.com/osbuild/bootc-image-builder/pull/238 the original reason to call mknod goes away so we can just revert it. osbuild now requires not only the loop device but also uses `losetup --partscan` quite a lot now so the mknod approach becomes impractical and the consumers of osbuild in a container should just setup devtmpfs.

This also fixes the issue that @supakeen raised that the mknod call is risky and racy and interferes with udev.
