### PR TITLE
osbuild: enable direct-io for our loop devices by default

### DIFF
--- a/osbuild/loop.py
+++ b/osbuild/loop.py
@@ -448,6 +448,8 @@ class Loop:
                 raise
             fcntl.ioctl(self.fd, self.LOOP_SET_FD, config.fd)
             fcntl.ioctl(self.fd, self.LOOP_SET_STATUS64, config.info)
+        # use direct-io by default
+        self.set_direct_io()
 
     def get_status(self) -> LoopInfo:
         """Get properties of the loopback device


### PR DESCRIPTION
Using `direct_io` by default for our loop devices should give us a nice performance increase.

[draft to see how it affects our overall performance (and tests)]
[edit2: seems to have *no* visible effect on performance in the tests we run]