### PR TITLE
osbuild: ensure a usable /var/tmp is available inside the buildroot

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -138,6 +138,12 @@ class BuildRoot(contextlib.AbstractContextManager):
 
             self.var = os.path.join(self.tmp, "var")
             os.makedirs(self.var, exist_ok=True)
+            # Ensure /var/tmp is available, see
+            #  https://github.com/osbuild/bootc-image-builder/issues/223
+            try:
+                os.symlink("/tmp", os.path.join(self.var, "tmp"))
+            except FileExistsError:
+                pass
 
             proc = os.path.join(self.tmp, "proc")
             os.makedirs(proc)

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -44,10 +44,18 @@ def test_basic(tempdir, runner):
 
         # Test we can use `.run` multiple times
         r = root.run(["/usr/bin/true"], monitor)
-        assert r.returncode == 0
+        assert r.returncode == 0, f"{r.stdout} {r.stderr}"
 
         r = root.run(["/usr/bin/false"], monitor)
         assert r.returncode != 0
+
+        # Test that fs setup looks correct
+        r = root.run(["readlink", "-f", "/var/tmp"], monitor)
+        assert r.returncode == 0
+        assert r.stdout.strip().split("\n")[-1] == "/tmp"
+        r = root.run(["stat", "-L", "--format=%a", "/var/tmp"], monitor)
+        assert r.returncode == 0
+        assert r.stdout.strip().split("\n")[-1] == "1777"
 
 
 @pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")


### PR DESCRIPTION
Colin asked for this in
https://github.com/osbuild/bootc-image-builder/issues/223 and it's easy enough.