### PR TITLE
linux: add new mount/umount2 libc6 wrappers

### DIFF
--- a/osbuild/testutil/fs.py
+++ b/osbuild/testutil/fs.py
@@ -1,0 +1,20 @@
+"""
+Fake filesystem content
+"""
+import os
+
+
+def make_fs_tree(basedir, fake_content: dict) -> str:
+    """
+    make_fs_tree creates a filesystem tree based on the fake_content dict.
+
+    Usage:
+    make_fs_tree("/tmp/", {"/test-dir/test-file": "file-content", ...})
+    """
+    for path, content in fake_content.items():
+        dirp, name = os.path.split(os.path.join(basedir, path.lstrip("/")))
+        os.makedirs(dirp, exist_ok=True)
+        if content is not None:
+            with open(os.path.join(dirp, name), "w", encoding="utf-8") as fp:
+                fp.write(content)
+    return basedir

--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -446,6 +446,11 @@ class Libc:
     UTIME_NOW = ctypes.c_long(((1 << 30) - 1))
     UTIME_OMIT = ctypes.c_long(((1 << 30) - 2))
 
+    # from <linux/mount.h>
+    MS_BIND = ctypes.c_ulong(4096)
+    MS_PRIVATE = ctypes.c_ulong((1 << 18))
+    MS_REC = ctypes.c_ulong(16384)
+
     _lock = threading.Lock()
     _inst = None
 
@@ -490,6 +495,44 @@ class Libc:
         setattr(proto, "errcheck", self._errcheck_errno)
         setattr(proto, "__name__", "futimens")
         self.futimens = proto
+        # prototype: mount
+        proto_mount = ctypes.CFUNCTYPE(
+            ctypes.c_int,  # restype (return type)
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.c_ulong,
+            ctypes.c_char_p,
+            use_errno=True,
+        )(
+            ("mount", self._lib),
+            (
+                (1, "source"),
+                (1, "target"),
+                (1, "fstype"),
+                (1, "flags"),
+                (1, "options", None),
+            ),
+        )
+        setattr(proto_mount, "errcheck", self._errcheck_errno)
+        setattr(proto_mount, "__name__", "mount")
+        self.mount = proto_mount
+        # prototype: umount2
+        proto_umount2 = ctypes.CFUNCTYPE(
+            ctypes.c_int,  # restype (return type)
+            ctypes.c_char_p,
+            ctypes.c_int,
+            use_errno=True,
+        )(
+            ("umount2", self._lib),
+            (
+                (1, "target"),
+                (1, "flags"),
+            ),
+        )
+        setattr(proto_mount, "errcheck", self._errcheck_errno)
+        setattr(proto_mount, "__name__", "umount2")
+        self.umount2 = proto_umount2
 
     @staticmethod
     def make() -> "Libc":

--- a/test/mod/test_mnt.py
+++ b/test/mod/test_mnt.py
@@ -1,0 +1,36 @@
+#
+# Tests for mount
+#
+import contextlib
+import os
+import pathlib
+
+import pytest
+
+from osbuild.testutil.fs import make_fs_tree
+from osbuild.util.mnt import mount_new, umount
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="root only")
+def test_mount_new(tmp_path):
+    # create a /src and bind mount on /dst
+    make_fs_tree(tmp_path, {
+        "/src/src-file": "some content",
+        "/dst/": None,
+    })
+    src_file_path = pathlib.Path(f"{tmp_path}/src/src-file")
+    src_dir = os.fspath(src_file_path.parent).encode("utf-8")
+    dst_file_path = pathlib.Path(f"{tmp_path}/dst/src-file")
+    dst_dir = os.fspath(dst_file_path.parent).encode("utf-8")
+
+    # fake src exists but dst not yet as it's not yet mounted
+    assert src_file_path.exists()
+    assert not dst_file_path.exists()
+    with contextlib.ExitStack() as cm:
+        mount_new(src_dir, dst_dir)
+        # cleanup (and test umount2 along the way)
+        cm.callback(umount, dst_dir)
+        # now src is bind mounted to dst and we can read the content
+        assert dst_file_path.read_bytes() == b"some content"
+    # ensure libc.umount2 unmounted dst again
+    assert not dst_file_path.exists()


### PR DESCRIPTION
To avoid having to use an external "mount" binary (and having to deal with the selinux labeling) this commit adds new "mount" and "umount2" syscalls to the osbuild.util.linux package and the coresponding tests.