### PR TITLE
stages/kickstart: add `noswap` to `autopart`

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -402,6 +402,10 @@ SCHEMA = r"""
       "nohome": {
         "description": "Disables automatic creation of the /home partition",
         "type": "boolean"
+      },
+      "noswap": {
+        "description": "Disables automatic creation of a swap partition",
+        "type": "boolean"
       }
     }
   },
@@ -536,7 +540,8 @@ def make_autopart(options: Dict) -> str:
     cmd = "autopart"
     for key in ["type", "fstype", "nolvm", "encrypted", "passphrase",
                 "escrowcert", "backuppassphrase", "cipher", "luks-version",
-                "pbkdf", "pbkdf-memory", "pbkdf-time", "pbkdf-iterations", "nohome"]:
+                "pbkdf", "pbkdf-memory", "pbkdf-time", "pbkdf-iterations", "nohome",
+                "noswap"]:
         if key not in autopart:
             continue
         val = autopart[key]

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -140,7 +140,10 @@ TEST_INPUT = [
     ({"autopart": {"pbkdf-time": 128}}, "autopart --pbkdf-time=128"),
     ({"autopart": {"pbkdf-iterations": 256}}, "autopart --pbkdf-iterations=256"),
     ({"autopart": {"nohome": True}}, "autopart --nohome"),
+    ({"autopart": {"noswap": True}}, "autopart --noswap"),
     ({"autopart": {"type": "plain", "fstype": "xfs", "nohome": True}}, "autopart --type=plain --fstype=xfs --nohome"),
+    ({"autopart": {"type": "plain", "fstype": "xfs", "nohome": True, "noswap": True}},
+     "autopart --type=plain --fstype=xfs --nohome --noswap"),
     ({
         "lang": "en_US.UTF-8",
         "keyboard": "us",


### PR DESCRIPTION
Allow passing the `noswap` option to `autopart`. This is to allow for the kickstart setup for https://github.com/osbuild/images/issues/309 