### PR TITLE
test: return container_id in `make_container`

### DIFF
--- a/inputs/test/test_containers.py
+++ b/inputs/test/test_containers.py
@@ -2,9 +2,7 @@
 
 import os
 import pathlib
-import random
 import socket
-import string
 import subprocess
 import tempfile
 
@@ -29,8 +27,7 @@ class FakeStoreClient:
 @pytest.mark.skipif(not has_executable("podman"), reason="no podman executable")
 @pytest.mark.skipif(os.getuid() != 0, reason="root only")
 def test_containers_local_inputs_integration(tmp_path, inputs_module):
-    base_tag = "container-" + "".join(random.choices(string.digits, k=12))
-    with make_container(tmp_path, base_tag, {"file1": "file1 content"}):
+    with make_container(tmp_path, {"file1": "file1 content"}) as base_tag:
         image_id = subprocess.check_output(
             ["podman", "inspect", "-f", "{{ .Id }}", base_tag],
             universal_newlines=True).strip()

--- a/sources/test/test_container_storage_source.py
+++ b/sources/test/test_container_storage_source.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python3
 
 import os
-import random
 import socket
-import string
 import subprocess
 
 import pytest
@@ -16,10 +14,9 @@ SOURCES_NAME = "org.osbuild.containers-storage"
 @pytest.mark.skipif(not has_executable("podman"), reason="no podman executable")
 @pytest.mark.skipif(os.getuid() != 0, reason="root only")
 def test_containers_storage_integration(tmp_path, sources_module):
-    base_tag = "container-" + "".join(random.choices(string.digits, k=12))
-    with make_container(tmp_path, base_tag, {
+    with make_container(tmp_path, {
         "file1": "file1 content",
-    }):
+    }) as base_tag:
         image_id = subprocess.check_output(["podman", "inspect", "-f", "{{ .Id }}", base_tag],
                                            universal_newlines=True).strip()
         checksum = f"sha256:{image_id}"

--- a/test/mod/test_testutil_make_container.py
+++ b/test/mod/test_testutil_make_container.py
@@ -1,0 +1,29 @@
+#
+# Tests for the 'osbuild.util.testutil.make_container'.
+#
+import subprocess
+import textwrap
+
+import pytest
+
+from osbuild.testutil import has_executable, make_container, mock_command
+
+
+def test_make_container_bad_podman_prints_podman_output(tmp_path, capsys):
+    fake_broken_podman = textwrap.dedent("""\
+    #!/bin/sh
+    echo fake-broken-podman
+    exit 1
+    """)
+    with mock_command("podman", fake_broken_podman):
+        with pytest.raises(subprocess.CalledProcessError):
+            with make_container(tmp_path, {}) as _:
+                pass
+    assert "fake-broken-podman" in capsys.readouterr().out
+
+
+@pytest.mark.skipif(not has_executable("podman"), reason="no podman executable")
+def test_make_container_integration(tmp_path, capsys):
+    with make_container(tmp_path, {"/etc/foo": "foo-content"}) as cref:
+        assert len(cref) == 64
+    assert "COMMIT" in capsys.readouterr().out


### PR DESCRIPTION
The current `make_container()` helper is a bit silly (which is entirely my fault). It requires a container tag as input but all tests end up creating a random number for this input. So instead just remove the input and return the container_id from the podman build in the contextmanager and use that.