### PR TITLE
tox.ini: update autopep8/pyocdestyle to support py3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 env_list =
-    py{36,37,38,39,310,311}
+    py{36,37,38,39,310,311,312}
     lint
     type
 
 labels =
-    test = py{36,37,38,39,310,311}
+    test = py{36,37,38,39,310,311,312}
     lint = ruff, autopep8, pylint
     type = mypy,mypy-strict
 
@@ -47,8 +47,8 @@ commands =
 
 [testenv:autopep8]
 deps =
-    autopep8==2.0.2
-    pycodestyle==2.10.0
+    autopep8==2.0.4
+    pycodestyle==2.11.0
 
 commands =
     bash -c 'python -m autopep8 --diff --max-line-length 120 -a -a -a -j0 -r --exit-code {env:LINTABLES}'


### PR DESCRIPTION
Trivial PR to update pycodestyle so that we have working python3.12 autopep8 (see https://github.com/hhatto/autopep8/issues/712)