### PR TITLE
stages: add functional user expiredate tests

### DIFF
--- a/stages/test/test_users.py
+++ b/stages/test/test_users.py
@@ -4,15 +4,18 @@ from unittest.mock import patch
 
 import pytest
 
-from osbuild.testutil import make_fake_tree
+from osbuild.testutil import make_fake_tree, mock_command
 
 STAGE_NAME = "org.osbuild.users"
 
-
-@pytest.mark.parametrize("user_opts,expected_args", [
+TEST_CASES = [
+    # user_opts,expected commandline args
     ({}, []),
-    ({"expiredate": 12345}, ["--expiredate", "12345"]),
-])
+    ({"expiredate": "12345"}, ["--expiredate", "12345"]),
+]
+
+
+@pytest.mark.parametrize("user_opts,expected_args", TEST_CASES)
 @patch("subprocess.run")
 def test_users_happy(mocked_run, tmp_path, stage_module, user_opts, expected_args):
     make_fake_tree(tmp_path, {
@@ -32,3 +35,22 @@ def test_users_happy(mocked_run, tmp_path, stage_module, user_opts, expected_arg
     args, kwargs = mocked_run.call_args_list[0]
     assert args[0] == ["chroot", tmp_path, "useradd"] + expected_args + ["foo"]
     assert kwargs.get("check")
+
+
+@pytest.mark.parametrize("user_opts,expected_args", TEST_CASES)
+def test_users_mock_bin(tmp_path, stage_module, user_opts, expected_args):
+    with mock_command("chroot", "") as mocked_chroot:
+        make_fake_tree(tmp_path, {
+            "/etc/passwd": "",
+        })
+
+        options = {
+            "users": {
+                "foo": {},
+            }
+        }
+        options["users"]["foo"].update(user_opts)
+
+        stage_module.main(tmp_path, options)
+        assert len(mocked_chroot.call_args_list) == 1
+        assert mocked_chroot.call_args_list[0][2:] == expected_args + ["foo"]

--- a/test/mod/test_testutil_mock_command.py
+++ b/test/mod/test_testutil_mock_command.py
@@ -12,14 +12,26 @@ def test_mock_command_integration():
     output = subprocess.check_output(["echo", "hello"])
     assert output == b"hello\n"
     fake_echo = textwrap.dedent("""\
-    #!/bin/sh
     echo i-am-not-echo
     """)
-    with mock_command("echo", fake_echo):
+    with mock_command("echo", fake_echo) as mocked_cmd:
         output = subprocess.check_output(["echo", "hello"])
         assert output == b"i-am-not-echo\n"
+        assert mocked_cmd.call_args_list == [
+            ["hello"],
+        ]
     output = subprocess.check_output(["echo", "hello"])
     assert output == b"hello\n"
+
+
+def test_mock_command_multi():
+    with mock_command("echo", "") as mocked_cmd:
+        subprocess.check_output(["echo", "call1-arg1", "call1-arg2"])
+        subprocess.check_output(["echo", "call2-arg1", "call2-arg2"])
+        assert mocked_cmd.call_args_list == [
+            ["call1-arg1", "call1-arg2"],
+            ["call2-arg1", "call2-arg2"],
+        ]
 
 
 def test_mock_command_environ_is_modified_and_restored():


### PR DESCRIPTION
During the review of https://github.com/osbuild/osbuild/pull/1648 we noticed a small gap in the way we test external programs. This PR helper improving this by allowing to mock real commands instead of mocking subprocess.run