### PR TITLE
stages(selinux): add option `exclude_paths`

### DIFF
--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -38,6 +38,13 @@ SCHEMA = """
     "type": "string",
     "description": "Path to the active SELinux policy's `file_contexts`"
   },
+  "exclude_paths": {
+    "type": "array",
+    "description": "Paths to exclude when setting labels via file_contexts",
+    "items": {
+      "type": "string"
+    }
+  },
   "labels": {
     "type": "object",
     "description": "Labels to set of the specified files or folders",
@@ -56,7 +63,8 @@ SCHEMA = """
 
 def main(tree, options):
     file_contexts = os.path.join(f"{tree}", options["file_contexts"])
-    selinux.setfiles(file_contexts, os.fspath(tree), "")
+    exclude_paths = options.get("exclude_paths")
+    selinux.setfiles(file_contexts, os.fspath(tree), "", exclude_paths=exclude_paths)
 
     labels = options.get("labels", {})
     for path, label in labels.items():

--- a/test/mod/test_util_selinux.py
+++ b/test/mod/test_util_selinux.py
@@ -74,3 +74,16 @@ def test_selinux_setfiles(mocked_run, tmp_path):
             ["setfiles", "-F", "-r", os.fspath(tmp_path),
              "/etc/selinux/thing", os.fspath(tmp_path) + "/boot"], check=True),
     ]
+
+
+@mock.patch("subprocess.run")
+def test_selinux_setfiles_exclude(mocked_run, tmp_path):
+    selinux.setfiles("/etc/selinux/thing", os.fspath(tmp_path), "/", exclude_paths=["/sysroot", "/other/dir"])
+
+    assert len(mocked_run.call_args_list) == 1
+    assert mocked_run.call_args_list == [
+        mock.call(
+            ["setfiles", "-F", "-r", os.fspath(tmp_path),
+             "-e", "/sysroot", "-e", "/other/dir",
+             "/etc/selinux/thing", os.fspath(tmp_path) + "/"], check=True),
+    ]


### PR DESCRIPTION
This option allows to exclude paths like  `/sysroot` from the
selinux labeling. This is needed because on a mounted `bootc` container `setfiles`
without excluding `/sysroot` will create many warnings like:
```
setfiles: conflicting specifications for /run/osbuild/tree/sysroot/ostree/repo/objects/00/0ef9ada2ee87792e8ba21afd65aa00d79a1253018832652b8694862fb80e84.file and /run/osbuild/tree/usr/lib/firmware/cirrus/cs35l41-dsp1-spk-prot-103c8b8f-r1.bin.xz, using system_u:object_r:lib_t:s0.
