### PR TITLE
github: add cache key to generate.yml flow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -45,6 +45,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /var/tmp/osbuild-mpp-cache
+        key: no-key-needed-here
     - name: "Regenerate Test Data"
       uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
       with:


### PR DESCRIPTION
There are recent GH failures because the github cache action complains:
```
Input required and not supplied: key
```
This is slightly odd as we did not provide a cache key before and it was fine but *shrug*. We also don't really need a cache key, we always get the same cache, osbuild is smart enough to figure it out.