### PR TITLE
osbuild: ensure /var/tmp is a real directory

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -138,12 +138,6 @@ class BuildRoot(contextlib.AbstractContextManager):
 
             self.var = os.path.join(self.tmp, "var")
             os.makedirs(self.var, exist_ok=True)
-            # Ensure /var/tmp is available, see
-            #  https://github.com/osbuild/bootc-image-builder/issues/223
-            try:
-                os.symlink("/tmp", os.path.join(self.var, "tmp"))
-            except FileExistsError:
-                pass
 
             proc = os.path.join(self.tmp, "proc")
             os.makedirs(proc)
@@ -226,6 +220,10 @@ class BuildRoot(contextlib.AbstractContextManager):
         mounts += ["--tmpfs", "/run"]
         mounts += ["--tmpfs", "/tmp"]
         mounts += ["--bind", self.var, "/var"]
+
+        # Create a usable /var/tmp, see
+        #  https://github.com/osbuild/bootc-image-builder/issues/223
+        os.makedirs(os.path.join(self.var, "tmp"), 0o1777, exist_ok=True)
 
         # Setup API file-systems.
         mounts += ["--proc", "/proc"]

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -50,10 +50,9 @@ def test_basic(tempdir, runner):
         assert r.returncode != 0
 
         # Test that fs setup looks correct
-        r = root.run(["readlink", "-f", "/var/tmp"], monitor)
+        r = root.run(["test", "-d", "/var/tmp"], monitor)
         assert r.returncode == 0
-        assert r.stdout.strip().split("\n")[-1] == "/tmp"
-        r = root.run(["stat", "-L", "--format=%a", "/var/tmp"], monitor)
+        r = root.run(["stat", "--format=%a", "/var/tmp"], monitor)
         assert r.returncode == 0
         assert r.stdout.strip().split("\n")[-1] == "1777"
 


### PR DESCRIPTION
This is a followup for https://github.com/osbuild/osbuild/pull/1649

Instead of symlinking /var/tmp to /tmp which may be on a tmpfs this commit puts it on a real filesystem.

This should fix:
https://github.com/osbuild/bootc-image-builder/issues/285