### PR TITLE
osbuild: make the entire /etc/selinux avaialble for the buildroot

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -248,8 +248,8 @@ class BuildRoot(contextlib.AbstractContextManager):
                    os.path.join(self._rootdir, "ostree"),
                    "/ostree"]
         mounts += ["--ro-bind-try",
-                   os.path.join(self._rootdir, "etc/selinux/targeted/contexts"),
-                   "/etc/selinux/targeted/contexts"]
+                   os.path.join(self._rootdir, "etc/selinux/"),
+                   "/etc/selinux/"]
 
         # We execute our own modules by bind-mounting them from the host into
         # the build-root. We have minimal requirements on the build-root, so


### PR DESCRIPTION
When moving to `bootc install to-filesystem` we need more information for bootc from /etc/selinux than our current /etc/selinux/targeted/contexts policy.

This commit makes all of /etc/selinux available which unblocks the bootc install.