### PR TITLE
workflow: set TEST_WORKER/OSBUILD_TEST_STORE for runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
           sed -i 's/overlay/vfs/g' /usr/share/containers/storage.conf  # default system config
           sed -i 's/overlay/vfs/g' /etc/containers/storage.conf || true  # potential overrides
           TEST_CATEGORY="${{ matrix.test }}" \
+          TEST_WORKERS="$TEST_WORKERS" \
+          OSBUILD_TEST_STORE="$OSBUILD_TEST_STORE" \
           tox -e "${{ matrix.environment }}"
 
   v1_manifests:
@@ -61,4 +63,6 @@ jobs:
           image: ghcr.io/osbuild/osbuild-ci:latest-202308241910
           run: |
             TEST_CATEGORY="test.run.test_assemblers" \
+            TEST_WORKERS="$TEST_WORKERS" \
+            OSBUILD_TEST_STORE="$OSBUILD_TEST_STORE" \
             tox -e "py36"


### PR DESCRIPTION
It seems in https://github.com/osbuild/osbuild/pull/1655 we lost parallel running. The issue seems to be that `env` does not actually define a shell environment but only a github environment.

This sets commit sets the shell env explicitly to unbreak us again.