### PR TITLE
stages: allow bootc.install-to-filesystem work without selinux (HMS-3453)

### DIFF
--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import os
 import subprocess
 import sys
 import tempfile
@@ -11,6 +12,17 @@ def main(options, inputs, paths):
     images = containers.parse_containers_input(inputs)
     assert len(images) == 1
     image = list(images.values())[0]
+
+    env = os.environ.copy()
+    # By default "bootc" will refuse to work on a non-selinux system if
+    # the bootc container requires selinux. This is a sensible approach
+    # in general but for us it's tricky because we want to be able to
+    # generate images when running on developer machines or CI machines
+    # that may not necessarily have selinux. So make bootc more relaxed.
+    #
+    # Can be dropped once https://github.com/containers/bootc/pull/420
+    # is available in all our downstreams.
+    env["BOOTC_SKIP_SELINUX_HOST_CHECK"] = "true"
 
     with containers.container_source(image) as (_, source):
         dst = paths["mounts"]
@@ -30,7 +42,7 @@ def main(options, inputs, paths):
             pargs.extend(["--karg", karg])
         # add target and go
         pargs.append(dst)
-        subprocess.run(pargs, check=True)
+        subprocess.run(pargs, env=env, check=True)
 
 
 if __name__ == "__main__":

--- a/stages/test/test_bootc_install_to_fs.py
+++ b/stages/test/test_bootc_install_to_fs.py
@@ -2,7 +2,7 @@
 
 import tempfile
 from contextlib import contextmanager
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -80,13 +80,15 @@ def test_bootc_install_to_fs(mock_run, mocked_named_tmp, mocked_temp_dir, stage_
     stage_module.main(options, inputs, paths)
 
     assert len(mock_run.call_args_list) == 1
-    assert mock_run.call_args_list == [
-        call(["bootc", "install", "to-filesystem",
-              "--source-imgref", f"oci-archive:{mocked_temp_dir}/image",
-              "--skip-fetch-check", "--generic-image",
-              ] + expected_args + ["/path/to/mounts"],
-             check=True)
-    ]
+    args, kwargs = mock_run.call_args_list[0]
+    assert args == (
+        ["bootc", "install", "to-filesystem",
+         "--source-imgref", f"oci-archive:{mocked_temp_dir}/image",
+         "--skip-fetch-check", "--generic-image",
+         ] + expected_args + ["/path/to/mounts"],
+    )
+    assert kwargs["check"] is True
+    assert kwargs["env"]["BOOTC_SKIP_SELINUX_HOST_CHECK"] == "true"
 
 
 @patch("subprocess.run")


### PR DESCRIPTION
By default "bootc" will refuse to work on a non-selinux system if the bootc container requires selinux. This is a sensible approach in general but for us it's tricky because we want to be able to generate images when running on developer machines or CI machines that may not necessarily have selinux. So make bootc more relaxed.

Fwiw with the recent improvements in bootc this seems to be working fine for me (i.e. installing from non-selinux).

Note that once https://github.com/containers/bootc/pull/420 is available in our various downstreams this can be dropped.