### PR TITLE
inputs,sources: add new `{inputs,sources}_service` fixtures

### DIFF
--- a/inputs/test/conftest.py
+++ b/inputs/test/conftest.py
@@ -1,14 +1,16 @@
+import inspect
 import os
 import pathlib
 from types import ModuleType
 
 import pytest
 
+from osbuild import inputs, testutil
 from osbuild.testutil.imports import import_module_from_path
 
 
-@pytest.fixture
-def inputs_module(request: pytest.FixtureRequest) -> ModuleType:
+@pytest.fixture(name="inputs_module")
+def inputs_module_fixture(request: pytest.FixtureRequest) -> ModuleType:
     """inputs_module is a fixture that imports a stage module by its name
     defined in INPUTS_NAME in the test module.
     """
@@ -19,3 +21,21 @@ def inputs_module(request: pytest.FixtureRequest) -> ModuleType:
     caller_dir = pathlib.Path(request.node.fspath).parent
     module_path = caller_dir.parent / inputs_name
     return import_module_from_path("inputs", os.fspath(module_path))
+
+
+@pytest.fixture
+def inputs_service(inputs_module) -> ModuleType:
+    """inputs_service is a fixture that imports a inputs module by its name
+    defined in INPUTS_NAME in the test module and returns a InputService
+    """
+    service_cls = None
+    for memb in inspect.getmembers(
+            inputs_module,
+            predicate=lambda obj: inspect.isclass(obj) and issubclass(
+                obj, inputs.InputService)):
+        if service_cls:
+            raise ValueError(f"already have {service_cls}, also found {memb}")
+        service_cls = memb[1]
+    fd = testutil.make_fake_service_fd()
+    srv_obj = service_cls.from_args(["--service-fd", str(fd)])
+    return srv_obj

--- a/inputs/test/conftest.py
+++ b/inputs/test/conftest.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import pathlib
 from types import ModuleType
@@ -28,14 +27,7 @@ def inputs_service(inputs_module) -> ModuleType:
     """inputs_service is a fixture that imports a inputs module by its name
     defined in INPUTS_NAME in the test module and returns a InputService
     """
-    service_cls = None
-    for memb in inspect.getmembers(
-            inputs_module,
-            predicate=lambda obj: inspect.isclass(obj) and issubclass(
-                obj, inputs.InputService)):
-        if service_cls:
-            raise ValueError(f"already have {service_cls}, also found {memb}")
-        service_cls = memb[1]
+    service_cls = testutil.find_one_subclass_in_module(inputs_module, inputs.InputService)
     fd = testutil.make_fake_service_fd()
     srv_obj = service_cls.from_args(["--service-fd", str(fd)])
     return srv_obj

--- a/inputs/test/test_containers.py
+++ b/inputs/test/test_containers.py
@@ -2,12 +2,12 @@
 
 import os
 import pathlib
-import socket
 import subprocess
 import tempfile
 
 import pytest
 
+from osbuild import testutil
 from osbuild.testutil import has_executable, make_container
 
 INPUTS_NAME = "org.osbuild.containers-storage"
@@ -40,8 +40,8 @@ def test_containers_local_inputs_integration(tmp_path, inputs_module):
                 }
             }
         }
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        cnt_inputs = inputs_module.ContainersStorageInput.from_args(["--service-fd", str(sock.fileno())])
+        fd = testutil.make_fake_service_fd()
+        cnt_inputs = inputs_module.ContainersStorageInput.from_args(["--service-fd", str(fd)])
         store = FakeStoreClient(tmp_path / "fake-sources")
         # not using "tmp_path" here as it will "rm -rf" on cleanup and
         # that is dangerous as during the tests we bind mount the

--- a/osbuild/testutil/__init__.py
+++ b/osbuild/testutil/__init__.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import re
 import shutil
+import socket
 import subprocess
 import tempfile
 import textwrap
@@ -155,3 +156,15 @@ def pull_oci_archive_container(archive_path, image_name):
         yield
     finally:
         subprocess.check_call(["skopeo", "delete", f"containers-storage:{image_name}"])
+
+
+def make_fake_service_fd() -> int:
+    """Create a file descriptor suitable as input for --service-fd for any
+    host.Service
+
+    Note that the service will take over the fd and take care of the
+    lifecycle so no need to close it.
+    """
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET)
+    fd = os.dup(sock.fileno())
+    return fd

--- a/osbuild/testutil/__init__.py
+++ b/osbuild/testutil/__init__.py
@@ -2,6 +2,7 @@
 Test related utilities
 """
 import contextlib
+import inspect
 import os
 import pathlib
 import re
@@ -10,6 +11,8 @@ import socket
 import subprocess
 import tempfile
 import textwrap
+from types import ModuleType
+from typing import Type
 
 
 def has_executable(executable: str) -> bool:
@@ -168,3 +171,18 @@ def make_fake_service_fd() -> int:
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET)
     fd = os.dup(sock.fileno())
     return fd
+
+
+def find_one_subclass_in_module(module: ModuleType, subclass: Type) -> object:
+    """Find the class in the given module that is a subclass of the given input
+
+    If multiple classes are found an error is raised.
+    """
+    cls = None
+    for name, memb in inspect.getmembers(
+            module,
+            predicate=lambda obj: inspect.isclass(obj) and issubclass(obj, subclass)):
+        if cls:
+            raise ValueError(f"already have {cls}, also found {name}:{memb}")
+        cls = memb
+    return cls

--- a/sources/test/conftest.py
+++ b/sources/test/conftest.py
@@ -1,14 +1,16 @@
+import inspect
 import os
 import pathlib
 from types import ModuleType
 
 import pytest
 
+from osbuild import sources, testutil
 from osbuild.testutil.imports import import_module_from_path
 
 
-@pytest.fixture
-def sources_module(request: pytest.FixtureRequest) -> ModuleType:
+@pytest.fixture(name="sources_module")
+def sources_module_fixture(request: pytest.FixtureRequest) -> ModuleType:
     """sources_module is a fixture that imports a stage module by its name
     defined in SOURCES_NAME in the test module.
     """
@@ -19,3 +21,21 @@ def sources_module(request: pytest.FixtureRequest) -> ModuleType:
     caller_dir = pathlib.Path(request.node.fspath).parent
     module_path = caller_dir.parent / sources_name
     return import_module_from_path("sources", os.fspath(module_path))
+
+
+@pytest.fixture
+def sources_service(sources_module) -> ModuleType:
+    """sources_service is a fixture that imports a sources module by its name
+    defined in SOURCES_NAME in the test module and returns a SourcesService
+    """
+    service_cls = None
+    for memb in inspect.getmembers(
+            sources_module,
+            predicate=lambda obj: inspect.isclass(obj) and issubclass(
+                obj, sources.SourceService)):
+        if service_cls:
+            raise ValueError(f"already have {service_cls}, also found {memb}")
+        service_cls = memb[1]
+    fd = testutil.make_fake_service_fd()
+    services_obj = service_cls.from_args(["--service-fd", str(fd)])
+    return services_obj

--- a/sources/test/conftest.py
+++ b/sources/test/conftest.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import pathlib
 from types import ModuleType
@@ -28,14 +27,7 @@ def sources_service(sources_module) -> ModuleType:
     """sources_service is a fixture that imports a sources module by its name
     defined in SOURCES_NAME in the test module and returns a SourcesService
     """
-    service_cls = None
-    for memb in inspect.getmembers(
-            sources_module,
-            predicate=lambda obj: inspect.isclass(obj) and issubclass(
-                obj, sources.SourceService)):
-        if service_cls:
-            raise ValueError(f"already have {service_cls}, also found {memb}")
-        service_cls = memb[1]
+    service_cls = testutil.find_one_subclass_in_module(sources_module, sources.SourceService)
     fd = testutil.make_fake_service_fd()
-    services_obj = service_cls.from_args(["--service-fd", str(fd)])
-    return services_obj
+    srv_obj = service_cls.from_args(["--service-fd", str(fd)])
+    return srv_obj

--- a/sources/test/test_container_storage_source.py
+++ b/sources/test/test_container_storage_source.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
 
 import os
-import socket
 import subprocess
 
 import pytest
 
+from osbuild import testutil
 from osbuild.testutil import has_executable, make_container
 
 SOURCES_NAME = "org.osbuild.containers-storage"
@@ -20,8 +20,8 @@ def test_containers_storage_integration(tmp_path, sources_module):
         image_id = subprocess.check_output(["podman", "inspect", "-f", "{{ .Id }}", base_tag],
                                            universal_newlines=True).strip()
         checksum = f"sha256:{image_id}"
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(sock.fileno())])
+        fd = testutil.make_fake_service_fd()
+        cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(fd)])
         assert cnt_storage.exists(checksum, None)
 
 
@@ -29,8 +29,8 @@ def test_containers_storage_integration(tmp_path, sources_module):
 @pytest.mark.skipif(os.getuid() != 0, reason="root only")
 def test_containers_storage_integration_missing(sources_module):
     checksum = "sha256:1234567890123456789012345678901234567890909b14ffb032aa20fa23d9ad6"
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(sock.fileno())])
+    fd = testutil.make_fake_service_fd()
+    cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(fd)])
     assert not cnt_storage.exists(checksum, None)
 
 
@@ -40,8 +40,8 @@ def test_containers_storage_integration_invalid(sources_module):
     # put an invalid reference into the source to ensure skopeo errors with
     # a different error than image not found
     checksum = "sha256:["
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(sock.fileno())])
+    fd = testutil.make_fake_service_fd()
+    cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(fd)])
     with pytest.raises(RuntimeError) as exc:
         cnt_storage.exists(checksum, None)
     assert "unknown skopeo error:" in str(exc)

--- a/sources/test/test_container_storage_source.py
+++ b/sources/test/test_container_storage_source.py
@@ -5,7 +5,6 @@ import subprocess
 
 import pytest
 
-from osbuild import testutil
 from osbuild.testutil import has_executable, make_container
 
 SOURCES_NAME = "org.osbuild.containers-storage"
@@ -13,35 +12,29 @@ SOURCES_NAME = "org.osbuild.containers-storage"
 
 @pytest.mark.skipif(not has_executable("podman"), reason="no podman executable")
 @pytest.mark.skipif(os.getuid() != 0, reason="root only")
-def test_containers_storage_integration(tmp_path, sources_module):
+def test_containers_storage_integration(tmp_path, sources_service):
     with make_container(tmp_path, {
         "file1": "file1 content",
     }) as base_tag:
         image_id = subprocess.check_output(["podman", "inspect", "-f", "{{ .Id }}", base_tag],
                                            universal_newlines=True).strip()
         checksum = f"sha256:{image_id}"
-        fd = testutil.make_fake_service_fd()
-        cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(fd)])
-        assert cnt_storage.exists(checksum, None)
+        assert sources_service.exists(checksum, None)
 
 
 @pytest.mark.skipif(not has_executable("podman"), reason="no podman executable")
 @pytest.mark.skipif(os.getuid() != 0, reason="root only")
-def test_containers_storage_integration_missing(sources_module):
+def test_containers_storage_integration_missing(sources_service):
     checksum = "sha256:1234567890123456789012345678901234567890909b14ffb032aa20fa23d9ad6"
-    fd = testutil.make_fake_service_fd()
-    cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(fd)])
-    assert not cnt_storage.exists(checksum, None)
+    assert not sources_service.exists(checksum, None)
 
 
 @pytest.mark.skipif(not has_executable("podman"), reason="no podman executable")
 @pytest.mark.skipif(os.getuid() != 0, reason="root only")
-def test_containers_storage_integration_invalid(sources_module):
+def test_containers_storage_integration_invalid(sources_service):
     # put an invalid reference into the source to ensure skopeo errors with
     # a different error than image not found
     checksum = "sha256:["
-    fd = testutil.make_fake_service_fd()
-    cnt_storage = sources_module.ContainersStorageSource.from_args(["--service-fd", str(fd)])
     with pytest.raises(RuntimeError) as exc:
-        cnt_storage.exists(checksum, None)
+        sources_service.exists(checksum, None)
     assert "unknown skopeo error:" in str(exc)

--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -3,17 +3,18 @@
 import contextlib
 import os
 import pathlib
-import socket
 import tempfile
 
 import pytest
+
+from osbuild import testutil
 
 SOURCES_NAME = "org.osbuild.curl"
 
 
 def test_curl_source_not_exists(sources_module):
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(sock.fileno())])
+    fd = testutil.make_fake_service_fd()
+    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(fd)])
     tmpdir = tempfile.TemporaryDirectory()
     curl_source.cache = tmpdir.name
     desc = {
@@ -24,8 +25,8 @@ def test_curl_source_not_exists(sources_module):
 
 
 def test_curl_source_exists(sources_module):
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(sock.fileno())])
+    fd = testutil.make_fake_service_fd()
+    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(fd)])
     tmpdir = tempfile.TemporaryDirectory()
     curl_source.cache = tmpdir.name
     desc = {
@@ -37,8 +38,8 @@ def test_curl_source_exists(sources_module):
 
 
 def test_curl_source_amend_secrets(sources_module):
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(sock.fileno())])
+    fd = testutil.make_fake_service_fd()
+    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(fd)])
     tmpdir = tempfile.TemporaryDirectory()
     curl_source.cache = tmpdir.name
     desc = {
@@ -65,8 +66,8 @@ def test_curl_source_amend_secrets(sources_module):
 
 
 def test_curl_source_amend_secrets_fail(sources_module):
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(sock.fileno())])
+    fd = testutil.make_fake_service_fd()
+    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(fd)])
     tmpdir = tempfile.TemporaryDirectory()
     curl_source.cache = tmpdir.name
     desc = {

--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -7,41 +7,33 @@ import tempfile
 
 import pytest
 
-from osbuild import testutil
-
 SOURCES_NAME = "org.osbuild.curl"
 
 
-def test_curl_source_not_exists(sources_module):
-    fd = testutil.make_fake_service_fd()
-    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(fd)])
+def test_curl_source_not_exists(sources_service):
     tmpdir = tempfile.TemporaryDirectory()
-    curl_source.cache = tmpdir.name
+    sources_service.cache = tmpdir.name
     desc = {
         "url": "http://localhost:80/a",
     }
     checksum = "sha256:1234567890123456789012345678901234567890909b14ffb032aa20fa23d9ad6"
-    assert not curl_source.exists(checksum, desc)
+    assert not sources_service.exists(checksum, desc)
 
 
-def test_curl_source_exists(sources_module):
-    fd = testutil.make_fake_service_fd()
-    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(fd)])
+def test_curl_source_exists(sources_service):
     tmpdir = tempfile.TemporaryDirectory()
-    curl_source.cache = tmpdir.name
+    sources_service.cache = tmpdir.name
     desc = {
         "url": "http://localhost:80/a",
     }
     checksum = "sha256:1234567890123456789012345678901234567890909b14ffb032aa20fa23d9ad6"
     pathlib.Path(os.path.join(tmpdir.name, checksum)).touch()
-    assert curl_source.exists(checksum, desc)
+    assert sources_service.exists(checksum, desc)
 
 
-def test_curl_source_amend_secrets(sources_module):
-    fd = testutil.make_fake_service_fd()
-    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(fd)])
+def test_curl_source_amend_secrets(sources_service):
     tmpdir = tempfile.TemporaryDirectory()
-    curl_source.cache = tmpdir.name
+    sources_service.cache = tmpdir.name
     desc = {
         "url": "http://localhost:80/a",
         "secrets": {
@@ -59,17 +51,15 @@ def test_curl_source_amend_secrets(sources_module):
         cm.callback(cb)
         checksum = "sha256:1234567890123456789012345678901234567890909b14ffb032aa20fa23d9ad6"
         pathlib.Path(os.path.join(tmpdir.name, checksum)).touch()
-        new_desc = curl_source.amend_secrets(checksum, desc)
+        new_desc = sources_service.amend_secrets(checksum, desc)
         assert new_desc[1]["secrets"]["ssl_client_key"] == "key"
         assert new_desc[1]["secrets"]["ssl_client_cert"] == "cert"
         assert new_desc[1]["secrets"]["ssl_ca_cert"] is None
 
 
-def test_curl_source_amend_secrets_fail(sources_module):
-    fd = testutil.make_fake_service_fd()
-    curl_source = sources_module.CurlSource.from_args(["--service-fd", str(fd)])
+def test_curl_source_amend_secrets_fail(sources_service):
     tmpdir = tempfile.TemporaryDirectory()
-    curl_source.cache = tmpdir.name
+    sources_service.cache = tmpdir.name
     desc = {
         "url": "http://localhost:80/a",
         "secrets": {
@@ -79,5 +69,5 @@ def test_curl_source_amend_secrets_fail(sources_module):
     checksum = "sha256:1234567890123456789012345678901234567890909b14ffb032aa20fa23d9ad6"
     pathlib.Path(os.path.join(tmpdir.name, checksum)).touch()
     with pytest.raises(RuntimeError) as exc:
-        curl_source.amend_secrets(checksum, desc)
+        sources_service.amend_secrets(checksum, desc)
     assert "mtls secrets required" in str(exc)


### PR DESCRIPTION
The code to create tests for inputs/sources is a bit repetitive and uses many {Inputs,Sources}Service.from_args() that are just scaffolding to setup the test. This PR consolidates them all into a single (well, two) fixtures to avoid distracting.

People might consider this too much magic, which is fine, in this case I would just open the first commit as I think it is useful to consolidate the helper for the fd into a single place.

