### PR TITLE
stages/org.osbuild.users: Add password changed date

### DIFF
--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -110,6 +110,7 @@ def main(tree, options):
         shell = user_options.get("shell")
         password = user_options.get("password")
         expiredate = user_options.get("expiredate")
+        password_changed_date = user_options.get("password_changed_date")
 
         passwd = getpwnam(tree, name)
         if passwd is not None:
@@ -124,6 +125,9 @@ def main(tree, options):
             ensure_homedir(tree, name, home)
         else:
             useradd(tree, name, uid, gid, groups, description, home, shell, password, expiredate)
+
+        if password_changed_date is not None:
+            subprocess.run(["chroot", tree, "chage", "--lastday", str(password_changed_date), name], check=True)
 
         # following maintains backwards compatibility for handling a single ssh key
         key = user_options.get("key")   # Public SSH key

--- a/stages/org.osbuild.users.meta.json
+++ b/stages/org.osbuild.users.meta.json
@@ -65,6 +65,10 @@
               "expiredate": {
                 "description": "The date on which the user account will be disabled. This date is represented as a number of days since January 1st, 1970.",
                 "type": "integer"
+              },
+              "password_changed_date": {
+                "description": "The number of days since January 1st, 1970 when the password was last changed. If set to 0 the user is forced to change their password on the next login.",
+                "type": "integer"
               }
             }
           }

--- a/stages/test/test_users.py
+++ b/stages/test/test_users.py
@@ -54,3 +54,25 @@ def test_users_mock_bin(tmp_path, stage_module, user_opts, expected_args):
         stage_module.main(tmp_path, options)
         assert len(mocked_chroot.call_args_list) == 1
         assert mocked_chroot.call_args_list[0][2:] == expected_args + ["foo"]
+
+
+# separate test right now as it results in two binaries being called
+# (adduser,chage) which our parameter tests cannot do yet
+def test_users_with_expire_date(tmp_path, stage_module):
+    with mock_command("chroot", "") as mocked_chroot:
+        make_fake_tree(tmp_path, {
+            "/etc/passwd": "",
+        })
+
+        options = {
+            "users": {
+                "foo": {
+                    "password_changed_date": "12345",
+                },
+            }
+        }
+
+        stage_module.main(tmp_path, options)
+        assert len(mocked_chroot.call_args_list) == 2
+        assert mocked_chroot.call_args_list[0][1:] == ["useradd", "foo"]
+        assert mocked_chroot.call_args_list[1][1:] == ["chage", "--lastday", "12345", "foo"]


### PR DESCRIPTION
Add the password_changed_date field to the users option in the org.osbuild.users stage. This option maps to the --lastday option of chage, which is used to control password expiry.