### PR TITLE
Stages: Remove CAP_ADMIN from org.osbuild.tar stage

### DIFF
--- a/stages/org.osbuild.tar.meta.json
+++ b/stages/org.osbuild.tar.meta.json
@@ -9,9 +9,6 @@
     "out of any of those by supplying the corresponding option.",
     "Buildhost commands used: `tar` and any needed compression program."
   ],
-  "capabilities": [
-    "CAP_MAC_ADMIN"
-  ],
   "schema_2": {
     "options": {
       "additionalProperties": false,


### PR DESCRIPTION
org.osbuild.tar stage has CAP_ADMIN capability requirement. It should not be required for compression operations.

This showed up as a part of https://github.com/osbuild/osbuild/pull/1692 review.