### PR TITLE
Makefile: implement "fully source containers" HMS-3883

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -90,3 +90,19 @@ jobs:
         run: find -iname "*.json" -print -exec sh -c 'jq --indent 2 . {} | sponge {}' \;
       - name: Check diff
         run: git diff --exit-code
+
+  # checks if the dev container can be built
+  dev_container:
+    name: "Dev container"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Install prerequisites"
+        run: |
+          sudo apt update
+          sudo apt install -y podman
+      - name: "Clone Repository"
+        uses: actions/checkout@v4
+      - name: "Create container from source"
+        run: make container.dev
+      - name: "Check if osbuild starts and returns its version"
+        run: podman run --rm -ti localhost/osbuild_dev:latest --version

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ venv
 /.tox
 
 /test/data/certs/lib.sh
+pkg
+container_built.info

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,27 @@ SHELL = /bin/bash
 VERSION := $(shell (cd "$(SRCDIR)" && python3 setup.py --version))
 COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
 
+# List of all files which trigger a rebuild of the
+# development targets and container
+
+# Directories to search
+SRC_DEPS_DIRS := assemblers devices inputs mounts osbuild runners sources stages tools
+
+# Function to search for Python files in a directory
+define find_python_files
+$(shell find $(1) -type f -exec file {} \; | grep "Python script" | grep -Eo "^[^:]+")
+endef
+
+# All files to check for rebuild!
+SRC_DEPS := $(shell find . -name "*.py") \
+       $(foreach dir,$(SRC_DEPS_DIRS),$(call find_python_files,$(dir))) \
+       $(shell find schemas -name "*.json")
+
+CONTAINER_EXECUTABLE ?= podman
+CONTAINER_IMAGE := osbuild_dev
+CONTAINERFILE := tools/Containerfile.dev
+
+
 #
 # Generic Targets
 #
@@ -84,6 +105,13 @@ help:
 	@echo
 	@echo "    help:               Print this usage information."
 	@echo "    man:                Generate all man-pages"
+	@echo
+	@echo "    rpm:                Generate the rpm to install osbuild"
+	@echo "    srpm:               Generate the source rpms"
+	@echo "    rpm.dev:            Generate development rpms that include uncommited changes"
+	@echo "    container.dev:      Generate a development container with osbuild"
+	@echo "                        from the current sources"
+	@echo "    clean:              Remove all build artifacts"
 	@echo
 	@echo "    lint:               Check the code with linter (tox)"
 	@echo "    lint-quick:         Check the code with fast linters only (local)"
@@ -289,10 +317,21 @@ git-diff-check:
 
 RPM_SPECFILE=rpmbuild/SPECS/osbuild-$(COMMIT).spec
 RPM_TARBALL=rpmbuild/SOURCES/osbuild-$(COMMIT).tar.gz
+RPM_SPECFILE_DEV=rpmbuild/SPECS/osbuild-SRC.spec
 
 $(RPM_SPECFILE):
 	mkdir -p $(CURDIR)/rpmbuild/SPECS
 	(echo "%global commit $(COMMIT)"; git show HEAD:osbuild.spec) > $(RPM_SPECFILE)
+
+# building rpm for development with a constant name
+# to avoid any semblance to a "release rpm"
+$(RPM_SPECFILE_DEV): osbuild.spec
+	mkdir -p $(CURDIR)/rpmbuild/SPECS
+	echo "%global commit SRC" > $@
+	echo "%define _rpmfilename %%{NAME}.rpm" >> $@
+	echo "%global source_date_epoch_from_changelog 1" >> $@
+	echo "%global clamp_mtime_to_source_date_epoch 1" >> $@
+	cat $< >> $@
 
 $(RPM_TARBALL):
 	mkdir -p $(CURDIR)/rpmbuild/SOURCES
@@ -310,6 +349,26 @@ rpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL)
 		--define "_topdir $(CURDIR)/rpmbuild" \
 		$(RPM_SPECFILE)
 
+
+RPM_DEV_FILES := osbuild.rpm \
+                 osbuild-depsolve-dnf.rpm \
+                 osbuild-luks2.rpm \
+                 osbuild-ostree.rpm \
+                 osbuild-selinux.rpm \
+                 osbuild-tools.rpm \
+                 python3-osbuild.rpm
+
+RPM_DEV := $(addprefix rpmbuild/RPMS/,$(RPM_DEV_FILES))
+
+.PHONY: rpm.dev
+rpm.dev: $(RPM_DEV)
+
+$(RPM_DEV): $(RPM_SPECFILE_DEV) $(SRC_DEPS)
+	export SOURCE_DATE_EPOCH=$(shell stat -c %Y $(RPM_SPECFILE_DEV))
+	rpmbuild -bb --build-in-place \
+		--define "_topdir $(CURDIR)/rpmbuild" \
+		$(RPM_SPECFILE_DEV)
+
 #
 # Releasing
 #
@@ -326,3 +385,15 @@ bump-version:
 .PHONY: format
 format:
 	autopep8 --in-place --max-line-length 120 -a -a -a -j0 -r .
+
+clean:
+	rm -rf rpmbuild
+	rm -f container_built.info
+
+container_built.info: $(CONTAINERFILE) osbuild.spec $(SRC_DEPS)
+	$(CONTAINER_EXECUTABLE) build -t $(CONTAINER_IMAGE) -f $(CONTAINERFILE) .
+	echo "Container last built on" > $@
+	date >> $@
+
+.PHONY: container.dev
+container.dev: container_built.info

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,12 @@ setuptools.setup(
     install_requires=[
         "jsonschema",
     ],
+    extras_require={
+        "dev": [
+            "pydevd_pycharm",
+            "debugpy",
+        ]
+    },
     entry_points={
         "console_scripts": [
             "osbuild = osbuild.main_cli:osbuild_cli"

--- a/tools/Containerfile.dev
+++ b/tools/Containerfile.dev
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora:latest
 
-RUN dnf groupinstall -y rpm-development-tools
+RUN dnf install -y @rpm-development-tools git
 
 RUN mkdir /prepare
 WORKDIR /prepare
@@ -8,6 +8,8 @@ WORKDIR /prepare
 COPY osbuild.spec .
 
 RUN dnf -y builddep ./osbuild.spec
+
+RUN pip install pydevd_pycharm debugpy
 
 RUN mkdir /app
 WORKDIR /app

--- a/tools/Containerfile.dev
+++ b/tools/Containerfile.dev
@@ -1,0 +1,24 @@
+FROM registry.fedoraproject.org/fedora:latest
+
+RUN dnf groupinstall -y rpm-development-tools
+
+RUN mkdir /prepare
+WORKDIR /prepare
+
+COPY osbuild.spec .
+
+RUN dnf -y builddep ./osbuild.spec
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY . /app
+
+RUN cp tools/main_cli_dev.py osbuild/
+RUN git apply tools/Containerfile.dev.patch
+
+RUN make rpm.dev
+
+RUN dnf install -y ./rpmbuild/RPMS/*.rpm
+
+ENTRYPOINT [ "/usr/bin/osbuild" ]

--- a/tools/Containerfile.dev.patch
+++ b/tools/Containerfile.dev.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 180b4cc3..c3c9612b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -17,7 +17,7 @@ setuptools.setup(
+     },
+     entry_points={
+         "console_scripts": [
+-            "osbuild = osbuild.main_cli:osbuild_cli"
++            "osbuild = osbuild.main_cli_dev:osbuild_dev"
+         ]
+     },
+     scripts=[

--- a/tools/main_cli_dev.py
+++ b/tools/main_cli_dev.py
@@ -1,0 +1,28 @@
+"""Development entry point for osbuild
+
+This is used while building a container with `make container.dev`
+This allows to attach the debugger even when more services
+of the stack are running in parallel
+"""
+import os
+
+import debugpy
+import pydevd_pycharm
+
+from osbuild.main_cli import osbuild_cli
+
+
+def osbuild_dev():
+    debug_port = os.getenv("OSBUILD_PYCHARM_DEBUG_PORT")
+    if debug_port:
+        debug_host = os.getenv("OSBUILD_PYCHARM_DEBUG_HOST", 'host.docker.internal')
+        print("Connecting to debugger...")
+        pydevd_pycharm.settrace(debug_host, port=int(debug_port), stdoutToServer=True, stderrToServer=True)
+
+    debug_port = os.getenv("OSBUILD_DEBUGPY_DEBUG_PORT")
+    if debug_port:
+        debug_host = os.getenv("OSBUILD_DEBUGPY_DEBUG_HOST", 'host.docker.internal')
+        print("Connecting to debugger...")
+        debugpy.listen(debug_host, port=int(debug_port))
+
+    osbuild_cli()


### PR DESCRIPTION
Getting the stack up and running locally but all from source
For more details, see https://issues.redhat.com/browse/HMS-3883

This essentially implements `make container.dev` which builds
RPMs and a container from local source including the local
modifications. This will then be used by [osbuild-getting-started](https://github.com/osbuild/osbuild-getting-started/) to be able to start developing on the whole stack locally.

Rationale for implementing and using `rpm.dev` here:
The `rpm` target builds committed code and even
fails on local changes. Which is good for releases but
not really helpful for local integration tests and experiments.
Also just copying and "installing" osbuild in the container is not trivial that's why 
we are reusing the spec file for this.