### PR TITLE
stages: add new `alt_root` option to users/selinux stages

### DIFF
--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -5,9 +5,14 @@ import sys
 
 import osbuild.api
 from osbuild.util import selinux
+from osbuild.util import parsing
 
+def main(args, options):
+    tree = args["tree"]
+    alt_root = options.get("alt_root")
+    if alt_root:
+        tree = os.path.normpath(parsing.parse_location(alt_root, args))
 
-def main(tree, options):
     file_contexts = os.path.join(f"{tree}", options["file_contexts"])
     exclude_paths = options.get("exclude_paths")
     if exclude_paths:
@@ -25,6 +30,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = osbuild.api.arguments()
-    r = main(args["tree"], args["options"])
+    _args = osbuild.api.arguments()
+    r = main(_args, _args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.selinux.meta.json
+++ b/stages/org.osbuild.selinux.meta.json
@@ -24,6 +24,11 @@
         "file_contexts"
       ],
       "properties": {
+        "alt_root": {
+	  "type": "string",
+	  "pattern": "^mount://[^/]+/|^tree:///",
+	  "description": "Specify an alternative tree/mount"
+	},
         "file_contexts": {
           "type": "string",
           "description": "Path to the active SELinux policy's `file_contexts`"

--- a/stages/org.osbuild.users
+++ b/stages/org.osbuild.users
@@ -4,6 +4,7 @@ import subprocess
 import sys
 
 import osbuild.api
+from osbuild.util import parsing
 
 
 def getpwnam(root, name):
@@ -98,8 +99,12 @@ def ensure_homedir(root, name, home):
     subprocess.run(["chroot", root, "mkhomedir_helper", name], check=True)
 
 
-def main(tree, options):
+def main(args, options):
+    tree = args["tree"]
     users = options["users"]
+    alt_root = options.get("alt_root")
+    if alt_root:
+        tree = os.path.normpath(parsing.parse_location(alt_root, args))
 
     for name, user_options in users.items():
         uid = user_options.get("uid")
@@ -137,6 +142,6 @@ def main(tree, options):
 
 
 if __name__ == '__main__':
-    args = osbuild.api.arguments()
-    r = main(args["tree"], args["options"])
+    _args = osbuild.api.arguments()
+    r = main(_args, _args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.users.meta.json
+++ b/stages/org.osbuild.users.meta.json
@@ -13,6 +13,11 @@
     "options": {
       "additionalProperties": false,
       "properties": {
+        "alt_root": {
+	  "type": "string",
+	  "pattern": "^mount://[^/]+/|^tree:///",
+	  "description": "Specify an alternative tree/mount"
+	},
         "users": {
           "additionalProperties": false,
           "type": "object",


### PR DESCRIPTION
[edit: see also https://github.com/osbuild/osbuild/pull/1535 for the inspiration/idea]
[edit2: ideas about the name also welcome and I really hope I did not miss a simpler way to do this :/]
[edit3: added @dustymabe as he has *way* more experience with ostree then me so his inputs is super welcome]

This option allows to specify alternative locations for the users/selinux
stages to operate on. The main use-case for this is to support
running the users stage inside the ostree deployment root of
a freshly created `bootc install to-filesystem` disk image.

This allows to write:
```json
{
    "type": "org.osbuild.users",
    "options": {
        "root": "mount:///",
        "users": {
            "test": {
                "password": "$6$2434234"
            }
        }
    },
    "devices": {
        "disk": {
            "type": "org.osbuild.loopback",
            "options": {
                "filename": "disk.raw",
                "partscan": true
            }
        }
    },
    "mounts": [
        {
            "name": "bootc-disk-root",
            "type": "org.osbuild.ext4",
            "source": "disk",
            "partition": 4,
            "target": "/"
        },
        {
            "name": "ostree.deployment",
            "type": "org.osbuild.ostree.deployment",
            "options": {
                "source": "mount",
                "deployment": {
                    "default": true
                }
            }
        }
    ]
}
