### PR TITLE
testutil: add AtomicCounter() as a threadsafe counter

### DIFF
--- a/osbuild/testutil/atomic.py
+++ b/osbuild/testutil/atomic.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+"""
+thread/atomic related utilities
+"""
+import threading
+
+
+class AtomicCounter:
+    """ A thread-safe counter """
+
+    def __init__(self, count: int = 0) -> None:
+        self._count = count
+        self._lock = threading.Lock()
+
+    def inc(self) -> None:
+        """ increase the count """
+        with self._lock:
+            self._count += 1
+
+    def dec(self) -> None:
+        """ decrease the count """
+        with self._lock:
+            self._count -= 1
+
+    @property
+    def count(self) -> int:
+        """ get the current count """
+        with self._lock:
+            return self._count

--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -130,7 +130,7 @@ def test_curl_download_many_with_retry(tmp_path, sources_service):
         sources_service.cache.mkdir()
         sources_service.fetch_all(test_sources)
         # we simulated N failures and we need to fetch K files
-        assert httpd.reqs == simulate_failures + len(test_sources)
+        assert httpd.reqs.count == simulate_failures + len(test_sources)
     # double downloads happend in the expected format
     for chksum in test_sources:
         assert (sources_service.cache / chksum).exists()
@@ -165,5 +165,5 @@ def test_curl_download_many_retries(tmp_path, sources_service):
         with pytest.raises(RuntimeError) as exp:
             sources_service.fetch_all(test_sources)
         # curl will retry 10 times
-        assert httpd.reqs == 10 * len(test_sources)
+        assert httpd.reqs.count == 10 * len(test_sources)
         assert "curl: error downloading http://localhost:" in str(exp.value)

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ setenv =
     LINTABLES_EXCLUDES = "*.json,*.sh"
     LINTABLES_EXCLUDES_RE = ".*\.json$,.*\.sh"
     TYPEABLES = osbuild
-    TYPEABLES_STRICT = ./osbuild/main_cli.py ./osbuild/util/parsing.py
+    TYPEABLES_STRICT = ./osbuild/main_cli.py ./osbuild/util/parsing.py ./osbuild/testutil/atomic.py
 
 passenv =
     TEST_CATEGORY


### PR DESCRIPTION
The existing code in the reqs counting is not really thread safe, this commit fixes that.

(Small followup to https://github.com/osbuild/osbuild/pull/1703#discussion_r1550058515)