### PR TITLE
stages(mkdir): allow to pass in devices/mounts

### DIFF
--- a/stages/org.osbuild.mkdir.meta.json
+++ b/stages/org.osbuild.mkdir.meta.json
@@ -52,6 +52,13 @@
           }
         }
       }
+    },
+    "devices": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "mounts": {
+      "type": "array"
     }
   }
 }


### PR DESCRIPTION
This allows to combine `org.osbuild.mkdir` with the `osbuild.deployment` mount and with the upcoming `org.osbuild.bind` mount. The use case is that we need to create the dir `/var/home` so that `useradd` from inside a ostree root works (there /home is a symlink and useradd will not follow the symlink and create a dir in the target by itself).

This allows to write:
```json
        {
          "type": "org.osbuild.mkdir",
          "options": {
            "paths": [
	      {
		"path": "/var/home"
	      }
	    ]
          },
          "devices": {
            "disk": {
              "type": "org.osbuild.loopback",
              "options": {
                "filename": "disk.raw",
                "partscan": true
              }
            }
          },
          "mounts": [
            {
              "name": "part4",
              "type": "org.osbuild.ext4",
              "source": "disk",
              "target": "/",
              "partition": 4
            },
            {
              "name": "part3",
              "type": "org.osbuild.ext4",
              "source": "disk",
              "target": "/boot",
              "partition": 3
            },
            {
              "name": "part2",
              "type": "org.osbuild.fat",
              "source": "disk",
              "target": "/boot/efi",
              "partition": 2
            },
            {
              "name": "ostree.deployment",
              "type": "org.osbuild.ostree.deployment",
              "options": {
                "source": "mount",
                "deployment": {
                  "default": true
                }
              }
            },
            {
              "name": "bind",
              "type": "org.osbuild.bind",
	      "target": "tree://",
	      "options": {
		"source": "mount://"
	      }
            }
          ]
        },
```
to fix this.