### PR TITLE
osbuild-depsolve-dnf(5): support proxy

### DIFF
--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -27,6 +27,7 @@ class Solver():
         arch = request["arch"]
         releasever = request.get("releasever")
         module_platform_id = request["module_platform_id"]
+        proxy = request["proxy"]
 
         arguments = request["arguments"]
         repos = arguments.get("repos", [])
@@ -64,6 +65,8 @@ class Solver():
         self.base.conf.substitutions['basearch'] = dnf.rpm.basearch(arch)
         if releasever:
             self.base.conf.substitutions['releasever'] = releasever
+        if proxy:
+            self.base.conf.proxy = proxy
 
         req_repo_ids = set()
         for repo in repos:

--- a/tools/osbuild-depsolve-dnf5
+++ b/tools/osbuild-depsolve-dnf5
@@ -93,6 +93,7 @@ class Solver():
         arch = request["arch"]
         releasever = request.get("releasever")
         module_platform_id = request["module_platform_id"]
+        proxy = request["proxy"]
 
         arguments = request["arguments"]
         repos = arguments.get("repos", [])
@@ -115,6 +116,8 @@ class Solver():
         self.base.get_vars().set("basearch", _BASEARCH_MAP[arch])
         if releasever:
             self.base.get_vars().set('releasever', releasever)
+        if proxy:
+            self.base.get_vars().set('proxy', proxy)
 
         # Enable fastestmirror to ensure we choose the fastest mirrors for
         # downloading metadata (when depsolving) and downloading packages.


### PR DESCRIPTION
---

To depsolve with snapshots generated on consoledot, we need to go via a proxy. But the proxy can't be set system-wide because that breaks some calls of the aws sdk. 