### PR TITLE
test: tiny tweaks for the output handling in the test_depsolve.py 

### DIFF
--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -4,6 +4,7 @@ import json
 import os
 import socket
 import subprocess as sp
+import sys
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -40,9 +41,7 @@ def depsolve(pkgs, repos, root_dir, cache_dir, command):
             ]
         }
     }
-    p = sp.run([command], input=json.dumps(req).encode(), check=True, capture_output=True)
-    if p.stderr:
-        print(p.stderr.decode())
+    p = sp.run([command], input=json.dumps(req).encode(), check=True, stdout=sp.PIPE, stderr=sys.stderr)
 
     return json.loads(p.stdout.decode())
 

--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -59,7 +59,7 @@ def repo_servers_fixture():
     addresses = []
     for path in REPO_PATHS:
         port = get_rand_port()  # this is racy, but should be okay
-        p = sp.Popen(["python3", "-m", "http.server", str(port)], cwd=path, stdout=sp.PIPE)
+        p = sp.Popen(["python3", "-m", "http.server", str(port)], cwd=path, stdout=sp.PIPE, stderr=sp.DEVNULL)
         procs.append(p)
         # use last path component as name
         name = os.path.basename(path.rstrip("/"))


### PR DESCRIPTION
tools: tweak repo_servers_fixture() to redirect stderr to  /dev/null

The default python http.server is very chatty, we don't need this
during the tests.

---
[PATCH] tools: tweak depsolve() helper to show stderr from depsolve

So that we see any error output during the tests in "realtime". With
subprocess check=True and capture_output=True on exit_code != 0 no
stderr as part of the exception by default so this change helps
seeing issues from depsolve-dnf more easily.
