### PR TITLE
tools: fix proxy key error when "proxy" is not set

### DIFF
--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -27,7 +27,7 @@ class Solver():
         arch = request["arch"]
         releasever = request.get("releasever")
         module_platform_id = request["module_platform_id"]
-        proxy = request["proxy"]
+        proxy = request.get("proxy")
 
         arguments = request["arguments"]
         repos = arguments.get("repos", [])

--- a/tools/osbuild-depsolve-dnf5
+++ b/tools/osbuild-depsolve-dnf5
@@ -93,7 +93,7 @@ class Solver():
         arch = request["arch"]
         releasever = request.get("releasever")
         module_platform_id = request["module_platform_id"]
-        proxy = request["proxy"]
+        proxy = request.get("proxy")
 
         arguments = request["arguments"]
         repos = arguments.get("repos", [])


### PR DESCRIPTION
The "main" branch is failing right now in tests. The reason is that we do not have a merge queue and when
https://github.com/osbuild/osbuild/pull/1715
was merged we had no test for `osbuild-depsolve-dnf` yet.

We have one now (THANK YOU achilleas-k) and it shows an issue :)

This commit fixes the issue.