### PR TITLE
tools/osbuild-depsolve-dnf(5): require releasever

### DIFF
--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -63,8 +63,7 @@ class Solver():
         self.base.conf.cachedir = cache_dir
         self.base.conf.substitutions['arch'] = arch
         self.base.conf.substitutions['basearch'] = dnf.rpm.basearch(arch)
-        if releasever:
-            self.base.conf.substitutions['releasever'] = releasever
+        self.base.conf.substitutions['releasever'] = releasever
         if proxy:
             self.base.conf.proxy = proxy
 
@@ -445,7 +444,11 @@ def validate_request(request):
             "kind": "InvalidRequest",
             "reason": "no 'module_platform_id' specified"
         }
-
+    if not request.get("releasever"):
+        return {
+            "kind": "InvalidRequest",
+            "reason": "no 'module_platform_id' specified"
+        }
     arguments = request.get("arguments")
     if not arguments:
         return {
@@ -457,16 +460,6 @@ def validate_request(request):
         return {
             "kind": "InvalidRequest",
             "reason": "no 'repos' or 'root_dir' specified"
-        }
-
-    # if root_dir is used, we also need releasever
-    # pylint: disable=fixme
-    # TODO: Make releasever mandatory in all cases.
-    # We temporarily keep it tied to root_dir for short-term backwards compatibility
-    if arguments.get("root_dir") and not request.get("releasever"):
-        return {
-            "kind": "InvalidRequest",
-            "reason": "'root_dir' requires setting 'releasever'"
         }
 
     return None

--- a/tools/osbuild-depsolve-dnf5
+++ b/tools/osbuild-depsolve-dnf5
@@ -570,7 +570,11 @@ def validate_request(request):
             "kind": "InvalidRequest",
             "reason": "no 'module_platform_id' specified"
         }
-
+    if not request.get("releasever"):
+        return {
+            "kind": "InvalidRequest",
+            "reason": "no 'module_platform_id' specified"
+        }
     arguments = request.get("arguments")
     if not arguments:
         return {
@@ -582,16 +586,6 @@ def validate_request(request):
         return {
             "kind": "InvalidRequest",
             "reason": "no 'repos' or 'root_dir' specified"
-        }
-
-    # if root_dir is used, we also need releasever
-    # pylint: disable=fixme
-    # TODO: Make releasever mandatory in all cases.
-    # We temporarily keep it tied to root_dir for short-term backwards compatibility
-    if arguments.get("root_dir") and not request.get("releasever"):
-        return {
-            "kind": "InvalidRequest",
-            "reason": "'root_dir' requires setting 'releasever'"
         }
 
     return None


### PR DESCRIPTION
Originally, I made releasever required only when root_dir was set.  This was initially done to maintain backwards compatibility but we broke that already and osbuild/images will always include releasever in the request.

This will conflict with #1721 so maybe we can pull this commit into that PR (@mvo5?).