### PR TITLE
stages(groups): add support for the mounts for `bootc install to-filesystem` 

### DIFF
--- a/stages/org.osbuild.groups.meta.json
+++ b/stages/org.osbuild.groups.meta.json
@@ -6,25 +6,34 @@
     "If no `gid` is given, `groupadd` will choose one.",
     "If the specified group name or GID is already in use, this stage will fail."
   ],
-  "schema": {
-    "additionalProperties": false,
-    "properties": {
-      "groups": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Keys are group names, values are objects with group info",
-        "patternProperties": {
-          "^[A-Za-z0-9_][A-Za-z0-9_-]{0,31}$": {
-            "type": "object",
-            "properties": {
-              "gid": {
-                "type": "number",
-                "description": "GID for this group"
+  "schema_2": {
+    "options": {
+      "additionalProperties": false,
+      "properties": {
+        "groups": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Keys are group names, values are objects with group info",
+          "patternProperties": {
+            "^[A-Za-z0-9_][A-Za-z0-9_-]{0,31}$": {
+              "type": "object",
+              "properties": {
+                "gid": {
+                  "type": "number",
+                  "description": "GID for this group"
+                }
               }
             }
           }
         }
       }
+    },
+    "devices": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "mounts": {
+      "type": "array"
     }
   }
 }

--- a/stages/test/test_groups.py
+++ b/stages/test/test_groups.py
@@ -29,3 +29,10 @@ def test_schema_validation(stage_schema, test_data, expected_err):
     else:
         assert res.valid is False
         assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
+
+
+def test_schema_supports_bootc_style_mounts(stage_schema, bootc_devices_mounts_dict):
+    test_input = bootc_devices_mounts_dict
+    test_input["type"] = STAGE_NAME
+    res = stage_schema.validate(test_input)
+    assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"

--- a/stages/test/test_groups.py
+++ b/stages/test/test_groups.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+
+import pytest
+
+from osbuild.testutil import assert_jsonschema_error_contains
+
+STAGE_NAME = "org.osbuild.groups"
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # bad
+    ({"groups": {"!invalid-name": {}}}, "'!invalid-name' does not match any of the regex"),
+    ({"groups": {"foo": {"gid": "x"}}}, "'x' is not of type 'number'"),
+    # good
+    ({}, ""),
+    ({"groups": {"foo": {}}}, ""),
+    ({"groups": {"foo": {"gid": 999}}}, ""),
+])
+def test_schema_validation(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "options": {},
+    }
+    test_input["options"].update(test_data)
+    res = stage_schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)


### PR DESCRIPTION
This will allow us to generate `bootc install to-filesystem` compatible devices/mount setups for the groups stage. 