### PR TITLE
meta: automatically allow `devices` as input in the stages schemas

### DIFF
--- a/osbuild/meta.py
+++ b/osbuild/meta.py
@@ -410,6 +410,11 @@ class ModuleInfo:
                 schema["properties"]["mounts"] = {
                     "type": "array"
                 }
+            if "devices" not in schema["properties"]:
+                schema["properties"]["devices"] = {
+                    "type": "object",
+                    "additionalProperties": True,
+                }
             schema["required"] = [type_id]
         elif self.type in ("Device"):
             schema["additionalProperties"] = True

--- a/test/mod/test_meta.py
+++ b/test/mod/test_meta.py
@@ -348,3 +348,14 @@ def test_meta_json_validation_schema(test_input, expected_err):
         assert expected_err in errs[0]["message"]
     else:
         assert not errs
+
+
+@pytest.mark.parametrize("property_key, expected_value", [
+    ("mounts", {"type": "array"}),
+    ("devices", {"type": "object", "additionalProperties": True}),
+])
+def test_get_schema_automatically_added(tmp_path, property_key, expected_value):
+    make_fake_meta_json(tmp_path, "org.osbuild.noop", version=2)
+    modinfo = osbuild.meta.ModuleInfo.load(tmp_path, "Stage", "org.osbuild.noop")
+    json_schema = modinfo.get_schema()
+    assert json_schema["properties"][property_key] == expected_value


### PR DESCRIPTION
[as suggested in https://github.com/osbuild/osbuild/pull/1726#pullrequestreview-2000367493]
[edit: note that if we merge this we should simplify org.osbuild.{selinux,users,groups}.meta.json to remove the now redudant/identical schemas for devices/mounts]

With the new `bootc install to-filesystem` support many stages will need a devices/mount setup to bind mount the deployment root from the bootc deployment root of the generated image. To make this globally available just allow "devices/mounts" for all stages in the schema validation.

Note that `mounts` is already globally allowed so this just adds devices (this was added in `7e776a076` with ostree as the use-case). Nothing will change for the filesystem stages that already define "devices" in a more specialized way.