### PR TITLE
Stages/cloud-init: support additional datasources (COMPOSER-2060)

### DIFF
--- a/stages/org.osbuild.cloud-init.meta.json
+++ b/stages/org.osbuild.cloud-init.meta.json
@@ -91,7 +91,9 @@
             "items": {
               "type": "string",
               "enum": [
-                "Azure"
+                "Azure",
+                "Ec2",
+                "None"
               ]
             }
           },


### PR DESCRIPTION
Add "Ec2" and "None" datasources, which is needed for RHEL-7.9 EC2 images.