### PR TITLE
tools/osbuild-depsolve-dnf(5): don't use str.removeprefix()

### DIFF
--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -326,7 +326,7 @@ def read_keys(paths, root_dir=None):
     for path in paths:
         url = urllib.parse.urlparse(path)
         if url.scheme == "file":
-            path = path.removeprefix("file://")
+            path = path[7:]  # remove file:// prefix
             path = modify_rootdir_path(path, root_dir)
             try:
                 with open(path, mode="r", encoding="utf-8") as keyfile:

--- a/tools/osbuild-depsolve-dnf5
+++ b/tools/osbuild-depsolve-dnf5
@@ -468,7 +468,7 @@ def read_keys(paths, root_dir=None):
     for path in paths:
         url = urllib.parse.urlparse(path)
         if url.scheme == "file":
-            path = path.removeprefix("file://")
+            path = path[7:]  # remove file:// prefix
             path = modify_rootdir_path(path, root_dir)
             try:
                 with open(path, mode="r", encoding="utf-8") as keyfile:


### PR DESCRIPTION
str.removeprefix() is not available in Python 3.6, which we need to support EL8.