### PR TITLE
workflow: simplify unit test running in the GH workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,40 +7,24 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # setting workers to 1 just to have the same syntax in all test
-  # but to disable parallelism for the majority who have concurrency issues
-  TEST_WORKERS: "-n 1"
   # Share the store between the workers speeds things up further
   OSBUILD_TEST_STORE: /var/tmp/osbuild-test-store
 
 jobs:
   test_suite:
-    name: "Unittest"
+    name: "Unittests"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         test:
-          - "test.mod"
-          - "test.run.test_boot"
-          - "test.run.test_devices"
-          - "test.run.test_executable"
-          - "test.run.test_mount"
-          - "test.run.test_noop"
-          - "test.run.test_sources"
-          - "test.run.test_stages"
-          - "stages/test"
-          - "tools/test"
+          # Using 4 workers is a bit arbitrary, "auto" is probably too aggressive.
+          - -k test_stages.py -n 4
+          - -k "not test_stages.py"
         environment:
           - "py36"    # RH8
           - "py39"    # RH9
           - "py312"   # latest fedora
-        # special keyword "include"
-        include:
-          # this test _can_ run in parallel
-          # Using 4 workers is a bit arbitrary, "auto" is probably too aggressive.
-          - test: "test.run.test_stages"
-            env_TEST_WORKERS: "-n 4"
     steps:
     - name: "Clone Repository"
       uses: actions/checkout@v4
@@ -54,10 +38,8 @@ jobs:
           # it to vfs for the local storage skopeo stage test.
           sed -i 's/overlay/vfs/g' /usr/share/containers/storage.conf  # default system config
           sed -i 's/overlay/vfs/g' /etc/containers/storage.conf || true  # potential overrides
-          TEST_CATEGORY="${{ matrix.test }}" \
-          TEST_WORKERS="${{ matrix.env_TEST_WORKERS || env.TEST_WORKERS }}" \
           OSBUILD_TEST_STORE="${{ env.OSBUILD_TEST_STORE }}" \
-          tox -e "${{ matrix.environment }}"
+          tox -e "${{ matrix.environment }}" -- ${{ matrix.test }}
 
   v1_manifests:
     name: "Assembler test (legacy)"
@@ -67,13 +49,9 @@ jobs:
         uses: actions/checkout@v4
       - name: "Run"
         uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
-        env:
-          # Using 4 workers is a bit arbitrary, "auto" is probably too aggressive.
-          TEST_WORKERS: "-n 4"
         with:
           image: ghcr.io/osbuild/osbuild-ci:latest-202308241910
           run: |
-            TEST_CATEGORY="test.run.test_assemblers" \
-            TEST_WORKERS="${{ env.TEST_WORKERS }}" \
+            # Using 4 workers is a bit arbitrary, "auto" is probably too aggressive.
             OSBUILD_TEST_STORE="${{ env.OSBUILD_TEST_STORE }}" \
-            tox -e "py36"
+            tox -e "py36" -- -n 4 test.run.test_assemblers

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ passenv =
     TEST_CATEGORY
 
 commands =
-    bash -c 'python -m pytest -v --pyargs --rootdir=. {env:TEST_CATEGORY} {env:TEST_WORKERS}'
+    python -m pytest -v --pyargs --rootdir=. {posargs}
 
 allowlist_externals =
     bash


### PR DESCRIPTION
Run only two jobs in the GH runner for the unittest. The `test_stage.py` because it takes a very long time and needs to run in parallel and all the other tests.

This split avoid that we forget to add new unittests to the matrix as we did before (see e.g. https://github.com/osbuild/osbuild/pull/1731) and it will also enable the tests in:
- sources/test
- inputs/tests
- mounts/test

to run.

This will reduce the "granularity" of the test output a bit, in the GH runner we only see two unit test matrix jobs now. However that should not be too bad because the non-stage tests are really quick to run.