### PR TITLE
stages: remove redundant entries of devices/mounts in schemas

### DIFF
--- a/stages/test/conftest.py
+++ b/stages/test/conftest.py
@@ -43,39 +43,3 @@ def stage_schema(request: pytest.FixtureRequest) -> osbuild.meta.Schema:
     root = caller_dir.parent.parent
     mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", stage_name)
     return osbuild.meta.Schema(mod_info.get_schema(version=schema_version), stage_name)
-
-
-@pytest.fixture
-def bootc_devices_mounts_dict() -> dict:
-    """ bootc_devices_mounts_dict returns a dict with a typical bootc
-    devices/mount dict
-    """
-    return {
-        "devices": {
-            "disk": {
-                "type": "org.osbuild.loopback",
-                "options": {
-                    "filename": "disk.raw",
-                    "partscan": True,
-                }
-            }
-        },
-        "mounts": [
-            {
-                "name": "root",
-                "type": "org.osbuild.ext4",
-                "source": "disk",
-                "partition": 4,
-                "target": "/"
-            }, {
-                "name": "ostree.deployment",
-                "type": "org.osbuild.ostree.deployment",
-                "options": {
-                    "source": "mount",
-                    "deployment": {
-                        "default": True,
-                    }
-                }
-            }
-        ]
-    }

--- a/stages/test/test_groups.py
+++ b/stages/test/test_groups.py
@@ -29,10 +29,3 @@ def test_schema_validation(stage_schema, test_data, expected_err):
     else:
         assert res.valid is False
         assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
-
-
-def test_schema_supports_bootc_style_mounts(stage_schema, bootc_devices_mounts_dict):
-    test_input = bootc_devices_mounts_dict
-    test_input["type"] = STAGE_NAME
-    res = stage_schema.validate(test_input)
-    assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"

--- a/stages/test/test_selinux.py
+++ b/stages/test/test_selinux.py
@@ -48,13 +48,6 @@ def test_schema_validation_selinux_file_context_required(stage_schema):
     testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
 
 
-def test_schema_supports_bootc_style_mounts(stage_schema, bootc_devices_mounts_dict):
-    test_input = bootc_devices_mounts_dict
-    test_input["type"] = STAGE_NAME
-    res = stage_schema.validate(test_input)
-    assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
-
-
 @patch("osbuild.util.selinux.setfiles")
 def test_selinux_file_contexts(mocked_setfiles, tmp_path, stage_module):
     options = {

--- a/stages/test/test_users.py
+++ b/stages/test/test_users.py
@@ -36,13 +36,6 @@ def test_schema_validation(stage_schema, test_data, expected_err):
         assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
 
 
-def test_schema_supports_bootc_style_mounts(stage_schema, bootc_devices_mounts_dict):
-    test_input = bootc_devices_mounts_dict
-    test_input["type"] = STAGE_NAME
-    res = stage_schema.validate(test_input)
-    assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
-
-
 TEST_CASES = [
     # user_opts,expected commandline args
     ({}, []),


### PR DESCRIPTION
With PR#1727 merged `devices` are now automatically added to all
stage schemas. This makes the existing schema entries of the form:
```json
...
    },
    "devices": {
      "type": "object",
      "additionalProperties": true
    },
    "mounts": {
      "type": "array"
    }
...
```
redundant. This commit removes them. There are still some left
that are more specific (e.g. for filesystems) than this generic
one.

Note that `mounts` was already part of the stages schema automatically
since https://github.com/osbuild/osbuild/pull/847 (2021).

---

It also removes the stage specific tests for checking that our required bootc devices/mounts get accepted by the schema and moves that into the `test/mod` as it's now a generic module functionality.