### PR TITLE
Makefile: make sure that `make test-all` really runs all tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,6 @@ test-run:
 .PHONY: test-all
 test-all:
 	@$(PYTHON3) -m pytest \
-			$(SRCDIR)/test \
 			--rootdir=$(SRCDIR) \
 			-v
 


### PR DESCRIPTION
The current `make test-all` will only run tests under `test/`. This is no longer the only place we have tests so update the code to just run `pytest` to collect all tests.