### PR TITLE
Stages/SELinux: force auto-relabel of full contexts

### DIFF
--- a/osbuild/testutil/imports.py
+++ b/osbuild/testutil/imports.py
@@ -3,7 +3,15 @@
 Import related utilities
 """
 import importlib
+import sys
 from types import ModuleType
+
+# Cache files will split the extension, this means that all pyc cache files
+# looks like we get many clashing `org.osbuild.cpython-py311.pyc` files.
+# Moreover, the cache bytecode invalidation is based on the timestamp (which
+# is the same after git checkout) and the file size (which may be the same
+# for two different files). This means that we can't rely on the cache files.
+sys.dont_write_bytecode = True
 
 
 def import_module_from_path(fullname, path: str) -> ModuleType:

--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -21,7 +21,13 @@ def main(tree, options):
 
     if options.get("force_autorelabel", False):
         stamp = pathlib.Path(tree, ".autorelabel")
-        stamp.touch()
+        # Creating just empty /.autorelabel resets only the type of files.
+        # To ensure that the full context is reset, we write "-F" into the file.
+        # This mimics the behavior of `fixfiles -F boot`. The "-F" option is
+        # then passed to `selinux-autorelabel` script [0].
+        # Note that this is missing from the selinux(8) and selinux_config(5) man-pages
+        # [0] https://src.fedoraproject.org/rpms/policycoreutils/blob/rawhide/f/selinux-autorelabel#_54
+        stamp.write_text("-F", encoding="utf-8")
 
 
 if __name__ == '__main__':

--- a/stages/test/test_selinux.py
+++ b/stages/test/test_selinux.py
@@ -114,3 +114,5 @@ def test_selinux_force_autorelabel(mocked_setfiles, tmp_path, stage_module):  # 
         stage_module.main(tmp_path, options)
 
         assert (tmp_path / ".autorelabel").exists() == enable_autorelabel
+        if enable_autorelabel:
+            assert (tmp_path / ".autorelabel").read_text() == "-F"


### PR DESCRIPTION
Previously, the SELinux stage would not force full contexts reset when forcing auto-relabel on first boot. As a result, all files remained `unconfined_u` after the auto-relabeling on first boot and only the type part was reset.

We really need to mimic the behavior of `fixfiles -F onboot` command, which creates the `/.autorelabel` file with "-F" in it.