### PR TITLE
stages: add support for `--target-imgref` to bootc install to-filesystem

### DIFF
--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -40,6 +40,9 @@ def main(options, inputs, paths):
         # customize kernel-args
         for karg in options.get("kernel-args", []):
             pargs.extend(["--karg", karg])
+        target_imgref = options.get("target-imgref")
+        if target_imgref:
+            pargs.extend(["--target-imgref", target_imgref])
         # add target and go
         pargs.append(dst)
         subprocess.run(pargs, env=env, check=True)

--- a/stages/org.osbuild.bootc.install-to-filesystem.meta.json
+++ b/stages/org.osbuild.bootc.install-to-filesystem.meta.json
@@ -40,6 +40,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "target-imgref": {
+          "description": "Specify the image to fetch for subsequent updates",
+          "type": "string"
         }
       }
     },

--- a/stages/test/test_bootc_install_to_fs.py
+++ b/stages/test/test_bootc_install_to_fs.py
@@ -53,9 +53,13 @@ FAKE_INPUTS = {
     ({"kernel-args": ["arg1", "arg2"]}, ["--karg", "arg1", "--karg", "arg2"]),
     # all
     ({"root-ssh-authorized-keys": ["key1", "key2"],
-      "kernel-args": ["arg1", "arg2"]},
+      "kernel-args": ["arg1", "arg2"],
+      "target-imgref": "quay.io/img/ref",
+      },
      ["--root-ssh-authorized-keys", "/tmp/fake-named-tmpfile-name",
-      "--karg", "arg1", "--karg", "arg2"],
+      "--karg", "arg1", "--karg", "arg2",
+      "--target-imgref", "quay.io/img/ref",
+      ],
      ),
 ])
 @patch("subprocess.run")


### PR DESCRIPTION
We currently do not set the `--target-imgref` and do not allow to override it. This means that on a fresh deploy it is set to an incorrect value. This commit allows to set it via the org.osbuild.bootc.install-to-filesystem stage.

We may need to make this as strict as in https://github.com/osbuild/osbuild/blob/main/stages/org.osbuild.ostree.deploy.container.meta.json#L37 ?