### PR TITLE
systemd.unit.create: support the After option in the Unit section (HMS-3814)

### DIFF
--- a/stages/org.osbuild.systemd.unit.create
+++ b/stages/org.osbuild.systemd.unit.create
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 import configparser
-import subprocess
 import sys
 
 import osbuild.api
@@ -47,8 +46,6 @@ def main(tree, options):
 
     with open(f"{systemd_dir}/{filename}", "w", encoding="utf8") as f:
         config.write(f, space_around_delimiters=False)
-
-    subprocess.run(["systemd-analyze", "verify", f"{systemd_dir}/{filename}"], check=True)
 
 
 if __name__ == '__main__':

--- a/stages/org.osbuild.systemd.unit.create.meta.json
+++ b/stages/org.osbuild.systemd.unit.create.meta.json
@@ -18,6 +18,7 @@
     "    - 'DefaultDependencies' - bool",
     "    - 'Requires' - [strings]",
     "    - 'Wants' - [strings]",
+    "    - 'After' - [strings]",
     "  - 'Service' section",
     "    - 'Type' - string",
     "    - 'RemainAfterExit' - bool",
@@ -78,6 +79,12 @@
                 "type": "string"
               },
               "Wants": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "After": {
                 "type": "array",
                 "items": {
                   "type": "string"

--- a/stages/test/test_systemd_unit_create.py
+++ b/stages/test/test_systemd_unit_create.py
@@ -66,7 +66,20 @@ def test_systemd_unit_create(tmp_path, stage_module, unit_type, unit_path, expec
                 ],
                 "ConditionPathIsDirectory": [
                     "|!/etc/mydir"
-                ]
+                ],
+                # need to use real units otherwise the validation will fail
+                "Wants": [
+                    "basic.target",
+                    "sysinit.target",
+                ],
+                "Requires": [
+                    "paths.target",
+                    "sockets.target",
+                ],
+                "After": [
+                    "sysinit.target",
+                    "default.target",
+                ],
             },
             "Service": {
                 "Type": "oneshot",
@@ -112,6 +125,12 @@ def test_systemd_unit_create(tmp_path, stage_module, unit_type, unit_path, expec
     DefaultDependencies=False
     ConditionPathExists=|!/etc/myfile
     ConditionPathIsDirectory=|!/etc/mydir
+    Wants=basic.target
+    Wants=sysinit.target
+    Requires=paths.target
+    Requires=sockets.target
+    After=sysinit.target
+    After=default.target
 
     [Service]
     Type=oneshot


### PR DESCRIPTION
**stage/systemd.unit.create: add After option**

Support the After option in the Unit section of the unit file.

---

**test/systemd_unit_create: Wants, Requires, After**

Add test values for Wants, Requires, and After.
Adding multiple values to test that arrays work and made sure they're
all different.
The units need to be valid, real unit names otherwise the
'systemd-analyze verify' check will fail.

---

**stage/systemd.unit.create: move systemd-analyze verify to tests**

Verifying the systemd unit also checks if any referred systemd units
(Wants, Requires, After) exist and if all commands in Exec exist and are
executable.  Without '--root', the systemd-analyze verify command is
testing this against files in the build root, which isn't valid.

Units and binaries might not exist in the build root when referenced in
the image root tree, making the unit fail when when it's valid.
Conversely, the verification can succeed by finding executables in the
build root that don't exist in the image root tree when it should be
failing.

When verifying user units, systemd expects runtime directories.

All of this makes it quite difficult to verify systemd units properly
when building an image.  The call is useful for making sure the unit is
structured properly, but the user unit verification setup is difficult
to accomplish in a general way while building.

Remove the systemd-analyze verify step from the stage.  Move it to the
unit test so that we have some assurance that our unit file structure is
correct and things work as expected.  Create referenced unit files and
commands to make the unit valid.

---
