### PR TITLE
stages: allow `bootloader --append` via kickstart

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -243,6 +243,9 @@ def main(tree, options):  # pylint: disable=too-many-branches
     if reboot:
         config += [reboot]
     config += make_network(options)
+    kargs_append = options.get("bootloader", {}).get("append")
+    if kargs_append:
+        config += [f"bootloader --append='{kargs_append}'"]
 
     target = os.path.join(tree, path)
     base = os.path.dirname(target)

--- a/stages/org.osbuild.kickstart.meta.json
+++ b/stages/org.osbuild.kickstart.meta.json
@@ -542,6 +542,17 @@
         "items": {
           "$ref": "#/definitions/network-options-ref"
         }
+      },
+      "bootloader": {
+        "description": "Specifies how the boot loader should be installed",
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "append": {
+            "description": "Specifies additional kernel parameters",
+            "type": "string"
+          }
+        }
       }
     }
   }

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -234,6 +234,7 @@ TEST_INPUT = [
         },
         "ostreecontainer --url=http://some-ostree-url.com/foo",
     ),
+    ({"bootloader": {"append": "karg1 karg2=0"}}, "bootloader --append='karg1 karg2=0'"),
 ]
 
 


### PR DESCRIPTION
This commit allows use to append kernel commandline options via the kickstart file. This is useful for e.g. the bootc installer where we support customizing this via blueprints.