### PR TITLE
Stages/SELinux: force auto-relabel of full contexts

### DIFF
--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -21,7 +21,13 @@ def main(tree, options):
 
     if options.get("force_autorelabel", False):
         stamp = pathlib.Path(tree, ".autorelabel")
-        stamp.touch()
+        # Creating just empty /.autorelabel resets only the type of files.
+        # To ensure that the full context is reset, we write "-F" into the file.
+        # This mimics the behavior of `fixfiles -F boot`. The "-F" option is
+        # then passed to `selinux-autorelabel` script [0].
+        # Note that this is missing from the selinux(8) and selinux_config(5) man-pages
+        # [0] https://src.fedoraproject.org/rpms/policycoreutils/blob/rawhide/f/selinux-autorelabel#_54
+        stamp.write_text("-F", encoding="utf-8")
 
 
 if __name__ == '__main__':

--- a/stages/test/test_selinux.py
+++ b/stages/test/test_selinux.py
@@ -114,3 +114,5 @@ def test_selinux_force_autorelabel(mocked_setfiles, tmp_path, stage_module):  # 
         stage_module.main(tmp_path, options)
 
         assert (tmp_path / ".autorelabel").exists() == enable_autorelabel
+        if enable_autorelabel:
+            assert (tmp_path / ".autorelabel").read_text() == "-F"


### PR DESCRIPTION
Previously, the SELinux stage would not force full contexts reset when forcing auto-relabel on first boot. As a result, all files remained `unconfined_u` after the auto-relabeling on first boot and only the type part was reset.

We really need to mimic the behavior of `fixfiles -F onboot` command, which creates the `/.autorelabel` file with "-F" in it.