### PR TITLE
spec: Add bcond for building --without=selinux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ srpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL)
 
 .PHONY: rpm
 rpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL)
-	rpmbuild -bb \
+	rpmbuild -bb $(RPMBUILD_ARGS) \
 		--define "_topdir $(CURDIR)/rpmbuild" \
 		$(RPM_SPECFILE)
 


### PR DESCRIPTION
selinux-policy-devel isn't even in RHEL CRB, so it's annoying to install there, and in the use case we have in one place for this we don't even need selinux support.

Add a build conditional to turn it off, and also a handy makefile variable so one can do:

```
$ make rpm RPMBUILD_ARGS="--without=selinux"
```