### PR TITLE
stages: Add new stage parameter to org.osbuild.ovf

### DIFF
--- a/stages/org.osbuild.ovf
+++ b/stages/org.osbuild.ovf
@@ -22,7 +22,7 @@ OVF_TEMPLATE = """<?xml version="1.0"?>
   <VirtualSystem ovf:id="image">
     <Info>A virtual machine</Info>
     <Name>VM</Name>
-    <OperatingSystemSection ovf:id="100" vmw:osType="other26xLinux64Guest">
+    <OperatingSystemSection ovf:id="100" vmw:osType={ostype}>
       <Info>The kind of installed guest operating system</Info>
     </OperatingSystemSection>
     <VirtualHardwareSection ovf:transport="com.vmware.guestInfo">
@@ -97,10 +97,11 @@ def virtual_size(vmdk):
     return json.loads(res.stdout)["virtual-size"]
 
 
-def write_template(vmdk):
+def write_template(vmdk, ostype):
     dirname, basename = os.path.split(vmdk)
     ovf_data = OVF_TEMPLATE.format(vmdk_size=os.stat(vmdk).st_size,
-                                   vmdk_capacity=virtual_size(vmdk), image_name=basename)
+                                   vmdk_capacity=virtual_size(vmdk), image_name=basename,
+                                   ostype=ostype)
     ovf = f"{os.path.join(dirname, os.path.splitext(basename)[0])}.ovf"
     with open(ovf, "w", encoding="utf8") as f:
         f.write(ovf_data)
@@ -116,8 +117,9 @@ def write_manifest(vmdk, ovf):
 
 
 def main(options, tree):
+    ostype = os.path.join(tree, options["ostype"])
     vmdk = os.path.join(tree, options["vmdk"])
-    ovf = write_template(vmdk)
+    ovf = write_template(vmdk, ostype)
     write_manifest(vmdk, ovf)
     return 0
 

--- a/stages/org.osbuild.ovf.meta.json
+++ b/stages/org.osbuild.ovf.meta.json
@@ -18,6 +18,12 @@
           "description": "The vmdk image filename present in the root of the tree",
           "type": "string",
           "pattern": "[a-zA-Z0-9+_.-]+.vmdk"
+        },
+        "ostype": {
+          "description": "The kind of installed guest operating system",
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_]+$",
+          "default": "other26xLinux64Guest"
         }
       }
     }

--- a/stages/test/test_ovf.py
+++ b/stages/test/test_ovf.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python3
+
+import pytest
+
+from osbuild import testutil
+
+STAGE_NAME = "org.osbuild.ovf"
+
+
+# Prepare dataset containing good and bad API call parameters
+@pytest.mark.parametrize("test_data, expected_err", [
+    # Bad API parameters
+    ({}, "'vmdk' is a required property"),
+    ({"vmdk": 123}, "123 is not of type 'string'"),
+    ({"vmdk": "imagename"}, "'imagename' does not match '[a-zA-Z0-9+_.-]+.vmdk'"),
+    ({"vmdk": "imagename.vmdk", "ostype": 123}, "123 is not of type 'string'"),
+    ({"vmdk": "imagename.vmdk", "ostype": "__++::"}, "'__++::' does not match '^[a-zA-Z0-9_]+$'"),
+    ({"vmdk": "imagename.vmdk", "ostype": "\"some_\"ostype\""},
+     '\'"some_"ostype"\' does not match \'^[a-zA-Z0-9_]+$\''),
+    # Good API parameters
+    ({"vmdk": "imagename.vmdk"}, ""),
+    ({"vmdk": "imagename.vmdk", "ostype": "osTypeTest"}, ""),
+])
+# This test validates only API calls using correct and incorrect queries
+def test_schema_validation_ovf(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "devices": {
+            "device": {
+                "path": "some-path",
+            },
+        },
+        "options": {
+        }
+    }
+    test_input["options"].update(test_data)
+    res = stage_schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
+
+
+def test_ovf_template_ostype(tmp_path, stage_module):
+    faked_vmdk_path = tmp_path / "some-image.vmdk"
+    faked_vmdk_path.write_bytes(b"1234")
+
+    opts = {
+        "vmdk": faked_vmdk_path,
+        "ostype": "some_ostype",
+    }
+    stage_module.main(opts, tmp_path)
+
+    expected_template_path = tmp_path / "some-image.ovf"
+    assert "some_ostype" in expected_template_path.read_text()


### PR DESCRIPTION
osType used in this stage has hardcoded osType value in the template. This commit allows to overwrite this value if needed.