### PR TITLE
workflow: show summary why tests are skipped

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
               TEST_CATEGORY="not test_stages.py and not test_assemblers.py"
           fi
           OSBUILD_TEST_STORE="${{ env.OSBUILD_TEST_STORE }}" \
-          tox -e "${{ matrix.environment }}" -- $TEST_WORKERS -k "$TEST_CATEGORY"
+          tox -e "${{ matrix.environment }}" -- -rs $TEST_WORKERS -k "$TEST_CATEGORY"
 
   v1_manifests:
     name: "Assembler test (legacy)"


### PR DESCRIPTION
In PR#1752 @schuellerf  noticed (thanks!) that `make_containers` is buggy [0] in one specific testcase. However the GH actions did not trigger and uppon inspection the test is skipped:
```
stages/test/test_container_deploy.py::test_container_deploy_integration SKIPPED [  7%]
```
This commit adds `-rs` to get a summary why the tests are skipped.

This is useful in general, I suspect the test container might miss podman but this commit will bring clarity:
```
2024-04-25T08:35:39.1993788Z SKIPPED [1] stages/test/test_container_deploy.py:17: no podman executable
2024-04-25T08:35:39.1994811Z SKIPPED [1] stages/test/test_container_deploy.py:59: no podman executable
```



[0] https://github.com/osbuild/osbuild/pull/1752#discussion_r1578294358