### PR TITLE
workflow,pytest: add new `--error-on-skip` for pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
               TEST_CATEGORY="not test_stages.py and not test_assemblers.py"
           fi
           OSBUILD_TEST_STORE="${{ env.OSBUILD_TEST_STORE }}" \
-          tox -e "${{ matrix.environment }}" -- $TEST_WORKERS -k "$TEST_CATEGORY"
+          tox -e "${{ matrix.environment }}" -- $TEST_WORKERS -k "$TEST_CATEGORY" --error-on-skip --ok-to-skip="no SELinux"
 
   v1_manifests:
     name: "Assembler test (legacy)"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    res = outcome.get_result()
+    if res.skipped:
+        error_on_skip = item.config.getoption('--error-on-skip')
+        allowlist_skip = item.config.getoption('--ok-to-skip')
+
+        reason = str(call.excinfo.value)
+        if error_on_skip and reason not in allowlist_skip:
+            res.outcome = "failed"
+            res.longrepr = f"skipping not allowed: {res.longrepr}"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--error-on-skip', action="store_store",
+    )
+    parser.addoption(
+        "--ok-to-skip", type=lambda arg: arg.split(","),
+    )


### PR DESCRIPTION
To ensure we do not skip tests in GH actions that we want to run add a new explicit way to allowlist tests that are okay to skip.

This is done via a small pytest plugin and the GH action will only set "no SELinux" initially.

Followup for https://github.com/osbuild/containers/pull/72 and https://github.com/osbuild/osbuild/pull/1755

[draft as a bunch of tests will fail because our container is missing some more binaries]