### PR TITLE
workflow: bump osbuild-ci container to include podman, et al.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: "Run"
       uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
       with:
-        image: ghcr.io/osbuild/osbuild-ci:latest-202404161303
+        image: ghcr.io/osbuild/osbuild-ci:latest-202404252004
         run: |
           # Hacky replacement of container storage driver:
           # The default overlayfs doesn't work in the runner, so let's change
@@ -60,7 +60,7 @@ jobs:
           # Using 4 workers is a bit arbitrary, "auto" is probably too aggressive.
           TEST_WORKERS: "-n 4"
         with:
-          image: ghcr.io/osbuild/osbuild-ci:latest-202404161303
+          image: ghcr.io/osbuild/osbuild-ci:latest-202404252004
           run: |
             OSBUILD_TEST_STORE="${{ env.OSBUILD_TEST_STORE }}" \
             tox -e "py36" -- ${{ env.TEST_WORKERS }} test.run.test_assemblers

--- a/test/mod/test_util_mnt.py
+++ b/test/mod/test_util_mnt.py
@@ -57,4 +57,4 @@ def test_osbuild_mount_failure_msg(tmp_path):
             "options": [],
         }
         mnt_service.mount(args)
-    assert "special device /dev/invalid-src does not exist" in str(e.value)
+    assert re.search(r"special device /dev/invalid-src does not exist|Can't open blockdev.", str(e.value))


### PR DESCRIPTION
This will include the latest osbuild-ci container changes from https://github.com/osbuild/containers/pull/73

This includes a bunch of binaries that were missing and lead to skpped tests.