### PR TITLE
Revert "Disable F40 CI (CVE-2024-3094 response)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,8 @@ RPM:
           - aws/fedora-38-aarch64
           - aws/fedora-39-x86_64
           - aws/fedora-39-aarch64
+          - aws/fedora-40-x86_64
+          - aws/fedora-40-aarch64
           - aws/centos-stream-8-x86_64
           - aws/centos-stream-8-aarch64
           - aws/centos-stream-9-x86_64


### PR DESCRIPTION
F40 is safe to use again

This reverts commit dc857025530354984912a6400929b9ca494e29e1.