### PR TITLE
stages/skopeo:  Fix the remove-signatures option

### DIFF
--- a/stages/org.osbuild.skopeo
+++ b/stages/org.osbuild.skopeo
@@ -13,7 +13,7 @@ def main(inputs, output, options):
 
     destination = options["destination"]
     dest_type = destination["type"]
-    remove_signatures = destination.get("remove-signatures")
+    remove_signatures = options.get("remove-signatures")
 
     for image in images.values():
         with containers.container_source(image) as (image_name, image_source):


### PR DESCRIPTION
It's defined on the options level, not on the destination level. The first commit adds a quick and dirty test for this, the second commit fixes that.