### PR TITLE
sources/curl: pretend to be libdnf in the user agent

### DIFF
--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -20,6 +20,7 @@ up the download.
 
 import concurrent.futures
 import os
+import platform
 import subprocess
 import sys
 import tempfile
@@ -153,6 +154,7 @@ class CurlSource(sources.SourceService):
             # some mirrors are sometimes broken. retry manually, because we could be
             # redirected to a different, working, one on retry.
             return_code = 0
+            arch = platform.machine()
             for _ in range(10):
                 curl_command = [
                     "curl",
@@ -163,6 +165,14 @@ class CurlSource(sources.SourceService):
                     "--location",
                     "--output", checksum,
                 ]
+                if url.endswith(".rpm"):
+                    # Some mirrors (e.g. mirror.cpsc.ucalgary.ca) denylist the curl user agent.
+                    # Let's pretend to be libdnf when downloading RPMs, because osbuild is doing basically the same
+                    # thing as dnf.
+                    # The schema is taken from here:
+                    # https://github.com/rpm-software-management/libdnf/blob/90d2ffad964a91a7a798b81e15c16eb1e840f257/libdnf/utils/os-release.cpp#L137
+                    curl_command.extend(["--header", f"User-Agent: libdnf (OSBuild; generic; Linux.{arch})"])
+
                 if proxy:
                     curl_command.extend(["--proxy", proxy])
                 if secrets:


### PR DESCRIPTION
Some RPM mirrors (e.g. mirror.cpsc.ucalgary.ca) apparently denylist the
curl user agent. Since we are doing basically the same thing as libdnf,
let's pretend that we are libdnf. However, since the curl source is
generic, we probably don't want to set it for all downloads, just for
the rpm ones. Let's use a simple heurestic based on the file extension
in the URI to determine whether to spoof the agent, or not.