### PR TITLE
osbuild-depsolve-dnf5: Wait until Fedora 41 to switch to DNF5

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -137,9 +137,9 @@ manifests and osbuild.
 Summary:        Dependency solving support for DNF
 Requires:       %{name} = %{version}-%{release}
 
-# Fedora 40 and later use libdnf5, RHEL and Fedora < 40 use libdnf
-%if 0%{?fedora} >= 40
-Requires: python3-libdnf5 >= 5.1.1
+# Fedora 41 and later use libdnf5, RHEL and Fedora < 41 use libdnf
+%if 0%{?fedora} >= 41
+Requires: python3-libdnf5 >= 5.2.0
 %else
 Requires: python3-libdnf
 %endif
@@ -213,8 +213,8 @@ install -p -m 0755 data/10-osbuild-inhibitor.rules %{buildroot}%{_udevrulesdir}
 
 # Install `osbuild-depsolve-dnf` into libexec
 mkdir -p %{buildroot}%{_libexecdir}
-# Fedora 40 and later use dnf5-json, RHEL and Fedora < 40 use dnf-json
-%if 0%{?fedora} >= 40
+# Fedora 41 and later use dnf5-json, RHEL and Fedora < 41 use dnf-json
+%if 0%{?fedora} >= 41
 install -p -m 0755 tools/osbuild-depsolve-dnf5 %{buildroot}%{_libexecdir}/osbuild-depsolve-dnf
 %else
 install -p -m 0755 tools/osbuild-depsolve-dnf %{buildroot}%{_libexecdir}/osbuild-depsolve-dnf

--- a/tools/osbuild-depsolve-dnf5
+++ b/tools/osbuild-depsolve-dnf5
@@ -382,7 +382,7 @@ class Solver():
 
             # Support group/environment names as well as ids
             settings = dnf5.base.GoalJobSettings()
-            settings.group_with_name = True
+            settings.set_group_with_name(True)
 
             # Packages are added individually, excludes are handled in the repo setup
             for pkg in transaction.get("package-specs"):


### PR DESCRIPTION
Due to dnf5 announcing dnf 5.2.0 with breaking API changes we need to update the current osbuild-depsolve-dnf5. This would mean carrying 3 different scripts if we support dnf 5.1.x on Fedora 40 so it switches back to using libdnf for 40, and switches to dnf 5.2.0 for Fedora 41.

NOTE: This needs to wait for libdnf5 version 5.2.0 to be merged into Fedora 41 (currently rawhide) before it should be merged.

It will also require the Schutzfile osbuild entry for Fedora 40 in the images repo to be updated so that it is testing the correct depsolver.