### PR TITLE
stages: ensure we do not allow \n in the ssh key or anaconda breaks

### DIFF
--- a/stages/org.osbuild.kickstart.meta.json
+++ b/stages/org.osbuild.kickstart.meta.json
@@ -269,6 +269,7 @@
               },
               "key": {
                 "description": "SSH Public Key to add to ~/.ssh/authorized_keys",
+                "pattern": "^[^\\n]*$",
                 "type": "string"
               }
             }

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -387,6 +387,9 @@ def test_kickstart_valid(tmp_path, stage_module, test_input, expected):  # pylin
             {"rootpw": {"iscrypted": True, "plaintext": True, "password": "pass"}},
             "is not valid under any of the given schemas"
         ),
+        # TODO: test with only \n at the end
+        ({"users": {"test": {"key": "a-ssh-key-with-wrong\nnewlines\n"}}},
+         "does not match '^[^\\\\n]*$'"),
     ],
 )
 @pytest.mark.parametrize("stage_schema", ["1"], indirect=True)


### PR DESCRIPTION
There was a bug found in
https://github.com/osbuild/bootc-image-builder/pull/363

where a stray newlnine in the ssh key broke the kickstart file.