### PR TITLE
tools/osbuild-depsolve-dnf: enable loading of optional metadata

### DIFF
--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -64,6 +64,9 @@ class Solver():
         self.base.conf.substitutions['arch'] = arch
         self.base.conf.substitutions['basearch'] = dnf.rpm.basearch(arch)
         self.base.conf.substitutions['releasever'] = releasever
+
+        self.base.conf.optional_metadata_types.extend(arguments.get("optional-metadata", []))
+
         if proxy:
             self.base.conf.proxy = proxy
 

--- a/tools/osbuild-depsolve-dnf5
+++ b/tools/osbuild-depsolve-dnf5
@@ -153,8 +153,10 @@ class Solver():
         conf.persistdir = persistdir
         conf.cachedir = cachedir
 
-        # Load the file lists, so dependency on paths will work
-        conf.optional_metadata_types = ['comps', 'filelists']
+        # Include comps metadata by default
+        metadata_types = ['comps']
+        metadata_types.extend(arguments.get("optional-metadata", []))
+        conf.optional_metadata_types = metadata_types
 
         try:
             # NOTE: With libdnf5 packages are excluded in the repo setup

--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -5,6 +5,7 @@ import pathlib
 import socket
 import subprocess as sp
 import sys
+from glob import glob
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -278,3 +279,11 @@ def test_depsolve(tmp_path, repo_servers, dnf_cmd, detect_fn, test_case):
             for repo in res["repos"].values():
                 assert repo["gpgkeys"] == [TEST_KEY + repo["id"]]
                 assert repo["sslverify"] is False
+
+            # if opt_metadata includes 'filelists', then each repository 'repodata' must include a file that matches
+            # *filelists*
+            n_filelist_files = len(glob(f"{cache_dir}/*/repodata/*filelists*"))
+            if "filelists" in opt_metadata:
+                assert n_filelist_files == len(REPO_PATHS)
+            else:
+                assert n_filelist_files == 0


### PR DESCRIPTION
This is required so that callers can enable loading of filelists when using newer versions of libdnf with old repositories or packages that specify dependencies on files.  For example, depsolving against RHEL 9.3 repos on Fedora 40 fails to resolve platform-python with the message

```
nothing provides /usr/libexec/platform-python needed by platform-python-...
```


Further reading:
- https://libdnf.readthedocs.io/en/stable/tutorial-py/#case-for-loading-the-filelists
- https://github.com/rpm-software-management/dnf/releases/tag/4.19.0
- https://dnf.readthedocs.io/en/stable/user_faq.html#starting-with-fedora-40-i-noticed-repository-metadata-is-synchronized-much-faster-what-happened
- https://fedoraproject.org/wiki/Changes/DNFConditionalFilelists