### PR TITLE
test: tweak test_osbuild_mount_failure_msg() for tmt/fc40

### DIFF
--- a/test/mod/test_util_mnt.py
+++ b/test/mod/test_util_mnt.py
@@ -57,4 +57,5 @@ def test_osbuild_mount_failure_msg(tmp_path):
             "options": [],
         }
         mnt_service.mount(args)
-    assert re.search(r"special device /dev/invalid-src does not exist|Can't open blockdev.", str(e.value))
+    assert re.search(
+        r"special device /dev/invalid-src does not exist|Can't open blockdev.|Can't lookup blockdev", str(e.value))


### PR DESCRIPTION
The `test_osbuild_mount_failure_msg` currently fails on fc40 when run in tmt, see:
https://artifacts.dev.testing-farm.io/c6588a82-a2cb-46df-8ca8-85dd809465f2/

This is because the failure output is slightly different between a container and a VM/real-machine. The test ensures that we capture the output of mount and present to the user (for easier debugging). So this commit updates this test once more for the error string (that part of the error comes directly from the kernels fsconfig).

If we need another update of the string we should reconsider this test and e.g. just use `testutil.mock_command()` for this. But for now it's easier to just add this one more failure string.