### PR TITLE
CompletedBuild: separate `stdout` and `stderr` content

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -30,25 +30,23 @@ class CompletedBuild:
 
     Contains the actual `process` that was executed but also has
     convenience properties to quickly access the `returncode` and
-    `output`. The latter is also provided via `stderr`, `stdout`
-    properties, making it a drop-in replacement for `CompletedProcess`.
+    `output`. The latter is a combination of `stderr` and `stdout`.
+    These are also provided as a separate properties, making it
+    a drop-in replacement for `CompletedProcess`.
     """
 
-    def __init__(self, proc: subprocess.CompletedProcess, output: str):
+    def __init__(self, proc: subprocess.CompletedProcess, stdout: str, stderr: str):
         self.process = proc
-        self.output = output
+        self.stdout = stdout
+        self.stderr = stderr
 
     @property
     def returncode(self):
         return self.process.returncode
 
     @property
-    def stdout(self):
-        return self.output
-
-    @property
-    def stderr(self):
-        return self.output
+    def output(self):
+        return self.stderr + self.stdout
 
 
 class ProcOverrides:
@@ -353,7 +351,7 @@ class BuildRoot(contextlib.AbstractContextManager):
         output = data.getvalue()
         data.close()
 
-        return CompletedBuild(proc, output)
+        return CompletedBuild(proc, output, "")
 
     def build_capabilities_args(self):
         """Build the capabilities arguments for bubblewrap"""

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -194,6 +194,10 @@ def test_timeout(tempdir, runner):
         with pytest.raises(TimeoutError):
             root.run(["/bin/sleep", "1"], monitor, timeout=0.1)
 
+        # test command printing to stdout and stderr
+        with pytest.raises(TimeoutError):
+            root.run(["watch", "-n", "0.2", "-t", "echo 'hello' | tee /dev/stderr"], monitor, timeout=2)
+
 
 @pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")
 def test_env_isolation(tempdir, runner):

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -55,7 +55,7 @@ def test_basic(tempdir, runner):
         assert r.returncode == 0
         r = root.run(["stat", "--format=%a", "/var/tmp"], monitor)
         assert r.returncode == 0
-        assert r.stdout.strip().split("\n")[-1] == "1777"
+        assert r.stdout.strip() == "1777"
 
 
 @pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")


### PR DESCRIPTION
The motivation for this change is to fix a failing unit test in c9s CI. Specifically an instance of https://artifacts.dev.testing-farm.io/2d07b8f3-5f52-4e61-b1fa-5328a0ff1058/#artifacts-/plans/unit-tests ([c9s MR#135](https://gitlab.com/redhat/centos-stream/rpms/osbuild/-/merge_requests/135))

```
=================================== FAILURES ===================================
__________________________________ test_basic __________________________________

tempdir = '/tmp/lvm2-5tydlzub'
runner = '/var/ARTIFACTS/work-unit-testsj5w4g1qg/plans/unit-tests/tree/osbuild-118/runners/org.osbuild.centos9'

    @pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")
    def test_basic(tempdir, runner):
        libdir = os.path.abspath(os.curdir)
        var = pathlib.Path(tempdir, "var")
        var.mkdir()
    
        monitor = NullMonitor(sys.stderr.fileno())
        with BuildRoot("/", runner, libdir, var) as root:
    
            r = root.run(["/usr/bin/true"], monitor)
            assert r.returncode == 0
    
            # Test we can use `.run` multiple times
            r = root.run(["/usr/bin/true"], monitor)
            assert r.returncode == 0, f"{r.stdout} {r.stderr}"
    
            r = root.run(["/usr/bin/false"], monitor)
            assert r.returncode != 0
    
            # Test that fs setup looks correct
            r = root.run(["test", "-d", "/var/tmp"], monitor)
            assert r.returncode == 0
            r = root.run(["stat", "--format=%a", "/var/tmp"], monitor)
            assert r.returncode == 0
>           assert r.stdout.strip().split("\n")[-1] == "1777"
E           AssertionError: assert '/usr/lib/tmp... such process' == '1777'
E             
E             - 1777
E             + /usr/lib/tmpfiles.d/rpcbind.conf:2: Failed to resolve user 'rpc': No such process

test/mod/test_buildroot.py:57: AssertionError
=========================== short test summary info ============================
FAILED test/mod/test_buildroot.py::test_basic - AssertionError: assert '/usr/...
```

The cause turned out to be that the `CompletedBuild.output` is a combination of process `stdout` and `stderr`, which looked differently in c9s CI, compared to the upstream CI. Specifically, the order of error messages was different.

Fix the unit test by reworking the `BuildRoot.run()` method to set a separate `stdout` and `stderr` on the returned `CompletedBuild` object.