### PR TITLE
test/buildroot: fix checking /var/tmp mode

### DIFF
--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -54,7 +54,7 @@ def test_basic(tempdir, runner):
         assert r.returncode == 0
         r = root.run(["stat", "--format=%a", "/var/tmp"], monitor)
         assert r.returncode == 0
-        assert r.stdout.strip().split("\n")[-1] == "1777"
+        assert "1777" in r.stdout.strip().split("\n")
 
 
 @pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")


### PR DESCRIPTION
The motivation for this change is to fix a failing unit test in c9s CI. Specifically an instance of:

https://artifacts.dev.testing-farm.io/2d07b8f3-5f52-4e61-b1fa-5328a0ff1058/#artifacts-/plans/unit-tests https://gitlab.com/redhat/centos-stream/rpms/osbuild/-/merge_requests/135