### PR TITLE
[RFC] stages: run "ksvalidator" optionally when generating kickstarts

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
+import contextlib
 import os
+import subprocess
 import sys
 from typing import Dict, List
 
@@ -255,6 +257,9 @@ def main(tree, options):  # pylint: disable=too-many-branches
         if config:
             f.write("\n".join(config))
         f.write("\n")
+
+    with contextlib.suppress(FileNotFoundError):
+        subprocess.run(["ksvalidator", target], check=True)
 
     print(f"created kickstarted at: {path}\n")
     with open(target, "r", encoding="utf8") as f:


### PR DESCRIPTION
There was a bug in osbuild/bootc-image-builder#363 where a stray newlnine in the ssh key broke the kickstart file (and it was a bit annoying/non-obvious to find).

The isse is that when auto-generating the config.json for an ssh keyfile it's easy to accidentally include the final `\n` in the ssh key json string. This will break in very non-obvious ways, i.e. the image will be generated but the kickstart file is broken because now it looks like:
```
sshkey --username foo "ssh-key
"
```
which make the kickstart invalid but that is only discovered much later when the image booted (or even later after the installer put the kickstart into the target system).

This commit runs `ksvalidator` (if available) to detect this kind of issue early. It requires `pykickstart` in the buildroot but that seems to be not too bad as we already have `python3-kickstart` in our buildroots AFAICT (unless I read the manifest-db incorrectly).

So it does require an extra tweak to `images` before it's fully useful, something like:
```go
diff --git a/pkg/runner/centos.go b/pkg/runner/centos.go
index 2c65fac9a..a56e938a5 100644
--- a/pkg/runner/centos.go
+++ b/pkg/runner/centos.go
@@ -14,6 +14,7 @@ func (c *CentOS) GetBuildPackages() []string {
        packages := []string{
                "glibc",           // ldconfig
                "platform-python", // osbuild
+               "pykickstart",     // ksvalidator
        }
        if c.Version >= 8 {
                packages = append(packages,
diff --git a/pkg/runner/fedora.go b/pkg/runner/fedora.go
index 3482b0e11..2430cf5c3 100644
--- a/pkg/runner/fedora.go
+++ b/pkg/runner/fedora.go
@@ -12,8 +12,9 @@ func (r *Fedora) String() string {
 
 func (p *Fedora) GetBuildPackages() []string {
        return []string{
-               "glibc",   // ldconfig
-               "systemd", // systemd-tmpfiles and systemd-sysusers
-               "python3", // osbuild
+               "glibc",       // ldconfig
+               "systemd",     // systemd-tmpfiles and systemd-sysusers
+               "pykickstart", // ksvalidator
+               "python3",     // osbuild
        }
 }
diff --git a/pkg/runner/rhel.go b/pkg/runner/rhel.go
index 8b921a211..cec510556 100644
--- a/pkg/runner/rhel.go
+++ b/pkg/runner/rhel.go
@@ -13,7 +13,8 @@ func (r *RHEL) String() string {
 
 func (p *RHEL) GetBuildPackages() []string {
        packages := []string{
-               "glibc", // ldconfig
+               "glibc",       // ldconfig
+               "pykickstart", // ksvalidator
        }
        if p.Major >= 8 {
                packages = append(packages,
```
probably(?).