### PR TITLE
Make `tailored_profile_id` required for `json` autotailoring

### DIFF
--- a/stages/org.osbuild.oscap.autotailor
+++ b/stages/org.osbuild.oscap.autotailor
@@ -14,10 +14,15 @@ def main(tree, options):
     profile = config.get("profile_id")
     new_profile = config.get("new_profile")
     tailoring_file = config.get("tailoring_file")
+    # use `new_profile` as a fallback for backwards compatibility
+    tailored_profile_id = config.get("tailored_profile_id", new_profile)
+
+    if new_profile is not None:
+        print("WARNING: use the `tailored_profile_id` option instead")
 
     # make sure either profile & new_profile are set
     # or tailoring_filepath is set
-    if not ((profile and new_profile) or tailoring_file):
+    if not ((profile and tailored_profile_id) or tailoring_file):
         raise ValueError("Either profile & new profile must be set or provide filepath to json tailoring file")
 
     if tailoring_file:
@@ -39,7 +44,7 @@ def main(tree, options):
     cmd = [
         "/usr/bin/autotailor",
         "--output", f"{tree}/{filepath.lstrip('/')}",
-        "--new-profile-id", new_profile
+        "--new-profile-id", tailored_profile_id,
     ]
 
     for s in selected:

--- a/stages/org.osbuild.oscap.autotailor
+++ b/stages/org.osbuild.oscap.autotailor
@@ -20,15 +20,20 @@ def main(tree, options):
     if new_profile is not None:
         print("WARNING: use the `tailored_profile_id` option instead")
 
-    # make sure either profile & new_profile are set
-    # or tailoring_filepath is set
-    if not ((profile and tailored_profile_id) or tailoring_file):
-        raise ValueError("Either profile & new profile must be set or provide filepath to json tailoring file")
+    # this is needed now since we have renamed the `new_profile` option
+    # to `tailored_profile_id`
+    if not tailored_profile_id:
+        raise ValueError("The tailoring profile id option is a required field")
+
+    # make sure either profile or tailoring_file is set
+    if not (profile or tailoring_file):
+        raise ValueError("Either profile must be set or a filepath to json tailoring file must be provided")
 
     if tailoring_file:
         cmd = [
             "/usr/bin/autotailor",
             "--output", f"{tree}/{filepath.lstrip('/')}",
+            "--new-profile-id", tailored_profile_id,
             "--json-tailoring", f"{tree}/{tailoring_file.lstrip('/')}",
             datastream,
         ]

--- a/stages/org.osbuild.oscap.autotailor.meta.json
+++ b/stages/org.osbuild.oscap.autotailor.meta.json
@@ -14,6 +14,7 @@
         "additionalProperties": false,
         "required": [
           "datastream",
+          "tailored_profile_id",
           "tailoring_file"
         ],
         "type": "object",
@@ -22,6 +23,10 @@
           "datastream": {
             "type": "string",
             "description": "The path to the datastream file"
+          },
+          "tailored_profile_id": {
+            "type": "string",
+            "description": "The id of the new customized (tailored) OpenSCAP profile"
           },
           "tailoring_file": {
             "type": "string",

--- a/stages/org.osbuild.oscap.autotailor.meta.json
+++ b/stages/org.osbuild.oscap.autotailor.meta.json
@@ -33,8 +33,7 @@
         "additionalProperties": false,
         "required": [
           "profile_id",
-          "datastream",
-          "new_profile"
+          "datastream"
         ],
         "type": "object",
         "description": "OpenSCAP configuration variables",
@@ -49,7 +48,11 @@
           },
           "new_profile": {
             "type": "string",
-            "description": "The name of the new customized OpenSCAP profile"
+            "description": "The id of the new customized (tailored) OpenSCAP profile"
+          },
+          "tailored_profile_id": {
+            "type": "string",
+            "description": "The id of the new customized (tailored) OpenSCAP profile"
           },
           "selected": {
             "type": "array",

--- a/stages/test/test_autotailor.py
+++ b/stages/test/test_autotailor.py
@@ -45,7 +45,7 @@ def fake_input_fixture():
             "config": {
                 "profile_id": "some-profile-id",
                 "datastream": "some-datastream",
-                "new_profile": "some-new-profile",
+                "tailoring_profile_id": "some-new-profile",
             }
         },
     }
@@ -90,7 +90,7 @@ def test_oscap_autotailor_overrides_smoke(mock_subprocess_run, fake_input, stage
                     "value": 50,
                 },
             ]
-        }, "{'profile_id': 'some-profile-id', 'datastream': 'some-datastream', 'new_profile': 'some-new-profile',"
+        }, "{'profile_id': 'some-profile-id', 'datastream': 'some-datastream', 'tailoring_profile_id': 'some-new-profile',"
             + " 'overrides': [{'no': 'var', 'value': 50}]} is not valid under any of the given schemas"),
         ({
             "overrides": [
@@ -99,7 +99,7 @@ def test_oscap_autotailor_overrides_smoke(mock_subprocess_run, fake_input, stage
                     "var": "some",
                 },
             ]
-        }, "{'profile_id': 'some-profile-id', 'datastream': 'some-datastream', 'new_profile': 'some-new-profile',"
+        }, "{'profile_id': 'some-profile-id', 'datastream': 'some-datastream', 'tailoring_profile_id': 'some-new-profile',"
             + " 'overrides': [{'no': 'value', 'var': 'some'}]} is not valid under any of the given schemas"),
         ({
             "overrides": [
@@ -108,7 +108,7 @@ def test_oscap_autotailor_overrides_smoke(mock_subprocess_run, fake_input, stage
                     "value": {"some": "object"},
                 },
             ]
-        }, "{'profile_id': 'some-profile-id', 'datastream': 'some-datastream', 'new_profile': 'some-new-profile',"
+        }, "{'profile_id': 'some-profile-id', 'datastream': 'some-datastream', 'tailoring_profile_id': 'some-new-profile',"
             + " 'overrides': [{'var': 'ssh_idle_timeout_value', 'value': {'some': 'object'}}]} is not valid under any of the given schemas"),
     ],
 )

--- a/stages/test/test_autotailor.py
+++ b/stages/test/test_autotailor.py
@@ -59,6 +59,7 @@ def fake_json_input_fixture():
             "filepath": "tailoring-output.xml",
             "config": {
                 "datastream": "some-datastream",
+                "tailored_profile_id": "some-new-profile",
                 "tailoring_file": "tailoring-file.json",
             }
         },
@@ -128,5 +129,6 @@ def test_oscap_autotailor_json_smoke(mock_subprocess_run, fake_json_input, stage
 
     assert mock_subprocess_run.call_args_list == [
         call(["/usr/bin/autotailor", "--output", "/some/sysroot/tailoring-output.xml",
+              "--new-profile-id", "some-new-profile",
               "--json-tailoring", "/some/sysroot/tailoring-file.json", "some-datastream"],
              encoding='utf8', stdout=sys.stderr, check=True)]

--- a/test/data/stages/oscap.autotailor-json/b.json
+++ b/test/data/stages/oscap.autotailor-json/b.json
@@ -902,6 +902,7 @@
             "filepath": "/usr/share/osbuild/oscap/tailoring.xml",
             "config": {
               "datastream": "/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml",
+              "tailored_profile_id": "ospp_osbuild_tailoring",
               "tailoring_file": "/json-tailoring.json"
             }
           }

--- a/test/data/stages/oscap.autotailor-json/b.mpp.yaml
+++ b/test/data/stages/oscap.autotailor-json/b.mpp.yaml
@@ -76,4 +76,5 @@ pipelines:
           filepath: /usr/share/osbuild/oscap/tailoring.xml
           config:
             datastream: /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml
+            tailored_profile_id: "ospp_osbuild_tailoring"
             tailoring_file: /json-tailoring.json

--- a/test/data/stages/oscap.autotailor/b.json
+++ b/test/data/stages/oscap.autotailor/b.json
@@ -464,7 +464,7 @@
             "config": {
               "datastream": "/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml",
               "profile_id": "xccdf_org.ssgproject.content_profile_ospp",
-              "new_profile": "xccdf_org.ssgproject.content_profile_ospp_osbuild_tailoring",
+              "tailored_profile_id": "xccdf_org.ssgproject.content_profile_ospp_osbuild_tailoring",
               "selected": [
                 "partition_for_var_log"
               ],

--- a/test/data/stages/oscap.autotailor/b.mpp.yaml
+++ b/test/data/stages/oscap.autotailor/b.mpp.yaml
@@ -21,7 +21,7 @@ pipelines:
           config:
             datastream: /usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml
             profile_id: xccdf_org.ssgproject.content_profile_ospp
-            new_profile: xccdf_org.ssgproject.content_profile_ospp_osbuild_tailoring
+            tailored_profile_id: xccdf_org.ssgproject.content_profile_ospp_osbuild_tailoring
             selected:
               - partition_for_var_log
             unselected:


### PR DESCRIPTION
We have a bit of a tradeoff with this. On one hand we can can just use the `autotailor` command to override the profile id set by the user in the json tailoring file. We would just need to document this very clearly. The benefit of this is that we can maintain the explicitness of the manifest and we wouldn't have to inspect the generated tailoring XML file for the `tailoring_id`.

The downside is that the user provided `profile_id` from the json contents will get overwritten.