### PR TITLE
tools/osbuild-depsolve-dnf: ignore optional-metadata for old dnf

### DIFF
--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -65,7 +65,9 @@ class Solver():
         self.base.conf.substitutions['basearch'] = dnf.rpm.basearch(arch)
         self.base.conf.substitutions['releasever'] = releasever
 
-        self.base.conf.optional_metadata_types.extend(arguments.get("optional-metadata", []))
+        if hasattr(self.base.conf, "optional_metadata_types"):
+            # the attribute doesn't exist on older versions of dnf; ignore the option when not available
+            self.base.conf.optional_metadata_types.extend(arguments.get("optional-metadata", []))
 
         if proxy:
             self.base.conf.proxy = proxy


### PR DESCRIPTION
The optional_metadata_types option isn't available in older versions of dnf.  We could version-guard the option, but let's be more explicit and check if it exists instead.

If it doesn't we can safely ignore it and rely on dnf's default behaviour.