### PR TITLE
tools/tree-diff: use `null` for timestamped files

### DIFF
--- a/tools/tree-diff
+++ b/tools/tree-diff
@@ -6,6 +6,14 @@ import hashlib
 import json
 import os
 
+TIMESTAMPED_FILES = [
+    "aux-cache",
+    "rpmdb.sqlite",
+    "cacerts",
+    "shadow",
+    "shadow-",
+]
+
 
 def hash_file(fd):
     BLOCK_SIZE = 4096
@@ -64,7 +72,10 @@ def content_diff(name, dir_fd1, dir_fd2, path, differences):
 
         if hash1 != hash2:
             props = differences.setdefault(path, {})
-            props["content"] = [hash1, hash2]
+            if name in TIMESTAMPED_FILES:
+                props["content"] = [None, None]
+            else:
+                props["content"] = [hash1, hash2]
     finally:
         os.close(fd1)
         os.close(fd2)


### PR DESCRIPTION
The `tree-diff` tool is used by the `gen-stage-diff` tool to generate the stage `diff.json` files. A few of these stages have timestamped files that need to be edited after the tool is run to replace the `sha256` content hash with `null` so the stage diff tests ignore these files.

This commit updates the `tree-diff` tool to check through a list of the files that contain timestamps and to use the `null` value rather than the `sha256` content hash so the stage tests don't fail.