### PR TITLE
osbuild/monitor.py: improve naming of progress

### DIFF
--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -317,7 +317,7 @@ class JSONSeqMonitor(BaseMonitor):
     def begin(self, pipeline: osbuild.Pipeline):
         self._context.set_pipeline(pipeline)
         if pipeline.stages:
-            self._progress.sub_progress = Progress("stages", len(pipeline.stages))
+            self._progress.sub_progress = Progress(f"pipeline: {pipeline.name}", len(pipeline.stages))
         self.log(f"Starting pipeline {pipeline.name}", origin="osbuild.monitor")
 
     # finish is for pipelines

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -233,6 +233,7 @@ def test_json_progress_monitor():
         logitem = json.loads(log[i])
         assert logitem["message"] == "Starting pipeline test-pipeline-first"
         assert logitem["context"]["pipeline"]["name"] == "test-pipeline-first"
+        assert logitem["progress"]["progress"]["name"] == "pipeline: test-pipeline-first"
         # empty items are omited
         assert "name" not in logitem["context"]["pipeline"]["stage"]
         i += 1
@@ -276,6 +277,7 @@ def test_json_progress_monitor():
 
         logitem = json.loads(log[i])
         assert logitem["message"] == "Starting pipeline test-pipeline-second"
+        assert logitem["progress"]["progress"]["name"] == "pipeline: test-pipeline-second"
         assert logitem["context"]["origin"] == "osbuild.monitor"
         assert logitem["context"]["pipeline"]["name"] == "test-pipeline-second"
         i += 1


### PR DESCRIPTION
Just improve naming of the progress steps…

This is a small preparation for handing over progress towards frontend.
