### PR TITLE
sources/curl: use `--user-agent` option to set the user-agent

### DIFF
--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -163,7 +163,7 @@ class CurlSource(sources.SourceService):
                     "--connect-timeout", "30",
                     "--fail",
                     "--location",
-                    "--header", f"User-Agent: osbuild (Linux.{arch}; https://osbuild.org/)",
+                    "--user-agent", f"osbuild (Linux.{arch}; https://osbuild.org/)",
                     "--output", checksum,
                 ]
                 if proxy:

--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -222,6 +222,6 @@ def test_curl_user_agent(mocked_run, tmp_path, sources_service):
 
     for call_args in mocked_run.call_args_list:
         args, _kwargs = call_args
-        idx = args[0].index("--header")
-        assert "User-Agent: osbuild" in args[0][idx + 1]
+        idx = args[0].index("--user-agent")
+        assert "osbuild" in args[0][idx + 1]
         assert "https://osbuild.org/" in args[0][idx + 1]


### PR DESCRIPTION
Setting the user-agent using `--header` is broken in combination with `--location`, `--proxy`, and an https endpoint which redirects. The user-agent sent to the proxy changes after the client is redirected, tripping up proxies.

For more information see https://issues.redhat.com/browse/RHEL-45364