### PR TITLE
osbuild: add support to run in osbuild-composer with json-seq

### DIFF
--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -100,7 +100,13 @@ monitor that is used. Valid types are:
 	about the progress. Progress can be nested and a progress object
 	may contain sub-progress. In addition each progress can emit
 	`message` strings that contain detailed log information from
-	the stage. An example:
+	the stage.
+
+	At the end of the build an object with the key
+	`overall_result` is emited that contains the overall result of
+	the build (in the same format as `--json`).
+
+	An example:
 
 	| {
 	|   "message": "Starting module org.osbuild.grub2.inst",

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -103,6 +103,8 @@ def parse_arguments(sys_argv: List[str]) -> argparse.Namespace:
     # nargs='?' const='*' means `--break` is equivalent to `--break=*`
     parser.add_argument("--break", dest='debug_break', type=str, nargs='?', const='*',
                         help="open debug shell when executing stage. Accepts stage name or id or * (for all)")
+    parser.add_argument("--quiet", "-q", action="store_true",
+                        help="supress normal output")
 
     return parser.parse_args(sys_argv[1:])
 
@@ -162,7 +164,7 @@ def osbuild_cli() -> int:
 
     monitor_name = args.monitor
     if not monitor_name:
-        monitor_name = "NullMonitor" if args.json else "LogMonitor"
+        monitor_name = "NullMonitor" if (args.json or args.quiet) else "LogMonitor"
     monitor = osbuild.monitor.make(monitor_name, args.monitor_fd, manifest)
     monitor.log(f"starting {args.manifest_path}", origin="osbuild.main_cli")
 
@@ -202,7 +204,7 @@ def osbuild_cli() -> int:
                 r = fmt.output(manifest, r, object_store)
                 json.dump(r, sys.stdout)
                 sys.stdout.write("\n")
-            else:
+            elif not args.quiet:
                 if r["success"]:
                     for name, pl in manifest.pipelines.items():
                         print(f"{name + ':': <10}\t{pl.id}")

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -191,6 +191,8 @@ def osbuild_cli() -> int:
             else:
                 # if we had monitor.error() we could use that here
                 monitor.log(f"manifest {args.manifest_path} failed\n", origin="osbuild.main_cli")
+            # log overall result
+            monitor.overall_result(fmt.output(manifest, r, object_store))
 
             if r["success"] and exports:
                 for pid in exports:

--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -234,6 +234,9 @@ class BaseMonitor(abc.ABC):
     def log(self, message: str, origin: Optional[str] = None):
         """Called for all module log outputs"""
 
+    def overall_result(self, result: Dict):
+        """Called when the entire build is finished"""
+
 
 class NullMonitor(BaseMonitor):
     """Monitor class that does not report anything"""
@@ -344,6 +347,10 @@ class JSONSeqMonitor(BaseMonitor):
 
     def log(self, message, origin: Optional[str] = None):
         entry = log_entry(message, self._context.with_origin(origin), self._progress)
+        self._jsonseq(entry)
+
+    def overall_result(self, result: Dict):
+        entry = {"overall_result": result}
         self._jsonseq(entry)
 
     def _jsonseq(self, entry):

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -166,7 +166,6 @@ def gen_curl_download_config(config_path: pathlib.Path, chksum_desc_tuple: List[
 
 def try_parse_curl_line(line):
     line = line.strip()
-    print(line)
     if not line.startswith("osbuild-dl\x1c"):
         print(f"WARNING: unexpected prefix in {line}", file=sys.stderr)
         return None

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -213,11 +213,12 @@ def test_json_progress_monitor():
         mon.begin(manifest.pipelines["test-pipeline-second"])
         mon.log("pipeline 2 starting", origin="org.osbuild")
         mon.log("pipeline 2 message 2")
+        mon.overall_result({"type": "result", "success": True, "metadata": {"a": "lot"}})
 
         tf.seek(0)
         log = tf.read().decode().strip().split("\x1e")
 
-        expected_total = 12
+        expected_total = 13
         assert len(log) == expected_total
         i = 0
         logitem = json.loads(log[i])
@@ -292,6 +293,10 @@ def test_json_progress_monitor():
         assert logitem["message"] == "pipeline 2 message 2"
         prev_ctx_id = json.loads(log[i - 1])["context"]["id"]
         assert logitem["context"]["id"] == prev_ctx_id
+        i += 1
+
+        logitem = json.loads(log[i])
+        assert logitem["overall_result"] == {"type": "result", "success": True, "metadata": {"a": "lot"}}
         i += 1
 
         assert i == expected_total


### PR DESCRIPTION
monitor: add new `overall_result` helper to the monitor

One goal of the json-seq mmonitor is that it can be used to get
all relevant information about the build process of an `osbuild`
run. But the overall result was missing, it is printed out-of-band
with `--json` to json but outside of the monitor.

---

osbuild add new `-q`, `--quiet` option

Current osbuild will always print some non json-seq output even
when run with `--monitor=JSONSeqMonitor` because of the
unconditional `print/sys.stdout.write()` in `main_cli.py`.
