### PR TITLE
sources(curl): disable `curl --parallel` by default

### DIFF
--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -102,6 +102,12 @@ def curl_has_parallel_downloads():
     Return true if curl has all the support we needed for parallel downloading
     (this include --write-out "%{json}" too
     """
+    # Re-enable this once the failures in
+    # https://github.com/osbuild/osbuild-composer/pull/4247
+    # are understood
+    if os.getenv("OSBUILD_SOURCES_CURL_USE_PARALLEL") not in ["1", "yes", "true"]:
+        return False
+
     output = subprocess.check_output(["curl", "--version"], universal_newlines=True)
     first_line = output.split("\n", maxsplit=1)[0]
     m = re.match(r'^curl (\d+\.\d+\.\d+)', first_line)

--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -160,7 +160,9 @@ def test_curl_download_many_chksum_validate(tmp_path, curl_parallel):
 
 
 @pytest.mark.parametrize("curl_parallel", [True, False], indirect=["curl_parallel"])
-def test_curl_download_many_retries(tmp_path, curl_parallel):
+def test_curl_download_many_retries(tmp_path, monkeypatch, curl_parallel):
+    monkeypatch.setenv("OSBUILD_SOURCES_CURL_USE_PARALLEL", "1")
+
     fake_httpd_root = tmp_path / "fake-httpd-root"
 
     with http_serve_directory(fake_httpd_root) as httpd:
@@ -291,7 +293,14 @@ Features: AsynchDNS IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz
 
 
 @patch("subprocess.check_output")
-def test_curl_has_parallel_download(mocked_check_output, sources_module):
+def test_curl_has_parallel_download(mocked_check_output, monkeypatch, sources_module):
+    # by default, --parallel is disabled
+    mocked_check_output.return_value = NEW_CURL_OUTPUT
+    assert not sources_module.curl_has_parallel_downloads()
+
+    # unless this environemnt is set
+    monkeypatch.setenv("OSBUILD_SOURCES_CURL_USE_PARALLEL", "1")
+
     mocked_check_output.return_value = NEW_CURL_OUTPUT
     assert sources_module.curl_has_parallel_downloads()
 


### PR DESCRIPTION
Disable `curl --parallel` by default until the failure in https://github.com/osbuild/osbuild-composer/pull/4247

is fully understood. It can be enabled via the environment:
```
OSBUILD_SOURCES_CURL_USE_PARALLEL=1
```
in the osbuild-composer test.