### PR TITLE
stages/oscap.remediation: small import adjustment

### DIFF
--- a/stages/org.osbuild.oscap.remediation
+++ b/stages/org.osbuild.oscap.remediation
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 import osbuild.api
-from osbuild.util.mnt import mount
+from osbuild.util import mnt
 
 DATA_DIR = "/root"
 XCCDF_RESULTS = "oscap_eval_xccdf_results.xml"
@@ -15,7 +15,7 @@ def setup_env(tree):
     for source in ("/dev", "/proc"):
         target = os.path.join(tree, source.lstrip("/"))
         os.makedirs(target, exist_ok=True)
-        mount(source, target, ro=False)
+        mnt.mount(source, target, ro=False)
     os.symlink("/proc/self/fd", f"{tree}/dev/fd")
 
 

--- a/stages/org.osbuild.oscap.remediation
+++ b/stages/org.osbuild.oscap.remediation
@@ -11,6 +11,14 @@ XCCDF_RESULTS = "oscap_eval_xccdf_results.xml"
 REMEDIATION_SCRIPT = "oscap_remediation.bash"
 
 
+def setup_env(tree):
+    for source in ("/dev", "/proc"):
+        target = os.path.join(tree, source.lstrip("/"))
+        os.makedirs(target, exist_ok=True)
+        mount(source, target, ro=False)
+    os.symlink("/proc/self/fd", f"{tree}/dev/fd")
+
+
 # pylint: disable=too-many-statements,too-many-branches
 def main(tree, options):
     # required vars
@@ -32,11 +40,7 @@ def main(tree, options):
     data_dir = data_dir.lstrip('/')
     os.makedirs(f"{tree}/{data_dir}", exist_ok=True)
 
-    for source in ("/dev", "/proc"):
-        target = os.path.join(tree, source.lstrip("/"))
-        os.makedirs(target, exist_ok=True)
-        mount(source, target, ro=False)
-    os.symlink("/proc/self/fd", f"{tree}/dev/fd")
+    setup_env(tree)
 
     # build common data stream-related args list
     ds_args = ["--profile", profile_id]


### PR DESCRIPTION
This is a small adjustment to how the `osbuild.util.mnt.mount` fuction is imported. While adding unit tests, the tests failed when trying to patch the function, this commit fixes the issue.