### PR TITLE
sources(curl): use `--next` for each url in curl config

### DIFF
--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -100,7 +100,7 @@ SCHEMA = """
 # We are not just using %{json} here because older curl (7.76) will
 # write {"http_connect":000} which python cannot parse so we write our
 # own json subset
-CURL_WRITE_OUT = r'\{\"url\": \"%{url}\"\, \"filename_effective\": \"%{filename_effective}\", \"exitcode\": %{exitcode}, \"errormsg\": \"%{errormsg}\" \}\n'
+CURL_WRITE_OUT_FMT = r'\{\"url\": \"%{url}\"\, \"filename_effective\": \"%{filename_effective}\", \"exitcode\": %{exitcode}, \"errormsg\": \"%{errormsg}\" \}\n'
 
 NR_RETRYS = 10
 
@@ -141,31 +141,37 @@ def _quote_url(url: str) -> str:
 
 def gen_curl_download_config(config_path: pathlib.Path, chksum_desc_tuple: List[Tuple[str, Dict]], parallel=False):
     with open(config_path, "w", encoding="utf8") as fp:
-        # global options
-        if parallel:
-            fp.write("parallel\n")
-        fp.write(textwrap.dedent(f"""\
+        # Because we use --next which resets the parser state we need to set
+        # these options for each url.
+        per_url_opts = textwrap.dedent(f"""\
         user-agent = "osbuild (Linux.{platform.machine()}; https://osbuild.org/)"
         silent
         speed-limit = 1000
         connect-timeout = 30
         fail
         location
-        """))
+        """)
         if parallel:
-            fp.write(textwrap.dedent(f"""\
-            write-out = "{CURL_WRITE_OUT}"
-            """))
-
+            per_url_opts += textwrap.dedent(f"""\
+            write-out = "{CURL_WRITE_OUT_FMT}"
+            """)
         proxy = os.getenv("OSBUILD_SOURCES_CURL_PROXY")
         if proxy:
-            fp.write(f'proxy = "{proxy}"\n')
-        fp.write("\n")
-        # per url options
-        for checksum, desc in chksum_desc_tuple:
+            per_url_opts += f'proxy = "{proxy}"\n'
+        # start with the global option(s)
+        if parallel:
+            fp.write(textwrap.dedent("""\
+            # global options
+            parallel
+
+            """))
+        # then generate the per-url config
+        fp.write("# per-url options\n")
+        for i, (checksum, desc) in enumerate(chksum_desc_tuple):
             url = _quote_url(desc.get("url"))
             fp.write(f'url = "{url}"\n')
             fp.write(f'output = "{checksum}"\n')
+            fp.write(f'{per_url_opts}')
             secrets = desc.get("secrets")
             if secrets:
                 ssl_ca_cert = secrets.get('ssl_ca_cert')
@@ -182,7 +188,8 @@ def gen_curl_download_config(config_path: pathlib.Path, chksum_desc_tuple: List[
                 fp.write('insecure\n')
             else:
                 fp.write('no-insecure\n')
-            fp.write("\n")
+            if i + 1 < len(chksum_desc_tuple):
+                fp.write("next\n\n")
 
 
 def try_parse_curl_line(line):

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -110,12 +110,6 @@ def curl_has_parallel_downloads():
     Return true if curl has all the support we needed for parallel downloading
     (this include --write-out "%{json}" too
     """
-    # Re-enable this once the failures in
-    # https://github.com/osbuild/osbuild-composer/pull/4247
-    # are understood
-    if os.getenv("OSBUILD_SOURCES_CURL_USE_PARALLEL") not in ["1", "yes", "true"]:
-        return False
-
     output = subprocess.check_output(["curl", "--version"], universal_newlines=True)
     first_line = output.split("\n", maxsplit=1)[0]
     m = re.match(r'^curl (\d+\.\d+\.\d+)', first_line)

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -102,6 +102,8 @@ SCHEMA = """
 # own json subset
 CURL_WRITE_OUT = r'\{\"url\": \"%{url}\"\, \"filename_effective\": \"%{filename_effective}\", \"exitcode\": %{exitcode}, \"errormsg\": \"%{errormsg}\" \}\n'
 
+NR_RETRYS = 10
+
 
 def curl_has_parallel_downloads():
     """
@@ -310,7 +312,7 @@ class CurlSource(sources.SourceService):
             # some mirrors are sometimes broken. retry manually, because we could be
             # redirected to a different, working, one on retry.
             return_code = 0
-            for _ in range(10):
+            for _ in range(NR_RETRYS):
                 return_code = fetch_many_new_curl(tmpdir, self.cache, dl_pairs)
                 if return_code == 0:
                     break
@@ -334,7 +336,7 @@ class CurlSource(sources.SourceService):
             # some mirrors are sometimes broken. retry manually, because we could be
             # redirected to a different, working, one on retry.
             return_code = 0
-            for _ in range(10):
+            for _ in range(NR_RETRYS):
                 curl_config_path = f"{tmpdir}/curl-config.txt"
                 gen_curl_download_config(curl_config_path, [(checksum, desc)])
                 curl = subprocess.run(

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -229,6 +229,7 @@ def fetch_many_new_curl(tmpdir, targetdir, dl_pairs):
         curl_p = subprocess.Popen(curl_command, encoding="utf-8", cwd=tmpdir, stdout=subprocess.PIPE)
         # ensure that curl is killed even if an unexpected exit happens
         cm.callback(curl_p.kill)
+        errors = []
         while True:
             line = curl_p.stdout.readline()
             # empty line means eof/process finished
@@ -238,10 +239,13 @@ def fetch_many_new_curl(tmpdir, targetdir, dl_pairs):
             if not dl_details:
                 continue
             url = dl_details['url']
-            # ignore individual download errors, the overall exit status will
-            # reflect them and the caller can retry
+            # Keep track of individual errors as curl will only report
+            # the last download operation success/failure via the global
+            # exit code. There is "--fail-early" but the downside of that
+            # is that abort all in progress downloads too.
             if dl_details["exitcode"] != 0:
                 print(f"WARNING: failed to download {url}: {dl_details['errormsg']}", file=sys.stderr)
+                errors.append(f'{url}: error code {dl_details["exitcode"]}')
                 continue
             # the way downloads are setup the filename is the expected hash
             # so validate now and move into place
@@ -260,7 +264,10 @@ def fetch_many_new_curl(tmpdir, targetdir, dl_pairs):
             print(f"Downloaded {url}")
         # return overall download status (this will be an error if any
         # transfer failed)
-        return curl_p.wait()
+        curl_exit_code = curl_p.wait()
+        if not errors and curl_exit_code > 0:
+            errors.append("curl exited non-zero but reported no errors")
+        return errors
 
 
 class CurlSource(sources.SourceService):
@@ -320,12 +327,12 @@ class CurlSource(sources.SourceService):
             # redirected to a different, working, one on retry.
             return_code = 0
             for _ in range(NR_RETRYS):
-                return_code = fetch_many_new_curl(tmpdir, self.cache, dl_pairs)
-                if return_code == 0:
+                errors = fetch_many_new_curl(tmpdir, self.cache, dl_pairs)
+                if not errors:
                     break
             else:
-                failed_urls = ",".join([itm[1]["url"] for itm in dl_pairs])
-                raise RuntimeError(f"curl: error downloading {failed_urls}: error code {return_code}")
+                details = ",".join(errors)
+                raise RuntimeError(f"curl: error downloading {details}")
 
         if len(dl_pairs) > 0:
             raise RuntimeError(f"curl: finished with return_code {return_code} but {dl_pairs} left to download")

--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -102,7 +102,8 @@ def test_curl_download_many_fail(curl_parallel):
     }
     with pytest.raises(RuntimeError) as exp:
         curl_parallel.fetch_all(TEST_SOURCES)
-    assert str(exp.value) == 'curl: error downloading http://localhost:9876/random-not-exists: error code 7'
+    assert str(exp.value).startswith("curl: error downloading http://localhost:9876/random-not-exists")
+    assert 'http://localhost:9876/random-not-exists: error code 7' in str(exp.value)
 
 
 def make_test_sources(fake_httpd_root, port, n_files, start_n=0, cacert=""):

--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -261,17 +261,16 @@ def test_curl_gen_download_config_old_curl(tmp_path, sources_module):
 
     assert config_path.exists()
     assert config_path.read_text(encoding="utf8") == textwrap.dedent(f"""\
+    # per-url options
+    url = "http://example.com/file/0"
+    output = "sha256:5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
     user-agent = "osbuild (Linux.{platform.machine()}; https://osbuild.org/)"
     silent
     speed-limit = 1000
     connect-timeout = 30
     fail
     location
-
-    url = "http://example.com/file/0"
-    output = "sha256:5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
     no-insecure
-
     """)
 
 
@@ -281,34 +280,59 @@ def test_curl_gen_download_config_parallel(tmp_path, sources_module):
 
     assert config_path.exists()
     assert config_path.read_text(encoding="utf8") == textwrap.dedent(f"""\
+    # global options
     parallel
+
+    # per-url options
+    url = "http://example.com/file/0"
+    output = "sha256:5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
     user-agent = "osbuild (Linux.{platform.machine()}; https://osbuild.org/)"
     silent
     speed-limit = 1000
     connect-timeout = 30
     fail
     location
-    write-out = "{sources_module.CURL_WRITE_OUT}"
-
-    url = "http://example.com/file/0"
-    output = "sha256:5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+    write-out = "{sources_module.CURL_WRITE_OUT_FMT}"
     no-insecure
+    next
 
     url = "http://example.com/file/1"
     output = "sha256:6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+    user-agent = "osbuild (Linux.{platform.machine()}; https://osbuild.org/)"
+    silent
+    speed-limit = 1000
+    connect-timeout = 30
+    fail
+    location
+    write-out = "{sources_module.CURL_WRITE_OUT_FMT}"
     insecure
+    next
 
     url = "http://example.com/file/2"
     output = "sha256:d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"
+    user-agent = "osbuild (Linux.{platform.machine()}; https://osbuild.org/)"
+    silent
+    speed-limit = 1000
+    connect-timeout = 30
+    fail
+    location
+    write-out = "{sources_module.CURL_WRITE_OUT_FMT}"
     cacert = "some-ssl_ca_cert"
     no-insecure
+    next
 
     url = "http://example.com/file/3"
     output = "sha256:4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce"
+    user-agent = "osbuild (Linux.{platform.machine()}; https://osbuild.org/)"
+    silent
+    speed-limit = 1000
+    connect-timeout = 30
+    fail
+    location
+    write-out = "{sources_module.CURL_WRITE_OUT_FMT}"
     cert = "some-ssl_client_cert"
     key = "some-ssl_client_key"
     no-insecure
-
     """)
 
 

--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -170,9 +170,7 @@ def test_curl_download_many_chksum_validate(tmp_path, curl_parallel):
 
 
 @pytest.mark.parametrize("curl_parallel", [True, False], indirect=["curl_parallel"])
-def test_curl_download_many_retries(tmp_path, monkeypatch, curl_parallel):
-    monkeypatch.setenv("OSBUILD_SOURCES_CURL_USE_PARALLEL", "1")
-
+def test_curl_download_many_retries(tmp_path, curl_parallel):
     fake_httpd_root = tmp_path / "fake-httpd-root"
 
     with http_serve_directory(fake_httpd_root) as httpd:
@@ -355,14 +353,7 @@ Features: AsynchDNS IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz
 
 
 @patch("subprocess.check_output")
-def test_curl_has_parallel_download(mocked_check_output, monkeypatch, sources_module):
-    # by default, --parallel is disabled
-    mocked_check_output.return_value = NEW_CURL_OUTPUT
-    assert not sources_module.curl_has_parallel_downloads()
-
-    # unless this environemnt is set
-    monkeypatch.setenv("OSBUILD_SOURCES_CURL_USE_PARALLEL", "1")
-
+def test_curl_has_parallel_download(mocked_check_output, sources_module):
     mocked_check_output.return_value = NEW_CURL_OUTPUT
     assert sources_module.curl_has_parallel_downloads()
 


### PR DESCRIPTION
This is a clean version of https://github.com/osbuild/osbuild/pull/1812

Before this gets merged we should:
a) redo a speed test with new curl to ensure we have no regressions in the speed because of the next --nex
b) open the equivalent of https://github.com/osbuild/osbuild-composer/pull/4253 for this PR and ensure all composer tests are green (this is done in https://github.com/osbuild/osbuild-composer/pull/4281 as WIP)