### PR TITLE
Tests: force checkout manifest-db

### DIFF
--- a/schutzbot/manifest_tests.sh
+++ b/schutzbot/manifest_tests.sh
@@ -9,7 +9,7 @@ MANIFEST_DB_COMMIT=$(cat Schutzfile | jq -r '.global.dependencies."manifest-db".
 MANIFEST_DB_REPO="https://github.com/osbuild/manifest-db"
 git clone "$MANIFEST_DB_REPO" manifest-db
 cd manifest-db
-git checkout "$MANIFEST_DB_COMMIT"
+git checkout --force "$MANIFEST_DB_COMMIT"
 
 # update selinux labels for the image-info tool
 OSBUILD_LABEL=$(matchpathcon -n /usr/bin/osbuild)


### PR DESCRIPTION
Manifest tests on Fedora 39 sometimes fail, because checking out the specific manifest-db commit fails with:

"error: The following untracked working tree files would be overwritten by checkout"

Use --force when checking out the ref, which will hopefully solve any error like this.

[1] https://gitlab.com/redhat/services/products/image-builder/ci/osbuild/-/jobs/7317097983