### PR TITLE
stages/autotailor: fix stage schema

### DIFF
--- a/stages/org.osbuild.oscap.autotailor.meta.json
+++ b/stages/org.osbuild.oscap.autotailor.meta.json
@@ -36,9 +36,21 @@
       },
       "tailoring": {
         "additionalProperties": false,
-        "required": [
-          "profile_id",
-          "datastream"
+        "oneOf": [
+          {
+            "required": [
+              "profile_id",
+              "datastream",
+              "new_profile"
+            ]
+          },
+          {
+            "required": [
+              "profile_id",
+              "datastream",
+              "tailored_profile_id"
+            ]
+          }
         ],
         "type": "object",
         "description": "OpenSCAP configuration variables",

--- a/stages/test/test_autotailor.py
+++ b/stages/test/test_autotailor.py
@@ -150,6 +150,11 @@ def test_oscap_autotailor_json_smoke(mock_subprocess_run, fake_json_input, stage
             + " is not valid under any of the given schemas"),
         ({
             "datastream": "some-datastream",
+            "profile_id": "some-profile-id",
+        }, "{'datastream': 'some-datastream', 'profile_id': 'some-profile-id'}"
+            + " is not valid under any of the given schemas"),
+        ({
+            "datastream": "some-datastream",
             "tailoring_file": "/some/tailoring/file.json"
         }, "{'datastream': 'some-datastream', 'tailoring_file': '/some/tailoring/file.json'}"
             + " is not valid under any of the given schemas"),


### PR DESCRIPTION
There was a small mistake in the schema since either one of `new_profile` or `tailored_profile_id` is required. 
This commit fixes this and updates the tests to check for this case.