### PR TITLE
Test: fix dnf4.mark stage test with DNF5

### DIFF
--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -537,9 +537,12 @@ class TestStages(test.TestBase):
             assert os.path.isdir(tree)
 
             # we're going to verify that packages in the tree are marked according to
+            # Explicitly use 'dnf4' for now, because 'dnf5' contains a breaking change
+            # in the repoquery --qf output, specifically it does not add a trailing newline.
+            # We can use plan 'dnf' again once https://github.com/rpm-software-management/dnf5/issues/709 is fixed.
             r = subprocess.run(
                 [
-                    "dnf",
+                    "dnf4",
                     "--installroot", tree,
                     "repoquery", "--installed",
                     "--qf", "%{name},%{reason}"


### PR DESCRIPTION
DNF5 contains a breaking change in the repoquery --qf output, specifically it does not include the trailing newline. This breaks the test case e.g. on the latest Fedora Rawhide [1].

As a fix, explicitly use 'dnf4' for now, until the inconsistency is fixed in the upstream [2].

[1] https://artifacts.dev.testing-farm.io/3a3a2898-0a6a-42eb-8792-660f03c35c3c/
[2] https://github.com/rpm-software-management/dnf5/issues/709