### PR TITLE
Fix dnf4 mark stage test

### DIFF
--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -557,7 +557,12 @@ class TestStages(test.TestBase):
                 # Upstream bug https://github.com/rpm-software-management/dnf5/issues/709
                 if not line:
                     continue
-                package, mark = line.strip().split(",")
+
+                try:
+                    package, mark = line.strip().split(",")
+                except ValueError:
+                    print(f"Failed to parse line: {line}")
+                    raise
 
                 if package == "dnf":
                     assert mark == "user"


### PR DESCRIPTION
Let's revert to using plain 'dnf', add an explicit newline in the query format and skip empty lines when processing the output. This makes the test case compatible with all DNF versions, even with dnf5 once this issue gets fixed.

The previous approach didn't work on c9s / el9, because there is no
`/usr/bin/dnf4 -> dnf-3` symlink.

Also see:
https://github.com/osbuild/osbuild/actions/runs/10136827918/job/28026181824

Additionally, make the failures to parse dnf output easier by printing the actual line.