### PR TITLE
main,monitor: fix total steps in progress reporting

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -163,8 +163,6 @@ def osbuild_cli() -> int:
     monitor_name = args.monitor
     if not monitor_name:
         monitor_name = "NullMonitor" if args.json else "LogMonitor"
-    monitor = osbuild.monitor.make(monitor_name, args.monitor_fd, manifest)
-    monitor.log(f"starting {args.manifest_path}", origin="osbuild.main_cli")
 
     try:
         with ObjectStore(args.store) as object_store:
@@ -175,6 +173,9 @@ def osbuild_cli() -> int:
             debug_break = args.debug_break
 
             pipelines = manifest.depsolve(object_store, exports)
+            total_steps = len(manifest.sources) + len(pipelines)
+            monitor = osbuild.monitor.make(monitor_name, args.monitor_fd, total_steps)
+            monitor.log(f"starting {args.manifest_path}", origin="osbuild.main_cli")
 
             manifest.download(object_store, monitor, args.libdir)
 

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -199,7 +199,7 @@ def test_json_progress_monitor():
     manifest.add_pipeline(pl2, "", "")
 
     with tempfile.TemporaryFile() as tf:
-        mon = JSONSeqMonitor(tf.fileno(), manifest)
+        mon = JSONSeqMonitor(tf.fileno(), len(manifest.sources) + len(manifest.pipelines))
         mon.log("test-message-1")
         mon.log("test-message-2", origin="test.origin.override")
         mon.begin(manifest.pipelines["test-pipeline-first"])


### PR DESCRIPTION
The existing code to record progress was a bit too naive. Instead of just counting the number os pipelines in a manifest to get the total steps we need to look at the resolved pipelines.

with this fix `bib` will report the correct number of steps left when doing e.g. a qcow2 image build. Right now the number of steps is incorrect because the osbuild manifest contains pipelines for qcow2,vdmk,raw,ami and all are currently considered steps that need to be completed. With this commit this is fixed.

C.f. https://github.com/osbuild/bootc-image-builder/pull/525