### PR TITLE
Test/dnf4.mark: adjust the test for markings used by DNF5

### DIFF
--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -565,9 +565,11 @@ class TestStages(test.TestBase):
                     raise
 
                 if package == "dnf":
-                    assert mark == "user"
+                    # dnf4 marks packages as 'user', while dnf5 marks them as 'User'
+                    assert mark in ("user", "User")
                 else:
-                    assert mark == "unknown"
+                    # dnf4 marks packages as 'unknown', while dnf5 marks them as 'External User'
+                    assert mark in ("unknown", "External User")
 
     @unittest.skipUnless(test.TestBase.has_filesystem_support("btrfs"), "btrfs needed")
     def test_btrfs(self):


### PR DESCRIPTION
When I rolled back from using 'dnf4', to check package markings, to using 'dnf', I didn't verify the test case on Fedora Rawhide with DNF5. It turns out that the strings reported by DNF5 differ and make the test case fail. This time I tested the change on Fedora Rawhide with DNF5 and it works.

See:

- https://src.fedoraproject.org/rpms/osbuild/pull-request/300
- https://artifacts.dev.testing-farm.io/dc84a6c8-1472-452e-8f1d-37255288d996/