### PR TITLE
solver: include "solver" key in the dnfjson reply

### DIFF
--- a/osbuild/solver/dnf.py
+++ b/osbuild/solver/dnf.py
@@ -306,6 +306,7 @@ class DNF(SolverBase):
                 "sslclientcert": repo.sslclientcert,
             }
         response = {
+            "solver": "dnf",
             "packages": packages,
             "repos": repositories,
         }

--- a/osbuild/solver/dnf5.py
+++ b/osbuild/solver/dnf5.py
@@ -429,6 +429,7 @@ class DNF5(SolverBase):
                 "sslcacert": get_string_option(repo_cfg.get_sslcacert_option()),
             }
         response = {
+            "solver": "dnf5",
             "packages": packages,
             "repos": repositories,
         }

--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -302,3 +302,12 @@ def test_depsolve(tmp_path, repo_servers, dnf_config, detect_fn, test_case):
                 assert n_filelist_files == len(REPO_PATHS)
             else:
                 assert n_filelist_files == 0
+
+            if dnf_config:
+                use_dnf5 = json.loads(dnf_config)["use_dnf5"]
+            else:
+                use_dnf5 = False
+            if use_dnf5:
+                assert res["solver"] == "dnf5"
+            else:
+                assert res["solver"] == "dnf"


### PR DESCRIPTION
This commit includes the used sovler in the dnfjson reply. This is mostly information (e.g. in service logs) but also useful in tests to ensure that the expected solver was really run.

Note that this needs https://github.com/osbuild/images/pull/723 first.

