### PR TITLE
monitor: include result in jsonseq monitor streaming (COMPOSER-2393)

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -44,14 +44,14 @@ def cleanup(*objs):
 
 
 class BuildResult:
-    def __init__(self, origin, returncode, output, error):
+    def __init__(self, origin: 'Stage', returncode: int, output: str, error: Dict[str, str]) -> None:
         self.name = origin.name
         self.id = origin.id
         self.success = returncode == 0
         self.output = output
         self.error = error
 
-    def as_dict(self):
+    def as_dict(self) -> Dict[str, Any]:
         return vars(self)
 
 
@@ -69,11 +69,11 @@ class Stage:
         self.mounts = {}
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.info.name
 
     @property
-    def id(self):
+    def id(self) -> str:
         m = hashlib.sha256()
         m.update(json.dumps(self.name, sort_keys=True).encode())
         m.update(json.dumps(self.build, sort_keys=True).encode())
@@ -82,11 +82,11 @@ class Stage:
         if self.source_epoch is not None:
             m.update(json.dumps(self.source_epoch, sort_keys=True).encode())
         if self.inputs:
-            data = {n: i.id for n, i in self.inputs.items()}
-            m.update(json.dumps(data, sort_keys=True).encode())
+            data_inp = {n: i.id for n, i in self.inputs.items()}
+            m.update(json.dumps(data_inp, sort_keys=True).encode())
         if self.mounts:
-            data = [m.id for m in self.mounts.values()]
-            m.update(json.dumps(data).encode())
+            data_mnt = [m.id for m in self.mounts.values()]
+            m.update(json.dumps(data_mnt).encode())
         return m.hexdigest()
 
     @property

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -52,7 +52,13 @@ class BuildResult:
         self.error = error
 
     def as_dict(self) -> Dict[str, Any]:
-        return vars(self)
+        return {
+            "name": self.name,
+            "id": self.id,
+            "success": self.success,
+            "output": self.output,
+            "error": self.error,
+        }
 
 
 class DownloadResult:
@@ -63,7 +69,12 @@ class DownloadResult:
         self.output = ""
 
     def as_dict(self) -> Dict[str, Any]:
-        return vars(self)
+        return {
+            "name": self.name,
+            "id": self.id,
+            "success": self.success,
+            "output": self.output,
+        }
 
 
 class Stage:

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -518,8 +518,8 @@ class Manifest:
         """
         results = {"success": True}
 
-        for pl in map(self.get, pipelines):
-            assert pl is not None
+        for name_or_id in pipelines:
+            pl = self[name_or_id]
             res = pl.run(store, monitor, libdir, debug_break, stage_timeout)
             results[pl.id] = res
             if not res["success"]:
@@ -569,7 +569,7 @@ class Manifest:
         pl = self.get(name_or_id)
         if pl:
             return pl
-        raise KeyError(f"'{name_or_id}' not found")
+        raise KeyError(f"'{name_or_id}' not found in manifest pipelines: {list(self.pipelines.keys())}")
 
     def __iter__(self) -> Iterator[Pipeline]:
         return iter(self.pipelines.values())

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -208,7 +208,7 @@ def test_json_progress_monitor():
         mon.log("pipeline 1 message 2")
         mon.log("pipeline 1 finished", origin="org.osbuild")
         mon.result(osbuild.pipeline.BuildResult(
-            fake_noop_stage, returncode=0, output="output", error=None))
+            fake_noop_stage, returncode=0, output="some output", error=None))
         mon.finish({"success": True, "name": "test-pipeline-first"})
         mon.begin(manifest.pipelines["test-pipeline-second"])
         mon.log("pipeline 2 starting", origin="org.osbuild")
@@ -268,6 +268,12 @@ def test_json_progress_monitor():
         logitem = json.loads(log[i])
         assert logitem["message"] == "Finished module org.osbuild.noop"
         assert logitem["context"]["id"] == id_start_module
+        assert logitem["result"] == {
+            "id": fake_noop_stage.id,
+            "name": "org.osbuild.noop",
+            "output": "some output",
+            "success": True,
+        }
         i += 1
 
         logitem = json.loads(log[i])


### PR DESCRIPTION
The jsonseq based status reporting does not have error handling right now. If anything goes wrong it will
not reported. This is a problem for frontends like bib or the new ibuilder (image-builder-cli). So this PR
adds error reporting via the "result" mechanism.

This also allows us to avoid having to add `--json` to the output to construct the build result.

With this commit in place consumers can now call `osbuild --monitor-fd` and stream the progress. The consumer needs to keep track of the "build_result" from osbuild to be able to reconstruct the equivalent of the result that is generated via `osbuild --json` [0]. Note that we mostly abandon the format/v2/v2.py:output() and putting the burden on the consumer (but I don't see a way around this).

This is a cleaner version of https://github.com/osbuild/osbuild/pull/1810 and with that we should be able to stream the output "live" from the worker-executor to have a more comprehensive log and it will also prepare us to forward progress/logs in realtime to the frontend.

This "result" reporting from each stage will be needed for the `ibuilder` (image-builder-cli) as well now to provide json based output and error reporting so even if this is not a full replacement for `--json` (I think it is because only the metadata from the objectstore is missing) it is still useful to be able to report proper errors.