### PR TITLE
Makefile: run `tox parallel` without the spinner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ test-all:
 
 .PHONY: lint
 lint:
-	tox run-parallel -e ruff,pylint,autopep8,mypy,mypy-strict
+	tox run-parallel --parallel-no-spinner -e ruff,pylint,autopep8,mypy,mypy-strict
 
 
 #


### PR DESCRIPTION
The spinner is mostly distracting IMHO and it makes the CI logs harder to read as it generates several dozens of lines like:
```
...
⠋ [3/5] pylint | autopep8 | mypy-strict
...
```

I was considering to make it conditional on GH but decided to just disable globally. If someone feels attached to the spinner I only disable it in GH.