### PR TITLE
test_dnf4_mark(): disable all plugins when inspecting markings

### DIFF
--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -541,6 +541,8 @@ class TestStages(test.TestBase):
                 [
                     "dnf",
                     "--installroot", tree,
+                    # disable all plugins to prevent them from modifying the output
+                    "--disableplugin", "*",
                     "repoquery", "--installed",
                     "--qf", "%{name},%{reason}\n"
                 ],


### PR DESCRIPTION
When subscription-manager DNF plugins are enabled (e.g. on RHEL), they produce messages to the stdout on any DNF command execution. E.g. "Updating Subscription Management repositories.".

Disable all plugins when inspecting package markings so prevent them from modifying the output.