### PR TITLE
jsoncomm: transparently handle huge messages via fds

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -210,7 +210,7 @@ class Stage:
 
             ipmgr = InputManager(mgr, storeapi, inputs_tmpdir)
             for key, ip in self.inputs.items():
-                data = ipmgr.map(ip, store)
+                data = ipmgr.map(ip)
                 inputs[key] = data
 
             devmgr = DeviceManager(mgr, build_root.dev, tree)

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -1,5 +1,4 @@
 import abc
-import contextlib
 import hashlib
 import json
 import os
@@ -29,6 +28,7 @@ class Source:
         cache = os.path.join(store.store, "sources")
 
         args = {
+            "items": self.items,
             "options": self.options,
             "cache": cache,
             "output": None,
@@ -36,19 +36,9 @@ class Source:
         }
 
         client = mgr.start(f"source/{source}", self.info.path)
-
-        with self.make_items_file(store.tmp) as fd:
-            fds = [fd]
-            reply = client.call_with_fds("download", args, fds)
+        reply = client.call("download", args)
 
         return reply
-
-    @contextlib.contextmanager
-    def make_items_file(self, tmp):
-        with tempfile.TemporaryFile("w+", dir=tmp, encoding="utf-8") as f:
-            json.dump(self.items, f)
-            f.seek(0)
-            yield f.fileno()
 
     # "name", "id", "stages", "results" is only here to make it looks like a
     # pipeline for the monitor. This should be revisited at some point
@@ -103,12 +93,6 @@ class SourceService(host.Service):
         """Returns True if the item to download is in cache. """
         return os.path.isfile(f"{self.cache}/{checksum}")
 
-    @staticmethod
-    def load_items(fds):
-        with os.fdopen(fds.steal(0)) as f:
-            items = json.load(f)
-        return items
-
     def setup(self, args):
         self.cache = os.path.join(args["cache"], self.content_type)
         os.makedirs(self.cache, exist_ok=True)
@@ -118,7 +102,7 @@ class SourceService(host.Service):
         if method == "download":
             self.setup(args)
             with tempfile.TemporaryDirectory(prefix=".unverified-", dir=self.cache) as self.tmpdir:
-                self.fetch_all(SourceService.load_items(fds))
+                self.fetch_all(args["items"])
                 return None, None
 
         raise host.ProtocolError("Unknown method")

--- a/osbuild/util/jsoncomm.py
+++ b/osbuild/util/jsoncomm.py
@@ -13,12 +13,20 @@ import os
 import socket
 from typing import Any, List, Optional
 
+from .linux import Libc
 from .types import PathLike
 
 
 @contextlib.contextmanager
 def memfd(name):
-    fd = os.memfd_create(name, 0)
+    if hasattr(os, "memfd_create"):
+        fd = os.memfd_create(name)
+    else:
+        # we can remove this "if/else" once we are at python3.8+
+        # and just use "os.memfd_create()"
+        libc = Libc.default()
+        fd = libc.memfd_create(name)
+
     try:
         yield fd
     finally:

--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -490,6 +490,29 @@ class Libc:
         setattr(proto, "errcheck", self._errcheck_errno)
         setattr(proto, "__name__", "futimens")
         self.futimens = proto
+        # prototype: _memfd_create() (takes a byte type name)
+        # (can be removed once we move to python3.8)
+        proto = ctypes.CFUNCTYPE(
+            ctypes.c_int,  # restype (return type)
+            ctypes.c_char_p,
+            ctypes.c_uint,
+            use_errno=True,
+        )(
+            ("memfd_create", self._lib),
+            (
+                (1, "name"),
+                (1, "flags", 0),
+            ),
+        )
+        setattr(proto, "errcheck", self._errcheck_errno)
+        setattr(proto, "__name__", "memfd_create")
+        self._memfd_create = proto
+
+    # (can be removed once we move to python3.8)
+    def memfd_create(self, name: str, flags: int = 0) -> int:
+        """ create an anonymous file """
+        char_p_name = name.encode()
+        return self._memfd_create(char_p_name, flags)
 
     @staticmethod
     def make() -> "Libc":

--- a/test/mod/test_util_linux.py
+++ b/test/mod/test_util_linux.py
@@ -187,6 +187,7 @@ def test_libc():
     assert libc0.RENAME_NOREPLACE
     assert libc0.RENAME_WHITEOUT
     assert libc0.renameat2
+    assert libc0.memfd_create
 
 
 def test_libc_renameat2_errcheck():
@@ -224,6 +225,23 @@ def test_libc_renameat2_exchange(tmpdir):
         assert f.read() == "bar"
     with open(f"{tmpdir}/bar", "r", encoding="utf8") as f:
         assert f.read() == "foo"
+
+
+def test_libc_memfd_create_errcheck():
+    libc = linux.Libc.default()
+    with pytest.raises(OSError) as exc:
+        libc.memfd_create("foo", -1)
+    assert "Invalid argument" in str(exc.value)
+
+
+def test_libc_memfd_create():
+    libc = linux.Libc.default()
+    fd = libc.memfd_create("foo", 0)
+    os.write(fd, b"file content")
+    fd2 = os.dup(fd)
+    os.close(fd)
+    os.lseek(fd2, 0, 0)
+    assert os.read(fd2, 4096) == b"file content"
 
 
 def test_proc_boot_id():


### PR DESCRIPTION
The existing jsoncomm is a work of beauty. For very big arguments however the used `SOCK_SEQPACKET` hits the limitations of the kernel network buffer size (see also [0]). This lead to various workarounds in #824,#1331,#1836 where parts of the request are encoded as part of the json method call and parts are done via a side-channel via fd-passing.

This commit changes the code so that the fd channel is automatically and transparently created and the workarounds are removed. A test is added that ensures that very big messages can be passed.

[0] https://github.com/osbuild/osbuild/pull/1833