### PR TITLE
[RFC] have a single DispatchMixin instead of multiple (subtly differnt) dispatch()

### DIFF
--- a/devices/org.osbuild.loopback
+++ b/devices/org.osbuild.loopback
@@ -25,7 +25,7 @@ import stat
 import sys
 from typing import Dict
 
-from osbuild import devices, loop
+from osbuild import devices, host, loop
 from osbuild.util import ctx
 from osbuild.util.udev import UdevInhibitor
 
@@ -93,7 +93,9 @@ class LoopbackService(devices.DeviceService):
 
         return lo
 
-    def open(self, devpath: str, parent: str, tree: str, options: Dict):
+    @host.callable
+    def open(self, dev: str, parent: str, tree: str, options: Dict):
+        devpath = dev
         filename = options["filename"]
         self.sector_size = options.get("sector-size", 512)
         start = options.get("start", 0) * self.sector_size
@@ -140,6 +142,7 @@ class LoopbackService(devices.DeviceService):
 
         return res
 
+    @host.callable
     def close(self):
         # Calling `close` is valid on closed
         # `LoopControl` and `Loop` objects

--- a/devices/org.osbuild.luks2
+++ b/devices/org.osbuild.luks2
@@ -20,7 +20,7 @@ import sys
 import uuid
 from typing import Dict, Optional
 
-from osbuild import devices
+from osbuild import devices, host
 from osbuild.util.udev import UdevInhibitor
 
 SCHEMA = """
@@ -74,6 +74,7 @@ class CryptDeviceService(devices.DeviceService):
             _, _, count = self.dminfo(name)
         return count
 
+    @host.callable
     def open(self, devpath: str, parent: str, tree: str, options: Dict):
         passphrase = options.get("passphrase", "")
 
@@ -123,6 +124,7 @@ class CryptDeviceService(devices.DeviceService):
         }
         return data
 
+    @host.callable
     def close(self):
         if not self.devname:
             return

--- a/devices/org.osbuild.lvm2.lv
+++ b/devices/org.osbuild.lvm2.lv
@@ -35,7 +35,7 @@ import sys
 import time
 from typing import Dict, Tuple, Union
 
-from osbuild import devices
+from osbuild import devices, host
 
 SCHEMA = """
 "additionalProperties": false,
@@ -171,6 +171,7 @@ class LVService(devices.DeviceService):
 
         return major, minor
 
+    @host.callable
     def open(self, devpath: str, parent: str, tree: str, options: Dict):
         lv = options["volume"]
 
@@ -212,6 +213,7 @@ class LVService(devices.DeviceService):
         }
         return data
 
+    @host.callable
     def close(self):
         if self.fullname:
             self.lv_set_active(self.fullname, False)

--- a/inputs/org.osbuild.containers
+++ b/inputs/org.osbuild.containers
@@ -20,7 +20,7 @@ root of the tree is used as the oci archive file to install.
 import os
 import sys
 
-from osbuild import inputs
+from osbuild import host, inputs
 from osbuild.util.mnt import MountGuard
 
 SCHEMA = r"""
@@ -190,7 +190,8 @@ class ContainersInput(inputs.InputService):
 
         return files[0], "oci-archive"
 
-    def map(self, store, origin, refs, target, _options):
+    @host.callable_with_store
+    def map(self, store, origin, refs, target, options):
         source = store.source("org.osbuild.containers")
         images = {}
 

--- a/inputs/org.osbuild.containers-storage
+++ b/inputs/org.osbuild.containers-storage
@@ -14,7 +14,7 @@ resource (the specific container) on the host.
 import os
 import sys
 
-from osbuild import inputs
+from osbuild import host, inputs
 from osbuild.util import containers
 from osbuild.util.mnt import MountGuard
 
@@ -99,7 +99,8 @@ class ContainersStorageInput(inputs.InputService):
         os.makedirs(dest, exist_ok=True)
         self.mg.mount(source, dest)
 
-    def map(self, store, origin, refs, target, _options):
+    @host.callable_with_store
+    def map(self, store, origin, refs, target, options):
         self.bind_mount_local_storage(target)
 
         images = {}

--- a/inputs/org.osbuild.files
+++ b/inputs/org.osbuild.files
@@ -18,7 +18,7 @@ import os
 import pathlib
 import sys
 
-from osbuild import inputs
+from osbuild import host, inputs
 
 SCHEMA = r"""
 "definitions": {
@@ -196,7 +196,8 @@ class FilesInput(inputs.InputService):
         data = data.get("metadata", {})
         return ref, data
 
-    def map(self, store, origin, refs, target, _options):
+    @host.callable_with_store
+    def map(self, store, origin, refs, target, options):
 
         source = store.source("org.osbuild.files")
         files = {}

--- a/inputs/org.osbuild.noop
+++ b/inputs/org.osbuild.noop
@@ -11,7 +11,7 @@ import os
 import sys
 import uuid
 
-from osbuild import inputs
+from osbuild import host, inputs
 
 SCHEMA = """
 "additionalProperties": true
@@ -20,7 +20,8 @@ SCHEMA = """
 
 class NoopInput(inputs.InputService):
 
-    def map(self, _store, _origin, refs, target, _options):
+    @host.callable_with_store
+    def map(self, store, origin, refs, target, options):
 
         uid = str(uuid.uuid4())
         path = os.path.join(target, uid)

--- a/inputs/org.osbuild.ostree
+++ b/inputs/org.osbuild.ostree
@@ -16,7 +16,7 @@ import json
 import os
 import sys
 
-from osbuild import inputs
+from osbuild import host, inputs
 from osbuild.util import ostree
 
 SCHEMA = """
@@ -117,7 +117,8 @@ def export(checksums, cache, output):
 
 class OSTreeInput(inputs.InputService):
 
-    def map(self, store, origin, refs, target, _options):
+    @host.callable_with_store
+    def map(self, store, origin, refs, target, options):
 
         if origin == "org.osbuild.pipeline":
             for ref, options in refs.items():

--- a/inputs/org.osbuild.ostree.checkout
+++ b/inputs/org.osbuild.ostree.checkout
@@ -13,7 +13,7 @@ import os
 import subprocess
 import sys
 
-from osbuild import inputs
+from osbuild import host, inputs
 
 SCHEMA = """
 "additionalProperties": false,
@@ -97,8 +97,8 @@ def checkout(checksums, cache, output):
 
 class OSTreeCheckoutInput(inputs.InputService):
 
-    def map(self, store, origin, refs, target, _options):
-
+    @host.callable_with_store
+    def map(self, store, origin, refs, target, options):
         ids = []
 
         if origin == "org.osbuild.pipeline":
@@ -118,7 +118,6 @@ class OSTreeCheckoutInput(inputs.InputService):
                 "refs": {i: {"path": i} for i in ids}
             }
         }
-
         return reply
 
 

--- a/inputs/org.osbuild.tree
+++ b/inputs/org.osbuild.tree
@@ -10,7 +10,7 @@ string it returns an empty tree.
 
 import sys
 
-from osbuild import inputs
+from osbuild import host, inputs
 
 SCHEMA = """
 "additionalProperties": false,
@@ -72,7 +72,8 @@ SCHEMA = """
 
 class TreeInput(inputs.InputService):
 
-    def map(self, store, _origin, refs, target, _options):
+    @host.callable_with_store
+    def map(self, store, origin, refs, target, options):
 
         # input verification *must* have been done via schema
         # verification. It is expected that origin is a pipeline

--- a/mounts/org.osbuild.bind
+++ b/mounts/org.osbuild.bind
@@ -8,10 +8,9 @@ Can (r)bind mount mounts to the tree.
 import os.path
 import subprocess
 import sys
-from typing import Dict
 from urllib.parse import urlparse
 
-from osbuild import mounts
+from osbuild import host, mounts
 
 SCHEMA_2 = """
 "additionalProperties": false,
@@ -52,17 +51,14 @@ class BindMount(mounts.MountService):
         super().__init__(args)
         self.mountpoint = ""
 
-    def mount(self, args: Dict):
-        tree = args["tree"]
-        mountroot = args["root"]
-        target = args["target"]
-        # we cannot use args["sources"] here because the osbuild code makes
+    @host.callable
+    def mount(self, source, target, root, tree, options):
+        # we cannot use "sources" here because the osbuild code makes
         # many assumptions about that it must link back to a "Device" so
         # we follow the pattern from org.osbuild.ostree.deployment here
         # and put it into "options"
-        options = args["options"]
-        source = parse_location(options.get("source"), tree, mountroot)
-        self.mountpoint = parse_location(target, tree, mountroot)
+        source = parse_location(options.get("source"), tree, root)
+        self.mountpoint = parse_location(target, tree, root)
         subprocess.run([
             "mount",
             "--rbind", source, self.mountpoint,

--- a/mounts/org.osbuild.noop
+++ b/mounts/org.osbuild.noop
@@ -8,9 +8,8 @@ Useful for testing.
 
 import os
 import sys
-from typing import Dict
 
-from osbuild import mounts
+from osbuild import host, mounts
 
 SCHEMA_2 = """
 "additionalProperties": false,
@@ -38,10 +37,8 @@ SCHEMA_2 = """
 class NoOpMount(mounts.MountService):
     mountpoint = None
 
-    def mount(self, args: Dict):
-        root = args["root"]
-        target = args["target"]
-
+    @host.callable
+    def mount(self, source, target, root, tree, options):
         mountpoint = os.path.join(root, target.lstrip("/"))
 
         os.makedirs(mountpoint, exist_ok=True)

--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -17,9 +17,8 @@ Host commands used: mount
 import os
 import subprocess
 import sys
-from typing import Dict
 
-from osbuild import mounts
+from osbuild import host, mounts
 from osbuild.util import ostree
 
 SCHEMA_2 = """
@@ -118,18 +117,15 @@ class OSTreeDeploymentMount(mounts.MountService):
             cp.check_returncode()  # will raise error
         return cp.returncode == 0
 
-    def mount(self, args: Dict):
-
-        tree = args["tree"]
-        mountroot = args["root"]
-        options = args["options"]
+    @host.callable
+    def mount(self, source, target, root, tree, options):
         source = options.get("source", "tree")
         deployment = options["deployment"]
 
         # The user could specify either the tree or mountroot as the
         # place where we want the deployment to be mounted.
         if source == "mount":
-            target = mountroot
+            target = root
         else:
             target = tree
 

--- a/osbuild/devices.py
+++ b/osbuild/devices.py
@@ -96,7 +96,7 @@ class DeviceManager:
         return res
 
 
-class DeviceService(host.Service):
+class DeviceService(host.DispatchMixin, host.Service):
     """Device host service"""
 
     @staticmethod
@@ -122,16 +122,3 @@ class DeviceService(host.Service):
 
     def stop(self):
         self.close()
-
-    def dispatch(self, method: str, args, _fds):
-        if method == "open":
-            r = self.open(args["dev"],
-                          args["parent"],
-                          args["tree"],
-                          args["options"])
-            return r, None
-        if method == "close":
-            r = self.close()
-            return r, None
-
-        raise host.ProtocolError("Unknown method")

--- a/osbuild/inputs.py
+++ b/osbuild/inputs.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, Optional, Tuple
 from osbuild import host
 from osbuild.util.types import PathLike
 
-from .objectstore import StoreClient, StoreServer
+from .objectstore import StoreServer
 
 
 class Input:
@@ -101,7 +101,7 @@ class InputManager:
         return reply
 
 
-class InputService(host.Service):
+class InputService(host.DispatchMixin, host.Service):
     """Input host service"""
 
     @abc.abstractmethod
@@ -113,15 +113,3 @@ class InputService(host.Service):
 
     def stop(self):
         self.unmap()
-
-    def dispatch(self, method: str, args, fds):
-        if method == "map":
-            store = StoreClient(connect_to=args["api"]["store"])
-            r = self.map(store,
-                         args["origin"],
-                         args["refs"],
-                         args["target"],
-                         args["options"])
-            return r, None
-
-        raise host.ProtocolError("Unknown method")

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -210,7 +210,7 @@ class Stage:
 
             ipmgr = InputManager(mgr, storeapi, inputs_tmpdir)
             for key, ip in self.inputs.items():
-                data = ipmgr.map(ip, store)
+                data = ipmgr.map(ip)
                 inputs[key] = data
 
             devmgr = DeviceManager(mgr, build_root.dev, tree)

--- a/osbuild/util/jsoncomm.py
+++ b/osbuild/util/jsoncomm.py
@@ -13,12 +13,20 @@ import os
 import socket
 from typing import Any, List, Optional
 
+from .linux import Libc
 from .types import PathLike
 
 
 @contextlib.contextmanager
 def memfd(name):
-    fd = os.memfd_create(name, 0)
+    if hasattr(os, "memfd_create"):
+        fd = os.memfd_create(name)
+    else:
+        # we can remove this "if/else" once we are at python3.8+
+        # and just use "os.memfd_create()"
+        libc = Libc.default()
+        fd = libc.memfd_create(name)
+
     try:
         yield fd
     finally:

--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -490,6 +490,29 @@ class Libc:
         setattr(proto, "errcheck", self._errcheck_errno)
         setattr(proto, "__name__", "futimens")
         self.futimens = proto
+        # prototype: _memfd_create() (takes a byte type name)
+        # (can be removed once we move to python3.8)
+        proto = ctypes.CFUNCTYPE(
+            ctypes.c_int,  # restype (return type)
+            ctypes.c_char_p,
+            ctypes.c_uint,
+            use_errno=True,
+        )(
+            ("memfd_create", self._lib),
+            (
+                (1, "name"),
+                (1, "flags", 0),
+            ),
+        )
+        setattr(proto, "errcheck", self._errcheck_errno)
+        setattr(proto, "__name__", "memfd_create")
+        self._memfd_create = proto
+
+    # (can be removed once we move to python3.8)
+    def memfd_create(self, name: str, flags: int = 0) -> int:
+        """ create an anonymous file """
+        char_p_name = name.encode()
+        return self._memfd_create(char_p_name, flags)
 
     @staticmethod
     def make() -> "Libc":

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -111,8 +111,8 @@ class OSTreeSource(sources.SourceService):
         # Remove the temporary remote again
         ostree.cli("remote", "delete", name, repo=self.repo)
 
-    def setup(self, args):
-        super().setup(args)
+    def setup(self, cache):
+        super().setup(cache)
         # Prepare the cache and the output repo
         self.repo = os.path.join(self.cache, "repo")
         ostree.cli("init", mode="archive", repo=self.repo)
@@ -124,6 +124,7 @@ class OSTreeSource(sources.SourceService):
 
     # pylint: disable=[no-self-use]
     def exists(self, checksum, _desc):
+
         try:
             ostree.show(self.repo, checksum)
         except RuntimeError:

--- a/test/mod/test_inputs.py
+++ b/test/mod/test_inputs.py
@@ -1,16 +1,17 @@
 import os
-from unittest.mock import call, patch
+from unittest.mock import patch
 
-from osbuild import inputs
+from osbuild import host, inputs
 
 
 class FakeInputService(inputs.InputService):
-    def __init__(self, args):  # pylint: disable=super-init-not-called
+    def __init__(self, args):
         # do not call "super().__init__()" here to make it testable
-        self.map_calls = []
+        self._map_calls = []
 
+    @host.callable_with_store
     def map(self, store, origin, refs, target, options):
-        self.map_calls.append([origin, refs, target, options])
+        self._map_calls.append([origin, refs, target, options])
         return "complex", 2, "reply"
 
 
@@ -29,12 +30,9 @@ def test_inputs_dispatches_map(tmp_path):
     }
 
     fake_service = FakeInputService(args="some")
-    with patch.object(inputs, "StoreClient") as mocked_store_client_klass:
+    with patch.object(host, "StoreClient"):
         r = fake_service.dispatch("map", args, None)
-    assert mocked_store_client_klass.call_args_list == [
-        call(connect_to=os.fspath(store_api_path)),
-    ]
-    assert fake_service.map_calls == [
+    assert fake_service._map_calls == [
         ["some-origin", "some-refs", "some-target", "some-options"],
     ]
     assert r == (("complex", 2, "reply"), None)

--- a/test/mod/test_util_linux.py
+++ b/test/mod/test_util_linux.py
@@ -187,6 +187,7 @@ def test_libc():
     assert libc0.RENAME_NOREPLACE
     assert libc0.RENAME_WHITEOUT
     assert libc0.renameat2
+    assert libc0.memfd_create
 
 
 def test_libc_renameat2_errcheck():
@@ -224,6 +225,23 @@ def test_libc_renameat2_exchange(tmpdir):
         assert f.read() == "bar"
     with open(f"{tmpdir}/bar", "r", encoding="utf8") as f:
         assert f.read() == "foo"
+
+
+def test_libc_memfd_create_errcheck():
+    libc = linux.Libc.default()
+    with pytest.raises(OSError) as exc:
+        libc.memfd_create("foo", -1)
+    assert "Invalid argument" in str(exc.value)
+
+
+def test_libc_memfd_create():
+    libc = linux.Libc.default()
+    fd = libc.memfd_create("foo", 0)
+    os.write(fd, b"file content")
+    fd2 = os.dup(fd)
+    os.close(fd)
+    os.lseek(fd2, 0, 0)
+    assert os.read(fd2, 4096) == b"file content"
 
 
 def test_proc_boot_id():

--- a/test/mod/test_util_mnt.py
+++ b/test/mod/test_util_mnt.py
@@ -54,8 +54,9 @@ def test_osbuild_mount_failure_msg(tmp_path):
             "source": "/dev/invalid-src",
             "target": os.fspath(tmp_path),
             "root": "/",
+            "tree": "",
             "options": [],
         }
-        mnt_service.mount(args)
+        mnt_service.mount(**args)
     assert re.search(
         r"special device /dev/invalid-src does not exist|Can't open blockdev.|Can't lookup blockdev", str(e.value))


### PR DESCRIPTION
[based on https://github.com/osbuild/osbuild/pull/1838]

This is an experiment to get rid of the various "dispatch()" helpers and replace them with a single Mixin (could also just be part of the base-class, no strong opinion here) and two decorators . This would allow us to handle them all in a more symetric way. Right now some (like mount) just pass an argument dict into the function and let the function decode it, other pass all args. I guess my worry would be if it's too much magic - but I think it woudl be worthwhile to bring them closer, i.e. at least call mounts in the same way as e.g. devices.