### PR TITLE
stages/dmverity: make device objects more generic

### DIFF
--- a/stages/org.osbuild.dmverity.meta.json
+++ b/stages/org.osbuild.dmverity.meta.json
@@ -30,27 +30,11 @@
       "properties": {
         "data_device": {
           "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "path"
-          ],
-          "properties": {
-            "path": {
-              "type": "string"
-            }
-          }
+          "additionalProperties": true
         },
         "hash_device": {
           "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "path"
-          ],
-          "properties": {
-            "path": {
-              "type": "string"
-            }
-          }
+          "additionalProperties": true
         }
       }
     }


### PR DESCRIPTION
We need to pass loopback devices for these properties, but the schema says that there will be a `path` property, so osbuild complains.

osbuild is right of course, but this definitely *did* work in an earlier version, so something changed. Ideally, we'd narrow down here what happened exactly, but at the same time this approach of just making the property more generic matches what's done in e.g. the `zipl.inst` stage where we also use a loopback device.

For reference, this is where we use this stage:

https://github.com/coreos/coreos-assembler/blob/ba45b296ec11734bafcae7728915016f17137a3d/src/osbuild-manifests/platform.qemu.ipp.yaml#L100-L119