### PR TITLE
Stages/`org.osbuild.dracut`: fix runtime environment for dracut (COMPOSER-2193)

### DIFF
--- a/stages/org.osbuild.dracut
+++ b/stages/org.osbuild.dracut
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import os
 import subprocess
 import sys
 
@@ -8,6 +9,36 @@ import osbuild.api
 def yesno(name: str, value: bool) -> str:
     prefix = "" if value else "no-"
     return f"--{prefix}{name}"
+
+
+class DracutMounts:
+    """
+    Setup the mounts inside a chroot root directory, which will be used
+    for running dracut inside it. Cleanup mounts when done.
+    This mounts /proc, /dev, and /sys.
+    """
+
+    def __init__(self, root: str):
+        self.root = root
+
+    def __enter__(self):
+        for d in ["/proc", "/dev", "/sys"]:
+            if not os.path.exists(self.root + d):
+                print(f"Making missing dracut chroot directory: {d}")
+                os.makedirs(self.root + d)
+
+        subprocess.check_call(["/usr/bin/mount", "-t", "proc", "-o",
+                               "nosuid,noexec,nodev", "proc", f"{self.root}/proc"])
+        subprocess.check_call(["/usr/bin/mount", "-t", "devtmpfs", "-o",
+                               "mode=0755,noexec,nosuid,strictatime", "devtmpfs", f"{self.root}/dev"])
+        subprocess.check_call(["/usr/bin/mount", "-t", "sysfs", "-o",
+                               "nosuid,noexec,nodev", "sysfs", f"{self.root}/sys"])
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, tracebk):
+        for d in ["/proc", "/dev", "/sys"]:
+            subprocess.check_call(["/usr/bin/umount", self.root + d])
 
 
 # pylint: disable=too-many-branches
@@ -82,11 +113,12 @@ def main(tree, options):
         if initoverlayfs:
             initfs_bin = "/usr/bin/initoverlayfs-install"
 
-        subprocess.run(["/usr/sbin/chroot", tree, initfs_bin,
-                        "--no-hostonly",
-                        "--kver", kver]
-                       + opts,
-                       check=True)
+        with DracutMounts(tree):
+            subprocess.run(["/usr/sbin/chroot", tree, initfs_bin,
+                            "--no-hostonly",
+                            "--kver", kver]
+                           + opts,
+                           check=True)
 
     return 0
 

--- a/stages/test/test_dracut.py
+++ b/stages/test/test_dracut.py
@@ -20,7 +20,7 @@ def test_dracut_with_initoverlayfs(mocked_run, tmp_path, stage_module, with_init
         "initoverlayfs": with_initoverlayfs,
     }
 
-    stage_module.main(tmp_path, options)
+    stage_module.main(str(tmp_path), options)
 
     assert len(mocked_run.call_args_list) == 1
     args, kwargs = mocked_run.call_args_list[0]


### PR DESCRIPTION
While adding support for `image-installer` image type for RHEL-10, I've ran into multiple issues when trying to boot the Anaconda ISO. One of them was related to Anaconda not being able to parse the kickstart due to missing CA certificates bundle in the initram disk. It turned out that this was caused by the fact that the dracut stage executes the dracut binary in an unsupported environment, which caused it to fail to copy the file into the initram disk.

Fix the stage and extend the unit test to check stage output for suspicious messages.

### Details

dracut expects the environment, in which it is run, to have properly mounted `/proc`, `/dev` and `/sys`. Otherwise, some of its modules don't work properly. E.g. dracut fails to embed the CA cert bundle into the initram disk, which means that HTTPS won't work in it. dracut also prints a lot of errors and warnings about this, but we used to ignore them until now.

The buildroot environment in which the stage runs is OK, but we actually run dracut using `chroot`, which is the core of the problem. The runtime environment in such case lacks the necessary mounts.

Add a context manager for setting up and cleaning up all the necessary mounts in the image FS tree when running dracut.

This change is related to:
https://bugzilla.redhat.com/show_bug.cgi?id=1962975

And the implementation has been inspired by the fix in lorax:
https://github.com/weldr/lorax/pull/1151