### PR TITLE
osbuild: drop `libdir` from `download()` methods

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -177,7 +177,7 @@ def osbuild_cli() -> int:
             monitor = osbuild.monitor.make(monitor_name, args.monitor_fd, total_steps)
             monitor.log(f"starting {args.manifest_path}", origin="osbuild.main_cli")
 
-            manifest.download(object_store, monitor, args.libdir)
+            manifest.download(object_store, monitor)
 
             r = manifest.build(
                 object_store,

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -409,13 +409,13 @@ class Manifest:
         self.sources.append(source)
         return source
 
-    def download(self, store, monitor, libdir):
+    def download(self, store, monitor):
         with host.ServiceManager(monitor=monitor) as mgr:
             for source in self.sources:
                 # Workaround for lack of progress from sources, this
                 # will need to be reworked later.
                 monitor.begin(source)
-                source.download(mgr, store, libdir)
+                source.download(mgr, store)
                 monitor.finish({"name": source.info.name})
 
     def depsolve(self, store: ObjectStore, targets: Iterable[str]) -> List[str]:

--- a/osbuild/sources.py
+++ b/osbuild/sources.py
@@ -8,7 +8,6 @@ from typing import ClassVar, Dict
 
 from . import host
 from .objectstore import ObjectStore
-from .util.types import PathLike
 
 
 class Source:
@@ -25,7 +24,7 @@ class Source:
         self.runner = None
         self.source_epoch = None
 
-    def download(self, mgr: host.ServiceManager, store: ObjectStore, libdir: PathLike):
+    def download(self, mgr: host.ServiceManager, store: ObjectStore):
         source = self.info.name
         cache = os.path.join(store.store, "sources")
 
@@ -34,7 +33,6 @@ class Source:
             "cache": cache,
             "output": None,
             "checksums": [],
-            "libdir": os.fspath(libdir)
         }
 
         client = mgr.start(f"source/{source}", self.info.path)

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -101,14 +101,14 @@ def make_test_cases():
                 yield source, case
 
 
-def check_case(source, case, store, libdir):
+def check_case(source, case_options, store):
     with host.ServiceManager() as mgr:
-        expects = case["expects"]
+        expects = case_options["expects"]
         if expects == "error":
             with pytest.raises(host.RemoteError):
-                source.download(mgr, store, libdir)
+                source.download(mgr, store)
         elif expects == "success":
-            source.download(mgr, store, libdir)
+            source.download(mgr, store)
         else:
             raise ValueError(f"invalid expectation: {expects}")
 
@@ -131,5 +131,5 @@ def test_sources(source, case, tmp_path):
 
     with osbuild.objectstore.ObjectStore(tmp_path) as store, \
             fileServer(test.TestBase.locate_test_data()):
-        check_case(src, case_options, store, index.path)
-        check_case(src, case_options, store, index.path)
+        check_case(src, case_options, store)
+        check_case(src, case_options, store)


### PR DESCRIPTION
The libdir is passed down for sources but it is never used in any of our sources. As this is confusing and we want to eventually support multiple libdirs remove this code.

It looks like the libdir for soruces was added a long time ago in 8423da368 but there is no indication if/how it is/was supposed to get used and AFACT from going over the git history it was very used.

~Technically it's API break because it was part of the json msg to a source so it could break third party sources modules.~ [actually no, SourceService:dispatch()  never sends it to the actual sources]