### PR TITLE
osbuild: add "Conflicts"/"Provides" to avoid breaking composer

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -144,6 +144,15 @@ Requires: python3-libdnf5 >= 5.2.1
 Requires: python3-libdnf
 %endif
 
+# osbuild 125 added a new "solver" field and osbuild-composer only
+# supports this since 116
+Conflicts: osbuild-composer <= 115
+
+# This version needs to get bumped every time the osbuild-dnf-json
+# version changes in an incompatible way. Packages like osbuild-composer
+# can depend on the exact API version this way
+Provides: osbuild-dnf-json-api = 7
+
 %description    depsolve-dnf
 Contains depsolving capabilities for package managers.
 


### PR DESCRIPTION
osbuild 126 added a new "solver" field in the osbuild-dnf-json output and osbuild-composer only supports this since 116.

This broke production (sorry!). This commit helps mitigate it.