### PR TITLE
osbuild: support multiple dirs in `--libdir` via PATH like ":" separator

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -72,8 +72,13 @@ def parse_arguments(sys_argv: List[str]) -> argparse.Namespace:
     parser.add_argument("--store", metavar="DIRECTORY", type=os.path.abspath,
                         default=".osbuild",
                         help="directory where intermediary os trees are stored")
-    parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath, default="/usr/lib/osbuild",
-                        help="directory containing stages, assemblers, and the osbuild library")
+    parser.add_argument(
+        "-l",
+        "--libdir",
+        metavar="DIRECTORY",
+        type=os.path.abspath,
+        action="append",
+        help="search path containing stages, assemblers, and the osbuild library (can contain ':' or can be given multiple times)")
     parser.add_argument("--cache-max-size", metavar="SIZE", type=parse_size, default=None,
                         help="maximum size of the cache (bytes) or 'unlimited' for no restriction")
     parser.add_argument(
@@ -114,7 +119,11 @@ def osbuild_cli() -> int:
     args = parse_arguments(sys.argv)
     desc = parse_manifest(args.manifest_path)
 
-    index = osbuild.meta.Index(args.libdir)
+    if args.libdir is None:
+        libdir = "/usr/lib/osbuild"
+    else:
+        libdir = ":".join(args.libdir)
+    index = osbuild.meta.Index(libdir)
 
     # detect the format from the manifest description
     info = index.detect_format_info(desc)
@@ -186,7 +195,7 @@ def osbuild_cli() -> int:
                 object_store,
                 pipelines,
                 monitor,
-                args.libdir,
+                libdir,
                 debug_break,
                 stage_timeout=stage_timeout
             )

--- a/osbuild/util/libdir.py
+++ b/osbuild/util/libdir.py
@@ -1,0 +1,37 @@
+import os.path
+from typing import List
+
+
+class Libdir:
+    """Libdir abstracts the osbuild --libdir handling"""
+
+    def __init__(self, libdir: str) -> None:
+        self._libdir = [os.path.abspath(p)
+                        for p in libdir.split(":")]
+
+    @property
+    def libdir(self) -> str:
+        """Return the libdir as a ":" separated PATH like string"""
+        return ":".join(self._libdir)
+
+    @property
+    def dirs(self) -> List[str]:
+        """Return a list of host libdirs"""
+        return self._libdir
+
+    @property
+    def buildroot_dirs(self) -> List[str]:
+        """Return a list of buildroot paths for the libdir"""
+        dirs = []
+        buildroot_base = "/run/osbuild/lib"
+        for i in range(len(self.dirs)):
+            if i == 0:
+                dirs.append(buildroot_base)
+            else:
+                dirs.append(buildroot_base + str(i))
+        return dirs
+
+    @property
+    def buildroot_libdir(self) -> str:
+        """Return the buildroot libdir as a ":" separated PATH like string"""
+        return ":".join(self.buildroot_dirs)

--- a/osbuild/util/libdir.py
+++ b/osbuild/util/libdir.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 from typing import List
 
 

--- a/test/mod/test_util_libdir.py
+++ b/test/mod/test_util_libdir.py
@@ -1,0 +1,32 @@
+from osbuild.util.libdir import Libdir
+
+
+def test_libdir_libdir():
+    ld = Libdir("/foo")
+    assert ld.libdir == "/foo"
+    ld = Libdir("/foo:/bar")
+    assert ld.libdir == "/foo:/bar"
+    # paths are normalized
+    ld = Libdir("/../foo:/bar/./")
+    assert ld.libdir == "/foo:/bar"
+
+
+def test_libdir_dirs():
+    ld = Libdir("/foo")
+    assert ld.dirs == ["/foo"]
+    ld = Libdir("/foo:/bar")
+    assert ld.dirs == ["/foo", "/bar"]
+
+
+def test_libdir_buildroot_dirs():
+    ld = Libdir("/foo")
+    assert ld.buildroot_dirs == ["/run/osbuild/lib"]
+    ld = Libdir("/foo:/bar")
+    assert ld.buildroot_dirs == ["/run/osbuild/lib", "/run/osbuild/lib1"]
+
+
+def test_libdir_buildroot_libdir():
+    ld = Libdir("/foo")
+    assert ld.buildroot_libdir == "/run/osbuild/lib"
+    ld = Libdir("/foo:/bar")
+    assert ld.buildroot_libdir == "/run/osbuild/lib:/run/osbuild/lib1"

--- a/test/run/test_exports.py
+++ b/test/run/test_exports.py
@@ -2,8 +2,6 @@ import contextlib
 import json
 import os
 import pathlib
-import shutil
-import subprocess
 
 import pytest
 
@@ -48,24 +46,10 @@ def osbuild_fixture():
         yield osb
 
 
-@pytest.fixture(name="testing_libdir", scope="module")
-def testing_libdir_fixture(tmpdir_factory):
+@pytest.fixture(name="testing_libdir")
+def testing_libdir_fixture():
     tests_path = pathlib.Path(__file__).parent.parent
-    project_path = tests_path.parent
-    testing_libdir_path = tests_path / "stages"
-    fake_libdir_path = tmpdir_factory.mktemp("fake-libdir")
-    # there must be an empty "osbild" dir for a "os.listdir(self._libdir)"
-    # in buildroot.py
-    (fake_libdir_path / "osbuild").mkdir()
-    # construct minimal viable libdir from current checkout
-    for d in ["stages", "runners", "schemas", "assemblers"]:
-        subprocess.run(
-            ["cp", "-a", os.fspath(project_path / d), f"{fake_libdir_path}"],
-            check=True)
-    # now inject testing stages
-    for p in testing_libdir_path.glob("org.osbuild.testing.*"):
-        shutil.copy2(p, fake_libdir_path / "stages")
-    yield fake_libdir_path
+    yield f".:{tests_path}"
 
 
 @pytest.mark.skipif(os.getuid() != 0, reason="root-only")


### PR DESCRIPTION
This allows to write:
```
$ osbuild --libdir /home/foo/osbuild:/usr/lib/osbuild
```

[draft as it needs more tests and also https://github.com/osbuild/osbuild/pull/1848]