### PR TITLE
Add toml utility module that wraps every toml Python module ever created

### DIFF
--- a/inputs/org.osbuild.containers-storage
+++ b/inputs/org.osbuild.containers-storage
@@ -15,7 +15,7 @@ import os
 import sys
 
 from osbuild import inputs
-from osbuild.util import containers
+from osbuild.util import host
 from osbuild.util.mnt import MountGuard
 
 SCHEMA = r"""
@@ -89,7 +89,7 @@ class ContainersStorageInput(inputs.InputService):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.mg = MountGuard()
-        self.storage_conf = containers.get_host_storage()
+        self.storage_conf = host.get_container_storage()
 
     def bind_mount_local_storage(self, target):
         source = self.storage_conf["storage"]["graphroot"]

--- a/osbuild/util/containers.py
+++ b/osbuild/util/containers.py
@@ -188,17 +188,12 @@ def get_host_storage():
     """
     # pylint: disable=import-outside-toplevel
     # importing this at the top level will break the buildroot
-    try:
-        import tomllib as toml
-    except ImportError:
-        import tomli as toml
+    from osbuild.util import toml
 
     config_paths = ("/etc/containers/storage.conf", "/usr/share/containers/storage.conf")
     for conf_path in config_paths:
         try:
-            with open(conf_path, "rb") as conf_file:
-                storage_conf = toml.load(conf_file)
-            return storage_conf
+            return toml.load_from_file(conf_path)
         except FileNotFoundError:
             pass
 

--- a/osbuild/util/containers.py
+++ b/osbuild/util/containers.py
@@ -180,21 +180,3 @@ def container_source(image):
 
     with container_source_fn(image, image_filepath, container_format) as image_source:
         yield image_name, image_source
-
-
-def get_host_storage():
-    """
-    Read the host storage configuration.
-    """
-    # pylint: disable=import-outside-toplevel
-    # importing this at the top level will break the buildroot
-    from osbuild.util import toml
-
-    config_paths = ("/etc/containers/storage.conf", "/usr/share/containers/storage.conf")
-    for conf_path in config_paths:
-        try:
-            return toml.load_from_file(conf_path)
-        except FileNotFoundError:
-            pass
-
-    raise FileNotFoundError(f"could not find container storage configuration in any of {config_paths}")

--- a/osbuild/util/host.py
+++ b/osbuild/util/host.py
@@ -1,0 +1,20 @@
+"""
+Utility functions that only run on the host (osbuild internals or host modules like sources).
+
+These should not be used by stages or code that runs in the build root.
+"""
+from osbuild.util import toml
+
+
+def get_container_storage():
+    """
+    Read the host storage configuration.
+    """
+    config_paths = ("/etc/containers/storage.conf", "/usr/share/containers/storage.conf")
+    for conf_path in config_paths:
+        try:
+            return toml.load_from_file(conf_path)
+        except FileNotFoundError:
+            pass
+
+    raise FileNotFoundError(f"could not find container storage configuration in any of {config_paths}")

--- a/osbuild/util/toml.py
+++ b/osbuild/util/toml.py
@@ -8,7 +8,7 @@ from types import ModuleType
 from typing import Optional
 
 # Different modules require different file mode (text vs binary)
-toml_modules = {
+_toml_modules = {
     "tomllib": {"mode": "rb"},  # stdlib since 3.11 (read-only)
     "tomli": {"mode": "rb"},  # EL9+
     "toml": {"mode": "r", "encoding": "utf-8"},  # older unmaintained lib, needed for backwards compatibility
@@ -18,7 +18,7 @@ toml_modules = {
 
 _toml: Optional[ModuleType] = None
 _rargs: dict = {}
-for module, args in toml_modules.items():
+for module, args in _toml_modules.items():
     try:
         _toml = importlib.import_module(module)
         _rargs = args
@@ -26,10 +26,10 @@ for module, args in toml_modules.items():
     except ModuleNotFoundError:
         pass
 else:
-    raise ModuleNotFoundError("No toml module found: " + ", ".join(toml_modules))
+    raise ModuleNotFoundError("No toml module found: " + ", ".join(_toml_modules))
 
 # Different modules require different file mode (text vs binary)
-tomlw_modules = {
+_tomlw_modules = {
     "tomli_w": {"mode": "wb"},  # EL9+
     "toml": {"mode": "w", "encoding": "utf-8"},  # older unmaintained lib, needed for backwards compatibility
     "pytoml": {"mode": "w", "encoding": "utf-8"},  # deprecated, needed for backwards compatibility (EL8 manifests)
@@ -38,7 +38,7 @@ tomlw_modules = {
 
 _tomlw: Optional[ModuleType] = None
 _wargs: dict = {}
-for module, args in tomlw_modules.items():
+for module, args in _tomlw_modules.items():
     try:
         _tomlw = importlib.import_module(module)
         _wargs = args
@@ -52,7 +52,7 @@ def load_from_file(path):
     if _toml is None:
         raise RuntimeError("no toml module available")
 
-    with open(path, **_rargs) as tomlfile:
+    with open(path, **_rargs) as tomlfile:  # pylint: disable=unspecified-encoding
         return _toml.load(tomlfile)
 
 
@@ -60,7 +60,7 @@ def dump_to_file(data, path, header=""):
     if _tomlw is None:
         raise RuntimeError("no toml module available with write support")
 
-    with open(path, **_wargs) as tomlfile:
+    with open(path, **_wargs) as tomlfile:  # pylint: disable=unspecified-encoding
         if header:
             _write_comment(tomlfile, header)
 

--- a/osbuild/util/toml.py
+++ b/osbuild/util/toml.py
@@ -51,12 +51,23 @@ def load_from_file(path):
         return toml.load(tomlfile)
 
 
-def dump_to_file(data, path, pre=None):
+def dump_to_file(data, path, header=""):
     if tomlw is None:
         raise RuntimeError("no toml module available with write support")
 
     with open(path, wmode) as tomlfile:
-        if pre:
-            tomlfile.write(pre)
+        if header:
+            _write_comment(tomlfile, header)
 
         tomlw.dump(data, tomlfile)
+
+
+def _write_comment(f, comment: list):
+    if not comment:
+        return
+
+    data = "\n".join(map(lambda c: f"# {c}", comment)) + "\n\n"
+    if "b" in f.mode:
+        f.write(data.encode())
+    else:
+        f.write(data)

--- a/osbuild/util/toml.py
+++ b/osbuild/util/toml.py
@@ -1,0 +1,62 @@
+"""
+Utility functions for reading and writing toml files.
+
+Handles module imports for all supported versions (in a build root or on a host).
+"""
+import importlib
+
+# Different modules require different file mode (text vs binary)
+toml_modules = {
+    "tomllib": "rb",  # stdlib since 3.11 (read-only)
+    "tomli": "rb",  # EL9+
+    "toml": "r",  # older unmaintained lib, needed for backwards compatibility with existing EL9 and Fedora manifests
+    "pytoml": "r",  # deprecated, needed for backwards compatibility (EL8 manifests)
+}
+
+
+toml = None
+rmode: str = None
+for module, mode in toml_modules.items():
+    try:
+        toml = importlib.import_module(module)
+        rmode = mode
+        break
+    except ModuleNotFoundError:
+        pass
+else:
+    raise ModuleNotFoundError("No toml module found: " + ", ".join(toml_modules))
+
+# Different modules require different file mode (text vs binary)
+tomlw_modules = {
+    "tomli_w": "wb",  # EL9+
+    "toml": "w",  # older unmaintained lib, needed for backwards compatibility with existing EL9 and Fedora manifests
+    "pytoml": "w",  # deprecated, needed for backwards compatibility (EL8 manifests)
+}
+
+
+tomlw = None
+wmode: str = None
+for module, mode in tomlw_modules.items():
+    try:
+        tomlw = importlib.import_module(module)
+        wmode = mode
+        break
+    except ModuleNotFoundError:
+        # allow importing without write support
+        pass
+
+
+def load_from_file(path):
+    with open(path, rmode) as tomlfile:
+        return toml.load(tomlfile)
+
+
+def dump_to_file(data, path, pre=None):
+    if tomlw is None:
+        raise RuntimeError("no toml module available with write support")
+
+    with open(path, wmode) as tomlfile:
+        if pre:
+            tomlfile.write(pre)
+
+        tomlw.dump(data, tomlfile)

--- a/sources/org.osbuild.containers-storage
+++ b/sources/org.osbuild.containers-storage
@@ -18,7 +18,7 @@ import subprocess as sp
 import sys
 
 from osbuild import sources
-from osbuild.util import containers
+from osbuild.util import host
 
 SCHEMA = """
 "additionalProperties": false,
@@ -49,7 +49,7 @@ class ContainersStorageSource(sources.SourceService):
         Construct the full image name that references an image with a given checksum in the local storage.
         """
         if self.storage_conf is None:
-            conf = containers.get_host_storage()
+            conf = host.get_container_storage()
         driver = conf["storage"]["driver"]
         graphroot = conf["storage"]["graphroot"]
         runroot = conf["storage"]["runroot"]

--- a/stages/org.osbuild.bootc.install.config
+++ b/stages/org.osbuild.bootc.install.config
@@ -2,12 +2,8 @@
 import pathlib
 import sys
 
-try:
-    import toml
-except ModuleNotFoundError:
-    import pytoml as toml
-
 import osbuild.api
+from osbuild.util import toml
 
 
 def main(tree, options):
@@ -17,8 +13,7 @@ def main(tree, options):
     path = pathlib.Path(tree) / "usr/lib/bootc/install" / filename
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(path, "w", encoding="utf8") as config_file:
-        toml.dump(config, config_file)
+    toml.dump_to_file(config, path)
 
     return 0
 

--- a/stages/org.osbuild.containers.storage.conf
+++ b/stages/org.osbuild.containers.storage.conf
@@ -4,12 +4,8 @@ import os
 import sys
 from typing import Dict
 
-try:
-    import toml
-except ModuleNotFoundError:
-    import pytoml as toml
-
 import osbuild.api
+from osbuild.util import toml
 
 DEFAULT_LOCATION = "/etc/containers/storage.conf"
 
@@ -50,14 +46,6 @@ def merge_config(section: str, data: Dict, config: Dict):
     have.update(want)
 
 
-def write_comment(f, comment: list):
-    if not comment:
-        return
-
-    data = "\n".join(map(lambda c: f"# {c}", comment))
-    f.write(data + "\n\n")
-
-
 def main(tree, options):
     location = options.get("filename", DEFAULT_LOCATION)
     config = options["config"]
@@ -69,24 +57,17 @@ def main(tree, options):
 
     # if a filebase was specified, we use it as base
     if filebase:
-        with open(filebase, "r", encoding="utf8") as f:
-            data = toml.load(f)
+        data = toml.load_from_file(filebase)
 
     # if the target exists, we merge it
     with contextlib.suppress(FileNotFoundError):
-        with open(path, "r", encoding="utf8") as f:
-            have = toml.load(f)
-
-            merge_config("storage", data, have)
+        have = toml.load_from_file(path)
+        merge_config("storage", data, have)
 
     # now merge our configuration into data
     merge_config("storage", data, config)
 
-    with open(path, "w", encoding="utf8") as f:
-        write_comment(f, HEADER)
-        write_comment(f, comment)
-
-        toml.dump(data, f)
+    toml.dump_to_file(data, path, header=HEADER + ["\n"] + comment)
 
     return 0
 

--- a/stages/test/test_containers_storage_conf.py
+++ b/stages/test/test_containers_storage_conf.py
@@ -5,12 +5,8 @@ import re
 
 import pytest
 
-try:
-    import toml
-except ModuleNotFoundError:
-    import pytoml as toml
-
 from osbuild import testutil
+from osbuild.util import toml
 
 TEST_INPUT = [
     ({}, {"additionalimagestores": ["/path/to/store"]}, [("storage.options.additionalimagestores", ["/path/to/store"])]),
@@ -49,8 +45,7 @@ def test_containers_storage_conf_integration(tmp_path, stage_module, test_filena
     assert os.path.exists(confpath)
 
     conf = None
-    with open(confpath, 'r', encoding="utf-8") as f:
-        conf = toml.load(f)
+    conf = toml.load_from_file(confpath)
 
     assert conf is not None
 

--- a/test/mod/test_util_toml.py
+++ b/test/mod/test_util_toml.py
@@ -1,0 +1,43 @@
+#
+# Tests for the 'osbuild.util.toml' module
+#
+import os
+from tempfile import TemporaryDirectory
+
+from osbuild.util import toml
+
+data_obj = {
+    "top": {
+        "t2-1": {
+            "list": ["a", "b", "c"]
+        },
+        "t2-2": {
+            "str": "test"
+        }
+    }
+}
+
+data_str = """
+[top.t2-1]
+list = ["a", "b", "c"]
+
+[top.t2-2]
+str = "test"
+"""
+
+
+def test_write_read():
+    with TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "test.toml")
+        toml.dump_to_file(data_obj, path)
+        rdata = toml.load_from_file(path)
+        assert data_obj == rdata
+
+
+def test_read():
+    with TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "test.toml")
+        with open(path, "w", encoding="utf-8") as test_file:
+            test_file.write(data_str)
+        rdata = toml.load_from_file(path)
+        assert rdata == data_obj

--- a/tox.ini
+++ b/tox.ini
@@ -74,3 +74,44 @@ deps =
 
 commands =
     bash -c 'python -m mypy --follow-imports=skip --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs {env:TYPEABLES_STRICT}'
+
+[testenv:tomllib]
+description = "test osbuild.util.toml with tomllib"
+deps =
+    pytest
+    mako
+    tomli-w
+
+commands =
+    python -m pytest -s -vvv -k test_util_toml
+
+[testenv:tomli]
+description = "test osbuild.util.toml with tomli"
+deps =
+    pytest
+    tomli
+    tomli-w
+    mako
+
+commands =
+    python -m pytest -s -vvv -k test_util_toml
+
+[testenv:toml]
+description = "test osbuild.util.toml with toml"
+deps =
+    pytest
+    toml
+    mako
+
+commands =
+    python -m pytest -s -vvv -k test_util_toml
+
+[testenv:pytoml]
+description = "test osbuild.util.toml with pytoml"
+deps =
+    pytest
+    pytoml
+    mako
+
+commands =
+    python -m pytest -s -vvv -k test_util_toml


### PR DESCRIPTION
The toml module story in osbuild is difficult. Different distro versions have different modules packaged or built-in, sometimes with different capabilities (no writing).  Since we need to support reading and writing toml files both on the host (osbuild internals, sources, inputs) and in the build root (stages), this PR centralises the import decision making in an internal utility module that covers all cases.

The wrapper is quite ugly and there's a few reasons for that.  Two of the modules we might import (`tomli` and `tomllib`) don't support writing, so we need to either import a separate module (`tomli_w`) or raise an exception when `dump()` is called without a write-capable module.  The `tomli` and `tomllib` modules require files be opened in binary mode (not text) while the others require text mode.  So we can't wrap the `toml.load()` and `toml.dump()` functions directly; the caller doesn't know which module it will be using.  We keep track of the mode based on which import succeeded and have our functions open the files as needed.

The wrapper functions are named `load_from_file()` and `dump_to_file()` to avoid confusion with the `load()` and `dump()` functions that take a file object.

The PR also adds simple read/write tests and tox configs for testing every supported toml module.

Feel free to suggest anything that might make the module less of a mess.

Fixes #1847 