### PR TITLE
sources/containers-storage: fix load caching

### DIFF
--- a/sources/org.osbuild.containers-storage
+++ b/sources/org.osbuild.containers-storage
@@ -49,10 +49,10 @@ class ContainersStorageSource(sources.SourceService):
         Construct the full image name that references an image with a given checksum in the local storage.
         """
         if self.storage_conf is None:
-            conf = host.get_container_storage()
-        driver = conf["storage"]["driver"]
-        graphroot = conf["storage"]["graphroot"]
-        runroot = conf["storage"]["runroot"]
+            self.storage_conf = host.get_container_storage()
+        driver = self.storage_conf["storage"]["driver"]
+        graphroot = self.storage_conf["storage"]["graphroot"]
+        runroot = self.storage_conf["storage"]["runroot"]
 
         return f"containers-storage:[{driver}@{graphroot}+{runroot}]{imagename}"
 


### PR DESCRIPTION
storage_conf was never not None, so the loading was called every time.
This never crashed because conf was always being set, but it wasn't
working properly regardless.