### PR TITLE
stages/update-crypto-policies: mountinfo in tree

### DIFF
--- a/stages/org.osbuild.update-crypto-policies
+++ b/stages/org.osbuild.update-crypto-policies
@@ -1,17 +1,23 @@
 #!/usr/bin/python3
+import os
 import subprocess
 import sys
 
 from osbuild import api
+from osbuild.util.mnt import MountGuard, MountPermissions
 
 
 def main(tree, options):
     policy = options["policy"]
 
-    cmd = ["/usr/sbin/chroot", tree,
-           "/usr/bin/update-crypto-policies", "--set", policy]
+    with MountGuard() as mg:
+        source = "/proc/self/mountinfo"
+        target = os.path.join(tree, source.lstrip("/"))
+        mg.mount(source, target, permissions=MountPermissions.READ_ONLY)
+        cmd = ["/usr/sbin/chroot", tree,
+               "/usr/bin/update-crypto-policies", "--set", policy]
 
-    subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True)
 
     return 0
 


### PR DESCRIPTION
In a recent commit [1], the update-crypto-policies script checks if the FIPS policy has been automounted by reading the /proc/self/mountinfo. The script will fail if the proc file isn't available.

Bind mount /proc/self/mountinfo from the build root into the tree so the script can read the file from the chroot.

[1] https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/commit/04ceadccfc07e5946b08157d06ca5c0d5a229d92