### PR TITLE
New utility module: chroot

### DIFF
--- a/osbuild/util/chroot.py
+++ b/osbuild/util/chroot.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+
+
+class Chroot:
+    """
+    Sets up mounts for the virtual filesystems inside a root tree, preparing it for running commands using chroot. This
+    should be used whenever a stage needs to run a command against the root tree but doesn't support a --root option or
+    similar.
+    Cleans up mounts when done.
+
+    This mounts /proc, /dev, and /sys.
+    """
+
+    def __init__(self, root: str):
+        self.root = root
+
+    def __enter__(self):
+        for d in ["/proc", "/dev", "/sys"]:
+            if not os.path.exists(self.root + d):
+                print(f"Making missing chroot directory: {d}")
+                os.makedirs(self.root + d)
+
+        subprocess.check_call(["/usr/bin/mount",
+                               "-t", "proc",
+                               "-o", "nosuid,noexec,nodev",
+                               "proc", f"{self.root}/proc"])
+        subprocess.check_call(["/usr/bin/mount",
+                               "-t", "devtmpfs",
+                               "-o", "mode=0755,noexec,nosuid,strictatime",
+                               "devtmpfs", f"{self.root}/dev"])
+        subprocess.check_call(["/usr/bin/mount",
+                               "-t", "sysfs",
+                               "-o", "nosuid,noexec,nodev",
+                               "sysfs", f"{self.root}/sys"])
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, tracebk):
+        for d in ["/proc", "/dev", "/sys"]:
+            subprocess.check_call(["/usr/bin/umount", self.root + d])

--- a/osbuild/util/chroot.py
+++ b/osbuild/util/chroot.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 
 
-class Chroot:
+class ChrootProcDevSys:
     """
     Sets up mounts for the virtual filesystems inside a root tree, preparing it for running commands using chroot. This
     should be used whenever a stage needs to run a command against the root tree but doesn't support a --root option or

--- a/stages/org.osbuild.dracut
+++ b/stages/org.osbuild.dracut
@@ -1,44 +1,14 @@
 #!/usr/bin/python3
-import os
 import subprocess
 import sys
 
 import osbuild.api
+from osbuild.util.chroot import Chroot
 
 
 def yesno(name: str, value: bool) -> str:
     prefix = "" if value else "no-"
     return f"--{prefix}{name}"
-
-
-class DracutMounts:
-    """
-    Setup the mounts inside a chroot root directory, which will be used
-    for running dracut inside it. Cleanup mounts when done.
-    This mounts /proc, /dev, and /sys.
-    """
-
-    def __init__(self, root: str):
-        self.root = root
-
-    def __enter__(self):
-        for d in ["/proc", "/dev", "/sys"]:
-            if not os.path.exists(self.root + d):
-                print(f"Making missing dracut chroot directory: {d}")
-                os.makedirs(self.root + d)
-
-        subprocess.check_call(["/usr/bin/mount", "-t", "proc", "-o",
-                               "nosuid,noexec,nodev", "proc", f"{self.root}/proc"])
-        subprocess.check_call(["/usr/bin/mount", "-t", "devtmpfs", "-o",
-                               "mode=0755,noexec,nosuid,strictatime", "devtmpfs", f"{self.root}/dev"])
-        subprocess.check_call(["/usr/bin/mount", "-t", "sysfs", "-o",
-                               "nosuid,noexec,nodev", "sysfs", f"{self.root}/sys"])
-
-        return self
-
-    def __exit__(self, exc_type, exc_value, tracebk):
-        for d in ["/proc", "/dev", "/sys"]:
-            subprocess.check_call(["/usr/bin/umount", self.root + d])
 
 
 # pylint: disable=too-many-branches
@@ -113,7 +83,7 @@ def main(tree, options):
         if initoverlayfs:
             initfs_bin = "/usr/bin/initoverlayfs-install"
 
-        with DracutMounts(tree):
+        with Chroot(tree):
             subprocess.run(["/usr/sbin/chroot", tree, initfs_bin,
                             "--no-hostonly",
                             "--kver", kver]

--- a/stages/org.osbuild.dracut
+++ b/stages/org.osbuild.dracut
@@ -3,7 +3,7 @@ import subprocess
 import sys
 
 import osbuild.api
-from osbuild.util.chroot import Chroot
+from osbuild.util.chroot import ChrootProcDevSys
 
 
 def yesno(name: str, value: bool) -> str:
@@ -83,7 +83,7 @@ def main(tree, options):
         if initoverlayfs:
             initfs_bin = "/usr/bin/initoverlayfs-install"
 
-        with Chroot(tree):
+        with ChrootProcDevSys(tree):
             subprocess.run(["/usr/sbin/chroot", tree, initfs_bin,
                             "--no-hostonly",
                             "--kver", kver]

--- a/stages/org.osbuild.update-crypto-policies
+++ b/stages/org.osbuild.update-crypto-policies
@@ -3,13 +3,13 @@ import subprocess
 import sys
 
 from osbuild import api
-from osbuild.util.chroot import Chroot
+from osbuild.util.chroot import ChrootProcDevSys
 
 
 def main(tree, options):
     policy = options["policy"]
 
-    with Chroot(tree):
+    with ChrootProcDevSys(tree):
         # update-crypto-polciies uses /proc/self/mountinfo to find and verify that fips paths have been mounted to their
         # expected locations by searching for the following path suffixes:
         #   /crypto-policies/default-fips-config

--- a/stages/org.osbuild.update-crypto-policies
+++ b/stages/org.osbuild.update-crypto-policies
@@ -3,15 +3,21 @@ import subprocess
 import sys
 
 from osbuild import api
+from osbuild.util.chroot import Chroot
 
 
 def main(tree, options):
     policy = options["policy"]
 
-    cmd = ["/usr/sbin/chroot", tree,
-           "/usr/bin/update-crypto-policies", "--set", policy]
+    with Chroot(tree):
+        # update-crypto-polciies uses /proc/self/mountinfo to find and verify that fips paths have been mounted to their
+        # expected locations by searching for the following path suffixes:
+        #   /crypto-policies/default-fips-config
+        #   /crypto-policies/back-ends/FIPS
+        cmd = ["/usr/sbin/chroot", tree,
+               "/usr/bin/update-crypto-policies", "--set", policy]
 
-    subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True)
 
     return 0
 

--- a/test/data/stages/update-crypto-policies/diff.json
+++ b/test/data/stages/update-crypto-policies/diff.json
@@ -1,7 +1,5 @@
 {
-  "added_files": [
-    "/dev/null"
-  ],
+  "added_files": [],
   "deleted_files": [],
   "differences": {
     "/etc/crypto-policies/back-ends/bind.config": {


### PR DESCRIPTION
**osbuild/util: new module: chroot**

New chroot utility module that sets up a tree with the necessary virtual
filesystems needed for running commands in the root tree in a similar
environment as they would run in the build root.

This is needed for some stages, but may also be used for all chroot
calls to unify the setup and teardown of the root environment.

The Chroot context class was previously part of the org.osbuild.dracut
stage, which was the first stage to need this setup.

---

**stages/update-crypto-policies: use Chroot context**

Recently [1], the update-crypto-policies script added a check to verify
that the FIPS policy was automounted by reading the
/proc/self/mountinfo.  The script will fail if the proc filesystem isn't
available.

Use the new Chroot context to set up the environment for the command.

[1] https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/commit/04ceadccfc07e5946b08157d06ca5c0d5a229d92

---

## Notes

We might expand the class to have a `call()` method or similar, so that we can do:
```python
with Chroot(path) as chroot:
  chroot.call("dracut" ...)
```

Leaving this for a follow-up though.