### PR TITLE
devices: create `/dev/mapper/<logical-volume>` as well

### DIFF
--- a/devices/org.osbuild.lvm2.lv
+++ b/devices/org.osbuild.lvm2.lv
@@ -67,6 +67,15 @@ def get_parent_path(parent: str, options: Dict) -> str:
     return parent_path
 
 
+def escaped_lv_mapper_name(vg, lv: str) -> str:
+    """
+    Return the name of the mapper device under /dev/mapper/ for the given vg, lv
+    """
+    # see also lvm2:libdm/libdm-string.c:dm_build_dm_name() at
+    # https://github.com/lvmteam/lvm2/blob/v2_03_26/libdm/libdm-string.c#L325
+    return f'{vg.replace("-", "--")}-{lv.replace("-", "--")}'
+
+
 class LVService(devices.DeviceService):
 
     def __init__(self, args):
@@ -215,6 +224,11 @@ class LVService(devices.DeviceService):
 
         os.makedirs(os.path.join(devpath, vg), exist_ok=True)  # type: ignore
         self.ensure_device_node(fullpath, major, minor)
+        # also create the device under the mapper dir as this is what
+        # findmnt will need to get the uuid of the filesystem
+        os.makedirs(os.path.join(devpath, "mapper"), exist_ok=True)
+        mapper_path = os.path.join(devpath, "mapper", escaped_lv_mapper_name(vg, lv))
+        self.ensure_device_node(mapper_path, major, minor)
 
         data = {
             "path": devname,

--- a/devices/test/test_lv.py
+++ b/devices/test/test_lv.py
@@ -10,3 +10,8 @@ DEVICES_NAME = "org.osbuild.lvm2.lv"
 def test_lvm2_lv_get_parent_path(devices_module, parent, options, expected_parent_path):
     pp = devices_module.get_parent_path(parent, options)
     assert pp == expected_parent_path
+
+
+def test_lvm2_escaped_lv_mapper_name(devices_module):
+    expected = "1d2b2150--8de2--4b68--b387--f9bc709190e8-lvroot"
+    assert devices_module.escaped_lv_mapper_name("1d2b2150-8de2-4b68-b387-f9bc709190e8", "lvroot") == expected


### PR DESCRIPTION
When we create the device node inside the buildroot so far it's
very minimal - just `/dev/{vg}-{lv}` with the appopriate major/minor.

However when mount runs it will create a mapper device with the
same major/minor under `/dev/mapper/{escaped(vg)}-{escaped(lv)}`
and use that to mount the actual filesystem. Without this additional
device findmnt will not be able to detect the udev attributes of
the source (as the source is just missing from /dev).

This commit create the right mapper in the same way that we
create the non-mapper device node.
