### PR TITLE
stages: workaround the two remaining autopep8 issues via `noqa`

### DIFF
--- a/stages/org.osbuild.debug-shell
+++ b/stages/org.osbuild.debug-shell
@@ -32,7 +32,7 @@ KillSignal=SIGHUP
 # Unset locale for the console getty since the console has problems
 # displaying some internationalized messages.
 UnsetEnvironment=LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION
-"""
+"""  # noqa
 
     with open(f"{tree}/etc/systemd/system/osbuild-debug-shell.service", "w", encoding="utf8") as f:
         f.write(unit)

--- a/stages/org.osbuild.skopeo
+++ b/stages/org.osbuild.skopeo
@@ -20,7 +20,7 @@ def main(inputs, output, options):
             if dest_type == "containers-storage":
                 storage_root = destination.get("storage-path", "/var/lib/containers/storage")
                 storage_driver = destination.get("storage-driver", "overlay")
-                dest = f"containers-storage:[{storage_driver}@{output}{storage_root}+/run/containers/storage]{image_name}"
+                dest = f"containers-storage:[{storage_driver}@{output}{storage_root}+/run/containers/storage]{image_name}"  # noqa
             elif dest_type in ("oci", "oci-archive", "dir"):
                 path = destination["path"]
                 dest = f"{dest_type}:{output}{path}"


### PR DESCRIPTION
Small followup for https://github.com/osbuild/osbuild/pull/1864

There were two issues from `autopep8` left, both can be just silenced via the `# noqa` directive.