### PR TITLE
test: checkpoint "build" stage too during `test_stages.py`

### DIFF
--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -223,12 +223,12 @@ class TestStages(test.TestBase):
 
             out_a = stack.enter_context(tempfile.TemporaryDirectory(dir="/var/tmp"))
             _ = osb.compile_file(os.path.join(test_dir, "a.json"),
-                                 checkpoints=["tree"],
+                                 checkpoints=["build", "tree"],
                                  exports=["tree"], output_dir=out_a)
 
             out_b = stack.enter_context(tempfile.TemporaryDirectory(dir="/var/tmp"))
             res = osb.compile_file(os.path.join(test_dir, "b.json"),
-                                   checkpoints=["tree"],
+                                   checkpoints=["build", "tree"],
                                    exports=["tree"], output_dir=out_b)
 
             tree1 = os.path.join(out_a, "tree")


### PR DESCRIPTION
Quick check to see if checkpointing "build" helps with the runtime. Note that the cache size is already 20GB, I doubled it for good measure but we probably can go back to 20, just want to make sure this is not the bottleneck.

Closes: https://github.com/osbuild/osbuild/issues/1874