### PR TITLE
osbuild: also print what export is availalble when one is not found

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -138,8 +138,9 @@ def osbuild_cli() -> int:
     exports = set(args.export)
     unresolved = [e for e in exports if e not in manifest]
     if unresolved:
+        available = list(manifest.pipelines.keys())
         for name in unresolved:
-            print(f"Export {vt.bold}{name}{vt.reset} not found!")
+            print(f"Export {vt.bold}{name}{vt.reset} not found in {available}")
         print(f"{vt.reset}{vt.bold}{vt.red}Failed{vt.reset}")
         return 1
 

--- a/test/run/test_main.py
+++ b/test/run/test_main.py
@@ -1,0 +1,24 @@
+import json
+
+import pytest
+
+from .. import test
+
+jsondata = json.dumps({
+    "version": "2",
+    "pipelines": [
+        {
+            "name": "noop",
+        },
+        {
+            "name": "noop2",
+        },
+    ],
+})
+
+
+def test_exports_are_shown_on_missing_exports(capsys):
+    with pytest.raises(AssertionError):
+        with test.OSBuild() as osb:
+            osb.compile(jsondata, exports=["not-existing"])
+    assert "Export not-existing not found in ['noop', 'noop2']\n" in capsys.readouterr().out


### PR DESCRIPTION
The current error message when an export is not found could be improved by printing what exports are actually availalble to make it easier for the user to e.g. spot typos.

[edit: this is ready for review now, I added a small test]