### PR TITLE
test: move (parts of) the stage tests to pytest

### DIFF
--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -86,10 +86,9 @@ def test_rawfs(osb, fs_type):
         "size": 1024 * MEBIBYTE,
         "fs_type": fs_type,
     }
-    with osb:
-        with run_assembler(osb, "org.osbuild.rawfs", options, "image.raw") as (tree, image):
-            assertImageFile(image, "raw", options["size"])
-            assertFilesystem(image, options["root_fs_uuid"], fs_type, tree)
+    with run_assembler(osb, "org.osbuild.rawfs", options, "image.raw") as (tree, image):
+        assertImageFile(image, "raw", options["size"])
+        assertFilesystem(image, options["root_fs_uuid"], fs_type, tree)
 
 
 @pytest.mark.skipif(not test.TestBase.have_tree_diff(), reason="tree-diff missing")
@@ -97,54 +96,53 @@ def test_rawfs(osb, fs_type):
 @pytest.mark.skipif(not test.TestBase.can_bind_mount(), reason="root-only")
 @pytest.mark.skipif(not test.TestBase.have_rpm_ostree(), reason="rpm-ostree missing")
 def test_ostree(osb):
-    with osb:
-        with open(os.path.join(test.TestBase.locate_test_data(),
-                               "manifests/fedora-ostree-commit.json"),
-                  encoding="utf8") as f:
-            manifest = json.load(f)
+    with open(os.path.join(test.TestBase.locate_test_data(),
+                           "manifests/fedora-ostree-commit.json"),
+              encoding="utf8") as f:
+        manifest = json.load(f)
 
-        data = json.dumps(manifest)
-        with tempfile.TemporaryDirectory(dir="/var/tmp") as output_dir:
-            result = osb.compile(data, output_dir=output_dir, exports=["ostree-commit"])
-            compose_file = os.path.join(output_dir, "ostree-commit", "compose.json")
-            repo = os.path.join(output_dir, "ostree-commit", "repo")
+    data = json.dumps(manifest)
+    with tempfile.TemporaryDirectory(dir="/var/tmp") as output_dir:
+        result = osb.compile(data, output_dir=output_dir, exports=["ostree-commit"])
+        compose_file = os.path.join(output_dir, "ostree-commit", "compose.json")
+        repo = os.path.join(output_dir, "ostree-commit", "repo")
 
-            with open(compose_file, encoding="utf8") as f:
-                compose = json.load(f)
-            commit_id = compose["ostree-commit"]
-            ref = compose["ref"]
-            rpmostree_inputhash = compose["rpm-ostree-inputhash"]
-            os_version = compose["ostree-version"]
-            assert commit_id
-            assert ref
-            assert rpmostree_inputhash
-            assert os_version
-            assert "metadata" in result
-            metadata = result["metadata"]
-            commit = metadata["ostree-commit"]
-            info = commit["org.osbuild.ostree.commit"]
-            assert "compose" in info
-            assert info["compose"] == compose
+        with open(compose_file, encoding="utf8") as f:
+            compose = json.load(f)
+        commit_id = compose["ostree-commit"]
+        ref = compose["ref"]
+        rpmostree_inputhash = compose["rpm-ostree-inputhash"]
+        os_version = compose["ostree-version"]
+        assert commit_id
+        assert ref
+        assert rpmostree_inputhash
+        assert os_version
+        assert "metadata" in result
+        metadata = result["metadata"]
+        commit = metadata["ostree-commit"]
+        info = commit["org.osbuild.ostree.commit"]
+        assert "compose" in info
+        assert info["compose"] == compose
 
-            md = subprocess.check_output(
-                [
-                    "ostree",
-                    "show",
-                    "--repo", repo,
-                    "--print-metadata-key=rpmostree.inputhash",
-                    commit_id
-                ], encoding="utf8").strip()
-            assert md == f"'{rpmostree_inputhash}'"
+        md = subprocess.check_output(
+            [
+                "ostree",
+                "show",
+                "--repo", repo,
+                "--print-metadata-key=rpmostree.inputhash",
+                commit_id
+            ], encoding="utf8").strip()
+        assert md == f"'{rpmostree_inputhash}'"
 
-            md = subprocess.check_output(
-                [
-                    "ostree",
-                    "show",
-                    "--repo", repo,
-                    "--print-metadata-key=version",
-                    commit_id
-                ], encoding="utf8").strip()
-            assert md == f"'{os_version}'"
+        md = subprocess.check_output(
+            [
+                "ostree",
+                "show",
+                "--repo", repo,
+                "--print-metadata-key=version",
+                commit_id
+            ], encoding="utf8").strip()
+        assert md == f"'{os_version}'"
 
 
 @pytest.mark.skipif(not test.TestBase.have_tree_diff(), reason="tree-diff missing")
@@ -154,49 +152,48 @@ def test_ostree(osb):
 @pytest.mark.parametrize("fs_type", ["ext4", "xfs", "btrfs"])
 def test_qemu(osb, fmt, fs_type):
     loctl = loop.LoopControl()
-    with osb:
-        if not test.TestBase.has_filesystem_support(fs_type):
-            pytest.skip(f"The {fs_type} was explicitly marked as unsupported on this platform.")
-        options = {
-            "format": fmt,
-            "filename": f"image.{fmt}",
-            "ptuuid": str(uuid4()),
-            "root_fs_uuid": str(uuid4()),
-            "size": 1024 * MEBIBYTE,
-            "root_fs_type": fs_type,
-        }
-        with run_assembler(osb,
-                           "org.osbuild.qemu",
-                           options,
-                           f"image.{fmt}") as (tree, image):
-            if fmt == "raw.xz":
-                subprocess.run(["unxz", "--keep", "--force", image], check=True)
-                image = image[:-3]
-                fmt = "raw"
-            assertImageFile(image, fmt, options["size"])
-            with open_image(loctl, image, fmt) as (target, device):
-                ptable = read_partition_table(device)
-                assertPartitionTable(ptable,
-                                     "dos",
-                                     options["ptuuid"],
-                                     1,
-                                     boot_partition=1)
-                if fs_type == "btrfs":
-                    l2hash = "dfea8604cdcdc2cf0dc3e816929d302f837f03c98f6bb19b366fda4ee26957f1"
-                elif fs_type == "xfs":
-                    l2hash = "18d145b699e0ff4a815868f0b761b4bd6ece391885830ddb56dac557eff8b732"
-                else:
-                    l2hash = "84792ea01e63bd60c4018d686d48b6207c56d5bc844f2791634b276ce82c9116"
-                assertGRUB2(device,
-                            "b8cea7475422d35cd6f85ad099fb4f921557fd1b25db62cd2a92709ace21cf0f",
-                            l2hash,
-                            1024 * 1024)
+    if not test.TestBase.has_filesystem_support(fs_type):
+        pytest.skip(f"The {fs_type} was explicitly marked as unsupported on this platform.")
+    options = {
+        "format": fmt,
+        "filename": f"image.{fmt}",
+        "ptuuid": str(uuid4()),
+        "root_fs_uuid": str(uuid4()),
+        "size": 1024 * MEBIBYTE,
+        "root_fs_type": fs_type,
+    }
+    with run_assembler(osb,
+                       "org.osbuild.qemu",
+                       options,
+                       f"image.{fmt}") as (tree, image):
+        if fmt == "raw.xz":
+            subprocess.run(["unxz", "--keep", "--force", image], check=True)
+            image = image[:-3]
+            fmt = "raw"
+        assertImageFile(image, fmt, options["size"])
+        with open_image(loctl, image, fmt) as (target, device):
+            ptable = read_partition_table(device)
+            assertPartitionTable(ptable,
+                                 "dos",
+                                 options["ptuuid"],
+                                 1,
+                                 boot_partition=1)
+            if fs_type == "btrfs":
+                l2hash = "dfea8604cdcdc2cf0dc3e816929d302f837f03c98f6bb19b366fda4ee26957f1"
+            elif fs_type == "xfs":
+                l2hash = "18d145b699e0ff4a815868f0b761b4bd6ece391885830ddb56dac557eff8b732"
+            else:
+                l2hash = "84792ea01e63bd60c4018d686d48b6207c56d5bc844f2791634b276ce82c9116"
+            assertGRUB2(device,
+                        "b8cea7475422d35cd6f85ad099fb4f921557fd1b25db62cd2a92709ace21cf0f",
+                        l2hash,
+                        1024 * 1024)
 
-                p1 = ptable["partitions"][0]
-                ssize = ptable.get("sectorsize", 512)
-                start, size = p1["start"] * ssize, p1["size"] * ssize
-                with loop_open(loctl, target, offset=start, size=size) as dev:
-                    assertFilesystem(dev, options["root_fs_uuid"], fs_type, tree)
+            p1 = ptable["partitions"][0]
+            ssize = ptable.get("sectorsize", 512)
+            start, size = p1["start"] * ssize, p1["size"] * ssize
+            with loop_open(loctl, target, offset=start, size=size) as dev:
+                assertFilesystem(dev, options["root_fs_uuid"], fs_type, tree)
 
 
 @pytest.mark.skipif(not test.TestBase.have_tree_diff(), reason="tree-diff missing")
@@ -208,36 +205,35 @@ def test_qemu(osb, fmt, fs_type):
      ("tree.tar.gz", "gzip", ["application/x-gzip", "application/gzip"])]
 )
 def test_tar(osb, filename, compression, expected_mimetypes):
-    with osb:
-        options = {"filename": filename}
+    options = {"filename": filename}
+    if compression:
+        options["compression"] = compression
+    with run_assembler(osb,
+                       "org.osbuild.tar",
+                       options,
+                       filename) as (tree, image):
+        output = subprocess.check_output(["file", "--mime-type", image], encoding="utf8")
+        _, mimetype = output.strip().split(": ")  # "filename: mimetype"
+        assert mimetype in expected_mimetypes
+
         if compression:
-            options["compression"] = compression
-        with run_assembler(osb,
-                           "org.osbuild.tar",
-                           options,
-                           filename) as (tree, image):
-            output = subprocess.check_output(["file", "--mime-type", image], encoding="utf8")
-            _, mimetype = output.strip().split(": ")  # "filename: mimetype"
-            assert mimetype in expected_mimetypes
+            return
 
-            if compression:
-                return
-
-            # In the non-compression case, we verify the tree's content
-            with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
-                args = [
-                    "tar",
-                    "--numeric-owner",
-                    "--selinux",
-                    "--acls",
-                    "--xattrs", "--xattrs-include", "*",
-                    "-xaf", image,
-                    "-C", tmp]
-                subprocess.check_output(args, encoding="utf8")
-                diff = test.TestBase.tree_diff(tree, tmp)
-                assert diff["added_files"] == []
-                assert diff["deleted_files"] == []
-                assert diff["differences"] == {}
+        # In the non-compression case, we verify the tree's content
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+            args = [
+                "tar",
+                "--numeric-owner",
+                "--selinux",
+                "--acls",
+                "--xattrs", "--xattrs-include", "*",
+                "-xaf", image,
+                "-C", tmp]
+            subprocess.check_output(args, encoding="utf8")
+            diff = test.TestBase.tree_diff(tree, tmp)
+            assert diff["added_files"] == []
+            assert diff["deleted_files"] == []
+            assert diff["differences"] == {}
 
 
 @contextlib.contextmanager

--- a/test/run/test_exports.py
+++ b/test/run/test_exports.py
@@ -7,7 +7,7 @@ import subprocess
 
 import pytest
 
-from .. import test
+from ..test import osbuild_fixture  # noqa: F401, pylint: disable=unused-import
 
 
 @pytest.fixture(name="jsondata", scope="module")
@@ -40,12 +40,6 @@ def jsondata_fixture():
             }
         ]
     })
-
-
-@pytest.fixture(name="osb", scope="module")
-def osbuild_fixture():
-    with test.OSBuild() as osb:
-        yield osb
 
 
 @pytest.fixture(name="testing_libdir", scope="module")

--- a/test/run/test_noop.py
+++ b/test/run/test_noop.py
@@ -10,6 +10,7 @@ import pytest
 import osbuild.main_cli
 
 from .. import test
+from ..test import osbuild_fixture  # noqa: F401, pylint: disable=unused-import
 
 
 @pytest.fixture(name="jsondata", scope="module")
@@ -38,11 +39,6 @@ def jsondata_fixture():
         ]
     })
 
-
-@pytest.fixture(name="osb", scope="module")
-def osbuild_fixture():
-    with test.OSBuild() as osb:
-        yield osb
 
 #
 # Run a noop Pipeline. Run twice to verify the cache does not affect

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -6,6 +6,7 @@ import difflib
 import glob
 import json
 import os
+import pathlib
 import pprint
 import random
 import re
@@ -188,6 +189,14 @@ def assert_tree_diffs_equal(tree_diff1, tree_diff2):
                     and difference2_values[1] is not None \
                     and difference1_values[1] != difference2_values[1]:
                 raise_assertion(f"after values are different: {difference1_values[1]}, {difference2_values[1]}")
+
+
+# T0DO: find a nicer way
+# overriding the build-in "tmp_path" so that we get the dir under /var/tmpx
+@pytest.fixture(name="tmp_path")
+def tmp_path_fixture():
+    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+        yield pathlib.Path(tmp)
 
 
 @pytest.mark.parametrize("test_dir", [

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -2,7 +2,6 @@
 # Runtime tests for the individual stages.
 #
 
-import contextlib
 import difflib
 import glob
 import json
@@ -21,10 +20,13 @@ import zipfile
 from collections.abc import Mapping
 from typing import Callable, Dict, List, Optional
 
+import pytest
+
 from osbuild.testutil import has_executable, pull_oci_archive_container
 from osbuild.util import checksum, selinux
 
 from .. import initrd, test
+from ..test import osbuild_fixture, tree_diff  # noqa: F401, pylint: disable=unused-import
 from .test_assemblers import mount
 
 
@@ -62,16 +64,6 @@ def find_stage(result, stageid):
         if stage["id"] == stageid:
             return stage
     return None
-
-
-def make_stage_tests(klass):
-    path = os.path.join(test.TestBase.locate_test_data(), "stages")
-    for t in glob.glob(f"{path}/*/diff.json"):
-        test_path = os.path.dirname(t)
-        test_name = os.path.basename(test_path).replace("-", "_")
-        setattr(klass, f"test_{test_name}",
-                lambda s, path=test_path: s.run_stage_diff_test(path))
-    return klass
 
 
 def mapping_is_subset(subset, other):
@@ -198,10 +190,47 @@ def assert_tree_diffs_equal(tree_diff1, tree_diff2):
                 raise_assertion(f"after values are different: {difference1_values[1]}, {difference2_values[1]}")
 
 
+@pytest.mark.parametrize("test_dir", [
+    os.path.dirname(p)
+    for p in glob.glob(os.path.join(test.TestBase.locate_test_data(), "stages/*/diff*.json"))
+])
+def test_run_stage_diff(tmp_path, osb, test_dir):
+    out_a = tmp_path / "out_a"
+    _ = osb.compile_file(os.path.join(test_dir, "a.json"),
+                         checkpoints=["build", "tree"],
+                         exports=["tree"], output_dir=out_a)
+
+    out_b = tmp_path / "out_b"
+    res = osb.compile_file(os.path.join(test_dir, "b.json"),
+                           checkpoints=["build", "tree"],
+                           exports=["tree"], output_dir=out_b)
+
+    tree1 = os.path.join(out_a, "tree")
+    tree2 = os.path.join(out_b, "tree")
+
+    actual_diff = tree_diff(tree1, tree2)
+
+    with open(os.path.join(test_dir, "diff.json"), encoding="utf8") as f:
+        expected_diff = json.load(f)
+
+    assert_tree_diffs_equal(expected_diff, actual_diff)
+
+    md_path = os.path.join(test_dir, "metadata.json")
+    if os.path.exists(md_path):
+        with open(md_path, "r", encoding="utf8") as f:
+            metadata = json.load(f)
+
+        assert metadata == res["metadata"]
+
+    # cache the downloaded data for the sources by copying
+    # it to self.cache, which is going to be used to initialize
+    # the osbuild cache with.
+    osb.copy_source_data(osb.cache_from, "org.osbuild.files")
+
+
 @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
 @unittest.skipUnless(test.TestBase.have_tree_diff(), "tree-diff missing")
 @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
-@make_stage_tests
 class TestStages(test.TestBase):
 
     @classmethod
@@ -217,42 +246,6 @@ class TestStages(test.TestBase):
 
     def setUp(self):
         self.osbuild = test.OSBuild(cache_from=self.store)
-
-    def run_stage_diff_test(self, test_dir: str):
-        with contextlib.ExitStack() as stack:
-            osb = stack.enter_context(self.osbuild)
-
-            out_a = stack.enter_context(tempfile.TemporaryDirectory(dir="/var/tmp"))
-            _ = osb.compile_file(os.path.join(test_dir, "a.json"),
-                                 checkpoints=["build", "tree"],
-                                 exports=["tree"], output_dir=out_a)
-
-            out_b = stack.enter_context(tempfile.TemporaryDirectory(dir="/var/tmp"))
-            res = osb.compile_file(os.path.join(test_dir, "b.json"),
-                                   checkpoints=["build", "tree"],
-                                   exports=["tree"], output_dir=out_b)
-
-            tree1 = os.path.join(out_a, "tree")
-            tree2 = os.path.join(out_b, "tree")
-
-            actual_diff = self.tree_diff(tree1, tree2)
-
-            with open(os.path.join(test_dir, "diff.json"), encoding="utf8") as f:
-                expected_diff = json.load(f)
-
-            assert_tree_diffs_equal(expected_diff, actual_diff)
-
-            md_path = os.path.join(test_dir, "metadata.json")
-            if os.path.exists(md_path):
-                with open(md_path, "r", encoding="utf8") as f:
-                    metadata = json.load(f)
-
-                self.assertEqual(metadata, res["metadata"])
-
-            # cache the downloaded data for the sources by copying
-            # it to self.cache, which is going to be used to initialize
-            # the osbuild cache with.
-            osb.copy_source_data(self.store, "org.osbuild.files")
 
     def test_dracut(self):
         datadir = self.locate_test_data()

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -103,7 +103,7 @@ def mapping_is_subset(subset, other):
     return False
 
 
-def assertTreeDiffsEqual(tree_diff1, tree_diff2):
+def assert_tree_diffs_equal(tree_diff1, tree_diff2):
     """
     Asserts two tree diffs for equality.
 
@@ -240,7 +240,7 @@ class TestStages(test.TestBase):
             with open(os.path.join(test_dir, "diff.json"), encoding="utf8") as f:
                 expected_diff = json.load(f)
 
-            assertTreeDiffsEqual(expected_diff, actual_diff)
+            assert_tree_diffs_equal(expected_diff, actual_diff)
 
             md_path = os.path.join(test_dir, "metadata.json")
             if os.path.exists(md_path):

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -234,7 +234,7 @@ def test_run_stage_diff(tmp_path, osb, test_dir):
     # cache the downloaded data for the sources by copying
     # it to self.cache, which is going to be used to initialize
     # the osbuild cache with.
-    osb.copy_source_data(osb.cache_from, "org.osbuild.files")
+    osb.copy_source_data(osb.store, "org.osbuild.files")
 
 
 @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")

--- a/test/test.py
+++ b/test/test.py
@@ -11,6 +11,8 @@ import sys
 import tempfile
 import unittest
 
+import pytest
+
 import osbuild.meta
 from osbuild.objectstore import ObjectStore
 from osbuild.util import linux
@@ -496,3 +498,10 @@ class OSBuild(contextlib.AbstractContextManager):
             "cp", "--reflink=auto", "-a",
             os.path.join(from_path, "."), to_path
         ], check=True)
+
+
+@pytest.fixture(name="osb", scope="module")
+def osbuild_fixture():
+    store = os.getenv("OSBUILD_TEST_STORE")
+    with OSBuild(cache_from=store) as osb:
+        yield osb

--- a/test/test.py
+++ b/test/test.py
@@ -505,7 +505,7 @@ class OSBuild(contextlib.AbstractContextManager):
         ], check=True)
 
 
-@pytest.fixture(name="osb", scope="module")
+@pytest.fixture(name="osb")
 def osbuild_fixture():
     cleanup_dir = None
     store = os.getenv("OSBUILD_TEST_STORE")

--- a/test/test.py
+++ b/test/test.py
@@ -302,6 +302,7 @@ class OSBuild(contextlib.AbstractContextManager):
 
     def __init__(self, *, cache_from=None):
         self._cache_from = cache_from
+        self.store = None
 
     def __enter__(self):
         self._exitstack = contextlib.ExitStack()
@@ -335,10 +336,6 @@ class OSBuild(contextlib.AbstractContextManager):
 
         self._cachedir = None
         self._exitstack = None
-
-    @property
-    def cache_from(self) -> str:
-        return self._cache_from
 
     @staticmethod
     def _print_result(code, data_stdout, data_stderr, log):
@@ -518,6 +515,7 @@ def osbuild_fixture():
         store = tempfile.mkdtemp(prefix="osbuild-test-", dir="/var/tmp")
         cleanup_dir = store
     with OSBuild(cache_from=store) as osb:
+        osb.store = store
         yield osb
     if cleanup_dir:
         shutil.rmtree(cleanup_dir)


### PR DESCRIPTION
This makes it more uniform with our other tests that are mostly
pytest based and it also makes it possible to easiyl do a
`pytest --collect-only` to see what is actually run.

Another nice reason to move more to pytest is that it allows
to use custom markers like `@pytest.mark.slow` which we
could use to have a `make quick-test` or something.

[draft: to double check that the tests are not regressing and not slowing down]