### PR TITLE
test: add test that ensures return value of `chroot.run()`

### DIFF
--- a/test/mod/test_util_chroot.py
+++ b/test/mod/test_util_chroot.py
@@ -22,7 +22,8 @@ class RunReturn:
 def test_chroot_context(mocked_run, tmp_path):
 
     with Chroot(os.fspath(tmp_path)) as chroot:
-        chroot.run(["/bin/true"], check=True)
+        ret = chroot.run(["/bin/true"], check=True)
+        assert isinstance(ret, RunReturn)
         chroot.run(["/bin/false"], check=False)
 
     assert mocked_run.call_args_list == [


### PR DESCRIPTION
Small followup for https://github.com/osbuild/osbuild/pull/1854 which added the return value to `util.Chroot.run`. This commit now adds a (super trivial) test for this.