### PR TITLE
Add support for creating quadlet and systemd socket units

### DIFF
--- a/stages/org.osbuild.containers.unit.create
+++ b/stages/org.osbuild.containers.unit.create
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+import configparser
+import sys
+
+import osbuild.api
+
+
+def validate(filename, cfg):
+    # ensure the service name does not exceed maximum filename length
+    if len(filename) > 255:
+        raise ValueError(f"Error: the {filename} unit exceeds the maximum filename length.")
+
+    # Filename extension must match the config:
+    #   .service requires a Service section
+    #   .mount requires a Mount section
+    if filename.endswith(".container") and "Container" not in cfg:
+        raise ValueError(f"Error: {filename} unit requires Container section")
+    if filename.endswith(".volume") and "Volume" not in cfg:
+        raise ValueError(f"Error: {filename} unit requires Volume section")
+    if filename.endswith(".network") and "Network" not in cfg:
+        raise ValueError(f"Error: {filename} unit requires Network section")
+
+
+def main(tree, options):
+    filename = options["filename"]
+    cfg = options["config"]
+    validate(filename, cfg)
+
+    # We trick configparser into letting us write multiple instances of the same option by writing them as keys with no
+    # value, so we enable allow_no_value
+    config = configparser.ConfigParser(allow_no_value=True, interpolation=None)
+    # prevent conversion of the option name to lowercase
+    config.optionxform = lambda option: option
+
+    for section, opts in cfg.items():
+        if not config.has_section(section):
+            config.add_section(section)
+        for option, value in opts.items():
+            if isinstance(value, list):
+                for v in value:
+                    if option == "Environment":
+                        # Option value becomes "KEY=VALUE" (quoted)
+                        v = '"' + v["key"] + "=" + str(v["value"]) + '"'
+                    config.set(section, str(option) + "=" + str(v))
+            else:
+                config.set(section, option, str(value))
+    persistent = options.get("unit-path", "usr")
+    systemd_dir = str()
+    if persistent == "usr":
+        systemd_dir = f"{tree}/usr/share/containers/systemd"
+    elif persistent == "etc":
+        systemd_dir = f"{tree}/etc/containers/systemd"
+
+    with open(f"{systemd_dir}/{filename}", "w", encoding="utf8") as f:
+        config.write(f, space_around_delimiters=False)
+
+
+if __name__ == '__main__':
+    args = osbuild.api.arguments()
+    r = main(args["tree"], args["options"])
+    sys.exit(r)

--- a/stages/org.osbuild.containers.unit.create.meta.json
+++ b/stages/org.osbuild.containers.unit.create.meta.json
@@ -78,10 +78,17 @@
               "Install"
             ],
             "not": {
-              "required": [
-                "Service",
-                "Volume",
-                "Network"
+              "anyOf": [
+                {
+                  "required": [
+                    "Volume"
+                  ]
+                },
+                {
+                  "required": [
+                    "Network"
+                  ]
+                }
               ]
             }
           },
@@ -90,10 +97,17 @@
               "Volume"
             ],
             "not": {
-              "required": [
-                "Container",
-                "Network",
-                "Service"
+              "anyOf": [
+                {
+                  "required": [
+                    "Container"
+                  ]
+                },
+                {
+                  "required": [
+                    "Network"
+                  ]
+                }
               ]
             }
           },
@@ -102,10 +116,17 @@
               "Network"
             ],
             "not": {
-              "required": [
-                "Service",
-                "Container",
-                "Volume"
+              "anyOf": [
+                {
+                  "required": [
+                    "Container"
+                  ]
+                },
+                {
+                  "required": [
+                    "Volume"
+                  ]
+                }
               ]
             }
           }
@@ -247,9 +268,6 @@
             "additionalProperties": false,
             "type": "object",
             "description": "'Volume' configuration section of a unit file.",
-            "required": [
-              "What"
-            ],
             "properties": {
               "VolumeName": {
                 "description": "Override volume name",

--- a/stages/org.osbuild.containers.unit.create.meta.json
+++ b/stages/org.osbuild.containers.unit.create.meta.json
@@ -1,0 +1,330 @@
+{
+  "summary": "Create a podman systemd unit file",
+  "description": [
+    "This stage allows to create Podman systemd (quadlet) unit files. The `filename` property",
+    "specifies the, '.service' or '.mount' file to be added. These names are",
+    "validated using the, same rules as specified by podman-systemd.unit(5) and they",
+    "must contain the, '.container', '.volume' or '.network' suffix (other types of unit files",
+    "are not supported). 'unit-path' determines determine the unit load path.",
+    "",
+    "The Unit configuration can currently specify the following subset",
+    "of options:",
+    "  - 'Unit' section",
+    "    - 'Description' - string",
+    "    - 'ConditionPathExists' - string",
+    "    - 'ConditionPathIsDirectory' - string",
+    "    - 'DefaultDependencies' - bool",
+    "    - 'Requires' - [strings]",
+    "    - 'Wants' - [strings]",
+    "    - 'After' - [strings]",
+    "    - 'Before' - [strings]",
+    "  - 'Service' section",
+    "    - 'Restart' - string",
+    "  - 'Container' section",
+    "    - 'Image' - string",
+    "    - 'Exec' - string",
+    "    - 'Volume' - [string]",
+    "    - 'User' - string",
+    "    - 'Group' - string",
+    "    - 'AddDevice' - string",
+    "    - 'Environment' - [object]",
+    "    - 'Network' - string",
+    "    - 'WorkingDir' - string",
+    "  - 'Volume' section",
+    "    - 'VolumeName' - string",
+    "    - 'Driver' - string",
+    "    - 'Image' - string",
+    "    - 'User' - string",
+    "    - 'Group' - string",
+    "  - 'Network' section",
+    "    - 'Gateway' - string",
+    "    - 'DNS' - string",
+    "    - 'IPRange' - string",
+    "    - 'Subnet' - string",
+    "    - 'Driver' - string",
+    "    - 'NetworkName' - string",
+    "  - 'Install' section",
+    "    - 'WantedBy' - [string]",
+    "    - 'RequiredBy' - [string]"
+  ],
+  "schema": {
+    "additionalProperties": false,
+    "required": [
+      "filename",
+      "config"
+    ],
+    "properties": {
+      "filename": {
+        "type": "string",
+        "pattern": "^[\\w:.\\\\-]+[@]{0,1}[\\w:.\\\\-]*\\.(container|volume|network)$"
+      },
+      "unit-path": {
+        "type": "string",
+        "enum": [
+          "usr",
+          "etc"
+        ],
+        "default": "usr",
+        "description": "Define the system load path"
+      },
+      "config": {
+        "additionalProperties": false,
+        "type": "object",
+        "oneOf": [
+          {
+            "required": [
+              "Unit",
+              "Container",
+              "Install"
+            ],
+            "not": {
+              "required": [
+                "Service",
+                "Volume",
+                "Network"
+              ]
+            }
+          },
+          {
+            "required": [
+              "Volume"
+            ],
+            "not": {
+              "required": [
+                "Container",
+                "Network",
+                "Service"
+              ]
+            }
+          },
+          {
+            "required": [
+              "Network"
+            ],
+            "not": {
+              "required": [
+                "Service",
+                "Container",
+                "Volume"
+              ]
+            }
+          }
+        ],
+        "description": "Configuration for a '.container' unit.",
+        "properties": {
+          "Unit": {
+            "additionalProperties": false,
+            "type": "object",
+            "description": "'Unit' configuration section of a unit file.",
+            "properties": {
+              "Description": {
+                "type": "string"
+              },
+              "Wants": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "After": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Before": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Requires": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "ConditionPathExists": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "ConditionPathIsDirectory": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "DefaultDependencies": {
+                "type": "boolean"
+              }
+            }
+          },
+          "Service": {
+            "additionalProperties": false,
+            "type": "object",
+            "description": "'Service' configuration section of a unit file.",
+            "properties": {
+              "Restart": {
+                "type": "string",
+                "enum": [
+                  "no",
+                  "on-success",
+                  "on-failure",
+                  "on-abnormal",
+                  "on-watchdog",
+                  "on-abort",
+                  "always"
+                ]
+              }
+            }
+          },
+          "Container": {
+            "additionalProperties": false,
+            "type": "object",
+            "description": "'Container' configuration section of a unit file.",
+            "required": [
+              "Image"
+            ],
+            "properties": {
+              "Environment": {
+                "type": "array",
+                "description": "Sets environment variables for executed process.",
+                "items": {
+                  "type": "object",
+                  "description": "Sets environment variables for executed process.",
+                  "additionalProperties": false,
+                  "properties": {
+                    "key": {
+                      "type": "string",
+                      "pattern": "^[A-Za-z_][A-Za-z0-9_]*"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "Image": {
+                "description": "Container Image to use",
+                "type": "string"
+              },
+              "Exec": {
+                "description": "Command to execute in container",
+                "type": "string"
+              },
+              "Volume": {
+                "description": "Volumes to use",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "User": {
+                "description": "Run as user",
+                "type": "string"
+              },
+              "Group": {
+                "description": "Run as group",
+                "type": "string"
+              },
+              "AddDevice": {
+                "description": "Add device to container",
+                "type": "string"
+              },
+              "Network": {
+                "description": "What network option to use",
+                "type": "string"
+              },
+              "WorkingDir": {
+                "description": "Working directory for initial process",
+                "type": "string"
+              }
+            }
+          },
+          "Volume": {
+            "additionalProperties": false,
+            "type": "object",
+            "description": "'Volume' configuration section of a unit file.",
+            "required": [
+              "What"
+            ],
+            "properties": {
+              "VolumeName": {
+                "description": "Override volume name",
+                "type": "string"
+              },
+              "Driver": {
+                "description": "What volume driver to use",
+                "type": "string"
+              },
+              "Image": {
+                "description": "Image to use if driver is image",
+                "type": "string"
+              },
+              "User": {
+                "description": "User to use as owner of the volume",
+                "type": "string"
+              },
+              "Group": {
+                "description": "Group to use as owner of the volume",
+                "type": "string"
+              }
+            }
+          },
+          "Network": {
+            "additionalProperties": false,
+            "type": "object",
+            "description": "'Network' configuration section of a unit file.",
+            "properties": {
+              "Gateway": {
+                "description": "Addres of gaterway",
+                "type": "boolean"
+              },
+              "DNS": {
+                "description": "Address of DNS server",
+                "type": "boolean"
+              },
+              "IPRange": {
+                "description": "Range to allocate IPs from",
+                "type": "boolean"
+              },
+              "Subnet": {
+                "description": "Subnet in CIDR notation",
+                "type": "boolean"
+              },
+              "Driver": {
+                "description": "What network driver to use",
+                "type": "boolean"
+              },
+              "NetworkName": {
+                "description": "Override network name",
+                "type": "boolean"
+              }
+            }
+          },
+          "Install": {
+            "additionalProperties": false,
+            "type": "object",
+            "description": "'Install' configuration section of a unit file.",
+            "properties": {
+              "WantedBy": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "RequiredBy": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/stages/org.osbuild.systemd.unit
+++ b/stages/org.osbuild.systemd.unit
@@ -24,7 +24,7 @@ def main(tree, options):
 
     # We trick configparser into letting us write multiple instances of the same option by writing them as keys with no
     # value, so we enable allow_no_value
-    config = configparser.ConfigParser(allow_no_value=True)
+    config = configparser.ConfigParser(allow_no_value=True, interpolation=None)
     # prevent conversion of the option name to lowercase
     config.optionxform = lambda option: option
 

--- a/stages/org.osbuild.systemd.unit.create
+++ b/stages/org.osbuild.systemd.unit.create
@@ -17,6 +17,8 @@ def validate(filename, cfg):
         raise ValueError(f"Error: {filename} unit requires Service section")
     if filename.endswith(".mount") and "Mount" not in cfg:
         raise ValueError(f"Error: {filename} unit requires Mount section")
+    if filename.endswith(".socket") and "Socket" not in cfg:
+        raise ValueError(f"Error: {filename} unit requires Socket section")
 
 
 def main(tree, options):

--- a/stages/org.osbuild.systemd.unit.create
+++ b/stages/org.osbuild.systemd.unit.create
@@ -28,7 +28,7 @@ def main(tree, options):
 
     # We trick configparser into letting us write multiple instances of the same option by writing them as keys with no
     # value, so we enable allow_no_value
-    config = configparser.ConfigParser(allow_no_value=True)
+    config = configparser.ConfigParser(allow_no_value=True, interpolation=None)
     # prevent conversion of the option name to lowercase
     config.optionxform = lambda option: option
 

--- a/stages/org.osbuild.systemd.unit.create.meta.json
+++ b/stages/org.osbuild.systemd.unit.create.meta.json
@@ -90,9 +90,17 @@
               "Install"
             ],
             "not": {
-              "required": [
-                "Mount",
-                "Socket"
+              "anyOf": [
+                {
+                  "required": [
+                    "Mount"
+                  ]
+                },
+                {
+                  "required": [
+                    "Socket"
+                  ]
+                }
               ]
             }
           },
@@ -101,9 +109,17 @@
               "Socket"
             ],
             "not": {
-              "required": [
-                "Mount",
-                "Service"
+              "anyOf": [
+                {
+                  "required": [
+                    "Mount"
+                  ]
+                },
+                {
+                  "required": [
+                    "Service"
+                  ]
+                }
               ]
             }
           },
@@ -112,9 +128,17 @@
               "Mount"
             ],
             "not": {
-              "required": [
-                "Service",
-                "Socket"
+              "anyOf": [
+                {
+                  "required": [
+                    "Service"
+                  ]
+                },
+                {
+                  "required": [
+                    "Socket"
+                  ]
+                }
               ]
             }
           }

--- a/stages/org.osbuild.systemd.unit.create.meta.json
+++ b/stages/org.osbuild.systemd.unit.create.meta.json
@@ -37,7 +37,7 @@
     "    - 'ListenStream' - string",
     "    - 'ListenDatagram' - string",
     "    - 'ListenSequentialPacket' - string",
-    "    - 'ListenFifo' - string",
+    "    - 'ListenFIFO' - string",
     "    - 'SocketUser' - string",
     "    - 'SocketGroup' - string",
     "    - 'SocketMode' - string",

--- a/stages/org.osbuild.systemd.unit.create.meta.json
+++ b/stages/org.osbuild.systemd.unit.create.meta.json
@@ -33,6 +33,19 @@
     "    - 'Where' - string",
     "    - 'Type' - string",
     "    - 'Options' - string",
+    "  - 'Socket' section",
+    "    - 'ListenStream' - string",
+    "    - 'ListenDatagram' - string",
+    "    - 'ListenSequentialPacket' - string",
+    "    - 'ListenFifo' - string",
+    "    - 'SocketUser' - string",
+    "    - 'SocketGroup' - string",
+    "    - 'SocketMode' - string",
+    "    - 'DirectoryMode' - string",
+    "    - 'Accept' - bool",
+    "    - 'Service' - string",
+    "    - 'RuntimeDirectory' - string",
+    "    - 'RemoveOnStop' - bool",
     "  - 'Install' section",
     "    - 'WantedBy' - [string]",
     "    - 'RequiredBy' - [string]"
@@ -46,7 +59,7 @@
     "properties": {
       "filename": {
         "type": "string",
-        "pattern": "^[\\w:.\\\\-]+[@]{0,1}[\\w:.\\\\-]*\\.(service|mount)$"
+        "pattern": "^[\\w:.\\\\-]+[@]{0,1}[\\w:.\\\\-]*\\.(service|mount|socket)$"
       },
       "unit-type": {
         "type": "string",
@@ -78,7 +91,19 @@
             ],
             "not": {
               "required": [
-                "Mount"
+                "Mount",
+                "Socket"
+              ]
+            }
+          },
+          {
+            "required": [
+              "Socket"
+            ],
+            "not": {
+              "required": [
+                "Mount",
+                "Service"
               ]
             }
           },
@@ -88,7 +113,8 @@
             ],
             "not": {
               "required": [
-                "Service"
+                "Service",
+                "Socket"
               ]
             }
           }
@@ -233,6 +259,61 @@
               "Options": {
                 "descriptions": "Mount options to use when mounting",
                 "type": "string"
+              }
+            }
+          },
+          "Socket": {
+            "additionalProperties": false,
+            "type": "object",
+            "description": "'Socket' configuration section of a unit file.",
+            "properties": {
+              "Service": {
+                "description": "",
+                "type": "string"
+              },
+              "ListenStream": {
+                "description": "",
+                "type": "string"
+              },
+              "ListenDatagram": {
+                "description": "",
+                "type": "string"
+              },
+              "ListenSequentialPacket": {
+                "description": "",
+                "type": "string"
+              },
+              "ListenFifo": {
+                "description": "",
+                "type": "string"
+              },
+              "SocketUser": {
+                "description": "",
+                "type": "string"
+              },
+              "SocketGroup": {
+                "description": "",
+                "type": "string"
+              },
+              "SocketMode": {
+                "description": "",
+                "type": "string"
+              },
+              "DirectoryMode": {
+                "description": "",
+                "type": "string"
+              },
+              "Accept": {
+                "description": "",
+                "type": "boolean"
+              },
+              "RuntimeDirectory": {
+                "description": "",
+                "type": "string"
+              },
+              "RemoveOnStop": {
+                "description": "",
+                "type": "boolean"
               }
             }
           },

--- a/stages/test/test_containers_unit_create.py
+++ b/stages/test/test_containers_unit_create.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python3
+
+import os
+import textwrap
+
+import pytest
+
+from osbuild import testutil
+
+STAGE_NAME = "org.osbuild.containers.unit.create"
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # good
+    (
+        {
+            "filename": "foo.container",
+            "config": {
+                "Unit": {},
+                "Service": {},
+                "Container": {
+                    "Image": "img"
+                },
+                "Install": {},
+            },
+        },
+        "",
+    ),
+    (
+        {
+            "filename": "foo.volume",
+            "config": {
+                "Unit": {},
+                "Volume": {},
+                "Install": {},
+            },
+        },
+        "",
+    ),
+    (
+        {
+            "filename": "foo.network",
+            "config": {
+                "Network": {},
+            },
+        },
+        "",
+    ),
+    # bad
+    ({"config": {"Unit": {}, "Container": {"Image": "img"}, "Install": {}}}, "'filename' is a required property"),
+    ({"filename": "foo.container"}, "'config' is a required property"),
+    ({"filename": "foo.container", "config": {"Container": {"Image": "img"}, "Install": {}}},
+     "{'Container': {'Image': 'img'}, 'Install': {}} is not valid under any of the given schemas"),
+    ({"filename": "foo.container", "config": {"Unit": {}, "Install": {}}},
+     "{'Unit': {}, 'Install': {}} is not valid under any of the given schemas"),
+    ({"filename": "foo.container", "config": {"Network": {}, "Volume": {}}},
+     "{'Network': {}, 'Volume': {}} is not valid under any of the given schemas")
+])
+@pytest.mark.parametrize("stage_schema", ["1"], indirect=True)
+def test_schema_validation(stage_schema, test_data, expected_err):
+    test_input = {
+        "name": STAGE_NAME,
+        "options": test_data,
+    }
+    res = stage_schema.validate(test_input)
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # good
+    (
+        {
+            "filename": "foo.service",
+            "config": {
+                "Unit": {},
+                "Service": {},
+                "Install": {},
+            },
+        },
+        "",
+    ),
+    (
+        {
+            "filename": "foo.network",
+            "config": {
+                "Unit": {},
+                "Network": {},
+                "Install": {},
+            },
+        },
+        "",
+    ),
+    (
+        {
+            "filename": "foo.volume",
+            "config": {
+                "Volume": {},
+            },
+        },
+        "",
+    ),
+    # bad
+    ({"filename": "something.container", "config": {"Unit": {}, "Volume": {}, "Install": {}}},
+     "Error: something.container unit requires Container section"),
+    ({"filename": "data-gifs-cats.volume", "config": {"Unit": {}, "Network": {}, "Install": {}}},
+     "Error: data-gifs-cats.volume unit requires Volume section"),
+])
+def test_name_config_match(tmp_path, stage_module, test_data, expected_err):
+    expected_unit_path = tmp_path / "usr/share/containers/systemd"
+    expected_unit_path.mkdir(parents=True, exist_ok=True)
+    try:
+        stage_module.main(tmp_path, test_data)
+    except ValueError as ve:
+        assert expected_err == str(ve)
+
+
+@pytest.mark.parametrize("unit_path,expected_prefix", [
+    ("usr", "usr/share/containers/systemd"),
+    ("etc", "etc/containers/systemd")
+])
+def test_systemd_unit_create(tmp_path, stage_module, unit_path, expected_prefix):
+    options = {
+        "filename": "create-directory.container",
+        "unit-path": unit_path,
+        "config": {
+            "Unit": {
+                "Description": "Create directory",
+                "DefaultDependencies": False,
+                "ConditionPathExists": [
+                    "|!/etc/myfile"
+                ],
+                "ConditionPathIsDirectory": [
+                    "|!/etc/mydir"
+                ],
+                # need to use real units otherwise the validation will fail
+                "Wants": [
+                    "basic.target",
+                    "sysinit.target",
+                ],
+                "Requires": [
+                    "paths.target",
+                    "sockets.target",
+                ],
+                "After": [
+                    "sysinit.target",
+                    "default.target",
+                ],
+                "Before": [
+                    "multi-user.target",
+                ],
+            },
+            "Container": {
+                "Image": "img",
+                "Environment": [
+                    {
+                        "key": "DEBUG",
+                        "value": "1",
+                    },
+                    {
+                        "key": "TRACE",
+                        "value": "1",
+                    },
+                ]
+            },
+            "Install": {
+                "WantedBy": [
+                    "local-fs.target"
+                ],
+                "RequiredBy": [
+                    "multi-user.target"
+                ]
+            }
+        }
+    }
+
+    expected_unit_path = tmp_path / expected_prefix / "create-directory.container"
+    expected_unit_path.parent.mkdir(parents=True, exist_ok=True)
+
+    stage_module.main(tmp_path, options)
+    assert os.path.exists(expected_unit_path)
+    assert expected_unit_path.read_text(encoding="utf-8") == textwrap.dedent("""\
+    [Unit]
+    Description=Create directory
+    DefaultDependencies=False
+    ConditionPathExists=|!/etc/myfile
+    ConditionPathIsDirectory=|!/etc/mydir
+    Wants=basic.target
+    Wants=sysinit.target
+    Requires=paths.target
+    Requires=sockets.target
+    After=sysinit.target
+    After=default.target
+    Before=multi-user.target
+
+    [Container]
+    Image=img
+    Environment="DEBUG=1"
+    Environment="TRACE=1"
+
+    [Install]
+    WantedBy=local-fs.target
+    RequiredBy=multi-user.target
+
+    """)


### PR DESCRIPTION
This adds enough to make the examples in the automotive documentation not have to use hand-written files for these units.

For example, one could use:
```
  - type: org.osbuild.systemd.unit.create
    options:
      filename: radio.socket
      config:
        Unit:
          Description: An example systemd unix socket
        Socket:
          ListenStream: "%t/asil-ipc-demo/asil_ipc.socket"
          RuntimeDirectory: asil-ipc-demo
        Install:
          WantedBy:
            - sockets.target
```
or
```
  - type: org.osbuild.containers.unit.create
    options:
      filename: radio.container
      config:
        Unit:
          Description: Demo radio service container
          Requires:
            - routingmanagerd.socket
          Wants:
            - engine.service
        Container:
          Image: localhost/auto-apps
          Exec: /usr/bin/radio-service
          Volume:
            - /run/vsomeip:/run/vsomeip
        Service:
          Restart: always
        Install:
          WantedBy:
            - multi-user.target
```