### PR TITLE
stages/selinux: don't require file_contexts if labels passed

### DIFF
--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -8,11 +8,14 @@ from osbuild.util import selinux
 
 
 def main(tree, options):
-    file_contexts = os.path.join(f"{tree}", options["file_contexts"])
+    file_contexts = options.get("file_contexts")
     exclude_paths = options.get("exclude_paths")
-    if exclude_paths:
-        exclude_paths = [os.path.join(tree, p.lstrip("/")) for p in exclude_paths]
-    selinux.setfiles(file_contexts, os.fspath(tree), "", exclude_paths=exclude_paths)
+
+    if file_contexts:
+        file_contexts = os.path.join(f"{tree}", options["file_contexts"])
+        if exclude_paths:
+            exclude_paths = [os.path.join(tree, p.lstrip("/")) for p in exclude_paths]
+        selinux.setfiles(file_contexts, os.fspath(tree), "", exclude_paths=exclude_paths)
 
     labels = options.get("labels", {})
     for path, label in labels.items():

--- a/stages/org.osbuild.selinux.meta.json
+++ b/stages/org.osbuild.selinux.meta.json
@@ -20,8 +20,17 @@
   "schema_2": {
     "options": {
       "additionalProperties": false,
-      "required": [
-        "file_contexts"
+      "anyOf": [
+        {
+          "required": [
+            "file_contexts"
+          ]
+        },
+        {
+          "required": [
+            "labels"
+          ]
+        }
       ],
       "properties": {
         "file_contexts": {


### PR DESCRIPTION
With the labels option the user is specifying the exact context they want to set on the path so it's not necessary to supply a context here. This can be also useful in the case where you want to set some labels and you haven't yet populated the tree yet.