### PR TITLE
sources: MTLS and proxy support for ostree

### DIFF
--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -135,6 +135,27 @@ def setup_remote(repo, name, remote):
         secrets = Subscriptions.get_consumer_secrets()
         remote_add_args.append(f"--set=tls-client-key-path={secrets['consumer_key']}")
         remote_add_args.append(f"--set=tls-client-cert-path={secrets['consumer_cert']}")
+    elif remote.get("secrets", {}).get("name") == "org.osbuild.mtls":
+        tlsca = os.getenv("OSBUILD_SOURCES_OSTREE_SSL_CA_CERT")
+        if tlsca:
+            remote_add_args.append(f"--set=tls-ca-path={tlsca}")
+
+        tlscert = os.getenv("OSBUILD_SOURCES_OSTREE_SSL_CLIENT_CERT")
+        if tlscert:
+            remote_add_args.append(f"--set=tls-client-cert-path={tlscert}")
+
+        tlskey = os.getenv("OSBUILD_SOURCES_OSTREE_SSL_CLIENT_KEY")
+        if tlskey:
+            remote_add_args.append(f"--set=tls-client-key-path={tlskey}")
+
+        proxy = os.getenv("OSBUILD_SOURCES_OSTREE_PROXY")
+        if proxy:
+            remote_add_args.append(f"--set=proxy={proxy}")
+
+        # Insecure mode is meant for development only
+        insecure = os.getenv("OSBUILD_SOURCES_OSTREE_INSECURE")
+        if insecure and insecure.lower() in ["true", "yes", "1"]:
+            remote_add_args.append("--set=tls-permissive=true")
 
     cli("remote", "add", name, url,
         *remote_add_args, repo=repo)

--- a/sources/org.osbuild.ostree
+++ b/sources/org.osbuild.ostree
@@ -3,7 +3,22 @@
 
 Uses ostree to pull specific commits from (remote) repositories
 at the provided `url`. Can verify the commit, if one or more
-gpg keys are provided via `gpgkeys`.
+gpg keys are provided via `gpgkeys`. The secret providers currently
+supported are:
+
+- `org.osbuild.mtls` for downloading content that requires client
+  certificate. The paths to the key and cert should be set in the
+  environment in OSBUILD_SOURCES_OSTREE_SSL_CLIENT_KEY,
+  OSBUILD_SOURCES_OSTREE_SSL_CLIENT_CERT, and optionally
+  OSBUILD_SOURCES_OSTREE_SSL_CA_CERT.
+
+- `org.osbuild.rhsm.consumer` for downloading content using RHSM
+  entitlement certificate. Secret fields `consumer_cert` and
+  `consumer_key` must be set.
+
+To skip TLS verification, set OSBUILD_SOURCES_OSTREE_INSECURE environment
+variable to "true". To set a HTTP(S) proxy, set OSBUILD_SOURCES_OSTREE_PROXY
+environment variable to the proxy URL.
 """
 
 


### PR DESCRIPTION
In order to move edge service from own S3 repo hosting to on-prem pulp, we need to be able to pull ostree commits from MTLS repo. Additionally, on stage we must use HTTPS proxy in order to reach out there from the cluster.

This patch is quite bold, I am being honest. It adds support for several configuration values from ostree repo config, namely:

* server ca
* permissive mode (useful for testing)
* client cert
* client key (yeah yeah!)
* proxy URL

For more config repo details head over to: https://ostreedev.github.io/ostree/man/ostree.repo-config.html

I really don’t know if this is the right path, sending keys over wire seems weird but I don’t see a better solution.

Please guide me through tests, how and where should test this? Thanks.

https://issues.redhat.com/browse/HMS-4751