### PR TITLE
Fix dependencies and test for DNF4 based osbuild-depsolve-dnf

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -137,11 +137,11 @@ manifests and osbuild.
 Summary:        Dependency solving support for DNF
 Requires:       %{name} = %{version}-%{release}
 
-# Fedora 41 and later use libdnf5, RHEL and Fedora < 41 use libdnf
+# Fedora 41 and later use libdnf5, RHEL and Fedora < 41 use dnf
 %if 0%{?fedora} >= 41
 Requires: python3-libdnf5 >= 5.2.1
 %else
-Requires: python3-libdnf
+Requires: python3-dnf
 %endif
 
 # osbuild 125 added a new "solver" field and osbuild-composer only

--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -35,8 +35,8 @@ def assert_dnf5():
 
 
 def assert_dnf():
-    if sp.run(["/usr/bin/python3", "-c", "import libdnf"], check=False).returncode != 0:
-        raise RuntimeError("Cannot import libdnf")
+    if sp.run(["/usr/bin/python3", "-c", "import dnf"], check=False).returncode != 0:
+        raise RuntimeError("Cannot import dnf")
 
 
 def depsolve(transactions, repos, root_dir, cache_dir, dnf_config, opt_metadata, with_sbom=False) -> Tuple[dict, int]:


### PR DESCRIPTION
For the DNF4 version, we actually use 'dnf' package and not 'libdnf'. Fix the SPEC file dependencies and also the check in unit test.