### PR TITLE
osbuild/solver: provide pacman depsolver

### DIFF
--- a/osbuild/solver/pacman.py
+++ b/osbuild/solver/pacman.py
@@ -1,0 +1,143 @@
+import json
+import pathlib
+import subprocess
+
+from osbuild.solver import SolverBase
+
+CONFIGURATION_TEMPLATE = """
+[options]
+Architecture = {architecture}
+CheckSpace
+SigLevel    = Required DatabaseOptional
+LocalFileSigLevel = Optional
+"""
+
+REPOSITORY_TEMPLATE = """
+[{id}]
+Server = {url}
+"""
+
+# Output format for pacman that's close enough to JSON to pretend it
+# is JSON
+PRINT_FORMAT = '{"url": "%l", "version": "%v", "name": "%n"},'
+
+
+def _parse_package_info(text: str) -> dict[str, str]:
+    lines = text.split("\n")
+
+    def parse_line(l):
+        k, v = l.split(":", maxsplit=1)
+        return k.strip(), v.strip()
+
+    return dict(parse_line(line) for line in lines if ":" in line)
+
+
+class Pacman(SolverBase):
+    def __init__(self, request: dict, cache_path: str) -> None:
+        self._cache_path = pathlib.Path(cache_path)
+
+        self._etc_path = self._cache_path / "etc"
+        self._cfg_path = self._etc_path / "pacman.conf"
+
+        self._lib_path = self._cache_path / "var/lib/pacman"
+
+        self._architecture = request["arch"]
+        self._repositories = request.get("arguments", {}).get("repos", [])
+
+    def _prepare_root(self) -> None:
+        """Prepares a pacman root for a our architecture by preparing the
+        necessary directories and writing a pacman configuration file that
+        includes the configured repositories."""
+
+        self._etc_path.mkdir(parents=True, exist_ok=True)
+        self._lib_path.mkdir(parents=True, exist_ok=True)
+
+        text = CONFIGURATION_TEMPLATE.format(architecture=self._architecture)
+
+        for repository in self._repositories:
+            text = text + REPOSITORY_TEMPLATE.format(
+                id=repository["id"], url=repository["baseurl"]
+            )
+
+        self._cfg_path.write_text(text)
+
+    def depsolve(self, arguments: dict) -> dict:
+        self._prepare_root()
+
+        # Ensure there is exactly one transaction given by unpacking the given
+        # transactions into a single name
+        (transaction,) = arguments.get("transactions", [])
+
+        # Run pacman's sync and refresh first to make sure the root is valid
+        subprocess.run(
+            [
+                "pacman", "-Sy",
+                "--root", str(self._cache_path),
+                "--config", str(self._cfg_path),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+
+        # Pacman does not have any form of JSON output so we're going to build
+        # JSON with string formatting!
+        result = subprocess.run(
+            [
+                "pacman", "-S",
+                "--print",
+                "--print-format", PRINT_FORMAT,
+                "--sysroot", str(self._cache_path),
+                *transaction["package-specs"]["include"],
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        ).stdout.decode("utf-8")
+
+        result = result.strip().rstrip(",")
+        result = f"[{result}]"
+
+        # The certainty of this being valid JSON is: "uhh, maybe" so let's try
+        # to load it.
+        selected = json.loads(result)
+        packages = []
+
+        for selection in selected:
+            # We need to request more information from pacman for each package
+            text = subprocess.run(
+                [
+                    "pacman", "-Sii",
+                    "--sysroot", str(self._cache_path),
+                    selection["name"],
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            ).stdout.decode("utf-8")
+
+            info = _parse_package_info(text)
+
+            packages.append({
+                "name": selection["name"],
+                "version": selection["version"],
+                "url": selection["url"],
+
+                "arch": info["Architecture"],
+
+                "license": info.get("Licenses"),
+                "description": info.get("Description"),
+                "buildtime": info.get("Build Date"),
+            })
+
+        return {
+            "solver": "pacman",
+            "packages": packages,
+            "repos": self._repositories,
+        }
+
+    def dump(self):
+        raise NotImplementedError()
+
+    def search(self, _):
+        raise NotImplementedError()

--- a/tools/osbuild-depsolve-pacman
+++ b/tools/osbuild-depsolve-pacman
@@ -1,0 +1,168 @@
+#!/usr/bin/python3
+# pylint: disable=invalid-name
+
+"""
+A JSON-based interface for depsolving using Pacman.
+
+Reads a request through stdin and prints the result to stdout.
+In case of error, a structured error is printed to stdout as well.
+"""
+import json
+import os
+import os.path
+import sys
+
+from osbuild.solver import DepsolveError, GPGKeyReadError, InvalidRequestError, MarkingError, RepoError
+from osbuild.solver.pacman import Pacman as Solver
+
+
+def get_string_option(option):
+    # option.get_value() causes an error if it's unset for string values, so check if it's empty first
+    if option.empty():
+        return None
+    return option.get_value()
+
+
+def setup_cachedir(request):
+    arch = request["arch"]
+    # If dnf-json is run as a service, we don't want users to be able to set the cache
+    cache_dir = os.environ.get("OVERWRITE_CACHE_DIR", "")
+    if cache_dir:
+        cache_dir = os.path.join(cache_dir, arch)
+    else:
+        cache_dir = request.get("cachedir", "")
+
+    if not cache_dir:
+        return "", {"kind": "Error", "reason": "No cache dir set"}
+
+    return cache_dir, None
+
+
+def solve(request, cache_dir):
+    command = request["command"]
+    arguments = request["arguments"]
+
+    try:
+        solver = Solver(request, cache_dir)
+        if command == "dump":
+            result = solver.dump()
+        elif command == "depsolve":
+            result = solver.depsolve(arguments)
+        elif command == "search":
+            result = solver.search(arguments.get("search", {}))
+    except GPGKeyReadError as e:
+        printe("error reading gpgkey")
+        return None, {
+            "kind": type(e).__name__,
+            "reason": str(e)
+        }
+    except RepoError as e:
+        return None, {
+            "kind": "RepoError",
+            "reason": f"There was a problem reading a repository: {e}"
+        }
+    except MarkingError as e:
+        printe("error install_specs")
+        return None, {
+            "kind": "MarkingErrors",
+            "reason": f"Error occurred when marking packages for installation: {e}"
+        }
+    except DepsolveError as e:
+        printe("error depsolve")
+        # collect list of packages for error
+        pkgs = []
+        for t in arguments.get("transactions", []):
+            pkgs.extend(t["package-specs"])
+        return None, {
+            "kind": "DepsolveError",
+            "reason": f"There was a problem depsolving {', '.join(pkgs)}: {e}"
+        }
+    except InvalidRequestError as e:
+        printe("error invalid request")
+        return None, {
+            "kind": "InvalidRequest",
+            "reason": str(e)
+        }
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        printe("error traceback")
+        import traceback
+        return None, {
+            "kind": type(e).__name__,
+            "reason": str(e),
+            "traceback": traceback.format_exc()
+        }
+
+    return result, None
+
+
+def printe(*msg):
+    print(*msg, file=sys.stderr)
+
+
+def fail(err):
+    printe(f"{err['kind']}: {err['reason']}")
+    print(json.dumps(err))
+    sys.exit(1)
+
+
+def respond(result):
+    print(json.dumps(result))
+
+
+# pylint: disable=too-many-return-statements
+def validate_request(request):
+    command = request.get("command")
+    valid_cmds = ("depsolve",)
+    if command not in valid_cmds:
+        return {
+            "kind": "InvalidRequest",
+            "reason": f"invalid command '{command}': must be one of {', '.join(valid_cmds)}"
+        }
+
+    if not request.get("arch"):
+        return {
+            "kind": "InvalidRequest",
+            "reason": "no 'arch' specified"
+        }
+
+    arguments = request.get("arguments")
+    if not arguments:
+        return {
+            "kind": "InvalidRequest",
+            "reason": "empty 'arguments'"
+        }
+
+    sbom = request["arguments"].get("sbom")
+    if sbom is not None:
+        return {
+            "kind": "InvalidRequest",
+            "reason": "SBOM support for DNF5 is not implemented"
+        }
+
+    if not arguments.get("repos"):
+        return {
+            "kind": "InvalidRequest",
+            "reason": "no 'repos'"
+        }
+
+    return None
+
+
+def main():
+    request = json.load(sys.stdin)
+    err = validate_request(request)
+    if err:
+        fail(err)
+
+    cachedir, err = setup_cachedir(request)
+    if err:
+        fail(err)
+    result, err = solve(request, cachedir)
+    if err:
+        fail(err)
+    else:
+        respond(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/osbuild-depsolve-pacman
+++ b/tools/osbuild-depsolve-pacman
@@ -136,7 +136,7 @@ def validate_request(request):
     if sbom is not None:
         return {
             "kind": "InvalidRequest",
-            "reason": "SBOM support for DNF5 is not implemented"
+            "reason": "SBOM support for Pacman is not available"
         }
 
     if not arguments.get("repos"):


### PR DESCRIPTION
We (used to) have a dependency solver for Pacman and we still have stages to install packages with Pacman. I'm spending some quality time trying to build alternative distributions to see what kind of problems I encounter.

This commit moves the Pacman depsolver into our new solver structure (e.g. living inside the `osbuild` package, with a separate executable in `tools/`).

Note that this is broken as we don't have a working Pacman on Fedora 40 at the moment, though 41 works.

Pacman isn't working due to:

```
user@muja osbuild € sudo ./tools/osbuild-depsolve-pacman < depsolve.json | jq .
error traceback
CalledProcessError: Command '['pacman', '-Sii', '--sysroot', '/tmp/depsolve-pacman', 'linux-api-headers']' died with <Signals.SIGABRT: 6>.
{
  "kind": "CalledProcessError",
  "reason": "Command '['pacman', '-Sii', '--sysroot', '/tmp/depsolve-pacman', 'linux-api-headers']' died with <Signals.SIGABRT: 6>.",
  "traceback": "Traceback (most recent call last):\n  File \"/home/user/src/rh/osbuild/./tools/osbuild-depsolve-pacman\", line 52, in solve\n    result = solver.depsolve(arguments)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/user/src/rh/osbuild/tools/osbuild/solver/pacman.py\", line 109, in depsolve\n    text = subprocess.run(\n           ^^^^^^^^^^^^^^^\n  File \"/usr/lib64/python3.12/subprocess.py\", line 571, in run\n    raise CalledProcessError(retcode, process.args,\nsubprocess.CalledProcessError: Command '['pacman', '-Sii', '--sysroot', '/tmp/depsolve-pacman', 'linux-api-headers']' died with <Signals.SIGABRT: 6>.\n"
}
user@muja osbuild € sudo pacman -Sii --sysroot /tmp/depsolve-pacman linux-api-headers
*** buffer overflow detected ***: terminated
zsh: IOT instruction  sudo pacman -Sii --sysroot /tmp/depsolve-pacman linux-api-headers
user@muja osbuild € pacman --version

 .--.                  Pacman v6.1.0 - libalpm v14.0.0
/ _.-' .-.  .-.  .-.   Copyright (C) 2006-2024 Pacman Development Team
\  '-. '-'  '-'  '-'   Copyright (C) 2002-2006 Judd Vinet
 '--'
                       This program may be freely redistributed under
                       the terms of the GNU General Public License.
```