### PR TITLE
CI: Update excluded tests list

### DIFF
--- a/.github/workflows/test-on-centos.yml
+++ b/.github/workflows/test-on-centos.yml
@@ -13,7 +13,7 @@ jobs:
           - version: "9"
             pytest_exclude: 'not (TestBoot and boot)'
           - version: "10"
-            pytest_exclude: 'not (TestBoot and boot)'
+            pytest_exclude: 'not (TestBoot and boot) and not (test_write_read)'
     name: "Unittests on Centos Stream ${{ matrix.centos.version }}"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
After removal of TOML write packages on c9s and c10s some tests using this library needs to be skipped.