### PR TITLE
schema: `metadata` at the top level

### DIFF
--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -166,6 +166,9 @@ def describe(manifest: Manifest, *, with_id=False) -> Dict:
         "pipelines": pipelines
     }
 
+    if manifest.metadata:
+        description["metadata"] = manifest.metadata
+
     if sources:
         description["sources"] = sources
 
@@ -355,9 +358,14 @@ def load(description: Dict, index: Index) -> Manifest:
 
     sources = description.get("sources", {})
     pipelines = description.get("pipelines", [])
+    metadata = description.get("metadata", {})
 
     manifest = Manifest()
     source_refs = set()
+
+    # metadata
+    for key, value in metadata.items():
+        manifest.add_metadata(key, value)
 
     # load the sources
     for name, desc in sources.items():

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import os
 from fnmatch import fnmatch
-from typing import Dict, Generator, Iterable, Iterator, List, Optional
+from typing import Any, Dict, Generator, Iterable, Iterator, List, Optional
 
 from . import buildroot, host, objectstore, remoteloop
 from .api import API
@@ -388,8 +388,12 @@ class Manifest:
     """Representation of a pipeline and its sources"""
 
     def __init__(self):
+        self.metadata = {}
         self.pipelines = collections.OrderedDict()
         self.sources = []
+
+    def add_metadata(self, name: str, data: Dict[str, Any]) -> None:
+        self.metadata[name] = data
 
     def add_pipeline(
         self,

--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -19,6 +19,9 @@
       "enum": [
         "2"
       ]
+    },
+    "metadata": {
+      "$ref": "#/definitions/metadata"
     }
   },
   "definitions": {
@@ -80,6 +83,31 @@
         "options": {
           "type": "object",
           "additionalProperties": true
+        }
+      }
+    },
+    "metadata": {
+      "title": "Metadata information for a manifest",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "generators": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/test/data/manifests/fedora-boot.json
+++ b/test/data/manifests/fedora-boot.json
@@ -1,5 +1,13 @@
 {
   "version": "2",
+  "metadata": {
+    "generators": [
+      {
+        "name": "osbuild-mpp",
+        "version": "unknown"
+      }
+    ]
+  },
   "pipelines": [
     {
       "runner": "org.osbuild.fedora39",

--- a/test/data/manifests/fedora-boot.mpp.yaml
+++ b/test/data/manifests/fedora-boot.mpp.yaml
@@ -2,6 +2,10 @@
 # Noticed the org.osbuild.test that was added.
 
 version: '2'
+metadata:
+  generators:
+    - name: osbuild-mpp
+      version: unknown
 pipelines:
   - mpp-import-pipelines:
       path: fedora-vars.ipp.yaml

--- a/test/mod/test_fmt_v2.py
+++ b/test/mod/test_fmt_v2.py
@@ -12,6 +12,14 @@ import osbuild.meta
 
 BASIC_PIPELINE = {
     "version": "2",
+    "metadata": {
+        "generators": [
+            {
+                "name": "handcrafted",
+                "version": "NaN",
+            },
+        ],
+    },
     "sources": {
         "org.osbuild.curl": {
             "items": {


### PR DESCRIPTION
A new metadata key at the top level which contains a generators key which is a list of all generators involved in the creation of the manifest.

Tools that generate manifests are, for example: [otk](https://github.com/osbuild/otk), [osbuild-composer](https://github.com/osbuild/osbuild-composer) (through [images](https://github.com/osbuild/images)).