### PR TITLE
chore: add dicussions link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ of the pipeline description, and more.
 
  * **Website**: https://www.osbuild.org
  * **Bug Tracker**: https://github.com/osbuild/osbuild/issues
+ * **Discussions**: https://github.com/orgs/osbuild/discussions
  * **Matrix**: #image-builder on [fedoraproject.org](https://matrix.to/#/#image-builder:fedoraproject.org)
  * **Mailing List**: image-builder@redhat.com
  * **Changelog**: https://github.com/osbuild/osbuild/releases


### PR DESCRIPTION
I am keeping mailing list link, however, nobody was able to tell me how one can subscribe to it. I think it is Google Groups list now and there is no join option.