### PR TITLE
osbuild: add new `"build":"container:..."` support

### DIFF
--- a/osbuild/formats/v2.py
+++ b/osbuild/formats/v2.py
@@ -391,7 +391,7 @@ def load(description: Dict, index: Index) -> Manifest:
     }
 
     for pipeline in pipelines:
-        if not pipeline.build:
+        if not pipeline.build or pipeline.build.startswith("org.osbuild.containers-storage:"):
             pipeline.runner = host_runner
             continue
 

--- a/test/run/test_buildroot.py
+++ b/test/run/test_buildroot.py
@@ -1,0 +1,48 @@
+import json
+import os
+import subprocess
+
+import pytest
+
+from osbuild.testutil import make_container
+
+# pylint: disable=unused-import
+from .test_exports import osbuild_fixture, testing_libdir_fixture  # noqa:F401
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="root-only")
+def test_build_root_from_container_registry(osb, tmp_path, testing_libdir):
+    cnt_ref = "registry.access.redhat.com/ubi9:latest"
+    with make_container(tmp_path, {"/usr/bin/buildroot-from-container": "foo"}, cnt_ref) as fake_cnt_tag:
+        img_id = subprocess.check_output(["podman", "inspect", "--format={{.Id}}", fake_cnt_tag], text=True).strip()
+        jsondata = json.dumps({
+            "version": "2",
+            "pipelines": [
+                {
+                    "name": "image",
+                    "build": f"org.osbuild.containers-storage:sha256:{img_id}",
+                    "stages": [
+                        {
+                            "type": "org.osbuild.testing.injectpy",
+                            "options": {
+                                "code": [
+                                    'import os.path',
+                                    'assert os.path.exists("/usr/bin/buildroot-from-container")',
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ],
+            "sources": {
+                "org.osbuild.containers-storage": {
+                    "items": {
+                        f"sha256:{img_id}": {}
+                    }
+                }
+            }
+        })
+        osb.compile(jsondata, output_dir=tmp_path, exports=["image"], libdir=testing_libdir)
+        # ensure no mounts left behind
+        mounted = subprocess.check_output(["podman", "image", "mount"], text=True)
+        assert fake_cnt_tag not in mounted

--- a/test/run/test_exports.py
+++ b/test/run/test_exports.py
@@ -58,7 +58,7 @@ def testing_libdir_fixture(tmpdir_factory):
     # in buildroot.py
     (fake_libdir_path / "osbuild").mkdir()
     # construct minimal viable libdir from current checkout
-    for d in ["stages", "runners", "schemas", "assemblers"]:
+    for d in ["stages", "runners", "schemas", "assemblers", "sources"]:
         subprocess.run(
             ["cp", "-a", os.fspath(project_path / d), f"{fake_libdir_path}"],
             check=True)


### PR DESCRIPTION
This commit adds support to construct a build root for a pipeline from a container instead of a previous pipeline/tree. This is based on the idea from Ondrej in issue 1804.

A bootc-image-builder manifest would look something like this:
```json
{
  "version": "2",
  "pipelines": [
    {
      "name": "image",
      "build": "org.osbuild.containers-storage:quay.io/centos-bootc/centos-bootc:stream9",
...
```

Note that this is just an experiment and needs more thinking how to abstract/generalize this. It is meant as a faster way to do the org.osbuild.deploy-container stage does. We should also probably enforce the uses the container hash instead of a tag when using "build" for a start.

Closes: https://github.com/osbuild/osbuild/issues/1804