### PR TITLE
osbuild.spec: Add python3-dnf dependency for osbuild-tools

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -120,6 +120,7 @@ containers it uses to build OS artifacts.
 Summary:        Extra tools and utilities
 Requires:       %{name} = %{version}-%{release}
 Requires:       python3-pyyaml
+Requires:       python3-dnf
 
 # These are required for `osbuild-dev`, only packaged for Fedora
 %if 0%{?fedora}


### PR DESCRIPTION
The recent change in https://github.com/osbuild/osbuild/pull/1896 removed the dnf dependency, leading to failures in osbuild-mpp with the following error:

    ModuleNotFoundError: No module named 'dnf'

To fix it, add the python3-dnf dependency for the
osbuild-tools package.