### PR TITLE
stages/org.osbuild.tar: implement disk-full test (RHEL-4653)

### DIFF
--- a/stages/test/conftest.py
+++ b/stages/test/conftest.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import subprocess
 from types import ModuleType
 
 import pytest
@@ -43,3 +44,17 @@ def stage_schema(request: pytest.FixtureRequest) -> osbuild.meta.Schema:
     root = caller_dir.parent.parent
     mod_info = osbuild.meta.ModuleInfo.load(root, "Stage", stage_name)
     return osbuild.meta.Schema(mod_info.get_schema(version=schema_version), stage_name)
+
+
+@pytest.fixture
+def tmp_path_disk_full(tmp_path, tmp_path_disk_full_size):
+    small_dir = tmp_path / "small-dir"
+    small_dir.mkdir()
+    subprocess.run(["mount",
+                    "-t", "tmpfs",
+                    "-o", f"size={tmp_path_disk_full_size}",
+                    "tmpfs",
+                    small_dir
+                    ], check=True)
+    yield small_dir
+    subprocess.run(["umount", small_dir], check=True)

--- a/stages/test/test_tar.py
+++ b/stages/test/test_tar.py
@@ -159,4 +159,4 @@ def test_tar_disk_full(stage_module, fake_inputs, tmp_path_disk_full, capfd):
         stage_module.main(fake_inputs, tmp_path_disk_full, options)
 
     assert ex.value.returncode == 2
-    assert re.match(r".*Wrote only \d+ of \d+ bytes.*", str(capfd.readouterr().err))
+    assert re.search(r"Wrote only \d+ of \d+ bytes", str(capfd.readouterr().err))


### PR DESCRIPTION
As a followup of https://issues.redhat.com/browse/RHEL-4653 it seems that the stages don't return proper
error messages back if the disk is full.

Probably this is known and there is an issue for this, but I didn't find it.

This should be an example environment for more stages to test if they return a proper error in a "disk full scenario"

This PR is ment for a proof of concept for a test environment and basis of discussion
as the error of "disk full" is not properly handled not transformed to a proper error code and not handed over to the stack above in this code.

I think at least stages that have high risk of "disk full", like `tar`, `rpm`, `cp` … should handle "disk full" more gracefully and return a proper error message.
