### PR TITLE
test: extract a common osbuild_fixture() helper

### DIFF
--- a/test/run/test_exports.py
+++ b/test/run/test_exports.py
@@ -7,7 +7,7 @@ import subprocess
 
 import pytest
 
-from .. import test
+from ..test import osbuild_fixture  # noqa: F401, pylint: disable=unused-import
 
 
 @pytest.fixture(name="jsondata", scope="module")
@@ -40,12 +40,6 @@ def jsondata_fixture():
             }
         ]
     })
-
-
-@pytest.fixture(name="osb", scope="module")
-def osbuild_fixture():
-    with test.OSBuild() as osb:
-        yield osb
 
 
 @pytest.fixture(name="testing_libdir", scope="module")

--- a/test/run/test_noop.py
+++ b/test/run/test_noop.py
@@ -10,6 +10,7 @@ import pytest
 import osbuild.main_cli
 
 from .. import test
+from ..test import osbuild_fixture  # noqa: F401, pylint: disable=unused-import
 
 
 @pytest.fixture(name="jsondata", scope="module")
@@ -38,11 +39,6 @@ def jsondata_fixture():
         ]
     })
 
-
-@pytest.fixture(name="osb", scope="module")
-def osbuild_fixture():
-    with test.OSBuild() as osb:
-        yield osb
 
 #
 # Run a noop Pipeline. Run twice to verify the cache does not affect

--- a/test/test.py
+++ b/test/test.py
@@ -11,6 +11,8 @@ import sys
 import tempfile
 import unittest
 
+import pytest
+
 import osbuild.meta
 from osbuild.objectstore import ObjectStore
 from osbuild.util import linux
@@ -496,3 +498,10 @@ class OSBuild(contextlib.AbstractContextManager):
             "cp", "--reflink=auto", "-a",
             os.path.join(from_path, "."), to_path
         ], check=True)
+
+
+@pytest.fixture(name="osb")
+def osbuild_fixture():
+    store = os.getenv("OSBUILD_TEST_STORE")
+    with OSBuild(cache_from=store) as osb:
+        yield osb


### PR DESCRIPTION
We currently have three copies of the osbuild_fixture() fixture that are slightly different. This commit extract it into a single place in `test.py` and shares it accross the various callers.

Note that it would be even nicer to put it into `conftest.py` but there is a circular import right now when trying this. We should still do it eventually it just requires a bit more preperation work.

Split out from https://github.com/osbuild/osbuild/pull/1878