### PR TITLE
test: move (parts of) the stage tests to pytest (cleaned up )

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,8 @@
+import pathlib
+import tempfile
+
+import pytest
+
 unsupported_filesystems = []
 """Globally accessible list of filesystems that are unsupported on the system when running test cases"""
 
@@ -17,3 +22,12 @@ def pytest_configure(config):
     # pylint: disable=global-statement
     global unsupported_filesystems
     unsupported_filesystems = config.getoption("--unsupported-fs")
+
+
+# overriding the build-in "tmp_path" to use /var/tmp because
+# /tmp is often of limited size (e.g.tmpfs) and our tests
+# produce large amounts of data
+@pytest.fixture(name="tmp_path")
+def tmp_path_fixture():
+    with tempfile.TemporaryDirectory(dir="/var/tmp") as tmp:
+        yield pathlib.Path(tmp)

--- a/test/run/test_exports.py
+++ b/test/run/test_exports.py
@@ -7,7 +7,7 @@ import subprocess
 
 import pytest
 
-from .. import test
+from ..test import osbuild_fixture  # noqa: F401, pylint: disable=unused-import
 
 
 @pytest.fixture(name="jsondata", scope="module")
@@ -40,12 +40,6 @@ def jsondata_fixture():
             }
         ]
     })
-
-
-@pytest.fixture(name="osb", scope="module")
-def osbuild_fixture():
-    with test.OSBuild() as osb:
-        yield osb
 
 
 @pytest.fixture(name="testing_libdir", scope="module")

--- a/test/run/test_noop.py
+++ b/test/run/test_noop.py
@@ -10,6 +10,7 @@ import pytest
 import osbuild.main_cli
 
 from .. import test
+from ..test import osbuild_fixture  # noqa: F401, pylint: disable=unused-import
 
 
 @pytest.fixture(name="jsondata", scope="module")
@@ -38,11 +39,6 @@ def jsondata_fixture():
         ]
     })
 
-
-@pytest.fixture(name="osb", scope="module")
-def osbuild_fixture():
-    with test.OSBuild() as osb:
-        yield osb
 
 #
 # Run a noop Pipeline. Run twice to verify the cache does not affect

--- a/test/run/test_stages.py
+++ b/test/run/test_stages.py
@@ -103,105 +103,106 @@ def mapping_is_subset(subset, other):
     return False
 
 
+def assert_tree_diffs_equal(tree_diff1, tree_diff2):
+    """
+    Asserts two tree diffs for equality.
+
+    Before assertion, the two trees are sorted, therefore order of files
+    doesn't matter.
+
+    There's a special rule for asserting differences where we don't
+    know the exact before/after value. This is useful for example if
+    the content of file is dependent on current datetime. You can use this
+    feature by putting null value in difference you don't care about.
+
+    Example:
+        "/etc/shadow": {content: ["sha256:xxx", null]}
+
+        In this case the after content of /etc/shadow doesn't matter.
+        The only thing that matters is the before content and that
+        the content modification happened.
+
+    The first tree diff can additionally contain an `added_directories`
+    array. Such an entry can be used when you care that a directory is
+    added, but you don't care about its content. This means that all
+    `added_files` in the second tree under the `added_directory` entry
+    in the first tree will be ignored. Note that tree diffs currently
+    don't distinguish between added files and added directories, so the
+    `added_directories` entry is satisfied also if there's a file added
+    with such a name.
+    """
+
+    def _sorted_tree(tree):
+        sorted_tree = json.loads(json.dumps(tree, sort_keys=True))
+        sorted_tree["added_files"] = sorted(sorted_tree["added_files"])
+        sorted_tree["deleted_files"] = sorted(sorted_tree["deleted_files"])
+
+        return sorted_tree
+
+    tree_diff1 = _sorted_tree(tree_diff1)
+    tree_diff2 = _sorted_tree(tree_diff2)
+
+    def raise_assertion(msg):
+        diff = '\n'.join(
+            difflib.ndiff(
+                pprint.pformat(tree_diff1).splitlines(),
+                pprint.pformat(tree_diff2).splitlines(),
+            )
+        )
+        raise AssertionError(f"{msg}\n\n{diff}")
+
+    def path_equal_or_is_descendant(path, potential_ancestor):
+        """
+        :return: Returns true if path == potential_ancestor or if path is inside potential_ancestor
+        """
+        return path == potential_ancestor or path.startswith(potential_ancestor + "/")
+
+    for added_dir in tree_diff1.get('added_directories', []):
+        original = tree_diff2['added_files']
+
+        filtered = [p for p in original if not path_equal_or_is_descendant(p, added_dir)]
+
+        if len(filtered) == len(original):
+            raise_assertion(f'{added_dir} was not added')
+
+        tree_diff2['added_files'] = filtered
+
+    assert tree_diff1['added_files'] == tree_diff2['added_files']
+    assert tree_diff1['deleted_files'] == tree_diff2['deleted_files']
+
+    if len(tree_diff1['differences']) != len(tree_diff2['differences']):
+        raise_assertion('length of differences different')
+
+    for (file1, differences1), (file2, differences2) in \
+            zip(tree_diff1['differences'].items(), tree_diff2['differences'].items()):
+
+        if file1 != file2:
+            raise_assertion(f"filename different: {file1}, {file2}")
+
+        if len(differences1) != len(differences2):
+            raise_assertion("length of file differences different")
+
+        for (difference1_kind, difference1_values), (difference2_kind, difference2_values) in \
+                zip(differences1.items(), differences2.items()):
+            if difference1_kind != difference2_kind:
+                raise_assertion(f"different difference kinds: {difference1_kind}, {difference2_kind}")
+
+            if difference1_values[0] is not None \
+                    and difference2_values[0] is not None \
+                    and difference1_values[0] != difference2_values[0]:
+                raise_assertion(f"before values are different: {difference1_values[0]}, {difference2_values[0]}")
+
+            if difference1_values[1] is not None \
+                    and difference2_values[1] is not None \
+                    and difference1_values[1] != difference2_values[1]:
+                raise_assertion(f"after values are different: {difference1_values[1]}, {difference2_values[1]}")
+
+
 @unittest.skipUnless(test.TestBase.have_test_data(), "no test-data access")
 @unittest.skipUnless(test.TestBase.have_tree_diff(), "tree-diff missing")
 @unittest.skipUnless(test.TestBase.can_bind_mount(), "root-only")
 @make_stage_tests
 class TestStages(test.TestBase):
-
-    def assertTreeDiffsEqual(self, tree_diff1, tree_diff2):
-        """
-        Asserts two tree diffs for equality.
-
-        Before assertion, the two trees are sorted, therefore order of files
-        doesn't matter.
-
-        There's a special rule for asserting differences where we don't
-        know the exact before/after value. This is useful for example if
-        the content of file is dependent on current datetime. You can use this
-        feature by putting null value in difference you don't care about.
-
-        Example:
-            "/etc/shadow": {content: ["sha256:xxx", null]}
-
-            In this case the after content of /etc/shadow doesn't matter.
-            The only thing that matters is the before content and that
-            the content modification happened.
-
-        The first tree diff can additionally contain an `added_directories`
-        array. Such an entry can be used when you care that a directory is
-        added, but you don't care about its content. This means that all
-        `added_files` in the second tree under the `added_directory` entry
-        in the first tree will be ignored. Note that tree diffs currently
-        don't distinguish between added files and added directories, so the
-        `added_directories` entry is satisfied also if there's a file added
-        with such a name.
-        """
-
-        def _sorted_tree(tree):
-            sorted_tree = json.loads(json.dumps(tree, sort_keys=True))
-            sorted_tree["added_files"] = sorted(sorted_tree["added_files"])
-            sorted_tree["deleted_files"] = sorted(sorted_tree["deleted_files"])
-
-            return sorted_tree
-
-        tree_diff1 = _sorted_tree(tree_diff1)
-        tree_diff2 = _sorted_tree(tree_diff2)
-
-        def raise_assertion(msg):
-            diff = '\n'.join(
-                difflib.ndiff(
-                    pprint.pformat(tree_diff1).splitlines(),
-                    pprint.pformat(tree_diff2).splitlines(),
-                )
-            )
-            raise AssertionError(f"{msg}\n\n{diff}")
-
-        def path_equal_or_is_descendant(path, potential_ancestor):
-            """
-            :return: Returns true if path == potential_ancestor or if path is inside potential_ancestor
-            """
-            return path == potential_ancestor or path.startswith(potential_ancestor + "/")
-
-        for added_dir in tree_diff1.get('added_directories', []):
-            original = tree_diff2['added_files']
-
-            filtered = [p for p in original if not path_equal_or_is_descendant(p, added_dir)]
-
-            if len(filtered) == len(original):
-                raise_assertion(f'{added_dir} was not added')
-
-            tree_diff2['added_files'] = filtered
-
-        self.assertEqual(tree_diff1['added_files'], tree_diff2['added_files'])
-        self.assertEqual(tree_diff1['deleted_files'], tree_diff2['deleted_files'])
-
-        if len(tree_diff1['differences']) != len(tree_diff2['differences']):
-            raise_assertion('length of differences different')
-
-        for (file1, differences1), (file2, differences2) in \
-                zip(tree_diff1['differences'].items(), tree_diff2['differences'].items()):
-
-            if file1 != file2:
-                raise_assertion(f"filename different: {file1}, {file2}")
-
-            if len(differences1) != len(differences2):
-                raise_assertion("length of file differences different")
-
-            for (difference1_kind, difference1_values), (difference2_kind, difference2_values) in \
-                    zip(differences1.items(), differences2.items()):
-                if difference1_kind != difference2_kind:
-                    raise_assertion(f"different difference kinds: {difference1_kind}, {difference2_kind}")
-
-                if difference1_values[0] is not None \
-                        and difference2_values[0] is not None \
-                        and difference1_values[0] != difference2_values[0]:
-                    raise_assertion(f"before values are different: {difference1_values[0]}, {difference2_values[0]}")
-
-                if difference1_values[1] is not None \
-                        and difference2_values[1] is not None \
-                        and difference1_values[1] != difference2_values[1]:
-                    raise_assertion(f"after values are different: {difference1_values[1]}, {difference2_values[1]}")
 
     @classmethod
     def setUpClass(cls):
@@ -239,7 +240,7 @@ class TestStages(test.TestBase):
             with open(os.path.join(test_dir, "diff.json"), encoding="utf8") as f:
                 expected_diff = json.load(f)
 
-            self.assertTreeDiffsEqual(expected_diff, actual_diff)
+            assert_tree_diffs_equal(expected_diff, actual_diff)
 
             md_path = os.path.join(test_dir, "metadata.json")
             if os.path.exists(md_path):

--- a/test/test.py
+++ b/test/test.py
@@ -506,6 +506,18 @@ class OSBuild(contextlib.AbstractContextManager):
 
 @pytest.fixture(name="osb")
 def osbuild_fixture(tmp_path):
+    # XXX: this fixture needs work, maybe it needs to be split up into two
+    # the issues(s):
+    # 1. it becomes slow now for tests like "test_noop.py" because those
+    #    did not use to use "cache_from" which is expensive as it does
+    #    a copy of the entire store but "test_noop.py" does not need this
+    #    so test_noop should could use it's own.
+    #    So either a new fixutre or a parameter (or we live with the
+    #    multiple copies of this fixture)
+    # 2. the TestStages::setUpClass sets up a central store that is then
+    #    shared via "TestStages.copy_source_data()" - this speeds up
+    #    the individual stages, we need something similar, a session
+    #    shared cache which means a new store fixture(?)
     store = os.getenv("OSBUILD_TEST_STORE")
     if not store:
         store = tmp_path

--- a/test/test.py
+++ b/test/test.py
@@ -11,6 +11,8 @@ import sys
 import tempfile
 import unittest
 
+import pytest
+
 import osbuild.meta
 from osbuild.objectstore import ObjectStore
 from osbuild.util import linux
@@ -496,3 +498,10 @@ class OSBuild(contextlib.AbstractContextManager):
             "cp", "--reflink=auto", "-a",
             os.path.join(from_path, "."), to_path
         ], check=True)
+
+
+@pytest.fixture(name="osb")
+def osbuild_fixture():
+    store = os.getenv("OSBUILD_TEST_STORE")
+    with OSBuild(cache_from=store) as osb:
+        yield osb

--- a/test/test.py
+++ b/test/test.py
@@ -20,6 +20,12 @@ from osbuild.util import linux
 from .conftest import unsupported_filesystems
 
 
+def tree_diff(path1, path2):
+    checkout = TestBase.locate_test_checkout()
+    output = subprocess.check_output([os.path.join(checkout, "tools/tree-diff"), path1, path2])
+    return json.loads(output)
+
+
 class TestBase(unittest.TestCase):
     """Base Class for Tests
 
@@ -262,10 +268,7 @@ class TestBase(unittest.TestCase):
         Run the `tree-diff` tool from the osbuild checkout. It produces a JSON
         output that describes the difference between 2 file-system trees.
         """
-
-        checkout = TestBase.locate_test_checkout()
-        output = subprocess.check_output([os.path.join(checkout, "tools/tree-diff"), path1, path2])
-        return json.loads(output)
+        return tree_diff(path1, path2)
 
     @staticmethod
     def has_filesystem_support(fs: str) -> bool:
@@ -298,6 +301,7 @@ class OSBuild(contextlib.AbstractContextManager):
 
     def __init__(self, *, cache_from=None):
         self._cache_from = cache_from
+        self.store = None
 
     def __enter__(self):
         self._exitstack = contextlib.ExitStack()

--- a/test/test.py
+++ b/test/test.py
@@ -505,7 +505,10 @@ class OSBuild(contextlib.AbstractContextManager):
 
 
 @pytest.fixture(name="osb")
-def osbuild_fixture():
+def osbuild_fixture(tmp_path):
     store = os.getenv("OSBUILD_TEST_STORE")
+    if not store:
+        store = tmp_path
     with OSBuild(cache_from=store) as osb:
+        osb.store = store
         yield osb


### PR DESCRIPTION
Cleanup of https://github.com/osbuild/osbuild/pull/1878 - build on top of https://github.com/osbuild/osbuild/pull/1912 

This makes it more uniform with our other tests that are mostly
pytest based and it also makes it possible to easiyl do a
`pytest --collect-only` to see what is actually run.

Another nice reason to move more to pytest is that it allows
to use custom markers like `@pytest.mark.slow` which we
could use to have a `make quick-test` or something.

[draft: to double check that the tests are not regressing and not slowing down]
