### PR TITLE
README: document test prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ To verify changes made to the code use included makefile rules:
  * `make test-all` to run base set of tests
  * `sudo make test-run` to run extended set of tests (takes long time)
 
+Also keep in mind that some tests require those prerequisites,
+otherwise they are skipped
+
+```
+sudo dnf install -y systemd-boot-unsigned erofs-utils pykickstart podman xfsprogs
+```
+
 ## Installation
 
 Installing `osbuild` requires to not only install the `osbuild` module, but also


### PR DESCRIPTION
Is this a good place to document this or rather introduce an `extras_require` in `setup.py`?

Also there seem to be more missing and the tests requiring an nfs-server need some more prerequisites to be executed, I guess?
e.g. `sudo python -m pytest --rootdir=$(pwd) -v test/mod/test_util_fscache_coherency.py`  
fails even when starting an unconfigured nfs-server