### PR TITLE
workflow,pytest: add new `--error-on-skip` for pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
               fi
           fi
           OSBUILD_TEST_STORE="${{ env.OSBUILD_TEST_STORE }}" \
-          tox -e "${{ matrix.environment }}" $TOX_ARGS -- -rs $TEST_WORKERS -k "$TEST_CATEGORY"
+          tox -e "${{ matrix.environment }}" $TOX_ARGS -- -rs $TEST_WORKERS -k "$TEST_CATEGORY" --error-on-skip -k "not test_selinux"
 
   v1_manifests:
     name: "Assembler test (legacy)"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    res = outcome.get_result()
+    if res.skipped:
+        error_on_skip = item.config.getoption('--error-on-skip')
+
+        reason = str(call.excinfo.value)
+        if error_on_skip:
+            res.outcome = "failed"
+            res.longrepr = f"skipping not allowed: {res.longrepr}"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--error-on-skip', action="store_store",
+    )


### PR DESCRIPTION
To ensure we do not skip tests in GH actions that we want to run this commit add a new explicit way to allowlist tests that are okay to skip.

This is done via a small pytest plugin and the GH action will now use `-k "not test_selinux_ro"` because this selinux tests requires a real selinux which is not available on GH runners.

[this was originally https://github.com/osbuild/osbuild/pull/1756 but I can open it again it seems]