### PR TITLE
CODEOWNERS: Assign ownership for CoreOS-related files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+
+# Specify code ownership for files containing 'coreos' in the filename
+*coreos* @dustymabe @jlebon @ravanelli
+


### PR DESCRIPTION
- Introduce a CODEOWNERS file to designate the CoreOS team as responsible for maintaining files related to CoreOS.
- This change ensures collaborative support, alleviating the burden solely on the osbuild team.
- By assigning ownership, we aim to enhance code quality and responsiveness to issues affecting CoreOS.