### PR TITLE
spec: depend on and use dnf4 in Fedora 41

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -138,7 +138,10 @@ Summary:        Dependency solving support for DNF
 Requires:       %{name} = %{version}-%{release}
 
 # RHEL 11 and Fedora 41 and later use libdnf5, RHEL < 11 and Fedora < 41 use dnf
-%if 0%{?fedora} >= 41 || 0%{?rhel} >= 11
+# On Fedora 41 however, we force dnf4 (and depend on python3-dnf) until dnf5 issues are resolved.
+# See https://github.com/rpm-software-management/dnf5/issues/1748
+# and https://issues.redhat.com/browse/COMPOSER-2361
+%if 0%{?rhel} >= 11
 Requires: python3-libdnf5 >= 5.2.1
 %else
 Requires: python3-dnf
@@ -227,7 +230,10 @@ install -p -m 0755 tools/osbuild-depsolve-dnf %{buildroot}%{_libexecdir}/osbuild
 # Configure the solver for dnf
 mkdir -p %{buildroot}%{_datadir}/osbuild
 # RHEL 11 and Fedora 41 and later use dnf5, RHEL < 11 and Fedora < 41 use dnf
-%if 0%{?fedora} >= 41 || 0%{?rhel} >= 11
+# On Fedora 41 however, we force dnf4 (and depend on python3-dnf) until dnf5 issues are resolved.
+# See https://github.com/rpm-software-management/dnf5/issues/1748
+# and https://issues.redhat.com/browse/COMPOSER-2361
+%if 0%{?rhel} >= 11
 install -p -m 0644 tools/solver-dnf5.json %{buildroot}%{pkgdir}/solver.json
 %else
 install -p -m 0644 tools/solver-dnf.json %{buildroot}%{pkgdir}/solver.json


### PR DESCRIPTION
The dnf5 library in Fedora 41 still has some issues that prevents us from using it in osbuild-composer.  Switch to using dnf4 on Fedora 41 as well until these issues are resolved.