### PR TITLE
osbuild-mpp: Allow using formating in the mpp-resolve-images handling

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -1673,6 +1673,8 @@ class ManifestFileV2(ManifestFile):
         if not mpp:
             return
 
+        self._process_format(mpp)
+
         refs = element_enter(inputs_images, "references", {})
         manifest_lists = []
 


### PR DESCRIPTION
This allows using e.g. mpp-eval in the resolve-image operation, similar to how it is now possible in the mpp-depsolve handling.

We want this so we can inject the list of images from a list variable (that can then be mpp-join:ed, etc).