### PR TITLE
osbuild-mpp: Fix error on python < 3.11

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -1604,17 +1604,22 @@ class ManifestFileV2(ManifestFile):
             if input_count > 1:
                 raise ValueError(f"Only one of 'path', 'url' or 'text' may be specified for '{uid}'")
 
+            checksum = None
             if path:
                 f, _ = self.find_and_open_file(path, [], mode="rb", encoding=None)
                 with f:
                     data = f.read()
-                checksum = hashlib.sha256(data).hexdigest()
             elif url:
                 response = urllib.request.urlopen(url)
-                h = hashlib.file_digest(response.fp, 'sha256')
-                checksum = h.hexdigest()
+                if hasattr(hashlib, "file_digest"):
+                    h = hashlib.file_digest(response.fp, 'sha256')
+                    checksum = h.hexdigest()
+                else:
+                    data = response.fp.read()
             else:
                 data = bytes(text, "utf-8")
+
+            if not checksum:
                 checksum = hashlib.sha256(data).hexdigest()
 
             digest = "sha256:" + checksum


### PR DESCRIPTION
The change in commit ed3386943069e138b346eef75ac64d9874a07810 to use hashlib.file_digest breaks with older python, because it was added in 3.11.

This change reverts back to hashing all the data in the case where file_digest doesn't exist.