### PR TITLE
schema/metadata: exports

### DIFF
--- a/schemas/osbuild2.json
+++ b/schemas/osbuild2.json
@@ -108,6 +108,13 @@
               }
             }
           }
+        },
+        "exports": {
+          "type": "array",
+          "title": "Default exports",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/test/mod/test_fmt_v2.py
+++ b/test/mod/test_fmt_v2.py
@@ -19,6 +19,9 @@ BASIC_PIPELINE = {
                 "version": "NaN",
             },
         ],
+        "exports": [
+            "build"
+        ]
     },
     "sources": {
         "org.osbuild.curl": {


### PR DESCRIPTION
Allows defining the identifiers of exports that should be exported by default by higher level tools, or in the future by osbuild itself to circumvent the need of passing `--export` multiple times.