### PR TITLE
Stages/dnf-automatic.config: don't fail on non-existent config file

### DIFF
--- a/stages/org.osbuild.dnf-automatic.config
+++ b/stages/org.osbuild.dnf-automatic.config
@@ -25,10 +25,13 @@ def main(tree, options):
         with open(dnf_automatic_config_path, "r", encoding="utf8") as f:
             dnf_automatic_conf.readfp(f)
     except FileNotFoundError:
-        print(f"Error: DNF automatic configuration file '{dnf_automatic_config_path}' does not exist.")
-        return 1
+        print(f"Warning: DNF automatic configuration file '{dnf_automatic_config_path}'" +
+              " does not exist, will create a new one.")
 
     for config_section, config_options in config.items():
+        if not dnf_automatic_conf.has_section(config_section):
+            dnf_automatic_conf.add_section(config_section)
+
         for option, value in config_options.items():
             if isinstance(value, bool):
                 value = bool_to_yes_no(value)


### PR DESCRIPTION
On Fedora 41 with DNF5, the dnf-automatic plugin by default does not install any configuration file. This means that the stage would fail in such case.

Previously, the full config file was placed in /etc and its purpose was also to document all possible options. The example config file is now installed only in /usr/share/dnf5/dnf5-plugins/automatic.conf.

Relax the stage implementation to not fail when the configuration file does not exist. Just log a warning and create the configuration file.