### PR TITLE
Test/autotailor: fix Python 3.6 compatibility

### DIFF
--- a/stages/test/test_autotailor.py
+++ b/stages/test/test_autotailor.py
@@ -212,7 +212,7 @@ def test_oscap_autotailor_json_profile_override(fake_json_input, stage_module, e
         ["oscap", "info", "--profiles", results_file],
         stdout=subprocess.PIPE,
         check=True,
-        text=True,
+        encoding="utf-8",
     )
 
     assert f"Id: {expected_profile}\n" in result.stdout


### PR DESCRIPTION
The test case is skipped in the upstream CI, because the `autotailor` executable is not installed in the `osbuild-ci` image. This will not be the case in the future and the CI run will reveal a Python 3.6 incompatibility in the test implementation. Fix it.