### PR TITLE
Lint/autopep8: update to the latest upstream version v2.3.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,8 +48,8 @@ commands =
 
 [testenv:autopep8]
 deps =
-    autopep8==2.0.4
-    pycodestyle==2.11.0
+    autopep8==2.3.1
+    pycodestyle==2.12.1
 
 commands =
     bash -c 'python -m autopep8 --diff --max-line-length 120 -a -a -a -j0 -r --exclude {env:LINTABLES_EXCLUDES} --exit-code {env:LINTABLES}'


### PR DESCRIPTION
This is needed to resolve fialure to find `lib2to3` module on F41, which was removed since Python 3.13 used by default there.

Update autopep8 and pycodestyle to the latest upstream releases.