### PR TITLE
Use the Chroot context in all stages that require chroot

### DIFF
--- a/stages/org.osbuild.authconfig
+++ b/stages/org.osbuild.authconfig
@@ -1,18 +1,14 @@
 #!/usr/bin/python3
 import shutil
-import subprocess
 import sys
 
 import osbuild.api
+from osbuild.util.chroot import Chroot
 
 
 def main(tree):
-    cmd = [
-        "/usr/sbin/chroot", tree,
-        "/usr/sbin/authconfig", "--nostart", "--updateall"
-    ]
-
-    subprocess.run(cmd, check=True)
+    with Chroot(tree) as chroot:
+        chroot.run(["/usr/sbin/authconfig", "--nostart", "--updateall"], check=True)
 
     shutil.rmtree(f"{tree}/var/lib/authselect/backups", ignore_errors=True)
 

--- a/stages/org.osbuild.firewall
+++ b/stages/org.osbuild.firewall
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
-import subprocess
 import sys
 
 import osbuild.api
+from osbuild.util.chroot import Chroot
 
 
 def main(tree, options):
@@ -18,14 +18,14 @@ def main(tree, options):
 
     # firewall-offline-cmd does not implement --root option so we must chroot it
     if default_zone:
-        subprocess.run(["chroot", tree, "firewall-offline-cmd", f"--set-default-zone={default_zone}"], check=True)
+        with Chroot(tree) as chroot:
+            chroot.run(["firewall-offline-cmd", f"--set-default-zone={default_zone}"], check=True)
 
     # The options below are "lokkit" compatibility options and can not be used
     # with other options.
     if ports or enabled_services or disabled_services:
-        subprocess.run(["chroot",
-                        tree,
-                        "firewall-offline-cmd"] +
+        with Chroot(tree) as chroot:
+            chroot.run(["firewall-offline-cmd"] +
                        list(map(lambda x: f"--port={x}", ports)) +
                        list(map(lambda x: f"--service={x}", enabled_services)) +
                        list(map(lambda x: f"--remove-service={x}", disabled_services)),
@@ -37,24 +37,21 @@ def main(tree, options):
         zone_name = zone_item['name']
         # check that the given zone exists, if not create it
         if zone_name != "":
-            res = subprocess.run(["chroot",
-                                  tree,
-                                  "firewall-offline-cmd",
+            with Chroot(tree) as chroot:
+                res = chroot.run(["firewall-offline-cmd",
                                   f"--info-zone={zone_name}"],
                                  check=False)
             # INVALID_ZONE error code
             if res.returncode == 112:
-                res = subprocess.run(["chroot",
-                                      tree,
-                                      "firewall-offline-cmd",
+                with Chroot(tree) as chroot:
+                    res = chroot.run(["firewall-offline-cmd",
                                       f"--new-zone={zone_name}"],
                                      check=False)
             if res.returncode != 0:
                 return 1
         if zone_item.get("sources", []):
-            subprocess.run(["chroot",
-                            tree,
-                            "firewall-offline-cmd", f"--zone={zone_name}"] +
+            with Chroot(tree) as chroot:
+                chroot.run(["firewall-offline-cmd", f"--zone={zone_name}"] +
                            list(map(lambda x: f"--add-source={x}",
                                     zone_item['sources'])),
                            check=True)


### PR DESCRIPTION
**stages: use util.chroot in all stages that call "chroot"**

Use the chroot utility module for all cases where we need to chroot
during a stage's execution.

The advantage is that all stages use the same tested code path for
setting up a chroot and all chrooted commands run in the same
environment, with the /proc, /dev, and /sys filesystems mounted.

---

**util/chroot: convert the root path to string**

The root argument of the Chroot constructor can be a pathlib.Pat in some
cases.  Let's ensure it's a string so that we can append paths to it
more freely.

---

**stages/test_users: update test to match new calls**

With the org.osbuild.users stage now using the Chroot context, the
subprocess.run() command is run 6 more times, 3 to mount the /proc,
/dev, and /sys, and 3 more to unmount them.  The call being tested is
the 4th.  Also the `tmp_path` is converted to string inside the Chroot
context, so we need to convert it as well when creating the expected
command line call.

---

**NOTE**: The Arch Linux stages, `org.osbuild.mkinitcpio` and `org.osbuild.pacman-keyring` weren't updated.  These stages require some extra work because they require linking fd linking from `/proc` to `/dev` and the stages themselves are very well tested.  I'd like to add some tests for these in a follow-up, perhaps even extend the Arch Linux testing more generally, and then change them to use the chroot utility.