### PR TITLE
workflow: add smoke test that runs unit tests as user

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,8 +83,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-    - run: sudo apt install -y tox
-    - name: "Run as user on default runner"
+      # The test_host.py:test_signals_on_separate_fd runs itself but that
+      # run will happen without the tox env so a pip/tox installed pytest
+      # will not be found, install the pytest package as a workaround
+    - run: sudo apt install -y tox python3-pytest
+    - name: "Run as user on default runer"
       # Run with -n 16 as depsolve tests tend to be slow but fast when
       # parallized, the runtime is around 1-2min with this setup.
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,3 +73,19 @@ jobs:
           run: |
             OSBUILD_TEST_STORE="${{ env.OSBUILD_TEST_STORE }}" \
             tox -e "py36" -- ${{ env.TEST_WORKERS }} test.run.test_assemblers
+
+  # This smoke test runs the unit tests directly on the runner and as a
+  # normal user - it is fast (2min) and should detect obvious issues
+  # (like from pr#1942)
+  unittests_as_user_smoke:
+    name: "Smoke run: unittest as normal user on default runner"
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - run: sudo apt install -y tox
+    - name: "Run as user on default runner"
+      # Run with -n 16 as depsolve tests tend to be slow but fast when
+      # parallized, the runtime is around 1-2min with this setup.
+      run: |
+        tox -e py312 -- -n 16

--- a/sources/test/test_ostree_source.py
+++ b/sources/test/test_ostree_source.py
@@ -3,18 +3,23 @@
 import pathlib
 import tempfile
 
+import pytest
+
+from osbuild.testutil import has_executable
 from osbuild.testutil.net import http_serve_directory, https_serve_directory
 from osbuild.util import ostree
 
 SOURCES_NAME = "org.osbuild.ostree"
 
 
+@pytest.mark.skipif(not has_executable("ostree"), reason="need ostree")
 def test_ostree_source_not_exists(tmp_path, sources_service):
     checksum = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
     sources_service.setup({"cache": tmp_path, "options": {}})
     assert not sources_service.exists(checksum, None)
 
 
+@pytest.mark.skipif(not has_executable("ostree"), reason="need ostree")
 def test_ostree_source_exists(tmp_path, sources_service):
     sources_service.setup({"cache": tmp_path, "options": {}})
     root = tmp_path / "org.osbuild.ostree" / "repo"
@@ -41,6 +46,7 @@ def make_repo(root):
         return ostree.cli("commit", f"--repo={root}", "--orphan", empty_tmpdir).stdout.rstrip()
 
 
+@pytest.mark.skipif(not has_executable("ostree"), reason="need ostree")
 def test_ostree_pull_plain(tmp_path, sources_service):
     fake_httpd_root = tmp_path / "fake-httpd-root"
     fake_httpd_root.mkdir(exist_ok=True)
@@ -53,6 +59,7 @@ def test_ostree_pull_plain(tmp_path, sources_service):
         assert sources_service.exists("sha256:" + fake_commit, None)
 
 
+@pytest.mark.skipif(not has_executable("ostree"), reason="need ostree")
 def test_ostree_pull_plain_mtls(tmp_path, sources_service, monkeypatch):
     fake_httpd_root = tmp_path / "fake-httpd-root"
     fake_httpd_root.mkdir(exist_ok=True)


### PR DESCRIPTION
This commit adds a tiny smoke test that runs the unit tests as
a normal user on a regular github runner. This should ensure that
we catch issues like in osbuild#1936.

---

workflow: install `python3-pytest` too to workaround
 `test_host.py`

The test_host.py:test_signals_on_separate_fd (and more)  runs
itself but that run will happen without the tox env so a pip/tox
installed pytest will not be found, install the pytest package
as a workaround.

---

sources: skip ostree tests if no ostree binary if found

This commit skips the ostree tests if no ostree binary is available.
