### PR TITLE
Expand the options available in containers.unit.create

### DIFF
--- a/stages/org.osbuild.containers.unit.create.meta.json
+++ b/stages/org.osbuild.containers.unit.create.meta.json
@@ -30,6 +30,9 @@
     "    - 'Environment' - [object]",
     "    - 'Network' - string",
     "    - 'WorkingDir' - string",
+    "    - 'SecurityLabelFileType' - string",
+    "    - 'SecurityLabelType' - string",
+    "    - 'Tmpfs' - string",
     "  - 'Volume' section",
     "    - 'VolumeName' - string",
     "    - 'Driver' - string",
@@ -260,6 +263,18 @@
               },
               "WorkingDir": {
                 "description": "Working directory for initial process",
+                "type": "string"
+              },
+              "SecurityLabelFileType": {
+                "description": "SELinux file label to apply",
+                "type": "string"
+              },
+              "SecurityLabelType": {
+                "description": "SELinux label to apply",
+                "type": "string"
+              },
+              "Tmpfs": {
+                "description": "Mount a temporary filesystems at the specified location",
                 "type": "string"
               }
             }

--- a/stages/test/test_containers_unit_create.py
+++ b/stages/test/test_containers_unit_create.py
@@ -164,7 +164,10 @@ def test_systemd_unit_create(tmp_path, stage_module, unit_path, expected_prefix)
                         "key": "TRACE",
                         "value": "1",
                     },
-                ]
+                ],
+                "SecurityLabelFileType": "usr_t",
+                "SecurityLabelType": "spc_t",
+                "Tmpfs": "/test.tmp",
             },
             "Install": {
                 "WantedBy": [
@@ -200,6 +203,9 @@ def test_systemd_unit_create(tmp_path, stage_module, unit_path, expected_prefix)
     Image=img
     Environment="DEBUG=1"
     Environment="TRACE=1"
+    SecurityLabelFileType=usr_t
+    SecurityLabelType=spc_t
+    Tmpfs=/test.tmp
 
     [Install]
     WantedBy=local-fs.target


### PR DESCRIPTION
Add the option to specify the SELinux type label and file type label for the process.
Add the option to specify a tmpfs mount to create into the container.