### PR TITLE
org.osbuild.xorriso: Add support for grub2 bootable iso

### DIFF
--- a/stages/org.osbuild.xorrisofs
+++ b/stages/org.osbuild.xorrisofs
@@ -6,7 +6,89 @@ import sys
 import osbuild.api
 
 
-def main(inputs, output_dir, options):
+# Create a grub2 bootable iso
+def grub2(inputs, output_dir, options):
+    tree = inputs["tree"]["path"]
+    boot = options.get("boot", {})
+    filename = options["filename"]
+    vol_id = options["volid"]
+    sys_id = options.get("sysid")
+    efi = options.get("efi")
+    isolevel = options.get("isolevel")
+    grub2mbr = options.get("grub2mbr")
+
+    cmd = [
+        "/usr/bin/xorrisofs",
+        "-verbose",
+        "-rock",
+        "-joliet",
+    ]
+
+    if isolevel:
+        cmd += [
+            "-iso-level", str(isolevel)
+        ]
+
+    cmd += [
+        "-V", vol_id
+    ]
+
+    if sys_id:
+        cmd += [
+            "-sysid", sys_id
+        ]
+
+    if not os.path.exists(grub2mbr):
+        raise RuntimeError(f"{grub2mbr} is missing from the buildroot")
+    cmd += [
+        "--grub2-mbr", grub2mbr
+    ]
+
+    if efi:
+        efi_path = os.path.join(tree, efi.lstrip("/"))
+        cmd += [
+            "-partition_offset", "16",
+            "-appended_part_as_gpt",
+            "-append_partition", "2", "C12A7328-F81F-11D2-BA4B-00A0C93EC93B", efi_path,
+        ]
+
+    cmd += [
+        "-iso_mbr_part_type", "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7"
+    ]
+
+    if boot:
+        image = boot["image"]
+        catalog = boot["catalog"]
+        cmd += [
+            "-b", image,
+            "-c", catalog,
+            "--boot-catalog-hide",
+            "-no-emul-boot",
+            "-boot-load-size", "4",
+            "-boot-info-table",
+            "--grub2-boot-info",
+        ]
+        if efi:
+            cmd += [
+                "-eltorito-alt-boot",
+                "-e", "--interval:appended_partition_2:all::",
+            ]
+
+    cmd += [
+        "-no-emul-boot"
+    ]
+
+    cmd += [
+        '-o', os.path.join(output_dir, filename),
+        tree
+    ]
+
+    print(cmd)
+    subprocess.run(cmd, check=True)
+
+
+# Create an syslinux bootable iso
+def syslinux(inputs, output_dir, options):
     tree = inputs["tree"]["path"]
     boot = options.get("boot", {})
     filename = options["filename"]
@@ -46,6 +128,7 @@ def main(inputs, output_dir, options):
         cmd += [
             "-b", image,
             "-c", catalog,
+            "--boot-catalog-hide",
             "-boot-load-size", "4",
             "-boot-info-table",
             "-no-emul-boot"
@@ -72,6 +155,13 @@ def main(inputs, output_dir, options):
 
     print(cmd)
     subprocess.run(cmd, check=True)
+
+
+def main(inputs, output_dir, options):
+    if "grub2mbr" not in options:
+        return syslinux(inputs, output_dir, options)
+
+    return grub2(inputs, output_dir, options)
 
 
 if __name__ == '__main__':

--- a/stages/org.osbuild.xorrisofs.meta.json
+++ b/stages/org.osbuild.xorrisofs.meta.json
@@ -54,6 +54,10 @@
         "efi": {
           "type": "string"
         },
+        "grub2mbr": {
+          "type": "string",
+          "description": "Install the argument (buildroot) as grub2 mbr, and create a grub2 bootable iso"
+        },
         "isohybridmbr": {
           "type": "string",
           "description": "Install the argument (buildroot) as ISOLINUX isohybrid MBR"


### PR DESCRIPTION
This creates an iso matching the current method used in Fedora where it uses grub2 for BIOS and UEFI booting. Pass the path to the grub2 hybrid mbr to the stage in the 'grub2' field. eg.
    "grub2": "/usr/lib/grub/i386-pc/boot_hybrid.img"