### PR TITLE
kickstart: Drop ostree signature verification flag

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -201,10 +201,6 @@ def main(tree, options):  # pylint: disable=too-many-branches
             if value:
                 cmd += f" --{name}={value}"
 
-        signature_verification = ostreecontainer.get("signatureverification", True)
-        if not signature_verification:
-            cmd += " --no-signature-verification"
-
         config += [cmd]
 
     liveimg = options.get("liveimg")

--- a/stages/org.osbuild.kickstart.meta.json
+++ b/stages/org.osbuild.kickstart.meta.json
@@ -197,7 +197,8 @@
           },
           "signatureverification": {
             "type": "boolean",
-            "default": true
+            "default": true,
+            "description": "This field is deprecated and does nothing."
           }
         }
       },

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -224,7 +224,7 @@ TEST_INPUT = [
                 "signatureverification": False,
             },
         },
-        "ostreecontainer --url=http://some-ostree-url.com/foo --stateroot=some-osname --transport=registry --remote=some-remote --no-signature-verification",
+        "ostreecontainer --url=http://some-ostree-url.com/foo --stateroot=some-osname --transport=registry --remote=some-remote",
     ),
     (
         {


### PR DESCRIPTION
It's a no-op nowadays, we dropped support for the custom ostree-container signature verification status.