### PR TITLE
Don't use f-strings for path construction in `tuned` and `dnf*.sbom.spdx` stages

### DIFF
--- a/osbuild/util/path.py
+++ b/osbuild/util/path.py
@@ -2,7 +2,7 @@
 import errno
 import os
 import os.path
-from typing import Optional
+from typing import Optional, Union
 
 from .ctx import suppress_oserror
 
@@ -41,3 +41,18 @@ def in_tree(path: str, tree: str, must_exist: bool = False) -> bool:
     if path.startswith(tree):
         return not must_exist or os.path.exists(path)
     return False
+
+
+def join_abs(root: Union[str, os.PathLike], *paths: Union[str, os.PathLike]) -> str:
+    """
+    Join root and paths together, handling the case where paths are absolute paths.
+    In that case, paths are just appended to root as if they were relative paths.
+    The result is always an absolute path relative to the filesystem root '/'.
+    """
+    final_path = root
+    for path in paths:
+        if os.path.isabs(path):
+            final_path = os.path.join(final_path, os.path.relpath(path, os.sep))
+        else:
+            final_path = os.path.join(final_path, path)
+    return os.path.normpath(os.path.join(os.sep, final_path))

--- a/stages/org.osbuild.dnf4.sbom.spdx
+++ b/stages/org.osbuild.dnf4.sbom.spdx
@@ -6,6 +6,7 @@ import tempfile
 import dnf
 
 import osbuild
+from osbuild.util import path
 from osbuild.util.sbom.dnf import dnf_pkgset_to_sbom_pkgset
 from osbuild.util.sbom.spdx import sbom_pkgset_to_spdx2_doc
 
@@ -14,11 +15,11 @@ def get_installed_packages(tree):
     with tempfile.TemporaryDirectory() as tempdir:
         conf = dnf.conf.Conf()
         conf.installroot = tree
-        conf.persistdir = f"{tempdir}{conf.persistdir}"
-        conf.cachedir = f"{tempdir}{conf.cachedir}"
-        conf.reposdir = [f"{tree}{d}" for d in conf.reposdir]
-        conf.pluginconfpath = [f"{tree}{d}" for d in conf.pluginconfpath]
-        conf.varsdir = [f"{tree}{d}" for d in conf.varsdir]
+        conf.persistdir = path.join_abs(tempdir, conf.persistdir)
+        conf.cachedir = path.join_abs(tempdir, conf.cachedir)
+        conf.reposdir = [path.join_abs(tree, d) for d in conf.reposdir]
+        conf.pluginconfpath = [path.join_abs(tree, d) for d in conf.pluginconfpath]
+        conf.varsdir = [path.join_abs(tree, d) for d in conf.varsdir]
         conf.prepend_installroot("config_file_path")
 
         base = dnf.Base(conf)

--- a/stages/org.osbuild.dnf4.sbom.spdx.meta.json
+++ b/stages/org.osbuild.dnf4.sbom.spdx.meta.json
@@ -1,5 +1,5 @@
 {
-  "summary": "Generate SPDX SBOM document for the installed packages.",
+  "summary": "Generate SPDX SBOM document for the installed packages using DNF4.",
   "description": [
     "The stage generates a Software Bill of Materials (SBOM) document",
     "in SPDX v2 format for the installed RPM packages. DNF4 API is used",

--- a/stages/org.osbuild.dnf5.sbom.spdx
+++ b/stages/org.osbuild.dnf5.sbom.spdx
@@ -7,6 +7,7 @@ import tempfile
 import libdnf5
 
 import osbuild
+from osbuild.util import path
 from osbuild.util.sbom.dnf5 import dnf_pkgset_to_sbom_pkgset
 from osbuild.util.sbom.spdx import sbom_pkgset_to_spdx2_doc
 
@@ -17,18 +18,18 @@ def get_installed_packages(tree):
 
         conf = base.get_config()
         conf.installroot = tree
-        conf.config_file_path = f"{tree}{conf.config_file_path}"
-        conf.pluginpath = f"{tree}{conf.pluginpath}"
-        conf.pluginconfpath = f"{tree}{conf.pluginconfpath}"
-        conf.persistdir = f"{tree}{conf.persistdir}"
-        conf.transaction_history_dir = f"{tree}{conf.transaction_history_dir}"
-        conf.system_cachedir = f"{tempdir}{conf.system_cachedir}"
-        conf.varsdir = [f"{tree}{d}" for d in conf.varsdir]
-        conf.reposdir = [f"{tree}{d}" for d in conf.reposdir]
-        conf.cachedir = f"{tempdir}{conf.cachedir}"
+        conf.config_file_path = path.join_abs(tree, conf.config_file_path)
+        conf.pluginpath = path.join_abs(tree, conf.pluginpath)
+        conf.pluginconfpath = path.join_abs(tree, conf.pluginconfpath)
+        conf.persistdir = path.join_abs(tree, conf.persistdir)
+        conf.transaction_history_dir = path.join_abs(tree, conf.transaction_history_dir)
+        conf.system_cachedir = path.join_abs(tempdir, conf.system_cachedir)
+        conf.varsdir = [path.join_abs(tree, d) for d in conf.varsdir]
+        conf.reposdir = [path.join_abs(tree, d) for d in conf.reposdir]
+        conf.cachedir = path.join_abs(tempdir, conf.cachedir)
 
-        if os.path.exists(f"{tree}{conf.system_state_dir}"):
-            conf.system_state_dir = f"{tree}{conf.system_state_dir}"
+        if os.path.exists(path.join_abs(tree, conf.system_state_dir)):
+            conf.system_state_dir = path.join_abs(tree, conf.system_state_dir)
         else:
             # NB: if the directory does not exist in the tree, DNF5 would create it.
             # We need to ensure that the stage does not taint the tree with directories

--- a/stages/org.osbuild.dnf5.sbom.spdx.meta.json
+++ b/stages/org.osbuild.dnf5.sbom.spdx.meta.json
@@ -1,5 +1,5 @@
 {
-  "summary": "Generate SPDX SBOM document for the installed packages.",
+  "summary": "Generate SPDX SBOM document for the installed packages using DNF5.",
   "description": [
     "The stage generates a Software Bill of Materials (SBOM) document",
     "in SPDX v2 format for the installed RPM packages. DNF5 API is used",

--- a/stages/org.osbuild.tuned
+++ b/stages/org.osbuild.tuned
@@ -34,6 +34,9 @@ class TunedProfilesDB:
 
         for path in profile_directories:
             profiles_dir = f"{tree}{path}"
+            if not os.path.isdir(profiles_dir):
+                continue
+
             # Since version 2.23.0, TuneD by default uses `profiles/` subdirectory.
             # If the subdirectory exists, we look for profiles there.
             if os.path.isdir(f"{profiles_dir}/profiles"):

--- a/stages/org.osbuild.tuned
+++ b/stages/org.osbuild.tuned
@@ -3,6 +3,7 @@ import os
 import sys
 
 import osbuild.api
+from osbuild.util import path
 
 
 class TunedProfilesDB:
@@ -32,18 +33,18 @@ class TunedProfilesDB:
         ]
         profile_config_file = "tuned.conf"
 
-        for path in profile_directories:
-            profiles_dir = f"{tree}{path}"
+        for directory in profile_directories:
+            profiles_dir = path.join_abs(tree, directory)
             if not os.path.isdir(profiles_dir):
                 continue
 
             # Since version 2.23.0, TuneD by default uses `profiles/` subdirectory.
             # If the subdirectory exists, we look for profiles there.
-            if os.path.isdir(f"{profiles_dir}/profiles"):
-                profiles_dir = f"{profiles_dir}/profiles"
+            if os.path.isdir(path.join_abs(profiles_dir, "profiles")):
+                profiles_dir = path.join_abs(profiles_dir, "profiles")
 
             for dir_entry in os.scandir(profiles_dir):
-                if dir_entry.is_dir() and os.path.isfile(f"{profiles_dir}/{dir_entry.name}/{profile_config_file}"):
+                if dir_entry.is_dir() and os.path.isfile(path.join_abs(profiles_dir, dir_entry.name, profile_config_file)):
                     available_profiles.add(dir_entry.name)
 
         return available_profiles
@@ -71,11 +72,11 @@ def main(tree, options):
             raise ValueError(f"TuneD profile '{profile}' does not exist")
 
     # Set the active profile
-    with open(f"{tree}{active_profile_file}", "w", encoding="utf8") as f:
+    with open(path.join_abs(tree, active_profile_file), "w", encoding="utf8") as f:
         f.write(" ".join(profiles) + "\n")
 
     # Mode needs to be set to "manual" if set explicitly
-    with open(f"{tree}{profile_mode_file}", "w", encoding="utf8") as f:
+    with open(path.join_abs(tree, profile_mode_file), "w", encoding="utf8") as f:
         f.write("manual\n")
 
     return 0

--- a/stages/org.osbuild.tuned.meta.json
+++ b/stages/org.osbuild.tuned.meta.json
@@ -19,7 +19,8 @@
         "description": "TuneD profile to activate. If multiple profiles are provided, TuneD will try to merge them.",
         "minItems": 1,
         "items": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         }
       }
     }

--- a/stages/test/test_tuned.py
+++ b/stages/test/test_tuned.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python3
+
+import pytest
+
+from osbuild.testutil import (
+    assert_jsonschema_error_contains,
+    make_fake_tree,
+)
+
+STAGE_NAME = "org.osbuild.tuned"
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # bad
+    ({"profiles": {}}, "{} is not of type 'array'"),
+    ({"profiles": ""}, "'' is not of type 'array'"),
+    ({"profiles": []}, "[] is too short"),
+    ({"profiles": [0]}, "0 is not of type 'string'"),
+    ({"profiles": [""]}, "'' is too short"),
+    ({}, "'profiles' is a required property"),
+    # good
+    ({"profiles": ["balanced"]}, ""),
+    ({"profiles": ["balanced", "sap-hana"]}, ""),
+])
+def test_schema_validation(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "options": {},
+    }
+    test_input["options"].update(test_data)
+    res = stage_schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
+
+
+@pytest.mark.parametrize("fake_tree,available_profiles", (
+    ({}, []),
+    # simple case with just installed profiles
+    (
+        {
+            "/usr/lib/tuned/balanced/tuned.conf": "",
+            "/usr/lib/tuned/sap/tuned.conf": ""
+        },
+        ["balanced", "sap"]
+    ),
+    # simple case with installed and custom profiles
+    (
+        {
+            "/usr/lib/tuned/balanced/tuned.conf": "",
+            "/usr/lib/tuned/sap/tuned.conf": "",
+            "/etc/tuned/custom/tuned.conf": ""
+        },
+        ["balanced", "sap", "custom"]
+    ),
+    # Tuned 2.23.0+ with profiles under profiles/ directory
+    # in which case we ignore profiles not under profiles/
+    (
+        {
+            "/usr/lib/tuned/profiles/balanced/tuned.conf": "",
+            "/usr/lib/tuned/sap/tuned.conf": ""
+        },
+        ["balanced"]
+    ),
+    (
+        {
+            "/usr/lib/tuned/profiles/balanced/tuned.conf": "",
+            "/etc/tuned/sap/tuned.conf": ""
+        },
+        ["balanced", "sap"]
+    ),
+    (
+        {
+            "/usr/lib/tuned/profiles/balanced/tuned.conf": "",
+            "/etc/tuned/profiles/sap/tuned.conf": ""
+        },
+        ["balanced", "sap"]
+    ),
+    (
+        {
+            "/etc/tuned/profiles/balanced/tuned.conf": "",
+            "/etc/tuned/sap/tuned.conf": ""
+        },
+        ["balanced"]
+    ),
+    (
+        {
+            "/usr/lib/tuned/profiles/profile1/tuned.conf": "",
+            "/usr/lib/tuned/profiles/profile2/tuned.conf": "",
+            "/usr/lib/tuned/profile3/tuned.conf": "",
+            "/etc/tuned/profiles/profile11/tuned.conf": "",
+            "/etc/tuned/profiles/profile12/tuned.conf": "",
+            "/etc/tuned/profile13/tuned.conf": "",
+        },
+        ["profile1", "profile2", "profile11", "profile12"]
+    ),
+))
+def test_tunedprofilesdb__load_available_profiles(tmp_path, stage_module, fake_tree, available_profiles):
+    make_fake_tree(tmp_path, fake_tree)
+    # pylint: disable=protected-access
+    assert sorted(stage_module.TunedProfilesDB._load_available_profiles(tmp_path)) == sorted(available_profiles)
+
+
+def test_tuned_happy(tmp_path, stage_module):
+    make_fake_tree(tmp_path, {
+        "/usr/lib/tuned/balanced/tuned.conf": "",
+        "/usr/lib/tuned/sap/tuned.conf": "",
+        "/etc/tuned/custom/tuned.conf": "",
+    })
+
+    options = {
+        "profiles": ["balanced", "sap", "custom"]
+    }
+
+    assert stage_module.main(tmp_path.as_posix(), options) == 0
+
+    active_profile_file = tmp_path / "etc/tuned/active_profile"
+    assert active_profile_file.is_file()
+    assert active_profile_file.read_text() == "balanced sap custom\n"
+
+    profile_mode_file = tmp_path / "etc/tuned/profile_mode"
+    assert profile_mode_file.is_file()
+    assert profile_mode_file.read_text() == "manual\n"
+
+
+def test_tuned_unhappy(tmp_path, stage_module):
+    make_fake_tree(tmp_path, {
+        "/usr/lib/tuned/balanced/tuned.conf": "",
+        "/usr/lib/tuned/sap/tuned.conf": "",
+        "/etc/tuned/custom/tuned.conf": "",
+    })
+
+    options = {
+        "profiles": ["balanced", "non-existing"]
+    }
+
+    try:
+        stage_module.main(tmp_path.as_posix(), options)
+    except ValueError as e:
+        assert "non-existing" in str(e)
+    else:
+        assert False, "Exception not raised"
+
+    active_profile_file = tmp_path / "etc/tuned/active_profile"
+    assert not active_profile_file.exists()
+
+    profile_mode_file = tmp_path / "etc/tuned/profile_mode"
+    assert not profile_mode_file.exists()

--- a/test/mod/test_util_path.py
+++ b/test/mod/test_util_path.py
@@ -71,6 +71,7 @@ def test_in_tree():
 
 
 @pytest.mark.parametrize("test_case", (
+    # Strings only
     {
         "args": ("",),
         "expected": "/"
@@ -99,9 +100,89 @@ def test_in_tree():
         "args": ("/", "/foo", "/bar"),
         "expected": "/foo/bar"
     },
+    # Path only
+    {
+        "args": (Path(""),),
+        "expected": "/"
+    },
+    {
+        "args": (Path(""), Path("file")),
+        "expected": "/file"
+    },
+    {
+        "args": (Path(""), Path("/file")),
+        "expected": "/file"
+    },
+    {
+        "args": (Path("/tmp"), Path("/file")),
+        "expected": "/tmp/file"
+    },
+    {
+        "args": (Path("/tmp"), Path("/foo"), Path("/bar")),
+        "expected": "/tmp/foo/bar"
+    },
+    {
+        "args": (Path("/"), Path("/foo")),
+        "expected": "/foo"
+    },
+    {
+        "args": (Path("/"), Path("/foo"), Path("/bar")),
+        "expected": "/foo/bar"
+    },
+    # Mixed strings and Path
     {
         "args": (Path("/tmp"), "/foo", "/bar"),
         "expected": "/tmp/foo/bar"
+    },
+    {
+        "args": ("/tmp", Path("/foo"), Path("/bar")),
+        "expected": "/tmp/foo/bar"
+    },
+    {
+        "args": ("/tmp", "/foo", Path("/bar")),
+        "expected": "/tmp/foo/bar"
+    },
+    # Dotted relative paths - strings
+    {
+        "args": ("/tmp", "../foo", "/bar"),
+        "expected": "/foo/bar"
+    },
+    {
+        "args": ("/tmp", "./foo", "/bar"),
+        "expected": "/tmp/foo/bar"
+    },
+    {
+        "args": ("/tmp", "..", "/bar"),
+        "expected": "/bar"
+    },
+    {
+        "args": ("..",),
+        "expected": "/"
+    },
+    {
+        "args": (".",),
+        "expected": "/"
+    },
+    # Dotted relative paths - mixed strings and Path
+    {
+        "args": ("/tmp", Path("../foo"), "/bar"),
+        "expected": "/foo/bar"
+    },
+    {
+        "args": ("/tmp", Path("./foo"), "/bar"),
+        "expected": "/tmp/foo/bar"
+    },
+    {
+        "args": ("/tmp", Path(".."), "/bar"),
+        "expected": "/bar"
+    },
+    {
+        "args": (Path(".."),),
+        "expected": "/"
+    },
+    {
+        "args": (Path("."),),
+        "expected": "/"
     },
 ))
 def test_join_abs(test_case):

--- a/test/mod/test_util_path.py
+++ b/test/mod/test_util_path.py
@@ -68,3 +68,41 @@ def test_in_tree():
 
     for args, expected in cases.items():
         assert path.in_tree(*args) == expected, args
+
+
+@pytest.mark.parametrize("test_case", (
+    {
+        "args": ("",),
+        "expected": "/"
+    },
+    {
+        "args": ("", "file"),
+        "expected": "/file"
+    },
+    {
+        "args": ("", "/file"),
+        "expected": "/file"
+    },
+    {
+        "args": ("/tmp", "/file"),
+        "expected": "/tmp/file"
+    },
+    {
+        "args": ("/tmp", "/foo", "/bar"),
+        "expected": "/tmp/foo/bar"
+    },
+    {
+        "args": ("/", "/foo"),
+        "expected": "/foo"
+    },
+    {
+        "args": ("/", "/foo", "/bar"),
+        "expected": "/foo/bar"
+    },
+    {
+        "args": (Path("/tmp"), "/foo", "/bar"),
+        "expected": "/tmp/foo/bar"
+    },
+))
+def test_join_abs(test_case):
+    assert path.join_abs(*test_case["args"]) == test_case["expected"]


### PR DESCRIPTION
- Add unit tests for the `org.osbuild.tuned` stage.
- Harden a few corner cases in the `org.osbuild.tuned` stage.
- Add a helper function `util.path.join_abs()` to join paths that may be absolute as if they weren't.
- Use the `util.path.join_abs()` function in the `tuned` and `dnf*.sbom.spdx` stages to construct paths instead of f-strings.

Fix #1941
Fix #1964
