### PR TITLE
erofs: Add zstd to the list of supported compression algorithms

### DIFF
--- a/stages/org.osbuild.erofs
+++ b/stages/org.osbuild.erofs
@@ -21,9 +21,13 @@ def main(inputs, output_dir, options):
             method += f",{compression['level']}"
         cmd += ["-z", method]
 
-    options = options.get("options")
-    if options:
-        cmd += ["-E", ",".join(options)]
+    erofs_options = options.get("options")
+    if erofs_options:
+        cmd += ["-E", ",".join(erofs_options)]
+
+    cluster_size = options.get("cluster-size")
+    if cluster_size:
+        cmd += ["-C", f"{cluster_size}"]
 
     subprocess.run(cmd, check=True)
 

--- a/stages/org.osbuild.erofs.meta.json
+++ b/stages/org.osbuild.erofs.meta.json
@@ -28,7 +28,8 @@
               "enum": [
                 "lz4",
                 "lz4hc",
-                "lzma"
+                "lzma",
+                "zstd"
               ]
             },
             "level": {

--- a/stages/org.osbuild.erofs.meta.json
+++ b/stages/org.osbuild.erofs.meta.json
@@ -38,6 +38,10 @@
             }
           }
         },
+        "cluster-size": {
+          "description": "Maximum size of the compress physical cluster in bytes",
+          "type": "number"
+        },
         "options": {
           "description": "Extended options for the filesystem, see mkfs.erofs(1)",
           "type": "array",

--- a/stages/test/test_erofs.py
+++ b/stages/test/test_erofs.py
@@ -15,6 +15,7 @@ TEST_INPUT = [
     ({"compression": {"method": "lz4hc", "level": 9}}, ["-z", "lz4hc,9"]),
     ({"options": ["dedupe"]}, ["-E", "dedupe"]),
     ({"options": ["all-fragments", "force-inode-compact"]}, ["-E", "all-fragments,force-inode-compact"]),
+    ({"cluster-size": 131072, "options": ["dedupe"]}, ["-E", "dedupe", "-C", "131072"]),
 ]
 
 


### PR DESCRIPTION
This is supported in erofs-utils 1.8 and later.