### PR TITLE
Install osbuild-image-info into /usr/sbin (HMS-5229)

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -308,9 +308,9 @@ fi
 %selinux_relabel_post -s %{selinuxtype}
 
 %files tools
-%{_bindir}/osbuild-image-info
 %{_bindir}/osbuild-mpp
 %{?fedora:%{_bindir}/osbuild-dev}
+%{_sbindir}/osbuild-image-info
 
 %files depsolve-dnf
 %{_libexecdir}/osbuild-depsolve-dnf

--- a/selinux/osbuild.fc
+++ b/selinux/osbuild.fc
@@ -1,5 +1,5 @@
 /usr/bin/osbuild		--	gen_context(system_u:object_r:osbuild_exec_t,s0)
-/usr/bin/osbuild-image-info	--	gen_context(system_u:object_r:osbuild_exec_t,s0)
+/usr/sbin/osbuild-image-info	--	gen_context(system_u:object_r:osbuild_exec_t,s0)
 /usr/lib/osbuild/assemblers/.*	--	gen_context(system_u:object_r:osbuild_exec_t,s0)
 /usr/lib/osbuild/stages/.*	--	gen_context(system_u:object_r:osbuild_exec_t,s0)
 /usr/lib/osbuild/sources/.*	--	gen_context(system_u:object_r:osbuild_exec_t,s0)

--- a/selinux/osbuild_selinux.8
+++ b/selinux/osbuild_selinux.8
@@ -18,7 +18,7 @@ The osbuild_t SELinux type can be entered via the \fBosbuild_exec_t\fP file type
 
 The default entrypoint paths for the osbuild_t domain are the following:
 
-/usr/lib/osbuild/stages/*, /usr/lib/osbuild/sources/*, /usr/lib/osbuild/assemblers/*, /usr/bin/osbuild, /usr/bin/osbuild-image-info
+/usr/lib/osbuild/stages/*, /usr/lib/osbuild/sources/*, /usr/lib/osbuild/assemblers/*, /usr/bin/osbuild, /usr/sbin/osbuild-image-info
 .SH PROCESS TYPES
 SELinux defines process types (domains) for each process running on the system
 .PP

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setuptools.setup(
     scripts=[
         "tools/osbuild-mpp",
         "tools/osbuild-dev",
-        "tools/osbuild-image-info",
+    ],
+    data_files=[
+        ("/usr/sbin", ["tools/osbuild-image-info"]),
     ],
 )


### PR DESCRIPTION
The tool requires root privileges to mount the inspected image, therefore it should be installed into /usr/sbin, instead of /usr/bin.

/jira-epic COMPOSER-2318

JIRA: [HMS-5229](https://issues.redhat.com/browse/HMS-5229)