### PR TITLE
sources: add an org.osbuild.librepo source

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,6 +29,7 @@ RUN dnf install -y \
     python3-iniparse \
     python3-mako \
     python3-jsonschema \
+    python3-librepo \
     python3-pip \
     python3-pycodestyle \
     python3-pylint \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Additionally, the built-in stages require:
  * `tar >= 1.32`
  * `util-linux >= 235`
  * `skopeo`
+ * `python3-librepo`
 
 At build-time, the following software is required:
 

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -37,6 +37,7 @@ Requires:       tar
 Requires:       util-linux
 Requires:       python3-%{pypi_name} = %{version}-%{release}
 Requires:       (%{name}-selinux if selinux-policy-%{selinuxtype})
+Requires:       python3-librepo
 
 # This is required for `osbuild`, for RHEL-10 and above
 # the stdlib toml package can be used instead

--- a/osbuild/formats/v1.py
+++ b/osbuild/formats/v1.py
@@ -133,6 +133,8 @@ def load_source(name: str, description: Dict, index: Index, manifest: Manifest):
         items = description["urls"]
     elif name == "org.osbuild.ostree":
         items = description["commits"]
+    elif name == "org.osbuild.librepo":
+        items = description["items"]
     else:
         raise ValueError(f"Unknown source type: {name}")
 

--- a/sources/org.osbuild.librepo
+++ b/sources/org.osbuild.librepo
@@ -22,6 +22,9 @@ from osbuild.util.rhsm import Subscriptions
 
 # NOTE: The top level schema properties are limited to items and options by the
 # v2 schema definition
+#
+# "mirror" pattern follows dnf repo_id as described in:
+# https://dnf.readthedocs.io/en/latest/conf_ref.html#description
 SCHEMA_2 = """
 "properties": {
   "items": {
@@ -57,7 +60,7 @@ SCHEMA_2 = """
         "type": "object",
         "additionalProperties": false,
         "patternProperties": {
-          "^[0-9a-f]+$": {
+          "^[0-9a-zA-Z-._:]+$": {
             "required": [
               "url",
               "type"

--- a/sources/org.osbuild.librepo
+++ b/sources/org.osbuild.librepo
@@ -189,22 +189,19 @@ class LibRepoSource(sources.SourceService):
             cbdata=path,
             endcb=self._endcb)
 
+    # pylint: disable=too-many-branches
     def fetch_all(self, items: Dict) -> None:
         """Use librepo to download the packages"""
         # Organize the packages by the mirror id
-        packages = dict()
-        for id, pkg in items.items():
+        packages_from_mirror = {}
+        for item_id, pkg in items.items():
             if pkg["mirror"] not in self.options["mirrors"]:
                 raise RuntimeError(f'Missing mirror: {pkg["mirror"]}')
-
-            if pkg["mirror"] not in packages:
-                packages[pkg["mirror"]] = [(pkg["path"], id)]
-            else:
-                packages[pkg["mirror"]].append((pkg["path"], id))
+            packages_from_mirror.setdefault(pkg["mirror"], []).append((pkg["path"], item_id))
 
         # Download packages from each of the mirror ids
-        for m in packages:
-            mirror = self.options["mirrors"][m]
+        for mirror_id, packages in packages_from_mirror.items():
+            mirror = self.options["mirrors"][mirror_id]
             handle = librepo.Handle()
             handle.repotype = librepo.YUMREPO
             if mirror["type"] == "metalink":
@@ -234,7 +231,7 @@ class LibRepoSource(sources.SourceService):
                 self._setup_rhsm(handle, mirror)
 
             download = []
-            for path, checksum in packages[m]:
+            for path, checksum in packages:
                 download.append(self.make_pkg_target(handle, f"{self.cache}/{checksum}", path, checksum))
 
             # Download everything from this mirror

--- a/sources/org.osbuild.librepo
+++ b/sources/org.osbuild.librepo
@@ -173,6 +173,17 @@ class LibRepoSource(sources.SourceService):
         """
         if status == librepo.TRANSFER_ERROR:
             self.errors.append(f"{data}: {msg}")
+        # Workaround the lack of structured progress reporting from
+        # stages/sources. See curl source for more details, once we
+        # have something better this block can be removed.
+        if status == librepo.TRANSFER_ERROR:
+            print(f"Error downloading {data}")
+        elif status == librepo.TRANSFER_SUCCESSFUL:
+            print(f"Downloaded {data}")
+        elif status == librepo.TRANSFER_ALREADYEXISTS:
+            print(f"Already downloaded {data}")
+        else:
+            print(f"Unknown status {status} for {data}")
 
     def make_pkg_target(self, handle, dest, path, checksum):
         """Return a librepo.PackageTarget populated with the package data

--- a/sources/org.osbuild.librepo
+++ b/sources/org.osbuild.librepo
@@ -1,0 +1,253 @@
+#!/usr/bin/python3
+"""
+Source for downloading rpms using librepo.
+
+Download the list of rpms using a metalink or mirrorlist URL, trying new
+mirrors if there is an error. The files are written to the osbuild file cache
+using the hash as the filename.
+
+It can download files that require secrets. The only secret provider currently
+supported is `org.osbuild.rhsm` for downloading Red Hat content that requires a
+subscriptions.
+"""
+
+import sys
+from typing import Dict
+
+import librepo
+
+from osbuild import sources
+from osbuild.util.rhsm import Subscriptions
+
+# NOTE: The top level schema properties are limited to items and options by the
+# v2 schema definition
+SCHEMA_2 = """
+"properties": {
+  "items": {
+    "description": "List of the packages and their hash to download from the mirror",
+    "type": "object",
+    "additionalProperties": false,
+    "patternProperties": {
+      "^(sha256|sha384|sha512):[0-9a-f]{64,128}$": {
+        "required": [
+          "path",
+          "mirror"
+        ],
+        "properties": {
+          "path": {
+            "description": "Name or path of the package file. Supports bare name or relative paths",
+            "type": "string"
+          },
+          "mirror": {
+            "description": "The mirror id (from options) to use for this package",
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "options": {
+    "required": [
+      "mirrors"
+    ],
+    "properties": {
+      "mirrors": {
+        "description": "List of mirrors to be used for downloading packages",
+        "type": "object",
+        "additionalProperties": false,
+        "patternProperties": {
+          "^[0-9a-f]+$": {
+            "required": [
+              "url",
+              "type"
+            ],
+            "properties": {
+              "url": {
+                "description": "URL of the mirrorlist or metalink",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of mirror: mirrorlist or metalink",
+                "type": "string",
+                "enum": [
+                  "mirrorlist",
+                  "metalink",
+                  "baseurl"
+                ]
+              },
+              "max-parallels": {
+                "description": "Maximum number of parallel downloads.",
+                "type": "number"
+              },
+              "fastest-mirror": {
+                "description": "When true the mirrorlist is sorted by connection speed.",
+                "type": "boolean",
+                "default": false
+              },
+              "insecure": {
+                "description": "Skip the verification step for secure connections and proceed without checking",
+                "type": "boolean",
+                "default": false
+              },
+              "secrets": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Name of the secrets provider.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class LibRepoSource(sources.SourceService):
+    """Use librepo to download rpm files.
+
+    This will download rpms, in parallel, retrying with a new mirror on errors,
+    and saving them into the store using their hash.
+
+    It support org.osbuild.rhsm secrets for downloading RHEL content.
+    """
+    content_type = "org.osbuild.files"
+
+    CHKSUM_TYPE = {
+        "sha256": librepo.SHA256,
+        "sha384": librepo.SHA384,
+        "sha512": librepo.SHA512,
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.subscriptions = None
+        self.errors = []
+
+    def fetch_one(self, checksum, desc) -> None:
+        raise RuntimeError("fetch_one is not used in org.osbuild.librepo")
+
+    def _setup_rhsm(self, handle, mirror):
+        """Setup the mirror's certificates if the secrets provider is org.osbuild.rhsm"""
+        # check if url needs rhsm secrets
+        if "secrets" not in mirror or mirror["secrets"].get("name") != "org.osbuild.rhsm":
+            return
+
+        # rhsm secrets only need to be retrieved once and can then be reused
+        if self.subscriptions is None:
+            self.subscriptions = Subscriptions.from_host_system()
+
+        secrets = self.subscriptions.get_secrets(mirror["url"])
+        if secrets:
+            if secrets.get('ssl_ca_cert'):
+                handle.sslcacert = secrets.get('ssl_ca_cert')
+            if secrets.get('ssl_client_cert'):
+                handle.sslclientcert = secrets.get('ssl_client_cert')
+            if secrets.get('ssl_client_key'):
+                handle.sslclientkey = secrets.get('ssl_client_key')
+
+    # This gets called when done
+    # data comes from cbdata
+    # status is librepo.TRANSFER_*
+    #   librepo.TRANSFER_SUCCESSFUL
+    #   librepo.TRANSFER_ALREADYEXISTS
+    #   librepo.TRANSFER_ERROR
+    def _endcb(self, data, status, msg):
+        """Callback for librepo transfers
+
+        data is the name/path of the package
+        status is a librepo TRANSFER_* status code
+        msg is a status message or error
+
+        TRANSFER_ERROR is returned if all mirrors are tried and it cannot download
+        the file.
+        """
+        if status == librepo.TRANSFER_ERROR:
+            self.errors.append(f"{data}: {msg}")
+
+    def make_pkg_target(self, handle, dest, path, checksum):
+        """Return a librepo.PackageTarget populated with the package data
+
+        This specifies what to download, where to save it, the checksum, etc.
+        """
+        chksum_type, checksum = checksum.split(":")
+        return librepo.PackageTarget(
+            path,
+            handle=handle,
+            checksum_type=self.CHKSUM_TYPE[chksum_type],
+            checksum=checksum,
+            dest=dest,
+            cbdata=path,
+            endcb=self._endcb)
+
+    def download(self, items: Dict) -> None:
+        """Use librepo to download the packages"""
+        # Organize the packages by the mirror id
+        packages = dict()
+        for id, pkg in items.items():
+            if pkg["mirror"] not in self.options["mirrors"]:
+                raise RuntimeError(f'Missing mirror: {pkg["mirror"]}')
+
+            if pkg["mirror"] not in packages:
+                packages[pkg["mirror"]] = [(pkg["path"], id)]
+            else:
+                packages[pkg["mirror"]].append((pkg["path"], id))
+
+        # Download packages from each of the mirror ids
+        for m in packages:
+            mirror = self.options["mirrors"][m]
+            handle = librepo.Handle()
+            handle.repotype = librepo.YUMREPO
+            if mirror["type"] == "metalink":
+                handle.metalinkurl = mirror["url"]
+            elif mirror["type"] == "mirrorlist":
+                handle.mirrorlisturl = mirror["url"]
+            elif mirror["type"] == "baseurl":
+                handle.urls = [mirror["url"]]
+
+            if mirror.get("insecure"):
+                # Disable peer certificate verification
+                handle.sslverifypeer = False
+                # Disable host name verification
+                handle.sslverifyhost = False
+            else:
+                handle.sslverifypeer = True
+                handle.sslverifyhost = True
+
+            if "max-parallels" in mirror:
+                handle.maxparalleldownloads = mirror["max-parallels"]
+
+            if mirror.get("fastest-mirror", False):
+                handle.fastestmirror = True
+
+            # If this mirror has secrets, set them up on the librepo handle
+            if "secrets" in m:
+                self._setup_rhsm(handle, mirror)
+
+            download = []
+            for path, checksum in packages[m]:
+                download.append(self.make_pkg_target(handle, f"{self.cache}/{checksum}", path, checksum))
+
+            # Download everything from this mirror
+            librepo.download_packages(download)
+
+        if self.errors:
+            raise RuntimeError(",".join(self.errors))
+
+
+def main():
+    service = LibRepoSource.from_args(sys.argv[1:])
+    service.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/sources/org.osbuild.librepo
+++ b/sources/org.osbuild.librepo
@@ -189,7 +189,7 @@ class LibRepoSource(sources.SourceService):
             cbdata=path,
             endcb=self._endcb)
 
-    def download(self, items: Dict) -> None:
+    def fetch_all(self, items: Dict) -> None:
         """Use librepo to download the packages"""
         # Organize the packages by the mirror id
         packages = dict()
@@ -230,7 +230,7 @@ class LibRepoSource(sources.SourceService):
                 handle.fastestmirror = True
 
             # If this mirror has secrets, set them up on the librepo handle
-            if "secrets" in m:
+            if "secrets" in mirror:
                 self._setup_rhsm(handle, mirror)
 
             download = []

--- a/sources/org.osbuild.librepo
+++ b/sources/org.osbuild.librepo
@@ -6,11 +6,12 @@ Download the list of rpms using a metalink or mirrorlist URL, trying new
 mirrors if there is an error. The files are written to the osbuild file cache
 using the hash as the filename.
 
-It can download files that require secrets. The only secret provider currently
-supported is `org.osbuild.rhsm` for downloading Red Hat content that requires a
-subscriptions.
+It can download files that require secrets. The support secret providers are:
+- `org.osbuild.rhsm` for downloading Red Hat content that requires a subscriptions.
+- `org.osbuild.mtls`
 """
 
+import os
 import sys
 from typing import Dict
 
@@ -118,7 +119,8 @@ class LibRepoSource(sources.SourceService):
     This will download rpms, in parallel, retrying with a new mirror on errors,
     and saving them into the store using their hash.
 
-    It support org.osbuild.rhsm secrets for downloading RHEL content.
+    It supports org.osbuild.rhsm secrets for downloading RHEL content and
+    org.osbuild.mtls
     """
     content_type = "org.osbuild.files"
 
@@ -138,10 +140,6 @@ class LibRepoSource(sources.SourceService):
 
     def _setup_rhsm(self, handle, mirror):
         """Setup the mirror's certificates if the secrets provider is org.osbuild.rhsm"""
-        # check if url needs rhsm secrets
-        if "secrets" not in mirror or mirror["secrets"].get("name") != "org.osbuild.rhsm":
-            return
-
         # rhsm secrets only need to be retrieved once and can then be reused
         if self.subscriptions is None:
             self.subscriptions = Subscriptions.from_host_system()
@@ -154,6 +152,18 @@ class LibRepoSource(sources.SourceService):
                 handle.sslclientcert = secrets.get('ssl_client_cert')
             if secrets.get('ssl_client_key'):
                 handle.sslclientkey = secrets.get('ssl_client_key')
+
+    def _setup_mtls(self, handle):
+        # this is currently using the CURL names, librepo is using
+        # curl under the hood so this is okay-ish, but maybe we should
+        # generalize the name
+        key = os.getenv("OSBUILD_SOURCES_CURL_SSL_CLIENT_KEY")
+        cert = os.getenv("OSBUILD_SOURCES_CURL_SSL_CLIENT_CERT")
+        if not (key and cert):
+            raise RuntimeError(f"mtls secrets required but key ({key}) or cert ({cert}) not defined")
+        handle.sslcacert = os.getenv("OSBUILD_SOURCES_CURL_SSL_CA_CERT")
+        handle.sslclientcert = cert
+        handle.sslclientkey = key
 
     # This gets called when done
     # data comes from cbdata
@@ -238,8 +248,11 @@ class LibRepoSource(sources.SourceService):
                 handle.fastestmirror = True
 
             # If this mirror has secrets, set them up on the librepo handle
-            if "secrets" in mirror:
+            secrets_name = mirror.get("secrets", {}).get("name")
+            if secrets_name == "org.osbuild.rhsm":
                 self._setup_rhsm(handle, mirror)
+            elif secrets_name == "org.osbuild.mtls":
+                self._setup_mtls(handle)
 
             download = []
             for path, checksum in packages:

--- a/sources/test/test_librepo.py
+++ b/sources/test/test_librepo.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python3
+from unittest.mock import patch
+
+import librepo
+
+SOURCES_NAME = "org.osbuild.librepo"
+
+
+@patch("librepo.download_packages")
+def test_librepo_download_mocked(mocked_download_pkgs, sources_service):
+    TEST_SOURCES = {
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111": {
+            "path": "Packages/a/a",
+            "mirror": "mirror_id",
+        },
+        "sha256:2111111111111111111111111111111111111111111111111111111111111111": {
+            "path": "Packages/b/b",
+            "mirror": "mirror_id2",
+        },
+    }
+    sources_service.options = {
+        "mirrors": {
+            "mirror_id": {
+                "url": "http://example.com/mirrorlist",
+                "type": "mirrorlist",
+            },
+            "mirror_id2": {
+                "url": "http://example.com/mirrorlist2",
+                "type": "mirrorlist",
+            }
+        }
+    }
+    sources_service.cache = "cachedir"
+    sources_service.fetch_all(TEST_SOURCES)
+    # we expect one download call per mirror
+    assert len(mocked_download_pkgs.call_args_list) == 2
+    # extract the list of packages to download (all_calls->call()->args->args[0])
+    download_pkgs = mocked_download_pkgs.call_args_list[0][0][0]
+    assert download_pkgs[0].checksum == "1111111111111111111111111111111111111111111111111111111111111111"
+    assert download_pkgs[0].checksum_type == librepo.SHA256
+    assert download_pkgs[0].relative_url == "Packages/a/a"
+    assert download_pkgs[0].dest == "cachedir/sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    assert download_pkgs[0].handle.mirrorlisturl == "http://example.com/mirrorlist"
+    # and now the second call
+    download_pkgs = mocked_download_pkgs.call_args_list[1][0][0]
+    assert download_pkgs[0].checksum == "2111111111111111111111111111111111111111111111111111111111111111"
+    assert download_pkgs[0].checksum_type == librepo.SHA256
+    assert download_pkgs[0].relative_url == "Packages/b/b"
+    assert download_pkgs[0].dest == "cachedir/sha256:2111111111111111111111111111111111111111111111111111111111111111"
+    assert download_pkgs[0].handle.mirrorlisturl == "http://example.com/mirrorlist2"
+
+
+class FakeSubscriptionManager:
+    def __init__(self):
+        self.get_secrets_calls = []
+
+    def get_secrets(self, url):
+        self.get_secrets_calls.append(url)
+        return {
+            "ssl_ca_cert": "rhsm-ca-cert",
+            "ssl_client_cert": "rhsm-client-cert",
+            "ssl_client_key": "rhsm-client-key",
+        }
+
+
+@patch("librepo.download_packages")
+def test_librepo_secrets(mocked_download_pkgs, sources_service):
+    TEST_SOURCES = {
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111": {
+            "path": "Packages/a/a",
+            "mirror": "mirror_id",
+        }
+    }
+    sources_service.options = {
+        "mirrors": {
+            "mirror_id": {
+                "url": "http://example.com/mirrorlist",
+                "type": "mirrorlist",
+                "secrets": {
+                    "name": "org.osbuild.rhsm",
+                }
+            }
+        }
+    }
+    sources_service.cache = "cachedir"
+    sources_service.subscriptions = FakeSubscriptionManager()
+    sources_service.fetch_all(TEST_SOURCES)
+    assert len(mocked_download_pkgs.call_args_list) == 1
+    # extract the list of packages to download (all_calls->call()->args->args[0])
+    download_pkgs = mocked_download_pkgs.call_args_list[0][0][0]
+    assert download_pkgs[0].checksum == "1111111111111111111111111111111111111111111111111111111111111111"
+    assert download_pkgs[0].handle.sslclientkey == "rhsm-client-key"
+    assert download_pkgs[0].handle.sslclientcert == "rhsm-client-cert"
+    assert download_pkgs[0].handle.sslcacert == "rhsm-ca-cert"
+    # double check that get_secrets() was called
+    assert sources_service.subscriptions.get_secrets_calls == ["http://example.com/mirrorlist"]

--- a/sources/test/test_librepo.py
+++ b/sources/test/test_librepo.py
@@ -140,9 +140,9 @@ def test_librepo_secrets_mtls(mocked_download_pkgs, sources_service, monkeypatch
 @pytest.mark.parametrize("test_mirrors,expected_err", [
     # bad
     (
-        # only hashes supported for mirror_ids
-        {"bad_mirror_id": {"url": "http://example.com", "type": "mirrorlist"}},
-        "'bad_mirror_id' does not match any of the regexes: '^[0-9a-f]+$'",
+        # no spaces in mirror_id
+        {"bad mirror": {"url": "http://example.com", "type": "mirrorlist"}},
+        "'bad mirror' does not match any of the regexes: ",
     ),
     (
         {"0123456789abcdef": {"type": "mirrorlist"}},
@@ -168,7 +168,10 @@ def test_librepo_secrets_mtls(mocked_download_pkgs, sources_service, monkeypatch
     ),
     (
         {"0123": {"url": "http://example.com", "type": "baseurl"}}, "",
-    )
+    ),
+    (
+        {"Com_plex:id.": {"url": "http://x.com", "type": "baseurl"}}, "",
+    ),
 ])
 def test_schema_validation(sources_schema, test_mirrors, expected_err):
     test_input = {

--- a/sources/test/test_librepo.py
+++ b/sources/test/test_librepo.py
@@ -1,7 +1,11 @@
 #!/usr/bin/python3
 from unittest.mock import patch
 
-import librepo
+try:
+    import librepo
+except ImportError:
+    import pytest
+    pytest.skip("need librepo to run this test", allow_module_level=True)
 import pytest
 
 from osbuild import testutil

--- a/test/data/sources/org.osbuild.librepo/cases/404-metalink.json
+++ b/test/data/sources/org.osbuild.librepo/cases/404-metalink.json
@@ -20,20 +20,20 @@
       }
     },
     "options": {
-        "mirrors": {
-          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/one404.xml",
-            "type": "metalink",
-            "fastest-mirror": true,
-            "name": "metalink"
-          },
-          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
-            "type": "metalink",
-            "fastest-mirror": true,
-            "name": "metalink"
-          }
+      "mirrors": {
+        "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/one404.xml",
+          "type": "metalink",
+          "fastest-mirror": true,
+          "name": "metalink"
+        },
+        "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
+          "type": "metalink",
+          "fastest-mirror": true,
+          "name": "metalink"
         }
+      }
     }
   }
 }

--- a/test/data/sources/org.osbuild.librepo/cases/404-metalink.json
+++ b/test/data/sources/org.osbuild.librepo/cases/404-metalink.json
@@ -1,0 +1,39 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:e99efe314a66334179236e5fb6a2e6a6431daf6aeb516162e01517a0ac708252": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/one404.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/404-mirrorlist.json
+++ b/test/data/sources/org.osbuild.librepo/cases/404-mirrorlist.json
@@ -1,0 +1,39 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:e99efe314a66334179236e5fb6a2e6a6431daf6aeb516162e01517a0ac708252": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/one404",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/404-mirrorlist.json
+++ b/test/data/sources/org.osbuild.librepo/cases/404-mirrorlist.json
@@ -20,20 +20,20 @@
       }
     },
     "options": {
-        "mirrors": {
-          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/one404",
-            "type": "mirrorlist",
-            "fastest-mirror": true,
-            "name": "mirrorlist"
-          },
-          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
-            "type": "mirrorlist",
-            "fastest-mirror": true,
-            "name": "mirrorlist"
-          }
+      "mirrors": {
+        "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/one404",
+          "type": "mirrorlist",
+          "fastest-mirror": true,
+          "name": "mirrorlist"
+        },
+        "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
+          "type": "mirrorlist",
+          "fastest-mirror": true,
+          "name": "mirrorlist"
         }
+      }
     }
   }
 }

--- a/test/data/sources/org.osbuild.librepo/cases/bad-baseurl-checksum.json
+++ b/test/data/sources/org.osbuild.librepo/cases/bad-baseurl-checksum.json
@@ -20,18 +20,18 @@
       }
     },
     "options": {
-        "mirrors": {
-          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/",
-            "type": "baseurl",
-            "name": "baseurl"
-          },
-          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/updates/",
-            "type": "baseurl",
-            "name": "updates"
-          }
+      "mirrors": {
+        "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/",
+          "type": "baseurl",
+          "name": "baseurl"
+        },
+        "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/updates/",
+          "type": "baseurl",
+          "name": "updates"
         }
+      }
     }
   }
 }

--- a/test/data/sources/org.osbuild.librepo/cases/bad-baseurl-checksum.json
+++ b/test/data/sources/org.osbuild.librepo/cases/bad-baseurl-checksum.json
@@ -1,0 +1,37 @@
+{
+  "expects": "error",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/",
+            "type": "baseurl",
+            "name": "baseurl"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/updates/",
+            "type": "baseurl",
+            "name": "updates"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/bad-metalink-checksum.json
+++ b/test/data/sources/org.osbuild.librepo/cases/bad-metalink-checksum.json
@@ -1,0 +1,39 @@
+{
+  "expects": "error",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/bad-metalink-checksum.json
+++ b/test/data/sources/org.osbuild.librepo/cases/bad-metalink-checksum.json
@@ -20,20 +20,20 @@
       }
     },
     "options": {
-        "mirrors": {
-          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
-            "type": "metalink",
-            "fastest-mirror": true,
-            "name": "metalink"
-          },
-          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
-            "type": "metalink",
-            "fastest-mirror": true,
-            "name": "metalink"
-          }
+      "mirrors": {
+        "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
+          "type": "metalink",
+          "fastest-mirror": true,
+          "name": "metalink"
+        },
+        "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
+          "type": "metalink",
+          "fastest-mirror": true,
+          "name": "metalink"
         }
+      }
     }
   }
 }

--- a/test/data/sources/org.osbuild.librepo/cases/bad-mirrorlist-checksum.json
+++ b/test/data/sources/org.osbuild.librepo/cases/bad-mirrorlist-checksum.json
@@ -20,20 +20,20 @@
       }
     },
     "options": {
-        "mirrors": {
-          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
-            "type": "mirrorlist",
-            "fastest-mirror": true,
-            "name": "mirrorlist"
-          },
-          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
-            "type": "mirrorlist",
-            "fastest-mirror": true,
-            "name": "mirrorlist"
-          }
+      "mirrors": {
+        "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
+          "type": "mirrorlist",
+          "fastest-mirror": true,
+          "name": "mirrorlist"
+        },
+        "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
+          "type": "mirrorlist",
+          "fastest-mirror": true,
+          "name": "mirrorlist"
         }
+      }
     }
   }
 }

--- a/test/data/sources/org.osbuild.librepo/cases/bad-mirrorlist-checksum.json
+++ b/test/data/sources/org.osbuild.librepo/cases/bad-mirrorlist-checksum.json
@@ -1,0 +1,39 @@
+{
+  "expects": "error",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/baseurl.json
+++ b/test/data/sources/org.osbuild.librepo/cases/baseurl.json
@@ -1,0 +1,25 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/",
+            "type": "baseurl",
+            "fastest-mirror": true,
+            "name": "baseurl"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/baseurl.json
+++ b/test/data/sources/org.osbuild.librepo/cases/baseurl.json
@@ -12,14 +12,14 @@
       }
     },
     "options": {
-        "mirrors": {
-          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/",
-            "type": "baseurl",
-            "fastest-mirror": true,
-            "name": "baseurl"
-          }
+      "mirrors": {
+        "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/",
+          "type": "baseurl",
+          "fastest-mirror": true,
+          "name": "baseurl"
         }
+      }
     }
   }
 }

--- a/test/data/sources/org.osbuild.librepo/cases/one-metalink.json
+++ b/test/data/sources/org.osbuild.librepo/cases/one-metalink.json
@@ -1,0 +1,25 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/one-metalink.json
+++ b/test/data/sources/org.osbuild.librepo/cases/one-metalink.json
@@ -12,14 +12,14 @@
       }
     },
     "options": {
-        "mirrors": {
-          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
-            "type": "metalink",
-            "fastest-mirror": true,
-            "name": "metalink"
-          }
+      "mirrors": {
+        "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
+          "type": "metalink",
+          "fastest-mirror": true,
+          "name": "metalink"
         }
+      }
     }
   }
 }

--- a/test/data/sources/org.osbuild.librepo/cases/one-mirrorlist.json
+++ b/test/data/sources/org.osbuild.librepo/cases/one-mirrorlist.json
@@ -1,0 +1,25 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/one-mirrorlist.json
+++ b/test/data/sources/org.osbuild.librepo/cases/one-mirrorlist.json
@@ -12,14 +12,14 @@
       }
     },
     "options": {
-        "mirrors": {
-          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
-            "type": "mirrorlist",
-            "fastest-mirror": true,
-            "name": "mirrorlist"
-          }
+      "mirrors": {
+        "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
+          "type": "mirrorlist",
+          "fastest-mirror": true,
+          "name": "mirrorlist"
         }
+      }
     }
   }
 }

--- a/test/data/sources/org.osbuild.librepo/cases/two-metalink.json
+++ b/test/data/sources/org.osbuild.librepo/cases/two-metalink.json
@@ -1,0 +1,39 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:e99efe314a66334179236e5fb6a2e6a6431daf6aeb516162e01517a0ac708252": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
+            "type": "metalink",
+            "fastest-mirror": true,
+            "name": "metalink"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/cases/two-metalink.json
+++ b/test/data/sources/org.osbuild.librepo/cases/two-metalink.json
@@ -20,20 +20,20 @@
       }
     },
     "options": {
-        "mirrors": {
-          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
-            "type": "metalink",
-            "fastest-mirror": true,
-            "name": "metalink"
-          },
-          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
-            "type": "metalink",
-            "fastest-mirror": true,
-            "name": "metalink"
-          }
+      "mirrors": {
+        "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/fedora.xml",
+          "type": "metalink",
+          "fastest-mirror": true,
+          "name": "metalink"
+        },
+        "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/metalink/updates.xml",
+          "type": "metalink",
+          "fastest-mirror": true,
+          "name": "metalink"
         }
+      }
     }
   }
 }

--- a/test/data/sources/org.osbuild.librepo/cases/two-mirrorlist.json
+++ b/test/data/sources/org.osbuild.librepo/cases/two-mirrorlist.json
@@ -20,20 +20,20 @@
       }
     },
     "options": {
-        "mirrors": {
-          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
-            "type": "mirrorlist",
-            "fastest-mirror": true,
-            "name": "mirrorlist"
-          },
-          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
-            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
-            "type": "mirrorlist",
-            "fastest-mirror": true,
-            "name": "mirrorlist"
-          }
+      "mirrors": {
+        "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
+          "type": "mirrorlist",
+          "fastest-mirror": true,
+          "name": "mirrorlist"
+        },
+        "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+          "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
+          "type": "mirrorlist",
+          "fastest-mirror": true,
+          "name": "mirrorlist"
         }
+      }
     }
   }
 }

--- a/test/data/sources/org.osbuild.librepo/cases/two-mirrorlist.json
+++ b/test/data/sources/org.osbuild.librepo/cases/two-mirrorlist.json
@@ -1,0 +1,39 @@
+{
+  "expects": "success",
+  "org.osbuild.librepo": {
+    "items": {
+      "sha256:99fa21f1b67fea84dcb9b3c7f7e09a4f150095cfa7163a19d03972fd7c826f00": {
+        "path": "Packages/a/a",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:77e6ed0bed2d720e44d77643f66b05f0eb42b06379990e5ef658ef314c415827": {
+        "path": "Packages/b/b",
+        "mirror": "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2"
+      },
+      "sha256:e99efe314a66334179236e5fb6a2e6a6431daf6aeb516162e01517a0ac708252": {
+        "path": "Packages/c/c",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      },
+      "sha256:354fe7c89ac014ed6479bf162fa7b9e8b37eddc7e46719ebd4349699d4e92c8c": {
+        "path": "Packages/d/d",
+        "mirror": "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703"
+      }
+    },
+    "options": {
+        "mirrors": {
+          "0cde5945566ff3feb627eaa84e31223d2b8be54fb446222cded36fc5e5debcc2": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/fedora",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          },
+          "d68132295d14ad03bd676009c4fe8727f5040adfb91e20ac9919101d14ff4703": {
+            "url": "http://localhost/sources/org.osbuild.librepo/data/mirrorlist/updates",
+            "type": "mirrorlist",
+            "fastest-mirror": true,
+            "name": "mirrorlist"
+          }
+        }
+    }
+  }
+}

--- a/test/data/sources/org.osbuild.librepo/data/Packages/a/a
+++ b/test/data/sources/org.osbuild.librepo/data/Packages/a/a
@@ -1,0 +1,1 @@
+DUMMY PACKAGE a

--- a/test/data/sources/org.osbuild.librepo/data/Packages/b/b
+++ b/test/data/sources/org.osbuild.librepo/data/Packages/b/b
@@ -1,0 +1,1 @@
+DUMMY PACKAGE b

--- a/test/data/sources/org.osbuild.librepo/data/metalink/fedora.xml
+++ b/test/data/sources/org.osbuild.librepo/data/metalink/fedora.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <metalink version="3.0" xmlns="http://www.metalinker.org/">
+   <files>
+     <file name="repomd.xml">
+       <resources maxconnections="1">
+           <url protocol="http" type="http" location="us" preference="100">http://localhost/sources/org.osbuild.librepo/data/repodata/repomd.xml</url>
+       </resources>
+     </file>
+   </files>
+ </metalink>

--- a/test/data/sources/org.osbuild.librepo/data/metalink/one404.xml
+++ b/test/data/sources/org.osbuild.librepo/data/metalink/one404.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <metalink version="3.0" xmlns="http://www.metalinker.org/">
+   <files>
+     <file name="repomd.xml">
+       <resources maxconnections="1">
+           <url protocol="http" type="http" location="us" preference="100">http://localhost/sources/org.osbuild.librepo/data/404/repodata/repomd.xml</url>
+           <url protocol="http" type="http" location="us" preference="50">http://localhost/sources/org.osbuild.librepo/data/repodata/repomd.xml</url>
+       </resources>
+     </file>
+   </files>
+ </metalink>

--- a/test/data/sources/org.osbuild.librepo/data/metalink/updates.xml
+++ b/test/data/sources/org.osbuild.librepo/data/metalink/updates.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <metalink version="3.0" xmlns="http://www.metalinker.org/">
+   <files>
+     <file name="repomd.xml">
+       <resources maxconnections="1">
+           <url protocol="http" type="http" location="us" preference="100">http://localhost/sources/org.osbuild.librepo/data/updates/repodata/repomd.xml</url>
+       </resources>
+     </file>
+   </files>
+ </metalink>

--- a/test/data/sources/org.osbuild.librepo/data/mirrorlist/fedora
+++ b/test/data/sources/org.osbuild.librepo/data/mirrorlist/fedora
@@ -1,0 +1,1 @@
+http://localhost/sources/org.osbuild.librepo/data/

--- a/test/data/sources/org.osbuild.librepo/data/mirrorlist/one404
+++ b/test/data/sources/org.osbuild.librepo/data/mirrorlist/one404
@@ -1,0 +1,2 @@
+http://localhost/sources/org.osbuild.librepo/data/404/
+http://localhost/sources/org.osbuild.librepo/data/

--- a/test/data/sources/org.osbuild.librepo/data/mirrorlist/updates
+++ b/test/data/sources/org.osbuild.librepo/data/mirrorlist/updates
@@ -1,0 +1,1 @@
+http://localhost/sources/org.osbuild.librepo/data/updates/

--- a/test/data/sources/org.osbuild.librepo/data/updates/Packages/c/c
+++ b/test/data/sources/org.osbuild.librepo/data/updates/Packages/c/c
@@ -1,0 +1,1 @@
+DUMMY PACKAGE c

--- a/test/data/sources/org.osbuild.librepo/data/updates/Packages/d/d
+++ b/test/data/sources/org.osbuild.librepo/data/updates/Packages/d/d
@@ -1,0 +1,1 @@
+DUMMY PACKAGE d

--- a/test/mod/test_osbuild.py
+++ b/test/mod/test_osbuild.py
@@ -282,6 +282,10 @@ class TestDescriptions(unittest.TestCase):
 
             try:
                 info = osbuild.meta.ModuleInfo.load(os.curdir, klass, name)
+                if not info.opts[version]:
+                    print(f"{klass} '{name}' does not support version '{version}'")
+                    continue
+
                 schema = osbuild.meta.Schema(info.get_schema(version), name)
                 res = schema.check()
                 if not res:
@@ -290,6 +294,10 @@ class TestDescriptions(unittest.TestCase):
                     self.fail(str(res) + "\n  " + err)
             except json.decoder.JSONDecodeError as e:
                 msg = f"{klass} '{name}' has invalid STAGE_OPTS\n\t" + str(e)
+                self.fail(msg)
+            # pylint: disable=broad-exception-caught
+            except Exception as e:
+                msg = f"{klass} '{name}': " + str(e)
                 self.fail(msg)
 
     def test_moduleinfo(self):

--- a/test/run/test_sources.py
+++ b/test/run/test_sources.py
@@ -127,6 +127,14 @@ def test_sources(source, case, tmp_path):
     items = desc.get("items", {})
     options = desc.get("options", {})
 
+    # What version to use for validation?
+    version = "2" if info.opts["2"] else "1"
+    schema = osbuild.meta.Schema(info.get_schema(version=version), source)
+    res = schema.validate(desc)
+    # NOTE: ValidationResult overrides __bool__ to return res.valid
+    if not res:
+        raise RuntimeError(f"Validation failed on {source}:{case}:{res.as_dict()}")
+
     src = osbuild.sources.Source(info, items, options)
 
     with osbuild.objectstore.ObjectStore(tmp_path) as store, \


### PR DESCRIPTION
[draft until the "images" (and possible "composer") side is ready so that we know if this really ready]

This is a reopen of https://github.com/osbuild/osbuild/pull/1304 with tiny tweaks to update it to current osbuild. All credit to @bcl.

This is prompted by the issues we see with fedora mirrors currently, e.g.
https://github.com/osbuild/image-builder-cli/issues/40
https://github.com/osbuild/bootc-image-builder/pull/766

The matching PRs for images/bootc-image-builder/image-builder-cli are here as drafts:
- https://github.com/osbuild/images/pull/1132
- https://github.com/osbuild/image-builder-cli/pull/51
- https://github.com/osbuild/bootc-image-builder/pull/786

This of course needs "images"/"bib" integration, I can make this draft until those pieces are added if desired.