### PR TITLE
stages/mkfs.ext4: disable lazy_itable_init

### DIFF
--- a/stages/org.osbuild.mkfs.ext4
+++ b/stages/org.osbuild.mkfs.ext4
@@ -10,10 +10,15 @@ def main(devices, options):
 
     uuid = options["uuid"]
     label = options.get("label")
+    lazy_init = options.get("lazy_init")
     opts = []
 
     if label:
         opts = ["-L", label]
+
+    if lazy_init is not None:
+        opts += ["-E", f"lazy_itable_init={int(lazy_init)}",
+                 "-E", f"lazy_journal_init={int(lazy_init)}"]
 
     for fsopt in ["verity", "orphan_file", "metadata_csum_seed"]:
         val = options.get(fsopt)

--- a/stages/org.osbuild.mkfs.ext4.meta.json
+++ b/stages/org.osbuild.mkfs.ext4.meta.json
@@ -34,6 +34,10 @@
           "type": "string",
           "maxLength": 16
         },
+        "lazy_init": {
+          "description": "Enable or disable lazy_itable_init and lazy_journal_init support",
+          "type": "boolean"
+        },
         "metadata_csum_seed": {
           "description": "Enable metadata_csum_seed support",
           "type": "boolean"

--- a/stages/test/test_mkfs_ext4.py
+++ b/stages/test/test_mkfs_ext4.py
@@ -19,9 +19,11 @@ STAGE_NAME = "org.osbuild.mkfs.ext4"
     ({"uuid": 123}, "123 is not of type 'string'"),
     ({"uuid": "vaild", "label": "12345678901234567"}, " is too long"),
     ({"uuid": "valid", "verity": "please"}, "'please' is not of type 'boolean'"),
+    ({"uuid": "valid", "lazy_init": "lazy"}, "'lazy' is not of type 'boolean'"),
     # good
     ({"uuid": "some", "label": "1234567890123456"}, ""),
     ({"uuid": "some", "label": "label", "verity": True}, ""),
+    ({"uuid": "valid", "lazy_init": True}, ""),
     # actually "some-uuid" will not be accepted by mkfs, it has to be a valid
     # uuid but our schema is not strict enough right now
     ({"uuid": "some-uuid"}, ""),
@@ -78,6 +80,8 @@ def test_mkfs_ext4_integration(tmp_path, stage_module):
     ({"metadata_csum_seed": True}, ["-O", "metadata_csum_seed"]),
     ({"metadata_csum_seed": False}, ["-O", "^metadata_csum_seed"]),
     ({"verity": True, "orphan_file": True, "metadata_csum_seed": True}, ["-O", "verity", "-O", "orphan_file", "-O", "metadata_csum_seed"]),
+    ({"lazy_init": True}, ["-E", "lazy_itable_init=1", "-E", "lazy_journal_init=1"]),
+    ({"lazy_init": False}, ["-E", "lazy_itable_init=0", "-E", "lazy_journal_init=0"]),
 ])
 @mock.patch("subprocess.run")
 def test_mkfs_ext4_cmdline(mock_run, stage_module, test_input, expected):


### PR DESCRIPTION
This helps to clear a risk concern for
automotive.

Add optional flag to org.osbuild.mkfs.ext4 stage
to enable/disable both lazy_itable_init and
lazy_journal_init extended options. Both mke2fs
options are controled by the same flag, namely
`lazy_init`.