### PR TITLE
README: remove mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ of the pipeline description, and more.
  * **Bug Tracker**: https://github.com/osbuild/osbuild/issues
  * **Discussions**: https://github.com/orgs/osbuild/discussions
  * **Matrix**: #image-builder on [fedoraproject.org](https://matrix.to/#/#image-builder:fedoraproject.org)
- * **Mailing List**: image-builder@redhat.com
  * **Changelog**: https://github.com/osbuild/osbuild/releases
 
 ### Principles


### PR DESCRIPTION
The mailing list was sunset by the IT department and
was rarely used, so we'll replace it with matrix & discussions.