### PR TITLE
Gitlab CI: use F41 for OSTree tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ OSTree Images:
     - schutzbot/deploy.sh
     - sudo test/cases/ostree-images --manifest "$MANIFEST" --export $EXPORT
   variables:
-    RUNNER: aws/fedora-39-x86_64
+    RUNNER: aws/fedora-41-x86_64
   parallel:
     matrix:
       - MANIFEST: fedora-ostree-tarball.json


### PR DESCRIPTION
Let's not use EOL F39 for OSTree tests and move to the latest supported Fedora version.