### PR TITLE
Add `--cache` flag as an alias for `--store`

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -69,7 +69,7 @@ def parse_arguments(sys_argv: List[str]) -> argparse.Namespace:
 
     parser.add_argument("manifest_path", metavar="MANIFEST",
                         help="json file containing the manifest that should be built, or a '-' to read from stdin")
-    parser.add_argument("--store", metavar="DIRECTORY", type=os.path.abspath,
+    parser.add_argument("--store", "--cache", metavar="DIRECTORY", type=os.path.abspath,
                         default=".osbuild",
                         help="directory where intermediary os trees are stored")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath, default="/usr/lib/osbuild",

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -69,7 +69,7 @@ def parse_arguments(sys_argv: List[str]) -> argparse.Namespace:
 
     parser.add_argument("manifest_path", metavar="MANIFEST",
                         help="json file containing the manifest that should be built, or a '-' to read from stdin")
-    parser.add_argument("--store", "--cache", metavar="DIRECTORY", type=os.path.abspath,
+    parser.add_argument("--cache", "--store", metavar="DIRECTORY", type=os.path.abspath,
                         default=".osbuild",
                         help="directory where sources and intermediary os trees are stored")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath, default="/usr/lib/osbuild",
@@ -168,7 +168,7 @@ def osbuild_cli() -> int:
         monitor_name = "NullMonitor" if (args.json or args.quiet) else "LogMonitor"
 
     try:
-        with ObjectStore(args.store) as object_store:
+        with ObjectStore(args.cache) as object_store:
             if args.cache_max_size is not None:
                 object_store.maximum_size = args.cache_max_size
 

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -71,7 +71,7 @@ def parse_arguments(sys_argv: List[str]) -> argparse.Namespace:
                         help="json file containing the manifest that should be built, or a '-' to read from stdin")
     parser.add_argument("--store", "--cache", metavar="DIRECTORY", type=os.path.abspath,
                         default=".osbuild",
-                        help="directory where intermediary os trees are stored")
+                        help="directory where sources and intermediary os trees are stored")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath, default="/usr/lib/osbuild",
                         help="directory containing stages, assemblers, and the osbuild library")
     parser.add_argument("--cache-max-size", metavar="SIZE", type=parse_size, default=None,


### PR DESCRIPTION
**osbuild/cli: add --cache as an alias for --store**

The name 'cache' is more recognisable and conveys the purpose of the
option just as well (if not better) than 'store'.
Also, the option that controls the size of this directory is called
'cache-max-size', so we're already referring to it as a cache.

---

**osbuild/cli: mention sources in cache/store help**

The cache/store directory is also used to keep sources.  Mention that in
the description of the option.

---
