### PR TITLE
osbuild-image-info: don't fail on no systemd default target (HMS-5375)

### DIFF
--- a/tools/osbuild-image-info
+++ b/tools/osbuild-image-info
@@ -602,7 +602,10 @@ def read_default_target(tree):
     An example return value:
     "multi-user.target"
     """
-    return subprocess_check_output(["systemctl", f"--root={tree}", "get-default"]).rstrip()
+    try:
+        return subprocess_check_output(["systemctl", f"--root={tree}", "get-default"]).rstrip()
+    except subprocess.CalledProcessError:
+        return ""
 
 
 def read_firewall_default_zone(tree):

--- a/tools/test/test_osbuild_image_info.py
+++ b/tools/test/test_osbuild_image_info.py
@@ -135,3 +135,41 @@ grub_class fedora""",
 def test_read_boot_entries(tmp_path, fake_tree, entries):
     make_fake_tree(tmp_path, fake_tree)
     assert osbuild_image_info.read_boot_entries(tmp_path / "boot") == entries
+
+
+def test_read_default_target_ok(tmp_path):
+    """
+    Test the happy case when determinig the systemd default target
+    """
+    make_fake_tree(tmp_path, {
+        "/usr/lib/systemd/system/multi-user.target": """#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Multi-User System
+Documentation=man:systemd.special(7)
+Requires=basic.target
+Conflicts=rescue.service rescue.target
+After=basic.target rescue.service rescue.target
+AllowIsolate=yes
+"""
+    })
+    etc_systemd_system_dir = tmp_path / "etc/systemd/system"
+    etc_systemd_system_dir.mkdir(parents=True)
+    default_target_link = etc_systemd_system_dir / "default.target"
+    default_target_link.symlink_to("/usr/lib/systemd/system/multi-user.target")
+
+    assert osbuild_image_info.read_default_target(tmp_path) == "multi-user.target"
+
+
+def test_read_default_target_none(tmp_path):
+    """
+    Test the case when when there is no default target set on the system
+    """
+    assert osbuild_image_info.read_default_target(tmp_path) == ""


### PR DESCRIPTION
Some image types don't have systemd installed and don't have any default target set, e.g. 'tar' image type. Running osbuild-image-info on such image would result in traceback (e.g. [1]). Handle this case gracefully.

[1] https://gitlab.com/redhat/services/products/image-builder/ci/osbuild/-/jobs/8911649248#L6480

Add a test case for this change.

/jira-epic COMPOSER-2318

JIRA: [HMS-5375](https://issues.redhat.com/browse/HMS-5375)