### PR TITLE
depsolve: remove nevra field

### DIFF
--- a/osbuild/solver/dnf.py
+++ b/osbuild/solver/dnf.py
@@ -302,7 +302,6 @@ class DNF(SolverBase):
         pkg_repos = {}
         for package in last_transaction:
             packages.append({
-                "nevra": f"{package.name}-{package.evr}.{package.arch}",
                 "name": package.name,
                 "epoch": package.epoch,
                 "version": package.version,
@@ -360,7 +359,7 @@ class DNF(SolverBase):
             if transaction.get("module-enable-specs") or modules_in_package_specs:
                 # we'll be checking later if any packages-from-modules are in the
                 # packages-to-install set so let's do this only once here
-                package_nevras = list(p["nevra"] for p in packages)
+                package_nevras = list(f"{p.name}-{p.evr}.{p.arch}" for p in packages)
 
                 for module_spec in itertools.chain(
                     transaction.get("module-enable-specs", []),


### PR DESCRIPTION
This field isn't necessary and is not used downstream; it's breaking the integration with images/etc.