### PR TITLE
spec: bump dnf json api version

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -155,7 +155,7 @@ Conflicts: osbuild-composer <= 115
 # This version needs to get bumped every time the osbuild-dnf-json
 # version changes in an incompatible way. Packages like osbuild-composer
 # can depend on the exact API version this way
-Provides: osbuild-dnf-json-api = 7
+Provides: osbuild-dnf-json-api = 8
 
 %description    depsolve-dnf
 Contains depsolving capabilities for package managers.


### PR DESCRIPTION
The modularity changes introduced a new field in the DNF JSON responses (#1933). This bump ensures that current deployments don't break.