### PR TITLE
spec: bump dnfjson api version

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -155,7 +155,7 @@ Conflicts: osbuild-composer <= 115
 # This version needs to get bumped every time the osbuild-dnf-json
 # version changes in an incompatible way. Packages like osbuild-composer
 # can depend on the exact API version this way
-Provides: osbuild-dnf-json-api = 7
+Provides: osbuild-dnf-json-api = 8
 
 %description    depsolve-dnf
 Contains depsolving capabilities for package managers.


### PR DESCRIPTION
Due to the `modules` field that was added to the depsolve result in #1933 the depsolve json response is now incompatible with previous versions. This requires a bump to the version.


This PR is an un-revert of the #1989 which reverted the API version bump but now based on the fact that we are actually breaking the API version by design and expectation.

---

Note that, as opposed to the nevra field on packages which was a big red herring today; this field is actually *expected* to be added. Hence we can't just remove it from the depsolve response. This also means that the DNF JSON version *will* need to be bumped; even though we didn't want to do that (cc: @ondrejbudai). See the images PR where this field gets added: https://github.com/osbuild/images/pull/1163
