### PR TITLE
stages/systemd.unit.create: support .swap units

### DIFF
--- a/stages/org.osbuild.systemd.unit.create
+++ b/stages/org.osbuild.systemd.unit.create
@@ -19,6 +19,8 @@ def validate(filename, cfg):
         raise ValueError(f"Error: {filename} unit requires Mount section")
     if filename.endswith(".socket") and "Socket" not in cfg:
         raise ValueError(f"Error: {filename} unit requires Socket section")
+    if filename.endswith(".swap") and "Swap" not in cfg:
+        raise ValueError(f"Error: {filename} unit requires Swap section")
 
 
 def main(tree, options):

--- a/stages/org.osbuild.systemd.unit.create.meta.json
+++ b/stages/org.osbuild.systemd.unit.create.meta.json
@@ -46,6 +46,11 @@
     "    - 'Service' - string",
     "    - 'RuntimeDirectory' - string",
     "    - 'RemoveOnStop' - bool",
+    "  - 'Swap' section",
+    "    - 'What' - string",
+    "    - 'Priority' - integer",
+    "    - 'Options' - string",
+    "    - 'TimeoutSec' - string",
     "  - 'Install' section",
     "    - 'WantedBy' - [string]",
     "    - 'RequiredBy' - [string]"
@@ -59,7 +64,7 @@
     "properties": {
       "filename": {
         "type": "string",
-        "pattern": "^[\\w:.\\\\-]+[@]{0,1}[\\w:.\\\\-]*\\.(service|mount|socket)$"
+        "pattern": "^[\\w:.\\\\-]+[@]{0,1}[\\w:.\\\\-]*\\.(service|mount|socket|swap)$"
       },
       "unit-type": {
         "type": "string",
@@ -100,6 +105,11 @@
                   "required": [
                     "Socket"
                   ]
+                },
+                {
+                  "required": [
+                    "Swap"
+                  ]
                 }
               ]
             }
@@ -119,6 +129,11 @@
                   "required": [
                     "Service"
                   ]
+                },
+                {
+                  "required": [
+                    "Swap"
+                  ]
                 }
               ]
             }
@@ -137,6 +152,35 @@
                 {
                   "required": [
                     "Socket"
+                  ]
+                },
+                {
+                  "required": [
+                    "Swap"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "required": [
+              "Swap"
+            ],
+            "not": {
+              "anyOf": [
+                {
+                  "required": [
+                    "Service"
+                  ]
+                },
+                {
+                  "required": [
+                    "Socket"
+                  ]
+                },
+                {
+                  "required": [
+                    "Mount"
                   ]
                 }
               ]
@@ -339,6 +383,32 @@
               "RemoveOnStop": {
                 "description": "",
                 "type": "boolean"
+              }
+            }
+          },
+          "Swap": {
+            "additionalProperties": false,
+            "type": "object",
+            "description": "'Swap' configuration section of a unit file",
+            "required": [
+              "What"
+            ],
+            "properties": {
+              "What": {
+                "description": "Absolute path to device node",
+                "type": "string"
+              },
+              "Priority": {
+                "descriptions": "Swap priority to use when activating the swap device or file",
+                "type": "integer"
+              },
+              "Options": {
+                "descriptions": "May contain an option string for the swap device",
+                "type": "string"
+              },
+              "TimeoutSec": {
+                "descriptions": "Configures the time to wait for the swapon command to finish",
+                "type": "string"
               }
             }
           },

--- a/stages/test/test_systemd_unit_create.py
+++ b/stages/test/test_systemd_unit_create.py
@@ -37,9 +37,9 @@ STAGE_NAME = "org.osbuild.systemd.unit.create"
     ),
     (
         {
-            "filename": "foo.mount",
+            "filename": "foo.socket",
             "config": {
-                "Mount": {"What": "", "Where": ""},
+                "Socket": {"ListenStream": "/run/test/api.socket"},
             },
         },
         "",
@@ -118,9 +118,9 @@ def test_schema_validation(stage_schema, test_data, expected_err):
     ),
     (
         {
-            "filename": "foo.mount",
+            "filename": "foo.socket",
             "config": {
-                "Mount": {"What": "", "Where": ""},
+                "Socket": {},
             },
         },
         "",
@@ -130,6 +130,8 @@ def test_schema_validation(stage_schema, test_data, expected_err):
      "Error: something.service unit requires Service section"),
     ({"filename": "data-gifs-cats.mount", "config": {"Unit": {}, "Service": {}, "Install": {}}},
      "Error: data-gifs-cats.mount unit requires Mount section"),
+    ({"filename": "data-gifs-cats.socket", "config": {"Unit": {}, "Service": {}, "Install": {}}},
+     "Error: data-gifs-cats.socket unit requires Socket section"),
 ])
 def test_name_config_match(tmp_path, stage_module, test_data, expected_err):
     expected_unit_path = tmp_path / "usr/lib/systemd/system"

--- a/stages/test/test_systemd_unit_create.py
+++ b/stages/test/test_systemd_unit_create.py
@@ -44,6 +44,15 @@ STAGE_NAME = "org.osbuild.systemd.unit.create"
         },
         "",
     ),
+    (
+        {
+            "filename": "foo.swap",
+            "config": {
+                "Swap": {"What": ""},
+            },
+        },
+        "",
+    ),
 
     # bad
     # # No filename
@@ -76,6 +85,11 @@ STAGE_NAME = "org.osbuild.systemd.unit.create"
     ({"filename": "foo.service", "config": {"Unit": {}, "Service": {},
                                             "Mount": {"What": "", "Where": ""}, "Install": {}}},
      "{'Unit': {}, 'Service': {}, 'Mount': {'What': '', 'Where': ''}, "
+     "'Install': {}} is not valid under any of the given schemas"),
+
+    # # .swap unit with Service section
+    ({"filename": "foo.swap", "config": {"Unit": {}, "Service": {}, "Swap": {"What": ""}, "Install": {}}},
+     "{'Unit': {}, 'Service': {}, 'Swap': {'What': ''}, "
      "'Install': {}} is not valid under any of the given schemas"),
 ])
 @pytest.mark.parametrize("stage_schema", ["1"], indirect=True)
@@ -125,6 +139,15 @@ def test_schema_validation(stage_schema, test_data, expected_err):
         },
         "",
     ),
+    (
+        {
+            "filename": "foo.swap",
+            "config": {
+                "Swap": {},
+            },
+        },
+        "",
+    ),
     # bad
     ({"filename": "something.service", "config": {"Unit": {}, "Mount": {}, "Install": {}}},
      "Error: something.service unit requires Service section"),
@@ -132,6 +155,8 @@ def test_schema_validation(stage_schema, test_data, expected_err):
      "Error: data-gifs-cats.mount unit requires Mount section"),
     ({"filename": "data-gifs-cats.socket", "config": {"Unit": {}, "Service": {}, "Install": {}}},
      "Error: data-gifs-cats.socket unit requires Socket section"),
+    ({"filename": "data-gifs-cats.swap", "config": {"Unit": {}, "Service": {}, "Install": {}}},
+     "Error: data-gifs-cats.swap unit requires Swap section"),
 ])
 def test_name_config_match(tmp_path, stage_module, test_data, expected_err):
     expected_unit_path = tmp_path / "usr/lib/systemd/system"

--- a/test/data/stages/systemd.unit.create/a.json
+++ b/test/data/stages/systemd.unit.create/a.json
@@ -672,6 +672,27 @@
             "filename": "/etc/systemd/user/create-directory.service",
             "size": "0"
           }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "/usr/lib/systemd/system/dev-disk-by-uuid-4f581be3-e8c2-4b44-9456-54df3ab92944.swap",
+            "size": "0"
+          }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "/usr/lib/systemd/system/service.socket",
+            "size": "0"
+          }
+        },
+        {
+          "type": "org.osbuild.truncate",
+          "options": {
+            "filename": "/usr/lib/systemd/system/data.mount",
+            "size": "0"
+          }
         }
       ]
     }

--- a/test/data/stages/systemd.unit.create/a.mpp.yaml
+++ b/test/data/stages/systemd.unit.create/a.mpp.yaml
@@ -29,7 +29,20 @@ pipelines:
             mpp-eval: gpgkeys
           exclude:
             docs: true
+
       - type: org.osbuild.truncate
         options:
           filename: "/etc/systemd/user/create-directory.service"
+          size: '0'
+      - type: org.osbuild.truncate
+        options:
+          filename: "/usr/lib/systemd/system/dev-disk-by-uuid-4f581be3-e8c2-4b44-9456-54df3ab92944.swap"
+          size: '0'
+      - type: org.osbuild.truncate
+        options:
+          filename: "/usr/lib/systemd/system/service.socket"
+          size: '0'
+      - type: org.osbuild.truncate
+        options:
+          filename: "/usr/lib/systemd/system/data.mount"
           size: '0'

--- a/test/data/stages/systemd.unit.create/b.json
+++ b/test/data/stages/systemd.unit.create/b.json
@@ -710,6 +710,49 @@
               }
             }
           }
+        },
+        {
+          "type": "org.osbuild.systemd.unit.create",
+          "options": {
+            "filename": "data.mount",
+            "config": {
+              "Unit": {
+                "DefaultDependencies": true
+              },
+              "Mount": {
+                "What": "/dev/sdb1",
+                "Where": "/data"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit.create",
+          "options": {
+            "filename": "service.socket",
+            "config": {
+              "Unit": {
+                "DefaultDependencies": true
+              },
+              "Socket": {
+                "ListenStream": "/run/service/api.socket"
+              }
+            }
+          }
+        },
+        {
+          "type": "org.osbuild.systemd.unit.create",
+          "options": {
+            "filename": "dev-disk-by-uuid-4f581be3-e8c2-4b44-9456-54df3ab92944.swap",
+            "config": {
+              "Unit": {
+                "DefaultDependencies": true
+              },
+              "Swap": {
+                "What": "/dev/disk/by-uuid/4f581be3-e8c2-4b44-9456-54df3ab92944"
+              }
+            }
+          }
         }
       ]
     }

--- a/test/data/stages/systemd.unit.create/b.mpp.yaml
+++ b/test/data/stages/systemd.unit.create/b.mpp.yaml
@@ -59,3 +59,31 @@ pipelines:
                 - local-fs.target
               RequiredBy:
                 - multi-user.target
+
+      - type: org.osbuild.systemd.unit.create
+        options:
+          filename: data.mount
+          config:
+            Unit:
+              DefaultDependencies: true
+            Mount:
+              What: "/dev/sdb1"
+              Where: "/data"
+
+      - type: org.osbuild.systemd.unit.create
+        options:
+          filename: service.socket
+          config:
+            Unit:
+              DefaultDependencies: true
+            Socket:
+              ListenStream: "/run/service/api.socket"
+
+      - type: org.osbuild.systemd.unit.create
+        options:
+          filename: "dev-disk-by\x2duuid-4f581be3\x2de8c2\x2d4b44\x2d9456\x2d54df3ab92944.swap"
+          config:
+            Unit:
+              DefaultDependencies: true
+            Swap:
+              What: "/dev/disk/by-uuid/4f581be3-e8c2-4b44-9456-54df3ab92944"

--- a/test/data/stages/systemd.unit.create/diff.json
+++ b/test/data/stages/systemd.unit.create/diff.json
@@ -14,6 +14,24 @@
         "sha256:69aa663d58cc063ea2d7659ac06354335c26e69e8fdb0036f952b082a70b5642"
       ]
     },
+    "/usr/lib/systemd/system/dev-disk-by-uuid-4f581be3-e8c2-4b44-9456-54df3ab92944.swap": {
+      "content": [
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "sha256:4bb9e774438a2857a3845936c551b945f2ed6edabec3f9955d8e7d6b794a5a59"
+      ]
+    },
+    "/usr/lib/systemd/system/service.socket": {
+      "content": [
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "sha256:2c029a69c7a57f920c99a3537c8db87b26825436e131a87106e25a69197d7eb6"
+      ]
+    },
+    "/usr/lib/systemd/system/data.mount": {
+      "content": [
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "sha256:2f7e14d9785faa8e9b31188473cb5f87a7bc2a37b31b4c0c533f0e3bfd9d427d"
+      ]
+    },
     "/usr/lib/sysimage/rpm/rpmdb.sqlite": {
       "content": [
         null,


### PR DESCRIPTION
Add support for .swap systemd units to the org.osbuild.systemd.unit.create stage.