### PR TITLE
Tools/osbuild-image-info: make read_selinux_ctx_mismatch more robust

### DIFF
--- a/tools/osbuild-image-info
+++ b/tools/osbuild-image-info
@@ -1118,9 +1118,13 @@ def read_selinux_ctx_mismatch(tree, is_ostree):
         setfiles_pattern = r"Would\s+relabel\s+(?P<filename>.+)\s+from\s+(?P<actual>.+)\s+to\s+(?P<expected>.+)"
         setfiles_re = re.compile(setfiles_pattern)
 
+        # skip messages about old compiled fcontext format
+        binary_fcontext_skip = rf"{tree}/etc/selinux/targeted/contexts/files/file_contexts.*\.bin:\s+Old compiled fcontext format, skipping"
+        binary_fcontext_skip_re = re.compile(binary_fcontext_skip)
+
         for line in output.splitlines():
             line = line.strip()
-            if not line:
+            if not line or binary_fcontext_skip_re.match(line):
                 continue
             match = setfiles_re.match(line)
             # do not silently ignore changes of 'setfiles' output

--- a/tools/test/test_osbuild_image_info.py
+++ b/tools/test/test_osbuild_image_info.py
@@ -267,6 +267,52 @@ Would relabel {tmp_path}/var/lib/alternatives/roff.7.gz from unconfined_u:object
         "",
         [],
         id="empty",
+    ),
+    pytest.param(
+        """{tmp_path}/etc/selinux/targeted/contexts/files/file_contexts.bin:  Old compiled fcontext format, skipping
+{tmp_path}/etc/selinux/targeted/contexts/files/file_contexts.homedirs.bin:  Old compiled fcontext format, skipping
+""",
+        [],
+        id="only lines to skip",
+    ),
+    pytest.param(
+        """{tmp_path}/etc/selinux/targeted/contexts/files/file_contexts.bin:  Old compiled fcontext format, skipping
+{tmp_path}/etc/selinux/targeted/contexts/files/file_contexts.homedirs.bin:  Old compiled fcontext format, skipping
+
+Would relabel {tmp_path}/etc/shells from unconfined_u:object_r:etc_t:s0 to system_u:object_r:etc_t:s0
+Would relabel {tmp_path}/etc/ld.so.cache from unconfined_u:object_r:ld_so_cache_t:s0 to system_u:object_r:ld_so_cache_t:s0
+Would relabel {tmp_path}/etc/alternatives/roff.7.gz from unconfined_u:object_r:etc_t:s0 to system_u:object_r:etc_t:s0
+Would relabel {tmp_path}/var/lib/selinux/targeted/active from unconfined_u:object_r:semanage_store_t:s0 to system_u:object_r:semanage_store_t:s0
+Would relabel {tmp_path}/var/lib/alternatives/roff.7.gz from unconfined_u:object_r:rpm_var_lib_t:s0 to system_u:object_r:rpm_var_lib_t:s0
+""",
+        [
+            {
+                "filename": "/etc/alternatives/roff.7.gz",
+                "actual": "unconfined_u:object_r:etc_t:s0",
+                "expected": "system_u:object_r:etc_t:s0",
+            },
+            {
+                "filename": "/etc/ld.so.cache",
+                "actual": "unconfined_u:object_r:ld_so_cache_t:s0",
+                "expected": "system_u:object_r:ld_so_cache_t:s0",
+            },
+            {
+                "filename": "/etc/shells",
+                "actual": "unconfined_u:object_r:etc_t:s0",
+                "expected": "system_u:object_r:etc_t:s0",
+            },
+            {
+                "filename": "/var/lib/alternatives/roff.7.gz",
+                "actual": "unconfined_u:object_r:rpm_var_lib_t:s0",
+                "expected": "system_u:object_r:rpm_var_lib_t:s0",
+            },
+            {
+                "filename": "/var/lib/selinux/targeted/active",
+                "actual": "unconfined_u:object_r:semanage_store_t:s0",
+                "expected": "system_u:object_r:semanage_store_t:s0",
+            },
+        ],
+        id="valid lines mixed with lines to skip",
     )
 ])
 def test_read_selinux_ctx_mismatch(tmp_path, subprocess_output, expected_report):


### PR DESCRIPTION
Modify the function able to handle messages about skipped binary fcontext files and skip them. This started to happen on c10s. Extend the unit test to cover this new scenario.

This will fix PR #1998