### PR TITLE
stages/coreos.live-artifacts: update comments/names to reflect erofs related changes

### DIFF
--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -553,8 +553,8 @@ def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
     Returns the bls entry kernel arguments for the ISO bootloader.
     """
     basearch = os.uname().machine
-    tmp_squashfs_dir = os.path.join(workdir, 'tmp-squashfs-dir')
-    os.mkdir(tmp_squashfs_dir)
+    tmp_rootfs_dir = os.path.join(workdir, 'tmp-rootfs-dir')
+    os.mkdir(tmp_rootfs_dir)
 
     # Since inputs are read-only and we want to modify it, we'll make a
     # copy of the metal.raw image and then mount that.
@@ -569,13 +569,13 @@ def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
             # If mounted via the manifest, the stage begins with mounts already in place,
             # but osmet also performs a mount operation, leading to conflicts due to duplicate
             # filesystem UUIDs. Perform the manual mount only after the osmet stage
-            subprocess.check_call(['mount', '-o', 'rw', loopdev + 'p4', tmp_squashfs_dir])
-            cm.callback(subprocess.run, ['umount', '-R', tmp_squashfs_dir], check=True)
+            subprocess.check_call(['mount', '-o', 'rw', loopdev + 'p4', tmp_rootfs_dir])
+            cm.callback(subprocess.run, ['umount', '-R', tmp_rootfs_dir], check=True)
             subprocess.check_call(['mount', '-o', 'rw', loopdev + 'p3',
-                                   os.path.join(tmp_squashfs_dir, 'boot')])
+                                   os.path.join(tmp_rootfs_dir, 'boot')])
             if basearch in ['x86_64', 'aarch64']:
                 subprocess.check_call(['mount', '-o', 'rw', loopdev + 'p2',
-                                       os.path.join(tmp_squashfs_dir, 'boot/efi')])
+                                       os.path.join(tmp_rootfs_dir, 'boot/efi')])
 
             # Implements necessary CoreOS adjustments
             # including creating hardlinks in the /boot/ filesystem
@@ -584,43 +584,41 @@ def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
             # Make sure to create it, if it is not created yet.
 
             # Remove the sysroot=readonly flag, see https://github.com/ostreedev/ostree/issues/1921
-            subprocess.check_call(['sed', '-i', '/readonly=true/d', f'{tmp_squashfs_dir}/ostree/repo/config'])
+            subprocess.check_call(['sed', '-i', '/readonly=true/d', f'{tmp_rootfs_dir}/ostree/repo/config'])
 
             # And ensure that the kernel binary and hmac file is in the place that dracut
             # expects it to be; xref https://issues.redhat.com/browse/OCPBUGS-15843
 
-            kernel_binary = glob.glob(f"{tmp_squashfs_dir}/boot/ostree/*/vmlinuz*")[0]
-            kernel_hmac = glob.glob(f"{tmp_squashfs_dir}/boot/ostree/*/.*.hmac")[0]
+            kernel_binary = glob.glob(f"{tmp_rootfs_dir}/boot/ostree/*/vmlinuz*")[0]
+            kernel_hmac = glob.glob(f"{tmp_rootfs_dir}/boot/ostree/*/.*.hmac")[0]
             kernel_binary_basename = os.path.basename(kernel_binary)
             kernel_hmac_basename = os.path.basename(kernel_hmac)
 
             # Create hard links in the /boot directory
-            os.link(kernel_hmac, f"{tmp_squashfs_dir}/boot/{kernel_hmac_basename}")
-            os.link(kernel_binary, f"{tmp_squashfs_dir}/boot/{kernel_binary_basename}")
+            os.link(kernel_hmac, f"{tmp_rootfs_dir}/boot/{kernel_hmac_basename}")
+            os.link(kernel_binary, f"{tmp_rootfs_dir}/boot/{kernel_binary_basename}")
 
-            print(f"Kernel binary linked: {tmp_squashfs_dir}/boot/{kernel_binary_basename}")
-            print(f"Kernel HMAC linked: {tmp_squashfs_dir}/boot/{kernel_hmac_basename}")
-            # Generate root squashfs
+            print(f"Kernel binary linked: {tmp_rootfs_dir}/boot/{kernel_binary_basename}")
+            print(f"Kernel HMAC linked: {tmp_rootfs_dir}/boot/{kernel_hmac_basename}")
+            # Generate root squashfs/erofs
             print(f'Creating {fstype} with {fsoptions}')
 
-            # Note the filename must be exactly "root.squashfs" because the 20live
-            # dracut module makes assumptions about the length of the name in sysroot.mount
-            # this matches the set of flags we implicitly passed when doing this
-            # through libguestfs' mksquashfs command
+            # Note the filename must be exactly "root.[squash|ero]fs"
+            # because the 35coreos-live dracut module requires it.
             if fstype == "erofs":
                 subprocess.check_call(['mkfs.erofs',
                                        *fsoptions.split(' '),
                                        paths["initrd-rootfs/root.erofs"],
-                                       tmp_squashfs_dir])
+                                       tmp_rootfs_dir])
             else:
-                subprocess.check_call(['mksquashfs', tmp_squashfs_dir,
+                subprocess.check_call(['mksquashfs', tmp_rootfs_dir,
                                        paths["initrd-rootfs/root.squashfs"],
-                                       '-root-becomes', tmp_squashfs_dir,
+                                       '-root-becomes', tmp_rootfs_dir,
                                        '-wildcards', '-no-recovery',
                                        *fsoptions.split(' ')])
 
             # while it's mounted here, also get the kargs
-            blsentry = ensure_glob(os.path.join(tmp_squashfs_dir, 'boot/loader/entries/*.conf'), n=1)[0]
+            blsentry = ensure_glob(os.path.join(tmp_rootfs_dir, 'boot/loader/entries/*.conf'), n=1)[0]
             blsentry_kargs = []
             with open(blsentry, encoding='utf8') as f:
                 for line in f:


### PR DESCRIPTION
This fixes what was skipped in https://github.com/osbuild/osbuild/pull/2002