### PR TITLE
Pin CI workflows to ubuntu 24.04

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   spelling_checker:
     name: "Spelling"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: codespell-project/actions-codespell@master
@@ -18,7 +18,7 @@ jobs:
 
   python_code_linters:
       name: "Python Linters"
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-24.04
       steps:
       - name: "Clone Repository"
         uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
 
   shell_linters:
     name: "Shell Linters"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: "Clone Repository"
@@ -47,7 +47,7 @@ jobs:
 
   packit-config-lint:
     name: "📦 Packit config lint"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: registry.fedoraproject.org/fedora:latest
     steps:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,7 @@ jobs:
   coverity:
     name: "Test Suite"
     if: github.repository == 'osbuild/osbuild'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: osbuild

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tag-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Even or odd week

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 jobs:
   generate_documentation:
     name: "Documentation"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: docker.io/library/python:3.7
     steps:
@@ -35,7 +35,7 @@ jobs:
 
   generate_test_data:
     name: "Test Data"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       OSBUILD_MPP_CACHEDIR: "/var/tmp/osbuild-mpp-cache"
     steps:

--- a/.github/workflows/pr_best_practices.yml
+++ b/.github/workflows/pr_best_practices.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pr-best-practices:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: PR best practice check
         uses: osbuild/pr-best-practices@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Upstream release
         uses: osbuild/release-action@main

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/test-on-centos.yml
+++ b/.github/workflows/test-on-centos.yml
@@ -15,7 +15,7 @@ jobs:
           - version: "10"
             pytest_exclude: 'not (TestBoot and boot) and not (test_write_read)'
     name: "Unittests on Centos Stream ${{ matrix.centos.version }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   test_suite:
     name: "Unittest"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +59,7 @@ jobs:
 
   v1_manifests:
     name: "Assembler test (legacy)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Clone Repository"
         uses: actions/checkout@v4

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   trigger-gitlab:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       IMAGEBUILDER_BOT_GITLAB_SSH_KEY: ${{ secrets.IMAGEBUILDER_BOT_GITLAB_SSH_KEY }}
     steps:

--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -10,7 +10,7 @@
     
     jobs:
       update-and-push:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
           - name: Apt update
             run: sudo apt update


### PR DESCRIPTION
This replaces ubuntu-latest with ubuntu-24.04 to avoid unexpected changes.