### PR TITLE
org.osbuild.cloud-init: add new datasources and network section

### DIFF
--- a/stages/org.osbuild.cloud-init.meta.json
+++ b/stages/org.osbuild.cloud-init.meta.json
@@ -93,6 +93,8 @@
               "enum": [
                 "Azure",
                 "Ec2",
+                "NoCloud",
+                "WSL",
                 "None"
               ]
             }
@@ -134,6 +136,18 @@
               "all": {
                 "description": "Redirect the output of all stages",
                 "type": "string"
+              }
+            }
+          },
+          "network": {
+            "type": "object",
+            "minProperties": 1,
+            "properties": {
+              "config": {
+                "type": "string",
+                "enum": [
+                  "disabled"
+                ]
               }
             }
           }

--- a/stages/test/test_cloud-init.py
+++ b/stages/test/test_cloud-init.py
@@ -24,3 +24,22 @@ def test_cloud_init_datasource_list_single_line(tmp_path, stage_module):
     stage_module.main(treedir, options)
     assert os.path.exists(confpath)
     assert confpath.read_text() == "datasource_list: [Azure]\n"
+
+
+def test_cloud_init_network(tmp_path, stage_module):
+    treedir = tmp_path / "tree"
+    confpath = treedir / "etc/cloud/cloud.cfg.d/network.cfg"
+    confpath.parent.mkdir(parents=True, exist_ok=True)
+
+    options = {
+        "filename": confpath.name,
+        "config": {
+            "network": {
+                "config": "disabled",
+            },
+        },
+    }
+
+    stage_module.main(treedir, options)
+    assert os.path.exists(confpath)
+    assert confpath.read_text() == "network:\n  config: disabled\n"


### PR DESCRIPTION
Adds WSL and NoCloud datasources. The network section only allows you to disable network configuration by cloud-init for now.