### PR TITLE
Rework `osbuild-depsolve-dnf` tests (HMS-5509)

### DIFF
--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -1500,12 +1500,6 @@ def test_depsolve_config_combos(tmp_path, repo_servers, dnf_config, detect_fn):
             res, exit_code = depsolve(
                 transactions, cache_dir, dnf_config, repo_configs, root_dir, opt_metadata)
 
-            if test_case.get("error", False):
-                assert exit_code != 0
-                assert res["kind"] == test_case["error_kind"]
-                assert re.match(test_case["error_reason_re"], res["reason"], re.DOTALL)
-                continue
-
             assert exit_code == 0
             assert {pkg["name"] for pkg in res["packages"]} == test_case["results"]["packages"]
             assert res["repos"].keys() == test_case["results"]["reponames"]
@@ -1546,12 +1540,6 @@ def test_depsolve_sbom(tmp_path, repo_servers, dnf_config, detect_fn, with_sbom)
     repo_configs = get_test_case_repo_configs(test_case, repo_servers)
 
     res, exit_code = depsolve(transactions, tmp_path.as_posix(), dnf_config, repo_configs, with_sbom=with_sbom)
-
-    if test_case.get("error", False):
-        assert exit_code != 0
-        assert res["kind"] == test_case["error_kind"]
-        assert re.match(test_case["error_reason_re"], res["reason"], re.DOTALL)
-        return
 
     assert exit_code == 0
     assert {pkg["name"] for pkg in res["packages"]} == test_case["results"]["packages"]
@@ -1703,12 +1691,6 @@ def test_search_config_combos(tmp_path, repo_servers, dnf_config, detect_fn):
     for repo_configs, root_dir, opt_metadata in config_combos(tmp_path, tc_repo_servers):
         with TemporaryDirectory() as cache_dir:
             res, exit_code = search(search_args, cache_dir, dnf_config, repo_configs, root_dir, opt_metadata)
-
-            if test_case.get("error", False):
-                assert exit_code != 0
-                assert res["kind"] == test_case["error_kind"]
-                assert re.match(test_case["error_reason_re"], res["reason"], re.DOTALL)
-                continue
 
             assert exit_code == 0
             for res, exp in zip(res, test_case["results"]):

--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -1275,6 +1275,21 @@ def test_gen_config_combos(items_count, expected_combos):
     assert list(gen_config_combos(items_count)) == expected_combos
 
 
+def gen_repo_config(server):
+    """
+    Generate a repository configuration dictionary for the provided server.
+    """
+    return {
+        "id": server["name"],
+        "name": server["name"],
+        "baseurl": server["address"],
+        "check_gpg": False,
+        "sslverify": False,
+        "rhsm": False,
+        "gpgkeys": [TEST_KEY + server["name"]],
+    }
+
+
 def config_combos(tmp_path, servers):
     """
     Return all configurations for the provided repositories, either as config files in a directory or as repository
@@ -1284,15 +1299,8 @@ def config_combos(tmp_path, servers):
         repo_configs = []
         for idx in combo[0]:  # servers to be configured through request
             server = servers[idx]
-            repo_configs.append({
-                "id": server["name"],
-                "name": server["name"],
-                "baseurl": server["address"],
-                "check_gpg": False,
-                "sslverify": False,
-                "rhsm": False,
-                "gpgkeys": [TEST_KEY + server["name"]],
-            })
+            repo_configs.append(gen_repo_config(server))
+
         root_dir, repos_dir, keys_dir = make_dnf_scafolding(tmp_path)
         for idx in combo[1]:  # servers to be configured through root_dir
             server = servers[idx]

--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -109,7 +109,7 @@ def dump(cache_dir, dnf_config, repos=None, root_dir=None, opt_metadata=None) ->
         env = None
         if dnf_config:
             cfg_file = pathlib.Path(cfg_dir) / "solver.json"
-            cfg_file.write_text(dnf_config)
+            json.dump(dnf_config, cfg_file.open("w"))
             env = {"OSBUILD_SOLVER_CONFIG": os.fspath(cfg_file)}
 
         p = sp.run(["./tools/osbuild-depsolve-dnf"], input=json.dumps(req), env=env,
@@ -147,7 +147,7 @@ def search(search_args, cache_dir, dnf_config, repos=None, root_dir=None, opt_me
         env = None
         if dnf_config:
             cfg_file = pathlib.Path(cfg_dir) / "solver.json"
-            cfg_file.write_text(dnf_config)
+            json.dump(dnf_config, cfg_file.open("w"))
             env = {"OSBUILD_SOLVER_CONFIG": os.fspath(cfg_file)}
 
         p = sp.run(["./tools/osbuild-depsolve-dnf"], input=json.dumps(req), env=env,
@@ -1551,8 +1551,8 @@ def test_depsolve(repo_servers, dnf_config, detect_fn, with_sbom, test_case):
 @pytest.mark.parametrize("test_case", dump_test_cases, ids=tcase_idfn)
 @pytest.mark.parametrize("dnf_config, detect_fn", [
     (None, assert_dnf),
-    ('{"use_dnf5": false}', assert_dnf),
-    ('{"use_dnf5": true}', assert_dnf5),
+    ({"use_dnf5": False}, assert_dnf),
+    ({"use_dnf5": True}, assert_dnf5),
 ], ids=["no-config", "dnf4", "dnf5"])
 def test_dump(tmp_path, repo_servers, dnf_config, detect_fn, test_case):
     try:
@@ -1596,8 +1596,8 @@ def test_dump(tmp_path, repo_servers, dnf_config, detect_fn, test_case):
 @pytest.mark.parametrize("test_case", search_test_cases, ids=tcase_idfn)
 @pytest.mark.parametrize("dnf_config, detect_fn", [
     (None, assert_dnf),
-    ('{"use_dnf5": false}', assert_dnf),
-    ('{"use_dnf5": true}', assert_dnf5),
+    ({"use_dnf5": False}, assert_dnf),
+    ({"use_dnf5": True}, assert_dnf5),
 ], ids=["no-config", "dnf4", "dnf5"])
 def test_search(tmp_path, repo_servers, dnf_config, detect_fn, test_case):
     try:

--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -1421,6 +1421,13 @@ def get_test_case_repo_servers(test_case, repo_servers):
     return repo_servers_copy
 
 
+def get_test_case_repo_configs(test_case, repo_servers):
+    """
+    Return a list of repository configurations for the test case.
+    """
+    return [gen_repo_config(server) for server in get_test_case_repo_servers(test_case, repo_servers)]
+
+
 @pytest.mark.parametrize("test_case,repo_servers,expected", [
     (
         {"enabled_repos": ["baseos", "custom"], "additional_servers": []},
@@ -1536,8 +1543,7 @@ def test_depsolve_sbom(repo_servers, dnf_config, detect_fn, with_sbom):
 
     test_case = depsolve_test_case_basic_2pkgs_2repos
     transactions = test_case["transactions"]
-    tc_repo_servers = get_test_case_repo_servers(test_case, repo_servers)
-    repo_configs = [gen_repo_config(server) for server in tc_repo_servers]
+    repo_configs = get_test_case_repo_configs(test_case, repo_servers)
 
     with TemporaryDirectory() as cache_dir:
         res, exit_code = depsolve(transactions, cache_dir, dnf_config, repo_configs, with_sbom=with_sbom)
@@ -1603,10 +1609,8 @@ def test_depsolve(repo_servers, dnf_config, detect_fn, test_case):
         pytest.skip("This test case is known to be broken with dnf5")
 
     transactions = test_case["transactions"]
+    repo_configs = get_test_case_repo_configs(test_case, repo_servers)
 
-    tc_repo_servers = get_test_case_repo_servers(test_case, repo_servers)
-
-    repo_configs = [gen_repo_config(server) for server in tc_repo_servers]
     with TemporaryDirectory() as cache_dir:
         res, exit_code = depsolve(transactions, cache_dir, dnf_config, repo_configs)
 
@@ -1741,8 +1745,7 @@ def test_search(repo_servers, dnf_config, detect_fn, test_case):
     except RuntimeError as e:
         pytest.skip(str(e))
 
-    tc_repo_servers = get_test_case_repo_servers(test_case, repo_servers)
-    repo_configs = [gen_repo_config(server) for server in tc_repo_servers]
+    repo_configs = get_test_case_repo_configs(test_case, repo_servers)
     search_args = test_case["search_args"]
 
     with TemporaryDirectory() as cache_dir:


### PR DESCRIPTION
The test matrix in `osbuild-depsolve-dnf` got out of hand. We were increasing the parametrization of `test_depsolve()` test case (and others) to test new features. However, for each test case instance, we also ran the same test case 8 times for each possible repo config combination and optional metadata requested in the request (2\*2\*2).

This PR improves the situation by extracting the repo config combo testing to dedicated test cases, which test all combinations with a single test scenario containing multiple repositories.

I've done some additional refactoring along the way to reduce code duplication and improve testing accuracy (e.g., don't set arguments in the request, which should not be used in the test scenario).

From local testing of `python3 -m pytest -vv tools/test/test_depsolve.py`:

- Before: 1083.64s - 00:18:03
- After: 290.32s - 00:04:50

**This means that tests run almost 4 times faster.**

The effect on `Test / Unittest (normal, pyxx)` in GH action is ~20m before vs. ~8m after.

/jira-epic COMPOSER-2405

JIRA: [HMS-5509](https://issues.redhat.com/browse/HMS-5509)