### PR TITLE
stages: add more options to qemu vmdk disk type

### DIFF
--- a/stages/org.osbuild.qemu
+++ b/stages/org.osbuild.qemu
@@ -21,14 +21,24 @@ def qcow2_arguments(options):
 
 def vmdk_arguments(options):
     argv = []
+    adapter_type = options.get("adapter_type")
+    compat6 = options.get("compat6", False)
     compression = options.get("compression", True)
     subformat = options.get("subformat")
 
     if compression:
         argv += ["-c"]
 
-    if subformat:
-        argv += ["-o", f"subformat={subformat}"]
+    if compat6 or subformat or adapter_type:
+        opts = []
+        if adapter_type:
+            opts += [f"adapter_type={adapter_type}"]
+        if compat6:
+            opts += ["compat6"]
+        if subformat:
+            opts += [f"subformat={subformat}"]
+        argv += ["-o", ",".join(opts)]
+
     return argv
 
 

--- a/stages/org.osbuild.qemu.meta.json
+++ b/stages/org.osbuild.qemu.meta.json
@@ -68,6 +68,21 @@
               "vmdk"
             ]
           },
+          "adapter_type": {
+            "description": "Virtual adapter type",
+            "type": "string",
+            "enum": [
+              "ide",
+              "lsilogic",
+              "buslogic",
+              "legacyESX"
+            ]
+          },
+          "compat6": {
+            "description": "VMDK version 6 image",
+            "type": "boolean",
+            "default": false
+          },
           "compression": {
             "description": "Enable/disable compression of the vmdk image",
             "type": "boolean",

--- a/test/data/stages/qemu/qemu.json
+++ b/test/data/stages/qemu/qemu.json
@@ -639,6 +639,34 @@
       ]
     },
     {
+      "name": "image-compat6-adapter-type.vmdk",
+      "build": "name:build",
+      "stages": [
+        {
+          "type": "org.osbuild.qemu",
+          "inputs": {
+            "image": {
+              "type": "org.osbuild.files",
+              "origin": "org.osbuild.pipeline",
+              "references": {
+                "name:image": {
+                  "file": "image.raw"
+                }
+              }
+            }
+          },
+          "options": {
+            "filename": "image-stream.vmdk",
+            "format": {
+              "type": "vmdk",
+              "compat6": true,
+              "adapter_type": "lsilogic"
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "image.vpc",
       "build": "name:build",
       "stages": [

--- a/test/data/stages/qemu/qemu.mpp.yaml
+++ b/test/data/stages/qemu/qemu.mpp.yaml
@@ -91,6 +91,23 @@ pipelines:
           format:
             type: vmdk
             subformat: streamOptimized
+  - name: image-compat6-adapter-type.vmdk
+    build: name:build
+    stages:
+      - type: org.osbuild.qemu
+        inputs:
+          image:
+            type: org.osbuild.files
+            origin: org.osbuild.pipeline
+            references:
+              name:image:
+                file: image.raw
+        options:
+          filename: image-stream.vmdk
+          format:
+            type: vmdk
+            compat6: true
+            adapter_type: lsilogic
   - name: image.vpc
     build: name:build
     stages:


### PR DESCRIPTION
The CoreOS team uses the compat6 and adapter_type options when creating a VMDK for AWS.

https://github.com/coreos/coreos-assembler/blob/e1943d6adb8f0cb257630a76d02d0aa333261c70/src/cosalib/qemuvariants.py#L48