### PR TITLE
stages/coreos.live-artifacts: use /var/tmp for mkfs.erofs

### DIFF
--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -606,10 +606,14 @@ def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
             # Note the filename must be exactly "root.[squash|ero]fs"
             # because the 35coreos-live dracut module requires it.
             if fstype == "erofs":
+                # Set TMPDIR='/var/tmp' to write temporary files into non-tmpfs
+                # (memory backed) storage. This helps reduce memory requirements.
+                # https://github.com/erofs/erofs-utils/issues/13
                 subprocess.check_call(['mkfs.erofs',
                                        *fsoptions.split(' '),
                                        paths["initrd-rootfs/root.erofs"],
-                                       tmp_rootfs_dir])
+                                       tmp_rootfs_dir],
+                                      env=dict(os.environ, TMPDIR='/var/tmp'))
             else:
                 subprocess.check_call(['mksquashfs', tmp_rootfs_dir,
                                        paths["initrd-rootfs/root.squashfs"],


### PR DESCRIPTION
This helps reduce the memory requirements of mkfs.erofs since it won't be writing to tmpfs (memory backed) storage, which is what is mounted on /tmp/.