### PR TITLE
stages: ensure dirs for dracut configs are available

### DIFF
--- a/stages/org.osbuild.dracut.conf
+++ b/stages/org.osbuild.dracut.conf
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import os
 import sys
 
 import osbuild.api
@@ -32,6 +33,7 @@ def main(tree, options):
     filename = options["filename"]
 
     config_files_dir = f"{tree}/usr/lib/dracut/dracut.conf.d"
+    os.makedirs(config_files_dir, exist_ok=True)
 
     SUPPORTED_OPTIONS = {
         # simple string options

--- a/stages/test/test_dracut_conf.py
+++ b/stages/test/test_dracut_conf.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+
+STAGE_NAME = "org.osbuild.dracut.conf"
+
+
+def test_dracut_conf_smoke(tmp_path, stage_module):
+    options = {
+        "filename": "qemu.conf",
+        "config": {
+            "add_drivers": ["virtio_blk"],
+        }
+    }
+
+    tree = tmp_path / "tree"
+    stage_module.main(tree, options)
+    expected_dracut_conf = tree / "usr/lib/dracut/dracut.conf.d/qemu.conf"
+    assert 'add_drivers+=" virtio_blk "\n' == expected_dracut_conf.read_text()


### PR DESCRIPTION
If the dracut config stage runs early the directory for the dracut config may not be available yet. So just create it.

[this is needed for the riscv work where we need to write the dracut config early, see https://github.com/osbuild/images/pull/1241]