### PR TITLE
stages/coreos.live-artifacts: loosen requirements on modules dir

### DIFF
--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -881,15 +881,14 @@ def main(workdir, tree, inputs, options, loop_client):
     paths = mk_paths(workdir, fstype)
     mk_workdirs(paths)
 
-    # Find the directory under `/usr/lib/modules/<kver>` where the
-    # kernel/initrd live. It will be the only entity in there.
-    modules_dir = ensure_glob(os.path.join(deployed_tree, 'usr/lib/modules/*'), n=1)[0]
+    # Find the kernel and initramfs. They should be the only ones on
+    # the system so we'll error here if more than one are found:
+    modules_dir_vmlinuz = ensure_glob(os.path.join(deployed_tree, 'usr/lib/modules/*/vmlinuz'), n=1)[0]
+    modules_dir_initramfs = ensure_glob(os.path.join(deployed_tree, 'usr/lib/modules/*/initramfs.img'), n=1)[0]
 
     # copy those files out of the ostree into the iso root dir
-    shutil.copyfile(os.path.join(modules_dir, 'vmlinuz'),
-                    paths["iso/images/pxeboot/vmlinuz"])
-    shutil.copyfile(os.path.join(modules_dir, 'initramfs.img'),
-                    paths["iso/images/pxeboot/initrd.img"])
+    shutil.copyfile(modules_dir_vmlinuz, paths["iso/images/pxeboot/vmlinuz"])
+    shutil.copyfile(modules_dir_initramfs, paths["iso/images/pxeboot/initrd.img"])
 
     # Generate initramfs stamp file indicating that this is a live
     # initramfs.  Store the build ID in it.


### PR DESCRIPTION
We originally required there to be only one kernel modules directory since we typically only have one kernel installed. Change this check up a bit since some kernel module RPMs aren't delivering a new kernel but do deliver kmods that were built against a different kernel.

For example v4l2loopback from https://elrepo.org/

```
bash-5.1# rpm -ql kmod-v4l2loopback
/etc/depmod.d/kmod-v4l2loopback.conf
/lib/modules/5.14.0-427.13.1.el9_4.x86_64
/lib/modules/5.14.0-427.13.1.el9_4.x86_64/extra
/lib/modules/5.14.0-427.13.1.el9_4.x86_64/extra/v4l2loopback
/lib/modules/5.14.0-427.13.1.el9_4.x86_64/extra/v4l2loopback/v4l2loopback.ko
/usr/share/doc/kmod-v4l2loopback-0.12.7
/usr/share/doc/kmod-v4l2loopback-0.12.7/GPL-v2.0.txt
/usr/share/doc/kmod-v4l2loopback-0.12.7/greylist.txt
```

This patch now allows an image built from a Containerfile like the following to work as input to the live artifacts stage.

```
FROM rhcos
RUN <<EOF
    set -eux -o pipefail
    dnf install -y https://www.elrepo.org/elrepo-release-9.el9.elrepo.noarch.rpm
    dnf install -y v4l2loopback
    dnf clean all
    ostree container commit
EOF
```