### PR TITLE
osbuild: add experimental flag `debug-qemu-user`

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -13,7 +13,7 @@ from .inputs import Input, InputManager
 from .mounts import Mount, MountManager
 from .objectstore import ObjectStore
 from .sources import Source
-from .util import osrelease
+from .util import experimentalflags, osrelease
 
 DEFAULT_CAPABILITIES = {
     "CAP_AUDIT_WRITE",
@@ -254,6 +254,8 @@ class Stage:
             extra_env = {}
             if self.source_epoch is not None:
                 extra_env["SOURCE_DATE_EPOCH"] = str(self.source_epoch)
+            if experimentalflags.get_bool("debug-qemu-user"):
+                extra_env["QEMU_LOG"] = "+unimp"
 
             debug_shell = debug_break in ('*', self.name, self.id)
 

--- a/osbuild/util/experimentalflags.py
+++ b/osbuild/util/experimentalflags.py
@@ -1,0 +1,31 @@
+"""Handling of experimental environment flags"""
+
+import os
+from typing import Any, Dict
+
+
+def _experimental_env_map() -> Dict[str, Any]:
+    env_map: Dict[str, Any] = {}
+    for exp_opt in os.environ.get("OSBUILD_EXPERIMENTAL", "").split(","):
+        l = exp_opt.split("=", maxsplit=1)
+        if len(l) == 1:
+            env_map[exp_opt] = "true"
+        elif len(l) == 2:
+            env_map[l[0]] = l[1]
+    return env_map
+
+
+def get_bool(option: str) -> bool:
+    env_map = _experimental_env_map()
+    opt = env_map.get(option, "")
+    # sadly python as no strconv.ParseBool() like golang so we roll our own
+    if opt.upper() in {"1", "T", "TRUE"}:
+        return True
+    if opt.upper() in {"", "0", "F", "FALSE"}:
+        return False
+    raise RuntimeError(f"unsupport bool val {opt}")
+
+
+def get_string(option: str) -> str:
+    env_map = _experimental_env_map()
+    return str(env_map.get(option, ""))

--- a/test/mod/test_util_experimentalflags.py
+++ b/test/mod/test_util_experimentalflags.py
@@ -1,0 +1,39 @@
+#
+# Test for the util.experimentalflags
+#
+import pytest
+
+from osbuild.util import experimentalflags
+
+
+@pytest.mark.parametrize("env,expected_foo", [
+    # implicit false
+    ("", False),
+    ("bar", False),
+    # explicit true
+    ("foo", True),
+    ("foo,bar", True),
+    ("foo=1", True),
+    ("foo=1,bar", True),
+    ("foo=true", True),
+    ("foo=t", True),
+    # explicit falgs
+    ("foo=false", False),
+    ("foo=0", False),
+    ("foo=f", False),
+    ("foo=F", False),
+    ("foo=FALSE", False),
+])
+def test_experimentalflags_bool(monkeypatch, env, expected_foo):
+    monkeypatch.setenv("OSBUILD_EXPERIMENTAL", env)
+    assert experimentalflags.get_bool("foo") == expected_foo
+
+
+@pytest.mark.parametrize("env,expected_key", [
+    ("", ""),
+    ("key=val", "val"),
+    ("foo,key=val,bar", "val"),
+])
+def test_experimentalflags_string(monkeypatch, env, expected_key):
+    monkeypatch.setenv("OSBUILD_EXPERIMENTAL", env)
+    assert experimentalflags.get_string("key") == expected_key


### PR DESCRIPTION
This commit adds support for more debug for `qemu-user` options. When settings:
```
$ sudo IMAGE_BUILDER_EXPERIMENAL=debug-qemu-user bootc-image-builder ...
```
extra debug will be printed. This hopefully helps to track down the root cause of
https://github.com/podman-desktop/extension-bootc/issues/1475

This is intended to help to track down https://github.com/podman-desktop/extension-bootc/issues/1475