### PR TITLE
runners: Add AlmaLinux runner links to permit AlmaLinux as a host

### DIFF
--- a/runners/org.osbuild.almalinux8
+++ b/runners/org.osbuild.almalinux8
@@ -1,0 +1,1 @@
+org.osbuild.rhel82

--- a/runners/org.osbuild.almalinux9
+++ b/runners/org.osbuild.almalinux9
@@ -1,0 +1,1 @@
+org.osbuild.centos9


### PR DESCRIPTION
As part of AlmaLinux shipping the OSBuild stack, allow osbuild to recognize AlmaLinux as a valid host.