### PR TITLE
Set the release version to 141.2

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -1,7 +1,7 @@
 %global         forgeurl https://github.com/osbuild/osbuild
 %global         selinuxtype targeted
 
-Version:        141
+Version:        141.2
 
 %forgemeta
 

--- a/osbuild/__init__.py
+++ b/osbuild/__init__.py
@@ -10,7 +10,7 @@ independent of osbuild but used across the osbuild codebase.
 
 from .pipeline import Manifest, Pipeline, Stage
 
-__version__ = "141"
+__version__ = "141.2"
 
 __all__ = [
     "Manifest",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="osbuild",
-    version="141",
+    version="141.2",
     description="A build system for OS images",
     packages=[
         "osbuild",


### PR DESCRIPTION
I forgot to bump the version to 141.1 before making the v141.1 release. Also, the release action's script that bumps the version did not support the dot releases. This should be fixed soon.

The version is always set to the "next" to be released version and it is bumped after we make a release by the GH action.