### PR TITLE
osbuild/solver/dnf.py: Add support for DNF variables for osbuild repos

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -15,6 +15,9 @@ ignore_missing_imports = True
 [mypy-dnf.*]
 ignore_missing_imports = True
 
+[mypy-libdnf.*]
+ignore_missing_imports = True
+
 [mypy-libdnf5.*]
 ignore_missing_imports = True
 

--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -1378,7 +1378,7 @@ def gen_repo_config(server):
     return {
         "id": server["name"],
         "name": server["name"],
-        "baseurl": server["address"],
+        "baseurl": [server["address"]],
         "check_gpg": False,
         "sslverify": False,
         "rhsm": False,


### PR DESCRIPTION
This change is in relation with #2027
@achilleas-k 

This PR is to parse dnfvars for repos in a request and includes a commit for fixing baseurl in testing to be a list which was needed to be able to test dnfvars, also I added it in a different commit to make maintainers able to keep the fix even if the dnfvar change would be removed.