### PR TITLE
Stages/rhsm: support setting 'auto_enable_yum_plugins' option

### DIFF
--- a/stages/org.osbuild.rhsm.meta.json
+++ b/stages/org.osbuild.rhsm.meta.json
@@ -71,6 +71,10 @@
               "manage_repos": {
                 "type": "boolean",
                 "description": "Whether subscription-manager should manage DNF repos file"
+              },
+              "auto_enable_yum_plugins": {
+                "type": "boolean",
+                "description": "Whether yum/dnf plugins subscription-manager and product-id should be enabled every-time subscription-manager or subscription-manager-gui is executed"
               }
             }
           },

--- a/test/data/stages/rhsm/b.json
+++ b/test/data/stages/rhsm/b.json
@@ -755,7 +755,8 @@
             },
             "subscription-manager": {
               "rhsm": {
-                "manage_repos": false
+                "manage_repos": false,
+                "auto_enable_yum_plugins": false
               },
               "rhsmcertd": {
                 "auto_registration": true

--- a/test/data/stages/rhsm/b.mpp.yaml
+++ b/test/data/stages/rhsm/b.mpp.yaml
@@ -38,5 +38,6 @@ pipelines:
           subscription-manager:
             rhsm:
               manage_repos: false
+              auto_enable_yum_plugins: false
             rhsmcertd:
               auto_registration: true

--- a/test/data/stages/rhsm/diff.json
+++ b/test/data/stages/rhsm/diff.json
@@ -17,7 +17,7 @@
     "/etc/rhsm/rhsm.conf": {
       "content": [
         "sha256:57e2bee5a30283ee95f3da2d5945f1d5852f1a4ed6900d22afd8f6a5ee5e5a11",
-        "sha256:aeb3eca521d423823acc5dc0e7d3409b6570e71174306871c1a861e387369933"
+        "sha256:881061a0cbca545ba30b76f84c47d623e086e0b5dadec91fb5d53a8292681652"
       ]
     }
   }


### PR DESCRIPTION
Support setting the `auto_enable_yum_plugins` option in the `rhsm` section of `rhsm.conf`.

Add a unit test for the stage schema and also adjust the stage test manifest.

Related to: https://github.com/osbuild/images/issues/1408