### PR TITLE
Stages/waagent.conf: support additional options

### DIFF
--- a/stages/org.osbuild.waagent.conf
+++ b/stages/org.osbuild.waagent.conf
@@ -12,9 +12,9 @@ def bool_to_y_n(b):
 
 
 def main(tree, options):
-    sshd_config = options.get("config", {})
-    resource_disk_format = sshd_config.get("ResourceDisk.Format")
-    resource_disk_enable_swap = sshd_config.get("ResourceDisk.EnableSwap")
+    waagent_config = options.get("config", {})
+    resource_disk_format = waagent_config.get("ResourceDisk.Format")
+    resource_disk_enable_swap = waagent_config.get("ResourceDisk.EnableSwap")
     changes = {}
     if resource_disk_format is not None:
         changes["resourcedisk.format"] = {

--- a/stages/org.osbuild.waagent.conf
+++ b/stages/org.osbuild.waagent.conf
@@ -13,9 +13,21 @@ def bool_to_y_n(b):
 
 def main(tree, options):
     waagent_config = options.get("config", {})
+    provisioning_use_cloud_init = waagent_config.get("Provisioning.UseCloudInit")
+    provisioning_enabled = waagent_config.get("Provisioning.Enabled")
     resource_disk_format = waagent_config.get("ResourceDisk.Format")
     resource_disk_enable_swap = waagent_config.get("ResourceDisk.EnableSwap")
     changes = {}
+    if provisioning_use_cloud_init is not None:
+        changes["provisioning.usecloudinit"] = {
+            "key": "Provisioning.UseCloudInit",
+            "value": bool_to_y_n(provisioning_use_cloud_init)
+        }
+    if provisioning_enabled is not None:
+        changes["provisioning.enabled"] = {
+            "key": "Provisioning.Enabled",
+            "value": bool_to_y_n(provisioning_enabled)
+        }
     if resource_disk_format is not None:
         changes["resourcedisk.format"] = {
             "key": "ResourceDisk.Format",

--- a/stages/org.osbuild.waagent.conf.meta.json
+++ b/stages/org.osbuild.waagent.conf.meta.json
@@ -16,6 +16,14 @@
         "description": "WALinuxAgent config options",
         "type": "object",
         "properties": {
+          "Provisioning.UseCloudInit": {
+            "description": "Enable or disable cloud-init provisioning.",
+            "type": "boolean"
+          },
+          "Provisioning.Enabled": {
+            "description": "Enable or disable provisioning.",
+            "type": "boolean"
+          },
           "ResourceDisk.Format": {
             "description": "Enable or disable disk formatting.",
             "type": "boolean"

--- a/stages/test/test_waagent_conf.py
+++ b/stages/test/test_waagent_conf.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+
+import re
+
+import pytest
+
+from osbuild.testutil import (
+    assert_jsonschema_error_contains,
+)
+
+STAGE_NAME = "org.osbuild.waagent.conf"
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # bad
+    ({}, r"'config' is a required property"),
+    ({"config": {"Unsupported": True}}, r"Additional properties are not allowed \('Unsupported' was unexpected\)"),
+    ({"config": {"Provisioning.UseCloudInit": 42}}, r"42 is not of type 'boolean'"),
+    ({"config": {"Provisioning.Enabled": "abc"}}, r"'abc' is not of type 'boolean'"),
+    ({"config": {"ResourceDisk.Format": 42}}, r"42 is not of type 'boolean'"),
+    ({"config": {"ResourceDisk.EnableSwap": "abc"}}, r"'abc' is not of type 'boolean'"),
+    # good
+    ({"config": {}}, ""),
+    ({
+        "config": {
+            "Provisioning.UseCloudInit": True,
+            "Provisioning.Enabled": True,
+            "ResourceDisk.Format": False,
+            "ResourceDisk.EnableSwap": False,
+        },
+    }, ""),
+])
+def test_schema_validation(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "options": {},
+    }
+    test_input["options"].update(test_data)
+    res = stage_schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        assert_jsonschema_error_contains(res, re.compile(expected_err), expected_num_errs=1)

--- a/test/data/stages/waagent.conf/b.json
+++ b/test/data/stages/waagent.conf/b.json
@@ -681,6 +681,8 @@
           "type": "org.osbuild.waagent.conf",
           "options": {
             "config": {
+              "Provisioning.UseCloudInit": true,
+              "Provisioning.Enabled": false,
               "ResourceDisk.Format": false,
               "ResourceDisk.EnableSwap": true
             }

--- a/test/data/stages/waagent.conf/b.mpp.yaml
+++ b/test/data/stages/waagent.conf/b.mpp.yaml
@@ -30,6 +30,8 @@ pipelines:
       - type: org.osbuild.waagent.conf
         options:
           config:
+            Provisioning.UseCloudInit: true
+            Provisioning.Enabled: false
             ResourceDisk.Format: false
             ResourceDisk.EnableSwap: true
       - type: org.osbuild.waagent.conf

--- a/test/data/stages/waagent.conf/diff.json
+++ b/test/data/stages/waagent.conf/diff.json
@@ -5,7 +5,7 @@
     "/etc/waagent.conf": {
       "content": [
         "sha256:9908ed1eeb7f4cd29ef3f1baa4f87d1de6ad6adaa08a09d83861a4a1fb88fb3a",
-        "sha256:7551a6a82c9133811b3e1a22504250fe8ced1f3bd4b47b14fceed028316ef5f5"
+        "sha256:746a295fa3c6aa3d90295611a55401d6c4b0bff1d2bbc5fb45ec4112bee84354"
       ]
     }
   }


### PR DESCRIPTION
Extend the stage to support setting new options:
 - Provisioning.UseCloudInit
 - Provisioning.Enabled

Extend the stage test to use them and add a simple stage unit test for
the schema.

Related to https://github.com/osbuild/images/issues/1416