### PR TITLE
 In Fedora 41+, depend on typer-slim rather than typer

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -127,7 +127,11 @@ Requires:       python3-dnf
 %if 0%{?fedora}
 Requires:       python3-rich
 Requires:       python3-attrs
+%if 0%{?fedora} > 40
+Requires:       python3dist(typer-slim[standard])
+%else
 Requires:       python3-typer
+%endif
 %endif
 
 %description    tools


### PR DESCRIPTION
This works around a file conflict on `/usr/bin/typer` between `python3-typer-cli` and `erlang-dialyzer` until the problem can be fixed in `python-typer` and/or `erlang`. See [RHBZ#2359557](https://bugzilla.redhat.com/show_bug.cgi?id=2359557), [RHBZ#2359567](https://bugzilla.redhat.com/show_bug.cgi?id=2359567).

After the file conflict is resolved, the `python3-typer-slim` dependency will still be more precise and minimal than `python3-typer`, so no further change will be required.

By depending on `typer-slim[standard]`, we still get the nice-to-have optional dependencies that plain `typer` would bring in (currently, `rich` and `shellingham`), but without the generic `typer` command-line tool.

After this PR, it is possible to install `osbuild-tools` and `erlang` at the same time; before the PR, this failed due to the file conflict on `/usr/bin/typer` in Fedora 41+.