### PR TITLE
Tests: fix packit config validation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Validate Packit config
         run: |
-          packit validate-config .packit.yaml
+          packit config validate .packit.yaml
 
   snapshots:
     name: "🔍 Check for valid snapshot urls"


### PR DESCRIPTION
Packit changed the command to validate its configuration, without keeping backward compatibility.