### PR TITLE
solver: Use load_repos instead of update_and_load_enabled_repos

### DIFF
--- a/osbuild/solver/dnf5.py
+++ b/osbuild/solver/dnf5.py
@@ -163,7 +163,7 @@ class DNF5(SolverBase):
                     )
                     repo_iter.next()
 
-            self.base.get_repo_sack().update_and_load_enabled_repos(load_system=False)
+            self.base.get_repo_sack().load_repos(dnf5.repo.Repo.Type_AVAILABLE)
         except RuntimeError as e:
             raise RepoError(e) from e
 


### PR DESCRIPTION
The old function has been deprecated by dnf5, use load_repos directly and only load the available repos (the ones osbuild has setup), not the system repos.

Fixes #2080