### PR TITLE
solver: Call update_cache

### DIFF
--- a/osbuild/solver/dnf.py
+++ b/osbuild/solver/dnf.py
@@ -86,6 +86,7 @@ class DNF(SolverBase):
                         repo_config.sslclientcert = modify_rootdir_path(repo_config.sslclientcert, root_dir)
                         repo_config.sslclientkey = modify_rootdir_path(repo_config.sslclientkey, root_dir)
 
+            self.base.update_cache()
             self.base.fill_sack(load_system_repo=False)
         except dnf.exceptions.Error as e:
             raise RepoError(e) from e


### PR DESCRIPTION
DNF apparently doesn't check the expiration time on the cache unless you call this first. It may help improve issues with the cache being out of sync.

Internally dnf checks the mtime of the main repomd.xml file when using baseurl, and it checks the hash values when using metalink so this should not result in any noticeable extra slowdowns when things are fresh.