### PR TITLE
[RFC] tools: drop requirement for `module_platform_id` from request

### DIFF
--- a/osbuild/solver/dnf.py
+++ b/osbuild/solver/dnf.py
@@ -20,7 +20,7 @@ class DNF(SolverBase):
     def __init__(self, request, persistdir, cache_dir, license_index_path=None):
         arch = request["arch"]
         releasever = request.get("releasever")
-        module_platform_id = request["module_platform_id"]
+        module_platform_id = request.get("module_platform_id")
         proxy = request.get("proxy")
 
         arguments = request["arguments"]
@@ -51,7 +51,8 @@ class DNF(SolverBase):
         self.base.conf.zchunk = False
 
         # Set the rest of the dnf configuration.
-        self.base.conf.module_platform_id = module_platform_id
+        if module_platform_id:
+            self.base.conf.module_platform_id = module_platform_id
         self.base.conf.config_file_path = "/dev/null"
         self.base.conf.persistdir = persistdir
         self.base.conf.cachedir = cache_dir

--- a/osbuild/solver/dnf5.py
+++ b/osbuild/solver/dnf5.py
@@ -59,7 +59,7 @@ class DNF5(SolverBase):
     def __init__(self, request, persistdir, cachedir, license_index_path=None):
         arch = request["arch"]
         releasever = request.get("releasever")
-        module_platform_id = request["module_platform_id"]
+        module_platform_id = request.get("module_platform_id")
         proxy = request.get("proxy")
 
         arguments = request["arguments"]
@@ -115,7 +115,8 @@ class DNF5(SolverBase):
         conf.zchunk = False
 
         # Set the rest of the dnf configuration.
-        conf.module_platform_id = module_platform_id
+        if module_platform_id:
+            conf.module_platform_id = module_platform_id
         conf.config_file_path = "/dev/null"
         conf.persistdir = persistdir
         conf.cachedir = cachedir

--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -141,12 +141,6 @@ def validate_request(request):
             "reason": "no 'arch' specified"
         }
 
-    if not request.get("module_platform_id"):
-        return {
-            "kind": "InvalidRequest",
-            "reason": "no 'module_platform_id' specified"
-        }
-
     if not request.get("releasever"):
         return {
             "kind": "InvalidRequest",

--- a/tools/test/test_depsolve.py
+++ b/tools/test/test_depsolve.py
@@ -66,12 +66,15 @@ def depsolve(transactions, cache_dir, dnf_config=None, repos=None, root_dir=None
     req = {
         "command": "depsolve",
         "arch": ARCH,
-        "module_platform_id": f"platform:el{RELEASEVER}",
         "releasever": RELEASEVER,
         "cachedir": cache_dir,
         "arguments": {
             "transactions": transactions,
         }
+        # Note that we are not setting "module_platform_id" here,
+        # none of our tests is using it. Once we start using it
+        # we need to add it (and maybe a "with_platform_id" as
+        # parameter on top)
     }
 
     if repos:


### PR DESCRIPTION
The PLATFORM_ID got retired from fedora-43 [0] and it seems like it was always kinda optional (at least on fedora). So lets make it optional for real to avoid failing to build fedora-43 images.

[0] https://fedoraproject.org/wiki/Changes/Drop_PLATFORM_ID

See also https://github.com/osbuild/bootc-image-builder/issues/868 which started to fail recently for f43 bootc images.