### PR TITLE
dnfjson: detect/error if no repositories are defined

### DIFF
--- a/osbuild/solver/__init__.py
+++ b/osbuild/solver/__init__.py
@@ -40,6 +40,10 @@ class RepoError(SolverException):
     pass
 
 
+class NoReposError(SolverException):
+    pass
+
+
 class MarkingError(SolverException):
     pass
 

--- a/osbuild/solver/dnf.py
+++ b/osbuild/solver/dnf.py
@@ -11,7 +11,15 @@ from typing import Dict, List
 import dnf
 import hawkey
 
-from osbuild.solver import DepsolveError, MarkingError, RepoError, SolverBase, modify_rootdir_path, read_keys
+from osbuild.solver import (
+    DepsolveError,
+    MarkingError,
+    NoReposError,
+    RepoError,
+    SolverBase,
+    modify_rootdir_path,
+    read_keys,
+)
 from osbuild.util.sbom.dnf import dnf_pkgset_to_sbom_pkgset
 from osbuild.util.sbom.spdx import sbom_pkgset_to_spdx2_doc
 
@@ -91,6 +99,9 @@ class DNF(SolverBase):
             self.base.fill_sack(load_system_repo=False)
         except dnf.exceptions.Error as e:
             raise RepoError(e) from e
+
+        if not self.base.repos._any_enabled():
+            raise NoReposError("There are no enabled repositories")
 
         # enable module resolving
         self.base_module = dnf.module.module_base.ModuleBase(self.base)

--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -13,7 +13,7 @@ import os.path
 import sys
 import tempfile
 
-from osbuild.solver import GPGKeyReadError, MarkingError, DepsolveError, RepoError, InvalidRequestError
+from osbuild.solver import GPGKeyReadError, MarkingError, DepsolveError, NoReposError, RepoError, InvalidRequestError
 
 # Load the solver configuration
 config = {"use_dnf5": False}
@@ -76,6 +76,11 @@ def solve(request, cache_dir):
             return None, {
                 "kind": "RepoError",
                 "reason": f"There was a problem reading a repository: {e}"
+            }
+        except NoReposError as e:
+            return None, {
+                "kind": "NoReposError",
+                "reason": f"There was a problem finding repositories: {e}"
             }
         except MarkingError as e:
             printe("error install_specs")


### PR DESCRIPTION
This commit adds an error message if no repositories are defined in the dnfjson query. We had the issue in
https://github.com/osbuild/bootc-image-builder/issues/922 that in a RHEL bootc-container no repositories are defined.

Here the error is quite confusing, as it complains about error marking packages which is technically correct but hides the root of the problem.

With this detect we can construct a more useful error message in the higher layers.