### PR TITLE
CI: don't build F39 RPMs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,8 +35,6 @@ RPM:
   parallel:
     matrix:
       - RUNNER:
-          - aws/fedora-39-x86_64
-          - aws/fedora-39-aarch64
           - aws/fedora-40-x86_64
           - aws/fedora-40-aarch64
           - aws/fedora-41-x86_64


### PR DESCRIPTION
These are no longer consumed by any dependent project AFAICT, so let's drop the EOL Fedora 39 builds.