### PR TITLE
stages/tar: allow chosen compression (HMS-8573, HMS-6116)

### DIFF
--- a/stages/org.osbuild.tar
+++ b/stages/org.osbuild.tar
@@ -37,10 +37,19 @@ def main(inputs, output_dir, options):
     if transform:
         extra_args += ["--transform", transform]
 
+    compression = options.get("compression", "auto")
+
+    if compression == "auto":
+        extra_args += ["--auto-compress"]
+    else:
+        # Note that the enums in the schema have been chosen exactly
+        # as the long forms for the compression flag(s) that GNU tar
+        # accepts
+        extra_args += [f"--{compression}"]
+
     # Set up the tar command.
     tar_cmd = [
         "tar",
-        "--auto-compress",
         f"--format={tarfmt}",
         *extra_args,
         "-cf", os.path.join(output_dir, filename),

--- a/stages/org.osbuild.tar.meta.json
+++ b/stages/org.osbuild.tar.meta.json
@@ -65,6 +65,17 @@
           ],
           "default": "gnu"
         },
+        "compression": {
+          "description": "Compression to use",
+          "type": "string",
+          "enum": [
+            "auto",
+            "xz",
+            "gzip",
+            "zstd"
+          ],
+          "default": "auto"
+        },
         "acls": {
           "description": "Enable support for POSIX ACLs",
           "type": "boolean",


### PR DESCRIPTION
The `org.osbuild.tar` stage only supports auto compression which is based on the filename. For several (newer) artifacts such as Vagrant (`.box`) and WSL (`.wsl`) we want to explicitly give the compression algorithm.

I've chosen a (few) commonly used compression algorithms. If others are needed they are one-line followups away.

---

The one "directly" needed is `gzip`, I'd be fine with dropping the others under YAGNI?
