### PR TITLE
test: simplify git clone command

### DIFF
--- a/test/cases/manifest_tests
+++ b/test/cases/manifest_tests
@@ -110,8 +110,18 @@ def checkout_images_repo(ref, workdir: os.PathLike) -> str:
         print(f"Checking out '{OSBUILD_IMAGES_REPO_URL}' repository at ref '{ref}'")
         try:
             subprocess.check_call(
-                ["git", "clone", "--depth=1", "--no-single-branch", OSBUILD_IMAGES_REPO_URL, "images"],
+                ["git", "clone", OSBUILD_IMAGES_REPO_URL, "images"],
                 cwd=workdir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            )
+
+            subprocess.check_call(
+                ["git", "fetch", "--all"],
+                cwd=images_path, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            )
+
+            subprocess.check_call(
+                ["git", "checkout", ref],
+                cwd=images_path, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             )
         except subprocess.CalledProcessError as e:
             print(f"Failed to clone 'images' repository: {e.stdout.decode()}")


### PR DESCRIPTION
In some (ununderstood) cases the combination of `--no-single-branch` and `--depth=1` leads to the revision we want to check out not being available.

@achilleas-k suggested to change the command to this instead.