### PR TITLE
Add support for runtime-cleanup.tmpl

### DIFF
--- a/stages/org.osbuild.lorax-script
+++ b/stages/org.osbuild.lorax-script
@@ -10,12 +10,14 @@ LORAX_TEMPLATES = "/usr/share/lorax/templates.d"
 
 
 Product = collections.namedtuple("Product", ["name", "version"])
+Branding = collections.namedtuple("Branding", ["release", "logos"])
 
 
 def main(tree, options):
     filename = options["path"]
     basearch = options.get("basearch", "x86_64")
     product = options.get("product", {})
+    branding = options.get("branding", {})
     libdir = options.get("libdir", "lib64")
 
     fullpath = os.path.join(LORAX_TEMPLATES, filename)
@@ -26,17 +28,22 @@ def main(tree, options):
     version = product.get("version", "")
     product = Product(name, version)
 
+    release = branding.get("release", None)
+    logos = branding.get("logos", None)
+    branding = Branding(release=release, logos=logos)
+
     args = {
         "root": tree,
         "basearch": basearch,
         "configdir": configdir,
         "libdir": libdir,
-        "product": product
+        "product": product,
+        "branding": branding
     }
 
     tpl = render_template(fullpath, args)
     script = Script(tpl, "/", tree)
-    print(f"running script: {os.path.dirname(filename)}")
+    print(f"running script: {os.path.basename(filename)}")
     script()
 
 

--- a/stages/org.osbuild.lorax-script.meta.json
+++ b/stages/org.osbuild.lorax-script.meta.json
@@ -41,6 +41,20 @@
             "type": "string"
           }
         }
+      },
+      "branding": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "release": {
+            "type": "string",
+            "description": "Release package name, like fedora-release"
+          },
+          "logos": {
+            "type": "string",
+            "description": "Logo package name, like fedora-logos"
+          }
+        }
       }
     }
   }

--- a/stages/org.osbuild.lorax-script.meta.json
+++ b/stages/org.osbuild.lorax-script.meta.json
@@ -26,6 +26,10 @@
         "default": "x86_64",
         "description": "The basic architecture param to supply to the template"
       },
+      "libdir": {
+        "type": "string",
+        "default": "lib64"
+      },
       "product": {
         "type": "object",
         "additionalProperties": false,
@@ -36,10 +40,6 @@
           "version": {
             "type": "string"
           }
-        },
-        "libdir": {
-          "type": "string",
-          "default": "lib64"
         }
       }
     }


### PR DESCRIPTION
This adds support for running the standard lorax `runtime-cleanup.tmpl` template.
I've been testing it by making a netinst manifest, inserting the runtime-cleanup.tmpl stage, and then running the manifest with osbuild. eg.

```
image-builder manifest everything-netinst | jq  > f42-cleanup.json
```
edit and add this after the dracut stage:
```
{
              "type": "org.osbuild.lorax-script",
              "options": {
                "path": "99-generic/runtime-cleanup.tmpl",
                "basearch": "x86_64",
                "product": {
                  "name": "",
                  "version": ""
                },
                "branding": {
                  "release": "fedora-release",
                  "logos": "fedora-logos"
                }
              }
            },
```
And cleanup the leftovers by excluding things from the squashfs stage. The complete stage looks like this:
```
             "type": "org.osbuild.squashfs",
              "inputs": {
                "tree": {
                  "type": "org.osbuild.tree",
                  "origin": "org.osbuild.pipeline",
                  "references": [
                    "name:anaconda-tree"
                  ]
                }
              },
              "options": {
                "filename": "images/install.img",
                "exclude_paths": [
                  "boot/efi/.*",
                  "boot/grub2/.*",
                  "boot/config-.*",
                  "boot/initramfs-.*",
                  "boot/loader/.*",
                  "boot/symvers-.*",
                  "boot/System.map-.*",
                  "usr/lib/sysimage/rpm/.*",
                  "var/lib/rpm/.*",
                  "var/lib/yum/.*",
                  "var/lib/dnf/.*"
                ],
                "compression": {
                  "method": "xz",
                  "options": {
                    "bcj": "x86"
                  }
                }
              }
            },
```
And then running it with osbuild like so:
```
cat f42-cleanup.json | osbuild --store /var/cache/image-builder/store --output-dir ./test1/  --export bootiso -
```
