### PR TITLE
ci: run tests on Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - "py36"    # RH8
           - "py39"    # RH9
           - "py313"   # latest fedora
+          - "py314"   # rawhide
     steps:
     - name: "Clone Repository"
       uses: actions/checkout@v4

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 env_list =
-    py{36,37,38,39,310,311,312,313}
+    py{36,37,38,39,310,311,312,313,314}
     lint
     type
 
 labels =
-    test = py{36,37,38,39,310,311,312,313}
+    test = py{36,37,38,39,310,311,312,313,314}
     lint = ruff, autopep8, pylint
     type = mypy,mypy-strict
 


### PR DESCRIPTION
Fedora Rawhide merged its Python 3.14 sidetag; this has broken the builds for Fedora IoT due to a change in config parser. Let's enable Python 3.14 in CI as a start to find the root cause(s).