### PR TITLE
test: drop python 3.6?

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
           - parallel
           - normal
         environment:
-          - "py36"    # RH8
           - "py39"    # RH9
           - "py313"   # latest fedora
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 env_list =
-    py{36,37,38,39,310,311,312,313}
+    py{37,38,39,310,311,312,313}
     lint
     type
 
 labels =
-    test = py{36,37,38,39,310,311,312,313}
+    test = py{37,38,39,310,311,312,313}
     lint = ruff, autopep8, pylint
     type = mypy,mypy-strict
 


### PR DESCRIPTION
`tox` (our test runner) dropped support for finding Python 3.6 interpreters in it's 4.0 release [1]. `tox` 4.0 is now in rawhide and making its way into our CI containers.

This drops Python 3.6 from our tox configuration.

[1]: https://tox.wiki/en/latest/changelog.html#v4-0-0a10-2022-01-04

---

This PR needs careful consideration. Python 3.6 is used on RHEL 8 and it would be extremely easy for us to thus break things there. Perhaps we need a different approach to running tests for 3.6 (not through tox?). Let's discuss in this PR.