### PR TITLE
spec: Don't use tomli on Fedora, fix comment

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -40,8 +40,8 @@ Requires:       (%{name}-selinux if selinux-policy-%{selinuxtype})
 Requires:       python3-librepo
 
 # This is required for `osbuild`, for RHEL-10 and above
-# the stdlib toml package can be used instead
-%if 0%{?rhel} < 10
+# the stdlib tomllib module can be used instead
+%if 0%{?rhel} && 0%{?rhel} < 10
 Requires:       python3-tomli
 %endif
 


### PR DESCRIPTION
The condition was evaluated as true on Fedora, because 0 < 10.

Also, the module in the standard library is called tomllib.