### PR TITLE
Always assert the correct architecture in test_curl_user_agent

### DIFF
--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -195,7 +195,7 @@ def test_curl_user_agent(tmp_path, sources_module):
 
     sources_module.gen_curl_download_config(config_path, test_sources.items())
     assert config_path.exists()
-    assert 'user-agent = "osbuild (Linux.x86_64; https://osbuild.org/)"' in config_path.read_text()
+    assert f'user-agent = "osbuild (Linux.{platform.machine()}; https://osbuild.org/)"' in config_path.read_text()
 
 
 @pytest.mark.parametrize("with_proxy", [True, False])


### PR DESCRIPTION
The test fails on every non-default architecture, e.g. https://download.copr.fedorainfracloud.org/results/packit/osbuild-osbuild-2116/centos-stream-10-ppc64le/09156332-osbuild/builder-live.log.gz