### PR TITLE
Adjust tests to work better in downstream environments

### DIFF
--- a/stages/test/test_bootc_install_config.py
+++ b/stages/test/test_bootc_install_config.py
@@ -73,6 +73,7 @@ STAGE_NAME = "org.osbuild.bootc.install.config"
         )
     ]
 )
+@pytest.mark.tomlwrite
 def test_bootc_install_config(tmp_path, stage_module, options, expected_config):
     stage_module.main(tmp_path, options)
     # different toml libraries write out arrays in different ways (one line vs many), so we need to parse the result

--- a/stages/test/test_containers_storage_conf.py
+++ b/stages/test/test_containers_storage_conf.py
@@ -18,6 +18,7 @@ TEST_INPUT = [
 STAGE_NAME = "org.osbuild.containers.storage.conf"
 
 
+@pytest.mark.tomlwrite
 @pytest.mark.parametrize("test_filename", ["/etc/containers/storage.conf", "/usr/share/containers/storage.conf"])
 @pytest.mark.parametrize("test_storage,test_options,expected", TEST_INPUT)
 def test_containers_storage_conf_integration(tmp_path, stage_module, test_filename, test_storage, test_options, expected):  # pylint: disable=unused-argument

--- a/stages/test/test_systemd_unit_create.py
+++ b/stages/test/test_systemd_unit_create.py
@@ -469,6 +469,8 @@ def test_systemd_unit_create(tmp_path, stage_module, unit_type, unit_path, expec
     stage_module.main(tmp_path, options)
     assert os.path.exists(expected_unit_path)
     if unit_type == "system":
+        if os.environ.get("RPM_BUILD_ROOT"):
+            pytest.skip("systemd-analyze can't be run in the RPM build root environment")
         # When verifying user units, systemd expects runtime directories and more generally a booted system. Setting
         # something up like that to verify it is more trouble than it's worth, especially since the system units are
         # identical.
@@ -562,6 +564,8 @@ def test_systemd_unit_create_mount(tmp_path, stage_module, unit_type, unit_path,
     stage_module.main(tmp_path, options)
     assert os.path.exists(expected_unit_path)
     if unit_type == "system":
+        if os.environ.get("RPM_BUILD_ROOT"):
+            pytest.skip("systemd-analyze can't be run in the RPM build root environment")
         # When verifying user units, systemd expects runtime directories and more generally a booted system. Setting
         # something up like that to verify it is more trouble than it's worth, especially since the system units are
         # identical.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,3 +17,6 @@ def pytest_configure(config):
     # pylint: disable=global-statement
     global unsupported_filesystems
     unsupported_filesystems = config.getoption("--unsupported-fs")
+    config.addinivalue_line(
+        "markers", "tomlwrite: mark test to run only in an environment with a TOML-writing library available"
+    )

--- a/test/mod/test_util_toml.py
+++ b/test/mod/test_util_toml.py
@@ -4,6 +4,8 @@
 import os
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from osbuild.util import toml
 
 data_obj = {
@@ -26,6 +28,7 @@ str = "test"
 """
 
 
+@pytest.mark.tomlwrite
 def test_write_read():
     with TemporaryDirectory() as tmpdir:
         path = os.path.join(tmpdir, "test.toml")


### PR DESCRIPTION
- don't attempt to create system units during the RPM build
- skip x86_64-specific tests on different architectures
- mark tests needing a TOML-writing library for easier exclusion downstream (no such library is present in RHEL currently)

This is all based on the test results from #2116 