### PR TITLE
solver/dnf5: switch base exception type

### DIFF
--- a/osbuild/solver/dnf5.py
+++ b/osbuild/solver/dnf5.py
@@ -172,7 +172,7 @@ class DNF5(SolverBase):
                     repo_iter.next()
 
             self.base.get_repo_sack().load_repos(dnf5.repo.Repo.Type_AVAILABLE)
-        except RuntimeError as e:
+        except Exception as e:
             raise RepoError(e) from e
 
         if not any_repos_enabled(self.base):


### PR DESCRIPTION
libdnf5 changed error types [1], [2], [3] and they no longer inherit from `RuntimeError`; instead catch `Exception` which is the new common base type.

This fixes issues in our CI.

[1]: https://github.com/rpm-software-management/dnf5/pull/2124
[2]: https://github.com/rpm-software-management/dnf5/pull/2118#issuecomment-2876601471
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=2365689