### PR TITLE
source/containers-storage: error message

### DIFF
--- a/sources/org.osbuild.containers-storage
+++ b/sources/org.osbuild.containers-storage
@@ -80,7 +80,8 @@ class ContainersStorageSource(sources.SourceService):
             # string not matching not ideal - this is ErrNotAnImage
             # which is unchanged since 2016 (added in ee99172905 in
             # containers/storage)
-            if "identifier is not an image" in res.stderr:
+            # update: 2025, the message did change!
+            if "identifier is not an image" in res.stderr or "does not resolve to an image ID" in res.stderr:
                 return False
             raise RuntimeError(f"unknown skopeo error: {res.stderr}")
 


### PR DESCRIPTION
An error message has changed in skopeo [1] (or one of it's underlying libraries). This new version is now in our CI so let's fix our tests.

[1]: https://github.com/containers/skopeo/commit/f423f01d1bc1e2c0c271de5f06a020f2a99e15be