### PR TITLE
stages/test: kickstart different messages

### DIFF
--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -352,14 +352,14 @@ def test_kickstart_valid(tmp_path, stage_module, test_input, expected):  # pylin
         ({"reboot": {"random": "option"}}, "{'random': 'option'} is not valid "),
         ({"display_mode": "invalid-mode"}, "'invalid-mode' is not one of "),
         # autopart
-        ({"autopart": {"type": "not-valid"}}, "'not-valid' is not one of ["),
+        ({"autopart": {"type": "not-valid"}}, r"'not-valid' is not one of \["),
         # Only one of --pbkdf-{time,iterations} can be specified at the same time
-        ({"autopart": {"pbkdf-time": 1, "pbkdf-iterations": 2}}, " should not be valid under "),
+        ({"autopart": {"pbkdf-time": 1, "pbkdf-iterations": 2}}, r"( should not be valid under| is not allowed for)"),
         # network is always a list
         ({"network": {"device": "foo"}}, " is not of type 'array'"),
         ({"network": [{"device": "foo", "activate": "string"}]}, " is not of type 'boolean'"),
         ({"network": [{"device": "foo", "random": "option"}]}, "Additional properties are not allowed "),
-        ({"network": [{"device": "foo", "bootproto": "invalid"}]}, " is not one of ["),
+        ({"network": [{"device": "foo", "bootproto": "invalid"}]}, r" is not one of \["),
         ({"network": [{"device": "foo", "ip": "invalid"}]}, " does not match "),
         ({"network": [{"device": "foo", "ip": "256.1.1.1"}]}, " does not match "),
         ({"network": [{"device": "foo", "ip": "1.256.1.1"}]}, " does not match "),
@@ -400,7 +400,7 @@ def test_kickstart_valid(tmp_path, stage_module, test_input, expected):  # pylin
                        }]}, " does not match "),
         # ostreecontainer
         ({"ostreecontainer": {"url": "http://some-ostree-url.com/foo",
-         "transport": "not-valid"}}, "'not-valid' is not one of ["),
+         "transport": "not-valid"}}, r"'not-valid' is not one of \["),
         # not both ostreecontainer and ostree
         (
             {
@@ -446,4 +446,4 @@ def test_schema_validation_bad_apples(stage_schema, test_input, expected_err):
     res = stage_schema.validate(test_data)
 
     assert res.valid is False
-    testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
+    testutil.assert_jsonschema_error_contains(res, re.compile(expected_err), expected_num_errs=1)


### PR DESCRIPTION
On Python 3.6 we're getting a *different* error message from other versions in CI. Let's accept both versions.

Specifically only on 3.6 we're getting:

```

stages/test/test_kickstart.py:449: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

res = <osbuild.meta.ValidationResult object at 0x7f2255d54bd0>
expected_err = ' should not be valid under ', expected_num_errs = 1

    def assert_jsonschema_error_contains(res, expected_err, expected_num_errs=None):
        err_msgs = [e.as_dict()["message"] for e in res.errors]
        if expected_num_errs is not None:
            assert len(err_msgs) == expected_num_errs, \
                f"expected exactly {expected_num_errs} errors in {[e.as_dict() for e in res.errors]}"
        re_typ = getattr(re, 'Pattern', None)
        # this can be removed once we no longer support py3.6 (re.Pattern is modern)
        if not re_typ:
            re_typ = getattr(re, '_pattern_type')
        if isinstance(expected_err, re_typ):
            finder = expected_err.search
        else:
            def finder(s): return expected_err in s  # pylint: disable=C0321
        assert any(finder(err_msg)
>                  for err_msg in err_msgs), f"{expected_err} not found in {err_msgs}"
E       AssertionError:  should not be valid under  not found in ["{'required': ['pbkdf-iterations', 'pbkdf-time']} is not allowed for {'pbkdf-time': 1, 'pbkdf-iterations': 2}"]
```