### PR TITLE
osbuild: drop `+` when doing `QEMU_LOG=unimp`

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -255,7 +255,7 @@ class Stage:
             if self.source_epoch is not None:
                 extra_env["SOURCE_DATE_EPOCH"] = str(self.source_epoch)
             if experimentalflags.get_bool("debug-qemu-user"):
-                extra_env["QEMU_LOG"] = "+unimp"
+                extra_env["QEMU_LOG"] = "unimp"
 
             debug_shell = debug_break in ('*', self.name, self.id)
 


### PR DESCRIPTION
This commit drops the `QEMU_LOG=+unimp` and replaces it with `QEMU_LOG=unimp`. The `+` format does not work and we found this in https://github.com/osbuild/bootc-image-builder/pull/963#issuecomment-3001154460