### PR TITLE
stages/gzip: introduce a gz stage

### DIFF
--- a/stages/org.osbuild.gzip
+++ b/stages/org.osbuild.gzip
@@ -18,24 +18,25 @@ def parse_input(inputs):
 
 def main(inputs, output, options):
     filename = options["filename"].lstrip("/")
-    level = options.get("level", 1)
 
     source = parse_input(inputs)
     target = os.path.join(output, filename)
 
     with open(target, "w", encoding="utf8") as f:
-        cmd = [
-            "gzip", "--no-name", "--stdout", f"-{level}", source
-        ]
+        # -6 is the 'medium' compression level trading off speed
+        # for size
+        cmd = ["gzip", "--keep", "--stdout", "-6", source]
 
         subprocess.run(
-            cmd, stdout=f, check=True
+            cmd,
+            stdout=f,
+            check=True,
         )
 
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = osbuild.api.arguments()
     r = main(args["inputs"], args["tree"], args["options"])
     sys.exit(r)

--- a/stages/org.osbuild.gzip.meta.json
+++ b/stages/org.osbuild.gzip.meta.json
@@ -1,5 +1,5 @@
 {
-  "summary": "Compress a file using gzip",
+  "summary": "Compress a file with gzip",
   "description": [
     "Buildhost commands used: `gzip`."
   ],
@@ -26,13 +26,6 @@
         "filename": {
           "description": "Filename to use for the compressed file",
           "type": "string"
-        },
-        "level": {
-          "description": "Compression level",
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 9,
-          "default": 1
         }
       }
     }

--- a/stages/test/test_gzip.py
+++ b/stages/test/test_gzip.py
@@ -1,41 +1,87 @@
 #!/usr/bin/python3
 
-from unittest.mock import patch
+import os.path
+import subprocess
+from unittest import mock
 
 import pytest
+
+from osbuild import testutil
+from osbuild.testutil import has_executable, make_fake_input_tree
 
 STAGE_NAME = "org.osbuild.gzip"
 
 
-@pytest.mark.parametrize("test_options,expected_level", [
-    # our default
-    ({}, "-1"),
-    # custom settings
-    ({"level": "1"}, "-1"),
-    ({"level": "6"}, "-6"),
-    ({"level": "9"}, "-9"),
+@pytest.mark.parametrize("test_data,expected_err", [
+    # bad
+    ({}, "'filename' is a required property"),
+    # good
+    ({"filename": "image.gz"}, ""),
 ])
-@patch("subprocess.run")
-def test_gzip_compression_default_to_level1(mocked_run, tmp_path, stage_module, test_options, expected_level):
-    inp = {
+def test_schema_validation_gzip(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "options": {
+        }
+    }
+    test_input["options"].update(test_data)
+    res = stage_schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
+
+
+@pytest.fixture(name="fake_input_tree")
+def fake_input(tmp_path):
+    fake_input_tree = make_fake_input_tree(tmp_path, {
+        "/sha256:ff3e910ceb79fd66e67b7ff4a9073b1d584c748a5f3d1e6b1873afa1cf35ec59": "A file to be compressed",
+    })
+    inputs = {
         "file": {
-            "path": "/input/file/path",
+            "path": fake_input_tree,
             "data": {
                 "files": {
-                    "hash:value": "some-file",
+                    "sha256:ff3e910ceb79fd66e67b7ff4a9073b1d584c748a5f3d1e6b1873afa1cf35ec59": {}
                 }
-            },
-        },
+            }
+        }
     }
-    output = tmp_path
-    options = {
-        "filename": "out.tar.gz",
-    }
-    options.update(test_options)
+    return (fake_input_tree, inputs)
 
-    stage_module.main(inp, output, options)
-    assert len(mocked_run.call_args_list) == 1
-    args, kwargs = mocked_run.call_args_list[0]
-    assert args == (["gzip", "--no-name", "--stdout", expected_level, "/input/file/path/hash:value"],)
-    assert kwargs["check"]
-    assert kwargs["stdout"].name.endswith("out.tar.gz")
+
+@pytest.mark.skipif(not has_executable("gzip"), reason="no gzip executable")
+def test_gzip_integration(tmp_path, stage_module, fake_input_tree):  # pylint: disable=unused-argument
+    inputs = fake_input_tree[1]
+    options = {
+        "filename": "image.txt.gz",
+    }
+    stage_module.main(inputs, tmp_path, options)
+
+    img_path = os.path.join(tmp_path, "image.txt.gz")
+    assert os.path.exists(img_path)
+    output = subprocess.check_output([
+        "gzip", "--decompress", "--stdout", img_path], encoding="utf-8")
+    assert "A file to be compressed" in output
+
+
+@mock.patch("subprocess.run")
+def test_gzip_cmdline(mock_run, tmp_path, stage_module, fake_input_tree):
+    fake_input_path = fake_input_tree[0]
+    inputs = fake_input_tree[1]
+    filename = "image.txt.gz"
+    options = {
+        "filename": filename,
+    }
+    stage_module.main(inputs, tmp_path, options)
+
+    expected = [
+        "gzip",
+        "--keep",
+        "--stdout",
+        "-6",
+        os.path.join(fake_input_path, "sha256:ff3e910ceb79fd66e67b7ff4a9073b1d584c748a5f3d1e6b1873afa1cf35ec59")
+    ]
+    mock_run.assert_called_with(expected, stdout=mock.ANY, check=True)


### PR DESCRIPTION
We have an `xz`, and `zstd`, stage to do compression with, which are being used. The `tar` stage supports `xz`, `zstd`, and `gzip`.

We don't have a `gzip` stage to do the same. Let's add it so we can generalize our compression between disk images and tarballs in `images`.