### PR TITLE
grub2.iso: Default to booting the iso test

### DIFF
--- a/stages/org.osbuild.grub2.iso
+++ b/stages/org.osbuild.grub2.iso
@@ -9,6 +9,8 @@ import osbuild.api
 # The main grub2 configuration file template. Used for UEFI.
 # NOTE: Changes to this should also be applied to the org.osbuild.grub2.iso.legacy stage
 GRUB2_EFI_CFG_TEMPLATE = """
+set default="1"
+
 function load_video {
   insmod efi_gop
   insmod efi_uga

--- a/stages/org.osbuild.grub2.iso.legacy
+++ b/stages/org.osbuild.grub2.iso.legacy
@@ -9,6 +9,8 @@ import osbuild.api
 # The main grub2 configuration file template. Used for BIOS.
 # NOTE: Changes to this should also be applied to the org.osbuild.grub2.iso stage
 GRUB2_CFG_TEMPLATE = """
+set default="1"
+
 function load_video {
   insmod all_video
 }

--- a/stages/test/test_grub2_iso_legacy.py
+++ b/stages/test/test_grub2_iso_legacy.py
@@ -8,6 +8,8 @@ import pytest
 STAGE_NAME = "org.osbuild.grub2.iso.legacy"
 
 expected_grub_cfg = """
+set default="1"
+
 function load_video {
   insmod all_video
 }


### PR DESCRIPTION
When booting the iso it should test it by default, this is menu entry 1 and make it match the behavior of the boot.iso

Fixes #2127