### PR TITLE
add ssh_pwauth  to org.osbuild.cloud-init

### DIFF
--- a/stages/org.osbuild.cloud-init.meta.json
+++ b/stages/org.osbuild.cloud-init.meta.json
@@ -40,6 +40,10 @@
         "description": "cloud-init configuration",
         "minProperties": 1,
         "properties": {
+          "ssh_pwauth": {
+            "type": "boolean",
+            "description": "enable/disable ssh password authentication"
+          },
           "system_info": {
             "additionalProperties": false,
             "type": "object",

--- a/test/data/stages/cloud-init/b.json
+++ b/test/data/stages/cloud-init/b.json
@@ -717,6 +717,7 @@
           "options": {
             "filename": "00-default_user.cfg",
             "config": {
+              "ssh_pwauth": false,
               "system_info": {
                 "default_user": {
                   "name": "ec2-user"

--- a/test/data/stages/cloud-init/b.mpp.yaml
+++ b/test/data/stages/cloud-init/b.mpp.yaml
@@ -31,6 +31,7 @@ pipelines:
         options:
           filename: 00-default_user.cfg
           config:
+            ssh_pwauth: false
             system_info:
               default_user:
                 name: ec2-user


### PR DESCRIPTION
Adds "ssh_pwauth" to `org.osbuild.cloud-init` to enable/disable (defaults to `false`) ssh authentication using username and password.