### PR TITLE
stages/vagrant: allow configuring synced folders (HMS-6116)

### DIFF
--- a/stages/org.osbuild.vagrant
+++ b/stages/org.osbuild.vagrant
@@ -59,6 +59,9 @@ def main(tree, options, inputs):
     if provider == "virtualbox":
         vagrant_content = VAGRANTFILE_VIRTUALBOX.format(mac_address=options["virtualbox"]["mac_address"])
 
+    for path, data in options.get("synced_folders", {}).items():
+        vagrant_content += f'    config.vm.synced_folder ".", "{path}", type: "{data["type"]}"\n'
+
     with open(f"{tree}/Vagrantfile", "w", encoding="utf8") as fp:
         fp.write(VAGRANTFILE.format(content=vagrant_content))
 

--- a/stages/org.osbuild.vagrant.meta.json
+++ b/stages/org.osbuild.vagrant.meta.json
@@ -41,6 +41,25 @@
                 "virtualbox"
               ]
             },
+            "synced_folders": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "/vagrant": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "vboxfs",
+                        "rsync"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
             "virtualbox": {
               "type": "object",
               "description": "VirtualBox specific settings",


### PR DESCRIPTION
When guest additions are not installed in VirtualBox Vagrant boxes then
the default shared `/vagrant` directory must be set to `rsync`,
otherwise Vagrant fails to start as the shared directory cannot be
mounted with the `vboxfs` filesystem.

Let's expand the schema to allow for `synced-folders` (currently only
accepted under the `virtualbox` variant of the schema) to allow setting
the bare subset of relevant options to configure this from `images`.