### PR TITLE
stages/tar: add --numeric-owner option [RHEL-102854]

### DIFF
--- a/stages/org.osbuild.tar
+++ b/stages/org.osbuild.tar
@@ -37,6 +37,9 @@ def main(inputs, output_dir, options):
     if transform:
         extra_args += ["--transform", transform]
 
+    if options.get("numeric-owner", False):
+        extra_args += ["--numeric-owner"]
+
     compression = options.get("compression", "auto")
 
     if compression == "auto":

--- a/stages/org.osbuild.tar.meta.json
+++ b/stages/org.osbuild.tar.meta.json
@@ -113,6 +113,10 @@
         "transform": {
           "type": "string",
           "description": "Used to transform filenames and directly passed to --transform"
+        },
+        "numeric-owner": {
+          "type": "boolean",
+          "description": "Always use numbers for user/group names"
         }
       }
     },


### PR DESCRIPTION
The numeric-owner option omits the inclusion of user and group names in the archive metadata.  This is often desirable since name and group mappings can change the ownership of files during extraction.

The test uses the tarfile module to check that the uname and gname attributes in the tar archive itself are empty, which is the intended effect of enabling numeric-owner [1].

RHEL-102854

[1] https://www.gnu.org/software/tar//manual/html_section/Attributes.html