### PR TITLE
org.osbuild.coreos.live-artifacts.mono: read os name from /usr/lib/os-release

### DIFF
--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -131,10 +131,8 @@ def make_stream_hash(src, dest):
 
 
 def get_os_name(tree):
-    file = os.path.join(tree, 'usr/share/rpm-ostree/treefile.json')
-    with open(file, encoding='utf8') as f:
-        treefile = json.load(f)
-    return treefile['metadata']['name']
+    os_release = osrelease.parse_files(os.path.join(tree, 'usr', 'lib', 'os-release'))
+    return f"{os_release['ID']}-{os_release['VARIANT_ID']}"
 
 
 def ensure_glob(pathname, n="", **kwargs):


### PR DESCRIPTION
When importing data from an already existing oci image in coreos-assembler [1] the treefile.json
file doesn't contain the `osname` field anymore.
Source a value from the `os-release` file instead. This should be a cosmetic change.

[1] https://github.com/coreos/coreos-assembler/pull/4164