### PR TITLE
stages/bootc.install-to-filesystem: add more knobs

### DIFF
--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -46,6 +46,23 @@ def main(options, inputs, paths):
         stateroot = options.get("stateroot")
         if stateroot:
             pargs.extend(["--stateroot", stateroot])
+        # Passing the flag with an empty value is intentional:
+        # it triggers a supported behaviour where mountspec
+        # kernel arguments are ommited.
+        # See https://github.com/bootc-dev/bootc/pull/1451
+        if "root-mount-spec" in options:
+            root_spec = options["root-mount-spec"]
+            if root_spec == "":
+                pargs.extend(["--root-mount-spec="])
+            else:
+                pargs.extend(["--root-mount-spec", root_spec])
+        if "boot-mount-spec" in options:
+            boot_spec = options["boot-mount-spec"]
+            if boot_spec == "":
+                pargs.extend(["--boot-mount-spec="])
+            else:
+                pargs.extend(["--boot-mount-spec", boot_spec])
+
         # add target and go
         pargs.append(dst)
         subprocess.run(pargs, env=env, check=True)

--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -43,6 +43,9 @@ def main(options, inputs, paths):
         target_imgref = options.get("target-imgref")
         if target_imgref:
             pargs.extend(["--target-imgref", target_imgref])
+        stateroot = options.get("stateroot")
+        if stateroot:
+            pargs.extend(["--stateroot", stateroot])
         # add target and go
         pargs.append(dst)
         subprocess.run(pargs, env=env, check=True)

--- a/stages/org.osbuild.bootc.install-to-filesystem.meta.json
+++ b/stages/org.osbuild.bootc.install-to-filesystem.meta.json
@@ -7,16 +7,12 @@
     "mounted in the \"mounts\" path.",
     "Buildhost commands used: bootc"
   ],
-  "capabilities": [
-    "CAP_MAC_ADMIN"
-  ],
+  "capabilities": ["CAP_MAC_ADMIN"],
   "schema_2": {
     "inputs": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "images"
-      ],
+      "required": ["images"],
       "properties": {
         "images": {
           "type": "object",
@@ -44,6 +40,10 @@
         "target-imgref": {
           "description": "Specify the image to fetch for subsequent updates",
           "type": "string"
+        },
+        "stateroot": {
+          "type": "string",
+          "description": "The stateroot name to use. If not specified, defer to bootc's default"
         }
       }
     },

--- a/stages/org.osbuild.bootc.install-to-filesystem.meta.json
+++ b/stages/org.osbuild.bootc.install-to-filesystem.meta.json
@@ -7,12 +7,16 @@
     "mounted in the \"mounts\" path.",
     "Buildhost commands used: bootc"
   ],
-  "capabilities": ["CAP_MAC_ADMIN"],
+  "capabilities": [
+    "CAP_MAC_ADMIN"
+  ],
   "schema_2": {
     "inputs": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["images"],
+      "required": [
+        "images"
+      ],
       "properties": {
         "images": {
           "type": "object",
@@ -44,6 +48,14 @@
         "stateroot": {
           "type": "string",
           "description": "The stateroot name to use. If not specified, defer to bootc's default"
+        },
+        "root-mount-spec": {
+          "type": "string",
+          "description": "Source device specification for the root filesystem. If not provided, the UUID of the target filesystem will be used."
+        },
+        "boot-mount-spec": {
+          "type": "string",
+          "description": "Mount specification for the /boot filesystem. If `/boot` is detected as a mounted partition, then its UUID will be used."
         }
       }
     },


### PR DESCRIPTION
This adds an extra option to make the stateroot name customizable.

Fixes https://github.com/osbuild/osbuild/issues/2151