### PR TITLE
Add ability to set grub2 default menu entry

### DIFF
--- a/stages/org.osbuild.grub2.iso
+++ b/stages/org.osbuild.grub2.iso
@@ -8,7 +8,7 @@ import osbuild.api
 
 # The main grub2 configuration file template. Used for UEFI.
 # NOTE: Changes to this should also be applied to the org.osbuild.grub2.iso.legacy stage
-GRUB2_EFI_CFG_TEMPLATE = """
+GRUB2_EFI_CFG_TEMPLATE = """$defaultentry
 function load_video {
   insmod efi_gop
   insmod efi_uga
@@ -58,6 +58,9 @@ menuentry 'Install ${product} ${version} in FIPS mode' --class fedora --class gn
 }
 """
 
+DEFAULT_ENTRY_TEMPLATE = """set default="${default}"
+"""
+
 
 def main(root, options):
     name = options["product"]["name"]
@@ -69,6 +72,7 @@ def main(root, options):
     kopts = options["kernel"].get("opts")
     cfg = options.get("config", {})
     timeout = cfg.get("timeout", 60)
+    default = cfg.get("default")    # None indicates not set
     fips = options.get("fips", False)
 
     efidir = os.path.join(root, "EFI", "BOOT")
@@ -101,8 +105,15 @@ def main(root, options):
         "isolabel": isolabel,
         "root": " ".join(kopts),
         "timeout": timeout,
+        "defaultentry": "",
         "fipsentry": ""
     }
+
+    # Insert default menu selection
+    if default is not None:
+        default_tmpl = string.Template(DEFAULT_ENTRY_TEMPLATE)
+        defaultentry = default_tmpl.safe_substitute({"default": default})
+        tplt_variables["defaultentry"] = defaultentry
 
     # Insert optional fips menu entry
     if fips:

--- a/stages/org.osbuild.grub2.iso.legacy
+++ b/stages/org.osbuild.grub2.iso.legacy
@@ -8,7 +8,7 @@ import osbuild.api
 
 # The main grub2 configuration file template. Used for BIOS.
 # NOTE: Changes to this should also be applied to the org.osbuild.grub2.iso stage
-GRUB2_CFG_TEMPLATE = """
+GRUB2_CFG_TEMPLATE = """$defaultentry
 function load_video {
   insmod all_video
 }
@@ -58,6 +58,9 @@ menuentry 'Install ${product} ${version} in FIPS mode' --class fedora --class gn
 }
 """
 
+DEFAULT_ENTRY_TEMPLATE = """set default="${default}"
+"""
+
 
 def main(root, options):
     name = options["product"]["name"]
@@ -67,6 +70,7 @@ def main(root, options):
     kopts = options["kernel"].get("opts")
     cfg = options.get("config", {})
     timeout = cfg.get("timeout", 60)
+    default = cfg.get("default")    # None indicates not set
     fips = options.get("fips", False)
 
     grub2dir = os.path.join(root, "boot", "grub2")
@@ -85,8 +89,15 @@ def main(root, options):
         "isolabel": isolabel,
         "root": " ".join(kopts),
         "timeout": timeout,
+        "defaultentry": "",
         "fipsentry": ""
     }
+
+    # Insert default menu selection
+    if default is not None:
+        default_tmpl = string.Template(DEFAULT_ENTRY_TEMPLATE)
+        defaultentry = default_tmpl.safe_substitute({"default": default})
+        tplt_variables["defaultentry"] = defaultentry
 
     # Insert optional fips menu entry
     if fips:

--- a/stages/org.osbuild.grub2.iso.legacy.meta.json
+++ b/stages/org.osbuild.grub2.iso.legacy.meta.json
@@ -60,6 +60,10 @@
               "type": "integer",
               "minimum": 0,
               "default": 60
+            },
+            "default": {
+              "description": "Default menu entry",
+              "type": "integer"
             }
           }
         }

--- a/stages/org.osbuild.grub2.iso.meta.json
+++ b/stages/org.osbuild.grub2.iso.meta.json
@@ -69,6 +69,10 @@
               "type": "integer",
               "minimum": 0,
               "default": 60
+            },
+            "default": {
+              "description": "Default menu entry",
+              "type": "integer"
             }
           }
         }

--- a/stages/test/test_grub2_iso.py
+++ b/stages/test/test_grub2_iso.py
@@ -58,13 +58,18 @@ menuentry 'Install Fedora 42 in FIPS mode' --class fedora --class gnu-linux --cl
 }
 """
 
+CONFIG_DEFAULT = """set default="1"
+"""
+
 
 @patch("shutil.copy2")
 @pytest.mark.parametrize("test_data,expected_conf", [
     # default
     ({}, CONFIG_PART_1 + CONFIG_PART_2),
     # fips menu enable
-    ({"fips": True}, CONFIG_PART_1 + CONFIG_FIPS + CONFIG_PART_2)
+    ({"fips": True}, CONFIG_PART_1 + CONFIG_FIPS + CONFIG_PART_2),
+    # default to menu entry 1
+    ({"config": {"default": 1}}, CONFIG_DEFAULT + CONFIG_PART_1 + CONFIG_PART_2)
 ])
 def test_grub2_iso(mocked_copy2, tmp_path, stage_module, test_data, expected_conf):
     treedir = tmp_path / "tree"
@@ -153,6 +158,22 @@ def test_grub2_iso(mocked_copy2, tmp_path, stage_module, test_data, expected_con
                 "dir": "/path/to",
             },
             "fips": True,
+        }, "",
+    ),
+    # good + default
+    (
+        {
+            "isolabel": "an-isolabel",
+            "product": {
+                "name": "a-name",
+                "version": "a-version",
+            },
+            "kernel": {
+                "dir": "/path/to",
+            },
+            "config": {
+                "default": 1,
+            }
         }, "",
     ),
 ])

--- a/stages/test/test_grub2_iso_legacy.py
+++ b/stages/test/test_grub2_iso_legacy.py
@@ -58,13 +58,18 @@ menuentry 'Install Fedora-IoT 41 in FIPS mode' --class fedora --class gnu-linux 
 }
 """
 
+CONFIG_DEFAULT = """set default="1"
+"""
+
 
 @patch("shutil.copytree")
 @pytest.mark.parametrize("test_data,expected_conf", [
     # default
     ({}, CONFIG_PART_1 + CONFIG_PART_2),
     # fips menu enable
-    ({"fips": True}, CONFIG_PART_1 + CONFIG_FIPS + CONFIG_PART_2)
+    ({"fips": True}, CONFIG_PART_1 + CONFIG_FIPS + CONFIG_PART_2),
+    # default to menu entry 1
+    ({"config": {"default": 1, "timeout": 10}}, CONFIG_DEFAULT + CONFIG_PART_1 + CONFIG_PART_2)
 ])
 def test_grub2_iso_legacy_smoke(mocked_copytree, tmp_path, stage_module, test_data, expected_conf):
     treedir = tmp_path / "tree"
@@ -149,6 +154,22 @@ def test_grub2_iso_legacy_smoke(mocked_copytree, tmp_path, stage_module, test_da
                 "dir": "/path/to",
             },
             "fips": True,
+        }, "",
+    ),
+    # good + default
+    (
+        {
+            "isolabel": "an-isolabel",
+            "product": {
+                "name": "a-name",
+                "version": "a-version",
+            },
+            "kernel": {
+                "dir": "/path/to",
+            },
+            "config": {
+                "default": 1
+            }
         }, "",
     ),
 ])


### PR DESCRIPTION
grub2 iso menus currently default to the first entry, but the official isos all default to the second, boot with test. This allows us to change that.