### PR TITLE
spec: explicitly buildrequire python-setuptools

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -21,6 +21,7 @@ Summary:        A build system for OS images
 BuildRequires:  make
 BuildRequires:  python3-devel
 BuildRequires:  python3-docutils
+BuildRequires:  python3-setuptools
 BuildRequires:  systemd
 
 Requires:       bash


### PR DESCRIPTION
Fedora is changing (some) things related to Python packaging. It seems setuptools is no longer a generated BuildRequire by default so let's explicitly add it.

The implicit installation of it was dropped in: https://src.fedoraproject.org/rpms/setools/c/17706eb7801657c220598912658cec2db91ce010?branch=rawhide

See also: #2170, the `%pyproject` migration will be done in a separate PR from this one as a follow-up but this unblocks us from building RPMs for newer Fedoras.