### PR TITLE
github: merge CODEOWNERS files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,15 +3,15 @@
 *               @osbuild/osbuild-reviewers
 
 # SBOM
-/osbuild/util/sbom/     @thozza
+/osbuild/util/sbom/     @thozza @osbuild/osbuild-reviewers
 
 # Depsolving
-/osbuild/solver/        @thozza
-/tools/solver*.json     @thozza
-/tools/**/*depsolve*    @thozza
+/osbuild/solver/        @thozza @osbuild/osbuild-reviewers
+/tools/solver*.json     @thozza @osbuild/osbuild-reviewers
+/tools/**/*depsolve*    @thozza @osbuild/osbuild-reviewers
 
 # image-info tool
-/tools/**/*osbuild*image*info*  @thozza
+/tools/**/*osbuild*image*info*  @thozza @osbuild/osbuild-reviewers
 
 # Specify code ownership for files containing 'coreos' in the filename
 *coreos* @dustymabe @jlebon @ravanelli

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,6 @@
 
 # image-info tool
 /tools/**/*osbuild*image*info*  @thozza
+
+# Specify code ownership for files containing 'coreos' in the filename
+*coreos* @dustymabe @jlebon @ravanelli

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,0 @@
-# Lines starting with '#' are comments.
-# Each line is a file pattern followed by one or more owners.
-
-# More details are here: https://help.github.com/articles/about-codeowners/
-
-
-# Specify code ownership for files containing 'coreos' in the filename
-*coreos* @dustymabe @jlebon @ravanelli
-


### PR DESCRIPTION
We somehow ended up with two CODEOWNERS files, one in the root created by the coreos team and one under .github/ for the rest.  This meant that only the one under .github/ was being used [1].

Merge the two files so all rules are active.  Prefer the file under .github/ to keep the repo root clean.

[1] https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners