### PR TITLE
osbuild-mpp: Automatically add extended partition as needed for MBR

### DIFF
--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -924,6 +924,10 @@ class PartitionTable:
         self.uuid = uuid
         self.partitions = partitions or []
 
+        # Add extended partition if needed
+        if label == "dos" and len(self.partitions) > 4 and not any(map(lambda p: p.type == "0f", self.partitions)):
+            self.partitions.insert(3, Partition(pttype="0f"))
+
     def __getitem__(self, key) -> Partition:
         if isinstance(key, int):
             return self.partitions[key]


### PR DESCRIPTION
If we're creating an MBR partition, with more than 4 partitions, and there is no extended partitions defined, then always add one.

Otherwise any partitions after the 4th will be dropped and we fail in the later:
        assert len(disk_parts) == len(self.partitions