### PR TITLE
Allow building bootc images in unprivileged containers

### DIFF
--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -39,7 +39,11 @@ class LoopServer(api.BaseAPI):
     def __init__(self, *, socket_address=None):
         super().__init__(socket_address)
         self.devs = []
-        self.ctl = loop.LoopControl()
+        self.ctl = None
+
+    def _lazy_init(self):
+        if not self.ctl:
+            self.ctl = loop.LoopControl()
 
     def _create_device(
             self,
@@ -51,6 +55,7 @@ class LoopServer(api.BaseAPI):
             partscan=False,
             read_only=False,
             sector_size=512):
+        self._lazy_init()
         lo = self.ctl.loop_for_fd(fd, lock=lock,
                                   offset=offset,
                                   sizelimit=sizelimit,
@@ -80,7 +85,8 @@ class LoopServer(api.BaseAPI):
     def _cleanup(self):
         for lo in self.devs:
             lo.close()
-        self.ctl.close()
+        if self.ctl:
+            self.ctl.close()
 
 
 class LoopClient:


### PR DESCRIPTION
In general, osbuild needs to run in a very privileged context, as it does all sorts of highly privileged operations. The most problematic is the use of loopback devices to create filesystems, etc. However, some types of images, in particular those creating bootc OCI images doesn't actually need to  use loopback devices, and we should be able to run those in containers with less privileges.

Unfortunately there are some places where osbuild unnecessarily uses highly privileged operations when that isn't necessary that makes this not currently work. However, with the changes in this MR I was able to run osbuild in a rootless podman container (i.e. with no real superuser privileges) and create a bootc container.