### PR TITLE
stages/systemd-repart: introduce systemd-repart

### DIFF
--- a/stages/org.osbuild.systemd-repart.create
+++ b/stages/org.osbuild.systemd-repart.create
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+import pathlib
+import subprocess
+import sys
+
+import osbuild.api
+
+
+def main(args, options):
+    tree = pathlib.Path(args["tree"])
+    root = args["inputs"]["root-tree"]["path"]
+
+    path = options["path"]
+    size = options["size"]
+    seed = options.get("seed", "random")
+
+    cmd = [
+        "systemd-repart",
+        "--empty", "create",
+        "--size", size,
+        "--root", root,
+        "--seed", seed,
+        str(tree / path),
+    ]
+
+    subprocess.run(cmd, check=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    _args = osbuild.api.arguments()
+    r = main(_args, _args["options"])
+    sys.exit(r)

--- a/stages/org.osbuild.systemd-repart.create.meta.json
+++ b/stages/org.osbuild.systemd-repart.create.meta.json
@@ -1,0 +1,42 @@
+{
+  "summary": "Run and/or configure systemd-repart in create mode.",
+  "description": [
+    "Use repart.d drop-in files included in a tree to create a disk image with",
+    "`systemd-repart`. The tree is also available to `CopyFiles` so `systemd-repart`",
+    "can take care of putting files into partitions."
+  ],
+  "schema_2": {
+    "options": {
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "size"
+      ],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "size": {
+          "type": "string"
+        },
+        "seed": {
+          "type": "string",
+          "default": "random"
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "root-tree"
+      ],
+      "properties": {
+        "root-tree": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/stages/test/test_systemd_repart_create.py
+++ b/stages/test/test_systemd_repart_create.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+
+import pytest
+
+from osbuild import testutil
+
+STAGE_NAME = "org.osbuild.systemd-repart.create"
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # bad
+    ({"path": "image.raw"}, "'size' is a required property"),
+    ({"size": "1G"}, "'path' is a required property"),
+    ({"path": "image.raw", "size": "1G", "seed": 1}, "1 is not of type"),
+    ({"path": 1, "size": "1G", "seed": "random"}, "1 is not of type"),
+    ({"path": "image.raw", "size": 1, "seed": "random"}, "1 is not of type"),
+    # good
+    ({"path": "image.raw", "size": "1G"}, ""),
+    ({"path": "image.raw", "size": "1G", "seed": "random"}, ""),
+])
+def test_systemd_repart_create_schema_validation(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "options": {
+        }
+    }
+    test_input["options"].update(test_data)
+    res = stage_schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)


### PR DESCRIPTION
This is a stage that allows for creating disk images with `systemd-repart`. It's set up so it reads any `repart.d` dropin files from the given root tree and creates a disk image based on that.

In the future we can iterate on this and allow for explicit passing of dropin files, and implement more arguments.

---

I've written this stage so it's expandable. In the future we can add a `repart.d` array property containing the files to use for `systemd-repart` and make the `inputs.root-tree` optional.

When using this stage in combination with `CopyFiles` in the `repart.d` files an entire `image` pipeline can be done with a single stage, though we could keep our copy stages if we also implement mounting of the `systemd-repart` created image (for example, through `systemd-dissect --mount`).

With a carefully crafted manifest and the work being done in #2187 it is possible to create disk images rootless as long as we operate within the capabilities of `systemd-repart` partition-layout wise (GPT, only supported things). This makes this also relevant to: https://github.com/osbuild/bootc-image-builder/issues/1046 and https://github.com/osbuild/bootc-image-builder/issues/98 and perhaps we can even, for simple cases, use `repart.d` files contained within bootable containers instead of the current `disk.yaml` though it's likely that `disk.yaml` can do *more* than what `repart.d` configuration can do, cc @alexlarsson.

Of course `systemd-repart` does *not* support all of the partitioning customizations and other bits/bobs we want to do from `image-builder` / `images` but we'll get there once we get to integrating this there.

I've left many options unimplemented, they should be easy to add in the future; most notably we might want to be explicit with `--offline` once we take a look at 'rootless osbuild'.