### PR TITLE
selinux: Add osbuild_container_t domain for using osbuild in a container

### DIFF
--- a/selinux/README.md
+++ b/selinux/README.md
@@ -63,3 +63,18 @@ transition rule is enabled that allows `setfiles` to transition to
     # execute setfiles in the setfiles_mac domain
     # when in the osbuild_t domain
     seutil_domtrans_setfiles_mac(osbuild_t)
+
+## Running osbuild in a container
+
+When osbuild is run in a container, it cannot use the default SELinux
+container policy. Historically this has been done i using a standard
+unconfined policy (`--security-opt label=type:unconfined_t`). However,
+the normal `unconfined_t` doamin does not have `CAP_MAC_ADMIN`
+capability, nor does it have the ability to use the normal osbuild
+policy inside the container. To allow this, there is a another custom
+OSBuild SELinux policy called `osbuild-container` which has an unconfined
+domain called `osbuild_container_t` domain that has this capability.
+
+This policy can be installed separately (from the
+`osbuild-container-selinux` package) and used with the podman option
+`--security-opt label=type:osbuild_container_t`.

--- a/selinux/osbuild-container.if
+++ b/selinux/osbuild-container.if
@@ -1,0 +1,1 @@
+## <summary>policy for running osbuild in container</summary>

--- a/selinux/osbuild-container.te
+++ b/selinux/osbuild-container.te
@@ -1,0 +1,63 @@
+policy_module(osbuild-container, 1.0.0)
+
+# The osbuild_container_t domain has enough permissions to run osbuild
+# in a container. This is meant to be used like:
+#   podman run --security-opt label=type:osbuild_container_t
+#
+# Other than the mac_admin capability (to allow setting unknown
+# selinux labels) this is better than using unconfined_t, as it
+# has less permissions. However, it is still a very permissive
+# domain, so use with caution.
+#
+# This is optional, as it depends on container-selinux
+
+optional_policy(`
+        # Declaration
+
+        gen_require(`
+            attribute container_domain;
+            role system_r;
+        ')
+
+        type osbuild_container_t, container_domain;
+        domain_type(osbuild_container_t)
+        role system_r types osbuild_container_t;
+
+        # Implementation
+
+        gen_require(`
+             class capability2 mac_admin;
+             type default_t;
+             type fixed_disk_device_t;
+             type kmsg_device_t;
+             type sysctl_irq_t;
+        ')
+
+        # Allow creating files with unknown selinux labels
+        # NOTE: This permission is not normally available to unconfined domains.
+        allow osbuild_container_t self:capability2 mac_admin;
+        # And allow relabeling default_t (i.e. unknown files)
+        allow osbuild_container_t default_t:file { relabelfrom relabelto };
+
+        # Allow loop device access
+        dev_rw_loop_control(osbuild_container_t)
+        allow osbuild_container_t fixed_disk_device_t:blk_file { getattr ioctl open read write lock };
+
+        # Create and use all kinds of files
+        files_unconfined(osbuild_container_t)
+
+        # Connect to stuff for downloading files
+        corenet_tcp_connect_all_ports(osbuild_container_t)
+
+        # osbuild logs to kmsg
+        dev_write_kmsg(osbuild_container_t)
+
+        # Allow covering /proc/irq
+        allow osbuild_container_t sysctl_irq_t:dir { mounton write };
+
+        # Bwrap needs this
+        allow osbuild_container_t self:netlink_route_socket nlmsg_write;
+
+        # ostree sets its selinux label
+        allow osbuild_container_t self:process setfscreate;
+')


### PR DESCRIPTION
osbuild is sometimes used in a privileged container. To do so you currently need to run with selinux domain unconfined_t. However, even then it doesn't work if any file label is set during the image build that is not part of the host selinux policy. To make that work, the domain requires the mac_admin capability, which unconfined_t doesn't allow. The osbuild_t type in the osbuild selinux policy allows this, but that can't be used in the container.

So, this instead adds a new osbuild_container_t type that can be used with podman run instead of unconfined_t, allowing osbuild to have the required capability. However, instead of making osbuild_container_t be unconfined, we define a tighter set of permissions that seems to make osbuild work for me.

I do sometimes see one remaining AVC:
```
AVC avc:  denied  { setsched } for  pid=1689360 comm="mount" scontext=system_u:system_r:osbuild_container_t:s0:c440,c895 tcontext=system_u:system_r:kernel_t:s0 tclass=process permissive=0
```

However, this doesn't break the build, and I prefer to not grant unnecessary permissions.