### PR TITLE
osbuild: add/use new `api.get_exception_from_msg()` helper

### DIFF
--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -142,15 +142,17 @@ class API(BaseAPI):
         super().__init__(socket_address)
         self.error = None
 
-    def _get_exception(self, message):
-        self.error = {
-            "type": "exception",
-            "data": message["exception"],
-        }
-
     def _message(self, msg, fds, sock):
-        if msg["method"] == 'exception':
-            self._get_exception(msg)
+        self.error = get_exception_from_msg(msg)
+
+
+def get_exception_from_msg(msg):
+    if msg.get("method") != 'exception':
+        return None
+    return {
+        "type": "exception",
+        "data": msg["exception"],
+    }
 
 
 def exception_on_path_and_die(e, path="/run/osbuild/api/osbuild"):

--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -128,8 +128,11 @@ class LoopClient:
         os.close(dir_fd)
         os.close(fd)
 
-        payload, _, _ = self.client.recv()
-        path = os.path.join("/dev", payload["devname"])
+        msg, _, _ = self.client.recv()
+        err = api.get_exception_from_msg(msg)
+        if err:
+            raise RuntimeError(err)
+        path = os.path.join("/dev", msg["devname"])
         try:
             yield path
         finally:


### PR DESCRIPTION
When a remote command fails in remoteloop.py we currently get a quite confusing error:
```
  File "/run/osbuild/bin/org.osbuild.rawfs", line 102, in main
    with loop_client.device(image) as loop, mount(loop, mountpoint):
  File "/usr/lib64/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/run/osbuild/lib/osbuild/remoteloop.py", line 138, in device
    path = os.path.join("/dev", payload["devname"])
                                ~~~~~~~^^^^^^^^^^^
KeyError: 'devname'
```
The reason is that there is no "devname" as this is a message of type "exception". So this code follows the pattern that objectstore is using to get errors from message now so that we get the get any remote errors and raise them.