### PR TITLE
stages: add `efi_src_dir` config to grub2.iso stage

### DIFF
--- a/stages/org.osbuild.grub2.iso
+++ b/stages/org.osbuild.grub2.iso
@@ -75,6 +75,7 @@ def main(root, options):
     default = cfg.get("default")    # None indicates not set
     fips = options.get("fips", False)
 
+    efi_src_dir = options.get("efi_src_dir", "/boot/efi/EFI/")
     efidir = os.path.join(root, "EFI", "BOOT")
     os.makedirs(efidir)
 
@@ -88,7 +89,7 @@ def main(root, options):
         ]
 
         for src, dst in targets:
-            shutil.copy2(os.path.join("/boot/efi/EFI/", vendor, src),
+            shutil.copy2(os.path.join(efi_src_dir, vendor, src),
                          os.path.join(efidir, dst))
 
     # the font

--- a/stages/org.osbuild.grub2.iso.meta.json
+++ b/stages/org.osbuild.grub2.iso.meta.json
@@ -44,6 +44,11 @@
             }
           }
         },
+        "efi_src_dir": {
+          "type": "string",
+          "description": "The source path to use for the EFI/ binaries",
+          "default": "/boot/efi/EFI/"
+        },
         "isolabel": {
           "type": "string"
         },

--- a/stages/test/test_grub2_iso.py
+++ b/stages/test/test_grub2_iso.py
@@ -62,21 +62,7 @@ CONFIG_DEFAULT = """set default="1"
 """
 
 
-@patch("shutil.copy2")
-@pytest.mark.parametrize("test_data,expected_conf", [
-    # default
-    ({}, CONFIG_PART_1 + CONFIG_PART_2),
-    # fips menu enable
-    ({"fips": True}, CONFIG_PART_1 + CONFIG_FIPS + CONFIG_PART_2),
-    # default to menu entry 1
-    ({"config": {"default": 1}}, CONFIG_DEFAULT + CONFIG_PART_1 + CONFIG_PART_2)
-])
-def test_grub2_iso(mocked_copy2, tmp_path, stage_module, test_data, expected_conf):
-    treedir = tmp_path / "tree"
-    treedir.mkdir(parents=True, exist_ok=True)
-    efidir = treedir / "EFI/BOOT"
-    confpath = efidir / "grub.cfg"
-
+def make_options(override_options):
     # from fedora-ostree-bootiso-xz.json
     options = {
         "product": {
@@ -95,9 +81,26 @@ def test_grub2_iso(mocked_copy2, tmp_path, stage_module, test_data, expected_con
         ],
         "vendor": "fedora"
     }
-    options.update(test_data)
+    options.update(override_options)
+    return options
 
-    stage_module.main(treedir, options)
+
+@patch("shutil.copy2")
+@pytest.mark.parametrize("test_data,expected_conf", [
+    # default
+    ({}, CONFIG_PART_1 + CONFIG_PART_2),
+    # fips menu enable
+    ({"fips": True}, CONFIG_PART_1 + CONFIG_FIPS + CONFIG_PART_2),
+    # default to menu entry 1
+    ({"config": {"default": 1}}, CONFIG_DEFAULT + CONFIG_PART_1 + CONFIG_PART_2)
+])
+def test_grub2_iso(mocked_copy2, tmp_path, stage_module, test_data, expected_conf):
+    treedir = tmp_path / "tree"
+    treedir.mkdir(parents=True, exist_ok=True)
+    efidir = treedir / "EFI/BOOT"
+    confpath = efidir / "grub.cfg"
+
+    stage_module.main(treedir, make_options(test_data))
 
     assert os.path.exists(confpath)
     assert confpath.read_text() == expected_conf
@@ -106,6 +109,28 @@ def test_grub2_iso(mocked_copy2, tmp_path, stage_module, test_data, expected_con
         call("/boot/efi/EFI/fedora/mmx64.efi", os.fspath(efidir / "mmx64.efi")),
         call("/boot/efi/EFI/fedora/gcdx64.efi", os.fspath(efidir / "grubx64.efi")),
         call("/usr/share/grub/unicode.pf2", os.fspath(efidir / "fonts"))
+    ]
+
+
+@patch("shutil.copy2")
+@pytest.mark.parametrize("test_data,expected_efi_path", [
+    # default
+    ({}, "/boot/efi/EFI"),
+    # uefi.efi_src_dir set
+    ({"efi_src_dir": "/usr/lib/bootupd/updates/"}, "/usr/lib/bootupd/updates"),
+])
+def test_grub2_iso_efi_src_path(mocked_copy2, tmp_path, stage_module, test_data, expected_efi_path):
+    treedir = tmp_path / "tree"
+    treedir.mkdir(parents=True, exist_ok=True)
+    efi_dst_dir = treedir / "EFI/BOOT"
+
+    stage_module.main(treedir, make_options(test_data))
+
+    assert mocked_copy2.call_args_list == [
+        call(f"{expected_efi_path}/fedora/shimx64.efi", os.fspath(efi_dst_dir / "BOOTX64.EFI")),
+        call(f"{expected_efi_path}/fedora/mmx64.efi", os.fspath(efi_dst_dir / "mmx64.efi")),
+        call(f"{expected_efi_path}/fedora/gcdx64.efi", os.fspath(efi_dst_dir / "grubx64.efi")),
+        call("/usr/share/grub/unicode.pf2", os.fspath(efi_dst_dir / "fonts"))
     ]
 
 
@@ -133,6 +158,19 @@ def test_grub2_iso(mocked_copy2, tmp_path, stage_module, test_data, expected_con
             },
         }, ["'name' is a required property", "'version' is a required property"],
     ),
+    (
+        {
+            "isolabel": "an-isolabel",
+            "product": {
+                "name": "a-name",
+                "version": "a-version",
+            },
+            "kernel": {
+                "dir": "/path/to",
+            },
+            "efi_src_dir": 111,
+        }, ["111 is not of type 'string'"],
+    ),
     # good
     (
         {
@@ -144,6 +182,7 @@ def test_grub2_iso(mocked_copy2, tmp_path, stage_module, test_data, expected_con
             "kernel": {
                 "dir": "/path/to",
             },
+            "efi_src_dir": "/path/to/efi",
         }, "",
     ),
     # good + fips


### PR DESCRIPTION
We currently hardcode the location of the efi binaries to `/boot/efi/EFI`. This makes sense in general but when working with bootc containers the location is usually different and inside `/usr/lib/bootupd/updates/EFI`. So this commit makes the location configurable in a  similar way as we already have it for the grub2 (non-iso) stage (in the grub2 stage its under `uefi` but in this stage everything is flat incuding the vendor so `efi_src_dir` is flat as well).

The rational is that we want to build ISOs from bootc base images (c.f.
https://github.com/osbuild/bootc-image-builder/pull/1053) but also do not want every bootc installer image to have a special bootupd grub iso configuration (which would also hard to maintain as it would be duplicated in every container). So instead we use this stage to generate the config and just point to a different EFI dir.

Needed for https://github.com/osbuild/bootc-image-builder/pull/1053