### PR TITLE
stages: tweak grub2.iso option to support `efi_src_dirs` (plural)

### DIFF
--- a/stages/org.osbuild.grub2.iso
+++ b/stages/org.osbuild.grub2.iso
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import contextlib
 import os
 import shutil
 import string
@@ -75,7 +76,7 @@ def main(root, options):
     default = cfg.get("default")    # None indicates not set
     fips = options.get("fips", False)
 
-    efi_src_dir = options.get("efi_src_dir", "/boot/efi/EFI/")
+    efi_src_dirs = options.get("efi_src_dirs", ["/boot/efi/EFI/"])
     efidir = os.path.join(root, "EFI", "BOOT")
     os.makedirs(efidir)
 
@@ -89,8 +90,13 @@ def main(root, options):
         ]
 
         for src, dst in targets:
-            shutil.copy2(os.path.join(efi_src_dir, vendor, src),
-                         os.path.join(efidir, dst))
+            for src_dir in efi_src_dirs:
+                with contextlib.suppress(FileNotFoundError):
+                    shutil.copy2(os.path.join(src_dir, vendor, src),
+                                 os.path.join(efidir, dst))
+                    break
+            else:
+                raise ValueError(f"cannot find {os.path.join(vendor, src)} in any of {efi_src_dirs}")
 
     # the font
     fontdir = os.path.join(efidir, "fonts")

--- a/stages/org.osbuild.grub2.iso.meta.json
+++ b/stages/org.osbuild.grub2.iso.meta.json
@@ -44,10 +44,15 @@
             }
           }
         },
-        "efi_src_dir": {
-          "type": "string",
-          "description": "The source path to use for the EFI/ binaries",
-          "default": "/boot/efi/EFI/"
+        "efi_src_dirs": {
+          "type": "array",
+          "description": "The source dirs to look for the EFI/ binaries",
+          "items": {
+            "type": "string"
+          },
+            "default": [
+                "/boot/efi/EFI/"
+            ]
         },
         "isolabel": {
           "type": "string"


### PR DESCRIPTION
[draft because it becomes ugly and we can try to fix it at the rpm level https://src.fedoraproject.org/rpms/shim/blob/rawhide/f/shim.spec#_111]

Sadly the support for a single custom `efi_src_dir` [0] to look for EFI binaries is not enough for the anaconda-bootc work:

The default shim on a bootc system is diverted from `/boot/efi/EFI/` to `/usr/lib/bootupd/updates/EFI/`.

We also need to install "grub2-iso-x64-cdboot" for a booting iso from the base bootc container. This will be put under the regular `/boot/efi/EFI/<vendor>/gcdx64.efi` location.

So the `org.osbuild.grub2.iso` stage will need to be able to lookup the required binaries in both places. Hence this commit tweaks the option to allow an array of paths for the `efi_src_dirs` so that this can be supported.

The images library will then set this to:
```go
bootTreePipeline.EfiSrcDirs = []string{
  "/boot/efi/EFI/",
  "/usr/lib/bootupd/updates/EFI/",
}
```

Note that this could have also been solved with something like `efi_fallback_dir` or even hardcoding the fallback here but an array feels more extensible (even though I don't foresee even more locations). So maybe? YAGNI, I'm open for ideas and we could also just hardcode the fallback here and drop the `efi_src_dir` option entirely.

This is needed for
https://github.com/osbuild/bootc-image-builder/pull/1059

[0] https://github.com/osbuild/osbuild/pull/2202