### PR TITLE
Revert "stages: add `efi_src_dir` config to grub2.iso stage"

### DIFF
--- a/stages/org.osbuild.grub2.iso
+++ b/stages/org.osbuild.grub2.iso
@@ -75,7 +75,6 @@ def main(root, options):
     default = cfg.get("default")    # None indicates not set
     fips = options.get("fips", False)
 
-    efi_src_dir = options.get("efi_src_dir", "/boot/efi/EFI/")
     efidir = os.path.join(root, "EFI", "BOOT")
     os.makedirs(efidir)
 
@@ -89,7 +88,7 @@ def main(root, options):
         ]
 
         for src, dst in targets:
-            shutil.copy2(os.path.join(efi_src_dir, vendor, src),
+            shutil.copy2(os.path.join("/boot/efi/EFI/", vendor, src),
                          os.path.join(efidir, dst))
 
     # the font

--- a/stages/org.osbuild.grub2.iso.meta.json
+++ b/stages/org.osbuild.grub2.iso.meta.json
@@ -44,11 +44,6 @@
             }
           }
         },
-        "efi_src_dir": {
-          "type": "string",
-          "description": "The source path to use for the EFI/ binaries",
-          "default": "/boot/efi/EFI/"
-        },
         "isolabel": {
           "type": "string"
         },


### PR DESCRIPTION
This reverts commit 135d4931d31c75a8db3ec97d16889ccc5c96d8c0.

See https://github.com/osbuild/osbuild/pull/2204 for the rational - just `efi_src_dir` is not enough so lets revert it before it gets released.