### PR TITLE
spec: Running lorax scripts requires mako

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Additionally, the built-in stages require:
  * `util-linux >= 235`
  * `skopeo`
  * `python3-librepo`
+ * `python3-mako`
 
 At build-time, the following software is required:
 

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -39,6 +39,7 @@ Requires:       util-linux
 Requires:       python3-%{pypi_name} = %{version}-%{release}
 Requires:       (%{name}-selinux if selinux-policy-%{selinuxtype})
 Requires:       python3-librepo
+Requires:       python3-mako
 
 # This is required for `osbuild`, for RHEL-10 and above
 # the stdlib tomllib module can be used instead


### PR DESCRIPTION
Usually the mako package gets pulled in by other things, but not always, and since it is used directly it really ought to be a direct dependency.
