### PR TITLE
org.osbuild.systemd.unit.create: add ExecStartPost option

### DIFF
--- a/stages/org.osbuild.systemd.unit.create.meta.json
+++ b/stages/org.osbuild.systemd.unit.create.meta.json
@@ -24,6 +24,7 @@
     "    - 'Type' - string",
     "    - 'RemainAfterExit' - bool",
     "    - 'ExecStartPre' - [string]",
+    "    - 'ExecStartPost' - [string]",
     "    - 'ExecStopPost' - [string]",
     "    - 'ExecStart' - [string]",
     "    - 'Environment' - [object]",
@@ -261,6 +262,12 @@
                 "type": "boolean"
               },
               "ExecStartPre": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "ExecStartPost": {
                 "type": "array",
                 "items": {
                   "type": "string"


### PR DESCRIPTION
The very same semantics as ExecStartPre, but executed after the service has been started, or failed. This is useful for oneshot services that need to perform some action after the main process has finished.

---

I need this for firstboot.