### PR TITLE
monitor: collect metadata alongside the result of a stage

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -377,7 +377,8 @@ class Pipeline:
                           debug_break,
                           stage_timeout)
 
-            monitor.result(r)
+            md = tree.meta.get(r.id)
+            monitor.result(r, md)
 
             results["stages"].append(r)
             if not r.success:

--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -11,6 +11,7 @@ import threading
 import time
 import unittest
 from collections import defaultdict
+from typing import Dict, Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -47,7 +48,7 @@ class TapeMonitor(osbuild.monitor.BaseMonitor):
         self.counter["stages"] += 1
         self.stages.add(stage.id)
 
-    def result(self, result: osbuild.pipeline.BuildResult):
+    def result(self, result: osbuild.pipeline.BuildResult, metadata: Optional[Dict] = None):
         self.counter["result"] += 1
         self.results.add(result.id)
 
@@ -238,7 +239,7 @@ def test_json_progress_monitor():
         mon.log("pipeline 1 message 2")
         mon.log("pipeline 1 finished", origin="org.osbuild")
         mon.result(osbuild.pipeline.BuildResult(
-            fake_noop_stage, returncode=0, output="some output", error=None))
+            fake_noop_stage, returncode=0, output="some output", error=None), metadata={"meta": "data"})
         mon.finish({"success": True, "name": "test-pipeline-first"})
         mon.begin(manifest.pipelines["test-pipeline-second"])
         mon.log("pipeline 2 starting", origin="org.osbuild")
@@ -304,6 +305,7 @@ def test_json_progress_monitor():
             "output": "some output",
             "success": True,
         }
+        assert logitem["metadata"] == {"meta": "data"}
         assert logitem["duration"] > 0
         i += 1
 


### PR DESCRIPTION
Some stages generate metadata which contains information that can only be generated when a stage is running. The v2 result contains this metadata which was lost when using the JSONSeqMonitor. By passing stage metadata along to the monitor's result function, the JSONSeqMonitor can print it alongside the result.