### PR TITLE
schutzbot/mockbuild: use the global AWS credentials

### DIFF
--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -185,7 +185,5 @@ createrepo_c "${REPO_DIR}"
 # Upload repository to S3.
 greenprint "☁ Uploading RPMs to S3"
 pushd repo
-    AWS_ACCESS_KEY_ID="$V2_AWS_ACCESS_KEY_ID" \
-    AWS_SECRET_ACCESS_KEY="$V2_AWS_SECRET_ACCESS_KEY" \
     s3cmd --acl-public put --recursive . s3://${REPO_BUCKET}/
 popd


### PR DESCRIPTION
We already inject AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY variables into our CI environment because the image tests need them in order to download cached images from S3.

These credentials seem to have sufficient privileges for what we need in mockbuild, so let's just reuse it instead of using an extra one.