### PR TITLE
stages/dracut: `remove`

### DIFF
--- a/stages/org.osbuild.dracut
+++ b/stages/org.osbuild.dracut
@@ -43,6 +43,7 @@ def main(tree, options):
     force_drivers = options.get("force_drivers", [])
     filesystems = options.get("filesystems", [])
     include = options.get("include", [])
+    remove = options.get("remove", [])
     install = options.get("install", [])
     early_microcode = options.get("early_microcode", False)
     reproducible = options.get("reproducible", True)
@@ -88,6 +89,10 @@ def main(tree, options):
         for l in include:
             for k, v in l.items():
                 opts += ["--include", k, v]
+
+    if remove:
+        for remove_path in remove:
+            opts += ["--remove", remove_path]
 
     if install:
         for i in install:

--- a/stages/org.osbuild.dracut.meta.json
+++ b/stages/org.osbuild.dracut.meta.json
@@ -104,6 +104,13 @@
           "type": "string"
         }
       },
+      "remove": {
+        "description": "Remove a list of files and/or directories from initramfs (dracut 108).",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
       "early_microcode": {
         "description": "Combine early microcode with the initramfs.",
         "type": "boolean",


### PR DESCRIPTION
Dracut 108 offers a new `--remove` argument [1]. This allows to remove files from the initramfs.

[1]: https://github.com/dracut-ng/dracut-ng/commit/f8dfe3ee5b958262c38a821b15443893e400dba0