### PR TITLE
stages/dracut.conf: `remove_items`

### DIFF
--- a/stages/org.osbuild.dracut.conf
+++ b/stages/org.osbuild.dracut.conf
@@ -48,6 +48,7 @@ def main(tree, options):
         "force_drivers": list_option_writer,
         "filesystems": list_option_writer,
         "install_items": list_option_writer,
+        "remove_items": list_option_writer,
         # bool options
         "early_microcode": bool_option_writer,
         "reproducible": bool_option_writer

--- a/stages/org.osbuild.dracut.conf.meta.json
+++ b/stages/org.osbuild.dracut.conf.meta.json
@@ -18,6 +18,7 @@
     "  - force_drivers",
     "  - filesystems",
     "  - install_items",
+    "  - remove_items",
     "  - early_microcode",
     "  - reproducible"
   ],
@@ -113,6 +114,14 @@
             "items": {
               "type": "string",
               "description": "Specify additional files to include in the initramfs."
+            }
+          },
+          "remove_items": {
+            "description": "Remove the specified files (dracut 108).",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Specify files to remove from the initramfs."
             }
           },
           "early_microcode": {


### PR DESCRIPTION
Dracut 108 has a new configuration option called `remove_items` [1]. This allows us to exclude paths from being present in the initramfs generated by dracut.

[1]: https://github.com/dracut-ng/dracut-ng/commit/f8dfe3ee5b958262c38a821b15443893e400dba0