### PR TITLE
Add rhivos runner

### DIFF
--- a/runners/org.osbuild.rhivos
+++ b/runners/org.osbuild.rhivos
@@ -1,0 +1,1 @@
+org.osbuild.rhel82


### PR DESCRIPTION
Adds org.osbuild.rhivos runner as a link to latest org.osbuild.rhelXY
runner to allow running osbuild on RHIVOS.

Fixes: https://github.com/osbuild/osbuild/issues/2211
Signed-off-by: Martin Perina <mperina@redhat.com>
