### PR TITLE
mockbuild: revert old workarounds and fix RHEL 10 builds

### DIFF
--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -123,7 +123,7 @@ greenprint "📦 Upgrading openssl-libs"
 sudo dnf upgrade -y openssl-libs
 # Install requirements for building RPMs in mock.
 greenprint "📦 Installing mock requirements"
-dnf_install_with_retry createrepo_c make mock python3-pip rpm-build s3cmd
+dnf_install_with_retry createrepo_c make mock mock-core-configs python3-pip rpm-build s3cmd
 
 # Print some data.
 greenprint "🧬 Using mock config: ${MOCK_CONFIG}"


### PR DESCRIPTION
RHEL 10.0 RPM builds started failing with:
```
rpmbuild: symbol lookup error: /lib64/librpm_sequoia.so.1: undefined symbol: EVP_PKEY_verify_message_init, version OPENSSL_3.4.0
```

This happens because of a version mismatch between openssl-libs and the version that other packages are built against.  To fix this, I added a `dnf upgrade openssl-libs` call before the call to install `mock` and other required packages.

This PR also reverts some old workarounds we had in the mockbuild script relating to bugs and missing el10 mock templates.

---

NOTE: There's currently an issue with the image refresh pipeline and we can't create updated RHEL 10.0 images, which would also solve the openssl issue.  The problem is that the refresh bot consults the RHEL product pages to add RHEL nightly versions to the build matrix and the authentication for those pages has changed.