### PR TITLE
org.osbuild.kickstart: add bootc support (HMS-9732)

### DIFF
--- a/stages/org.osbuild.kickstart
+++ b/stages/org.osbuild.kickstart
@@ -189,7 +189,7 @@ def make_post(post_list):
     return res
 
 
-def main(tree, options):  # pylint: disable=too-many-branches
+def main(tree, options):  # pylint: disable=too-many-branches,too-many-statements
     path = options["path"].lstrip("/")
     ostree = options.get("ostree")
 
@@ -220,6 +220,15 @@ def main(tree, options):  # pylint: disable=too-many-branches
             if value:
                 cmd += f" --{name}={value}"
 
+        config += [cmd]
+
+    bootc = options.get("bootc")
+    if bootc:
+        source_imgref = bootc["source-imgref"]
+        cmd = f"bootc --source-imgref {source_imgref}"
+        target_imgref = bootc.get("target-imgref")
+        if target_imgref:
+            cmd += f" --target-imgref {target_imgref}"
         config += [cmd]
 
     liveimg = options.get("liveimg")

--- a/stages/org.osbuild.kickstart.meta.json
+++ b/stages/org.osbuild.kickstart.meta.json
@@ -117,6 +117,11 @@
               "required": [
                 "ostreecontainer"
               ]
+            },
+            {
+              "required": [
+                "bootc"
+              ]
             }
           ]
         }
@@ -130,6 +135,12 @@
       {
         "required": [
           "ostreecontainer",
+          "path"
+        ]
+      },
+      {
+        "required": [
+          "bootc",
           "path"
         ]
       }
@@ -197,6 +208,23 @@
             "type": "boolean",
             "default": true,
             "description": "This field is deprecated and does nothing."
+          }
+        }
+      },
+      "bootc": {
+        "type": "object",
+        "required": [
+          "source-imgref"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "source-imgref": {
+            "type": "string",
+            "description": "Install the system from an explicitly given source. See containers-transport(5) for the list of supported transports."
+          },
+          "target-imgref": {
+            "type": "string",
+            "description": "Specify the image to fetch for subsequent updates. If not presented defaults to 'source-imgref' value. See containers-transport(5) for the list of supported transports."
           }
         }
       },

--- a/stages/test/test_kickstart.py
+++ b/stages/test/test_kickstart.py
@@ -242,6 +242,12 @@ TEST_INPUT = [
      "ostreecontainer --url=/run/install/repo/container --transport=dir",),
     ({"bootloader": {"append": "karg1 karg2=0"}}, "bootloader --append='karg1 karg2=0'"),
 
+    # bootc
+    ({"bootc": {"source-imgref": "docker://quay.io/fedora/fedora-bootc:latest"}},
+     "bootc --source-imgref docker://quay.io/fedora/fedora-bootc:latest"),
+    ({"bootc": {"source-imgref": "oci:/run/install/repo/container", "target-imgref": "docker://quay.io/fedora/fedora-bootc:latest"}},
+     "bootc --source-imgref oci:/run/install/repo/container --target-imgref docker://quay.io/fedora/fedora-bootc:latest"),
+
     # %post
     ({"%post": [{"commands": ["mkdir /scratch"]}]}, "%post\nmkdir /scratch\n%end"),
     (
@@ -417,6 +423,34 @@ def test_kickstart_valid(tmp_path, stage_module, test_input, expected):  # pylin
             },
             "is valid under each of",
         ),
+        # not both bootc and ostree
+        (
+            {
+                "bootc": {
+                    "source-imgref": "docker://quay.io/fedora/fedora-bootc:latest",
+                },
+                "ostree": {
+                    "osname": "some-osname",
+                    "url": "http://some-ostree-url.com/foo",
+                    "ref": "some-ref",
+                },
+            },
+            "is valid under each of",
+        ),
+        # not both bootc and ostreecontainer
+        (
+            {
+                "bootc": {
+                    "source-imgref": "docker://quay.io/fedora/fedora-bootc:latest",
+                },
+                "ostreecontainer": {
+                    "url": "http://some-ostree-url.com/foo",
+                },
+            },
+            "is valid under each of",
+        ),
+        # bootc requires source-imgref
+        ({"bootc": {}}, "'source-imgref' is a required property"),
         ({"rootpw": {}}, "is not valid under any of the given schemas"),
         ({"rootpw": {"lock": True, "allow_ssh": True}}, "is not valid under any of the given schemas"),
         ({"rootpw": {"plaintext": True}}, "is not valid under any of the given schemas"),


### PR DESCRIPTION
pykickstart now has a native support for installing bootc containers, so let's add it into our stage. --stateroot is currently not implemented as we have no usecase for it.

See https://github.com/pykickstart/pykickstart/pull/536

/jira-epic HMS-9266

JIRA: [HMS-9732](https://issues.redhat.com/browse/HMS-9732)