### PR TITLE
monitor: add module options to JSON logger

### DIFF
--- a/test/mod/test_monitor.py
+++ b/test/mod/test_monitor.py
@@ -221,7 +221,8 @@ def test_json_progress_monitor():
 
     manifest = osbuild.Manifest()
     pl1 = manifest.add_pipeline("test-pipeline-first", "", "")
-    first_stage = pl1.add_stage(info, {})
+    first_stage_options = {"foo": "bar"}
+    first_stage = pl1.add_stage(info, first_stage_options)
     pl1.add_stage(info, {})
 
     pl2 = manifest.add_pipeline("test-pipeline-second", "", "")
@@ -299,6 +300,7 @@ def test_json_progress_monitor():
         logitem = json.loads(log[i])
         assert logitem["message"] == "Finished module org.osbuild.noop"
         assert logitem["context"]["id"] == id_start_module
+        assert logitem["options"] == first_stage_options
         assert logitem["result"] == {
             "id": fake_noop_stage.id,
             "name": "org.osbuild.noop",


### PR DESCRIPTION
In order to match the information available in the LogMonitor and be able to print the module options for debugging, add them to the JSON logger so that can be printed in the client if needed.