### PR TITLE
ci: remove testing on Fedora 41 (EOL)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,8 +35,6 @@ RPM:
   parallel:
     matrix:
       - RUNNER:
-          - aws/fedora-41-x86_64
-          - aws/fedora-41-aarch64
           - aws/fedora-42-x86_64
           - aws/fedora-42-aarch64
           - aws/fedora-43-x86_64
@@ -67,7 +65,7 @@ OSTree Images:
     - schutzbot/deploy.sh
     - sudo test/cases/ostree-images --manifest "$MANIFEST" --export $EXPORT
   variables:
-    RUNNER: aws/fedora-41-x86_64
+    RUNNER: aws/fedora-42-x86_64
   parallel:
     matrix:
       - MANIFEST: fedora-ostree-tarball.json
@@ -133,8 +131,8 @@ Manifests:
   parallel:
     matrix:
       - RUNNER:
-          - aws/fedora-41-x86_64
-          - aws/fedora-41-aarch64
+          - aws/fedora-42-x86_64
+          - aws/fedora-42-aarch64
           - aws/centos-stream-9-x86_64
           - aws/centos-stream-9-aarch64
           - aws/centos-stream-10-x86_64


### PR DESCRIPTION
Drop Fedora 41 RPM builds (EOL is in 2 days from this writing).

For tests that were only running on F41, change the runners to run on F42.