### PR TITLE
sources: add quoting to librepos "path" component

### DIFF
--- a/sources/org.osbuild.librepo
+++ b/sources/org.osbuild.librepo
@@ -13,6 +13,7 @@ It can download files that require secrets. The support secret providers are:
 
 import os
 import sys
+import urllib.parse
 from typing import Dict
 
 import librepo
@@ -205,7 +206,7 @@ class LibRepoSource(sources.SourceService):
         """
         chksum_type, checksum = checksum.split(":")
         return librepo.PackageTarget(
-            path,
+            urllib.parse.quote(path),
             handle=handle,
             checksum_type=self.CHKSUM_TYPE[chksum_type],
             checksum=checksum,


### PR DESCRIPTION
We ran into a strange download error with librepo when downloading filenames with ^ in them - but only when downloading from rpmrepo.osbuild.org.

After some debugging with Achilleas and Brian we figured it is a missing escape in the librepo code (we use this escape in libcurl already).