### PR TITLE
github: free disk space before running unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,13 @@ jobs:
     steps:
     - name: "Clone Repository"
       uses: actions/checkout@v4
+
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        tool-cache: true
+        # The following line runs apt remove which is slow
+        large-packages: false
     - name: "Run"
       uses: osbuild/containers/src/actions/privdocker@552e30cf1b4ed19c6ddaa57f96c342b3dff4227b
       with:


### PR DESCRIPTION
GitHub runners have 72GiB allocated for / but only 16 GiB available because of all stacks and SDKs shipped in the image. Let's use the jlumbroso/free-disk-space to get rid of most of them since we use our own container image anyway.