### PR TITLE
runner: add new `minimal_passwd()` helper and use in linux

### DIFF
--- a/osbuild/util/runners.py
+++ b/osbuild/util/runners.py
@@ -105,3 +105,10 @@ def quirks():
         env["OSBUILD_QEMU_IMG_COROUTINES"] = "1"
 
     return env
+
+
+def minimal_passwd():
+    # ensure minimal /etc/passwd, "podman mount" needs that
+    passwd_path = pathlib.Path("/etc/passwd")
+    if not passwd_path.exists():
+        passwd_path.write_text("root:x:0:0:root:/root:/bin/bash")

--- a/runners/org.osbuild.linux
+++ b/runners/org.osbuild.linux
@@ -3,6 +3,13 @@
 import subprocess
 import sys
 
+from osbuild import api
+from osbuild.util import runners
+
 if __name__ == "__main__":
-    r = subprocess.run(sys.argv[1:], check=False)
-    sys.exit(r.returncode)
+    with api.exception_handler():
+        runners.minimal_passwd()
+
+        r = subprocess.run(sys.argv[1:], check=False)
+
+        sys.exit(r.returncode)


### PR DESCRIPTION
This commit adds a new runner helper to create a minimal /etc/passwd so that `podman mount` works. It requires either a passwd entry for uid=0 or a HOME environment set.

Thanks to Ondrej for reporting/debugging this!