### PR TITLE
stages/kickstart: support containers-storage transport

### DIFF
--- a/stages/org.osbuild.kickstart.meta.json
+++ b/stages/org.osbuild.kickstart.meta.json
@@ -197,7 +197,8 @@
               "registry",
               "oci",
               "oci-archive",
-              "dir"
+              "dir",
+              "containers-storage"
             ],
             "description": "Use the given transport, Anaconda's default is 'registry'"
           },


### PR DESCRIPTION
While not documented in the Kickstart docs, the transport value is passed directly to the rpm-ostree command, which also supports containers-storage.