### PR TITLE
ostree.grub2: ostree requires leading /

### DIFF
--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -241,14 +241,14 @@ def parse_input_commits(commits):
 def default_boot_path(root: PathLike) -> str:
     """Find the default ostree boot path and return it
 
-    eg. ostree/boot.1/default/b6cdf47cafd171e003c001802f1829ad39e20f7177d6e27401aba73efb71be22/0
+    eg. /ostree/boot.1/default/b6cdf47cafd171e003c001802f1829ad39e20f7177d6e27401aba73efb71be22/0
     """
     filenames = glob.glob(os.path.join(root, 'ostree/boot.?/*/*/*'))
     if len(filenames) < 1:
         raise ValueError("Could not find boot path")
     if len(filenames) > 1:
         raise ValueError(f"More than one boot path found: {filenames}")
-    return os.path.relpath(filenames[0], root)
+    return "/" + os.path.relpath(filenames[0], root)
 
 
 def parse_deployment_option(root: PathLike, deployment: Dict) -> Tuple[str, str, str]:

--- a/stages/test/test_ostree_grub2.py
+++ b/stages/test/test_ostree_grub2.py
@@ -30,4 +30,4 @@ def test_ostree_grub2_boot(tmp_path, stage_module):
 
     confpath = tmp_path / "grub.cfg"
     assert os.path.exists(confpath)
-    assert confpath.read_text() == "linux /vmlinux ostree=ostree/boot.1/default/b6cdf47cafd171e003c001802f1829ad39e20f7177d6e27401aba73efb71be22/0"
+    assert confpath.read_text() == "linux /vmlinux ostree=/ostree/boot.1/default/b6cdf47cafd171e003c001802f1829ad39e20f7177d6e27401aba73efb71be22/0"

--- a/test/mod/test_util_ostree.py
+++ b/test/mod/test_util_ostree.py
@@ -250,7 +250,7 @@ def test_parse_deployment_happy(tmp_path):
 
 
 def test_boot_path_happy(tmp_path):
-    test_path = "ostree/boot.1/default/b6cdf47cafd171e003c001802f1829ad39e20f7177d6e27401aba73efb71be22/0"
+    test_path = "/ostree/boot.1/default/b6cdf47cafd171e003c001802f1829ad39e20f7177d6e27401aba73efb71be22/0"
     make_fake_tree(tmp_path, {test_path: ""})
     assert ostree.default_boot_path(tmp_path) == test_path
 


### PR DESCRIPTION
ostree requires the leading /, if it is missing it will still boot but its internal regex to match the ostree target will fail and it will not generate the var.mount unit needed to setup /var. A side effect of this is a missing /var/home/user directory.

Related: HMS-9662
Related: HMS-8933