### PR TITLE
stages: search for files two levels below` EFI/`

### DIFF
--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -152,7 +152,10 @@ def ensure_glob(pathname, n="", **kwargs):
 #
 # [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
 def find_efi_source_paths(tree):
-    if glob.glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI')):
+    # The pattern searches for files or directories two levels below EFI/,
+    # on ppc64le, there is only one existing empty directory would make
+    # ensure_glob failed.
+    if glob.glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI/*/*')):
         # BootLoaderUpdatesPhase1 has been implemented and we should
         # be able to pick up files from usr/lib/efi/(grub|shim)/<version>/EFI/
         # Let's ensure there's only 2 dirs that match (i.e. one for grub


### PR DESCRIPTION
On ppc64le, there is only one existing empty directory
`/usr/lib/efi/grub2/1\:2.12-47.fc44/EFI/fedora/` would make
`ensure_glob()` failed. Update the pattern to search for files or
directories two levels below `EFI/`.

See error logs
`ValueError: Matches for /run/osbuild/inputs/deployed-tree/usr/lib/efi/*/*/EFI does not match expected (2)`