### PR TITLE
osbuild/util/rhsm: make Subscriptions.get_secrets() take list of URLs (HMS-9062)

### DIFF
--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -286,7 +286,7 @@ class CurlSource(sources.SourceService):
             # rhsm secrets only need to be retrieved once and can then be reused
             if self.subscriptions is None:
                 self.subscriptions = Subscriptions.from_host_system()
-            desc["secrets"] = self.subscriptions.get_secrets(desc.get("url"))
+            desc["secrets"] = self.subscriptions.get_secrets([desc.get("url")])
         elif desc.get("secrets", {}).get("name") == "org.osbuild.mtls":
             key = os.getenv("OSBUILD_SOURCES_CURL_SSL_CLIENT_KEY")
             cert = os.getenv("OSBUILD_SOURCES_CURL_SSL_CLIENT_CERT")

--- a/sources/org.osbuild.librepo
+++ b/sources/org.osbuild.librepo
@@ -148,7 +148,7 @@ class LibRepoSource(sources.SourceService):
         if self.subscriptions is None:
             self.subscriptions = Subscriptions.from_host_system()
 
-        secrets = self.subscriptions.get_secrets(mirror["url"])
+        secrets = self.subscriptions.get_secrets([mirror["url"]])
         if secrets:
             if secrets.get('ssl_ca_cert'):
                 handle.sslcacert = secrets.get('ssl_ca_cert')

--- a/sources/test/test_curl_source.py
+++ b/sources/test/test_curl_source.py
@@ -81,7 +81,7 @@ def test_curl_source_amend_secrets_subscription_mgr(sources_service):
     sources_service.subscriptions = FakeSubscriptionManager()
     checksum = "sha256:1234567890123456789012345678901234567890909b14ffb032aa20fa23d9ad6"
     checksum, desc = sources_service.amend_secrets(checksum, desc)
-    assert desc["secrets"] == "secret-for-http://localhost:80/a"
+    assert desc["secrets"] == "secret-for-['http://localhost:80/a']"
 
 
 @pytest.fixture(name="curl_parallel")

--- a/sources/test/test_librepo.py
+++ b/sources/test/test_librepo.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+
+from typing import List
 from unittest.mock import patch
 
 try:
@@ -61,8 +63,8 @@ class FakeSubscriptionManager:
     def __init__(self):
         self.get_secrets_calls = []
 
-    def get_secrets(self, url):
-        self.get_secrets_calls.append(url)
+    def get_secrets(self, urls: List[str]):
+        self.get_secrets_calls.append(urls)
         return {
             "ssl_ca_cert": "rhsm-ca-cert",
             "ssl_client_cert": "rhsm-client-cert",
@@ -100,7 +102,7 @@ def test_librepo_secrets_rhsm(mocked_download_pkgs, sources_service):
     assert download_pkgs[0].handle.sslclientcert == "rhsm-client-cert"
     assert download_pkgs[0].handle.sslcacert == "rhsm-ca-cert"
     # double check that get_secrets() was called
-    assert sources_service.subscriptions.get_secrets_calls == ["http://example.com/mirrorlist"]
+    assert sources_service.subscriptions.get_secrets_calls == [["http://example.com/mirrorlist"]]
 
 
 @patch("librepo.download_packages")

--- a/test/mod/test_util_rhsm.py
+++ b/test/mod/test_util_rhsm.py
@@ -173,9 +173,9 @@ class TestSubscribedSystem:
         subscriptions = Subscriptions.parse_repo_file(StringIO(REPO_FILE))
         if not should_succeed:
             with pytest.raises(RuntimeError, match="no RHSM secret associated"):
-                subscriptions.get_secrets(url)
+                subscriptions.get_secrets([url])
         else:
-            secrets = subscriptions.get_secrets(url)
+            secrets = subscriptions.get_secrets([url])
             assert secrets["ssl_ca_cert"] == "/etc/rhsm/ca/redhat-uep.pem"
             assert secrets["ssl_client_key"] == f"/etc/pki/entitlement/{key}-key.pem"
             assert secrets["ssl_client_cert"] == f"/etc/pki/entitlement/{key}.pem"
@@ -188,7 +188,7 @@ class TestUnsubscribedSystem:
     def test_no_repositories_no_secrets(self, repositories):
         subscriptions = Subscriptions(repositories=repositories)
         with pytest.raises(RuntimeError, match="no RHSM secret associated"):
-            subscriptions.get_secrets("https://cdn.redhat.com/any/url")
+            subscriptions.get_secrets(["https://cdn.redhat.com/any/url"])
 
 
 class TestRhcSubscribedSystem:
@@ -202,7 +202,7 @@ class TestRhcSubscribedSystem:
         assert subscriptions.repositories["rhel-baseos"]["sslcacert"] == Subscriptions.DEFAULT_SSL_CA_CERT
 
         # verify that the secrets are retrieved correctly
-        secrets = subscriptions.get_secrets("https://cdn.redhat.com/9/baseos/x86_64/os/Packages/test.rpm")
+        secrets = subscriptions.get_secrets(["https://cdn.redhat.com/9/baseos/x86_64/os/Packages/test.rpm"])
         assert secrets["ssl_ca_cert"] == Subscriptions.DEFAULT_SSL_CA_CERT
         assert secrets["ssl_client_key"] == "/etc/pki/entitlement/123-key.pem"
         assert secrets["ssl_client_cert"] == "/etc/pki/entitlement/123.pem"
@@ -304,7 +304,7 @@ class TestIntegration:
 
         # Test URL matching and secret retrieval
         url = "https://cdn.redhat.com/1.0/x86_64/os/Packages/test.rpm"
-        secrets = subscriptions.get_secrets(url)
+        secrets = subscriptions.get_secrets([url])
 
         assert "ssl_ca_cert" in secrets
         assert "ssl_client_key" in secrets
@@ -330,7 +330,7 @@ sslclientcert = /etc/pki/entitlement/999.pem
 
         # URL doesn't match unrelated repo, should use fallback
         url = "https://cdn.redhat.com/some/path/test.rpm"
-        secrets = subscriptions.get_secrets(url)
+        secrets = subscriptions.get_secrets([url])
 
         assert secrets["ssl_ca_cert"] == "/fallback/ca.pem"
         assert secrets["ssl_client_key"] == "/fallback/key.pem"

--- a/tools/osbuild-mpp
+++ b/tools/osbuild-mpp
@@ -748,7 +748,7 @@ class DepSolver:
             # rhsm secrets only need to be retrieved once and can then be reused
             if not self.subscriptions:
                 self.subscriptions = Subscriptions.from_host_system()
-            secrets = self.subscriptions.get_secrets(url)
+            secrets = self.subscriptions.get_secrets([url])
         except RuntimeError as e:
             raise ValueError(f"Error getting secrets: {e.args[0]}") from None
 


### PR DESCRIPTION
Given the way get_secrets() is implemented, it is hard to call it multiple times for each baseurl or subsequently for metalink or mirrorlist. Specifically, because if the passed URL does not match any redhat.repo URLs, the function falls back to default secrets or raises a RuntimeError if these are not found. Therefore it is hard to tell for the caller if there was an URL match, or if the returned secrets are the fall-back secrets.

Modify the get_secrets() method to accept list of URLs. It iterates over them and returns secrets for the first matching URL. In case of no match, the old behavior is preserved.

The reason for this change is so that V2 Solver API has all the features to support fixing https://github.com/osbuild/images/issues/2055