### PR TITLE
runners: set up sequoia on RHEL

### DIFF
--- a/runners/org.osbuild.centos9
+++ b/runners/org.osbuild.centos9
@@ -13,6 +13,7 @@ if __name__ == "__main__":
         with runners.create_machine_id_if_needed():
             runners.tmpfiles()
             runners.nsswitch()
+            runners.sequoia()
             r = subprocess.run(sys.argv[1:], check=False)
 
         sys.exit(r.returncode)

--- a/runners/org.osbuild.rhel82
+++ b/runners/org.osbuild.rhel82
@@ -13,6 +13,7 @@ if __name__ == "__main__":
         with runners.create_machine_id_if_needed():
             runners.tmpfiles()
             runners.nsswitch()
+            runners.sequoia()
             runners.python_alternatives()
             env = runners.quirks()
             r = subprocess.run(sys.argv[1:], env=env, check=False)


### PR DESCRIPTION
With RHEL 10.1 z-stream a new cryptographic key is used to sign RPMs. This means that RPM versions that understand multiple signatures will try to verify through sequoia that this key is valid.

When verifying packages post-buildroot (so using an RPM version from the buildroot which understands these multi-signatures) sequoia-gpg will be used to validate. We don't set up sequoia-gpg and it needs its config to understand the new signature as its not in the defaults.

Change this so we always set up crypto-policies so sequoia knows what to use instead of its defaults.