### PR TITLE
monitor: deep copy stage options in JSONSeqMonitor

### DIFF
--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -348,7 +348,7 @@ class JSONSeqMonitor(BaseMonitor):
 
     def _module(self, module: osbuild.Stage):
         self._context.set_stage(module)
-        self._module_options = module.options or {}
+        self._module_options = copy.deepcopy(module.options) if module.options else {}
         self.log(f"Starting module {module.name}", origin="osbuild.monitor")
         self._module_start_time = time.monotonic()
 


### PR DESCRIPTION
Commit 3cc0c94be0054ff1a72b73d4b36f170179ba4242 added module options to the JSONSeqMonitor monitor.  When a monitor creates a log entry to print, it removes empty fields (None or "") using the 'omitempty' function.  This runs recursively on the log entry dictionary and its sub-objects.

The stage options are passed into the monitor by reference (not copied), which means that the log entry modifies the stage options if any property is empty.

This bug manifested in testing in osbuild-composer, where we use the JSONSeqMonitor now, as a failure to export the final pipeline but only when building openstack, because the qcow2 stage sets an empty string for the 'compat' option for that image type.  The failure occurs because pipeline and stage IDs are always calculated on the fly, so the order of operations was:
1. The stage tree is created using a hash of the original stage options.
2. The log monitor modifies the stage options by removing the 'compat' option, which has a "" value.
3. The export function looks for a tree with the ID of the modified options, which doesn't exist.

Deep-copying the module options in the JSONSeqMonitor when setting the _module_options field on the monitor fixes the issue.