### PR TITLE
stages/rpm: add option to ignore key import errors (HMS-9986)

### DIFF
--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -146,15 +146,20 @@ def main(tree, inputs, options):
 
     for key in options.get("gpgkeys", []):
         with tempfile.NamedTemporaryFile(prefix="gpgkey.", mode="w") as keyfile:
+            ignore_gpg_import_failures = options.get("ignore_gpg_import_failures", False)
             keyfile.write(key)
             keyfile.flush()
-            subprocess.run([
+            res = subprocess.run([
                 "rpmkeys",
                 *rpm_args,
                 "--root", tree,
                 "--import", keyfile.name
-            ], check=True)
-        print("imported gpg key")
+            ], check=not ignore_gpg_import_failures)
+            if res.returncode != 0:
+                # if rpm doesn't understand some of the keys, it returns the number of such keys
+                print(f"failed to import {res.returncode} keys, ignoring them")
+            else:
+                print("all gpg keys imported successfully")
 
     for filename, data in packages.items():
         if data.get("rpm.check_gpg"):

--- a/stages/org.osbuild.rpm.meta.json
+++ b/stages/org.osbuild.rpm.meta.json
@@ -119,6 +119,11 @@
             "type": "string"
           }
         },
+        "ignore_gpg_import_failures": {
+          "type": "boolean",
+          "description": "Ignore errors when importing gpg keys specified in the `gpgkeys` option",
+          "default": false
+        },
         "disable_dracut": {
           "description": "Prevent dracut from running",
           "type": "boolean"


### PR DESCRIPTION
This is needed because RHEL 9's rpm does not understand PQC keys, but the RHEL 9 packages are still signed with PQC. This means that when building the RHEL 9 buildroot on RHEL 10 the PQC keys need to be imported successfully, but when building the RHEL 9 OS pipeline inside of the RHEL 9 buildroot, the import errors need to be ignored.

`rpmkeys` will fail to import keys it does not understand (e.g. post-quantum keys). Note that rpmkeys does not stop when it encounters a key it does not understand. So just setting `check=` to False is enough. [1]

We assume that if rpm actually requires them for checking the signatures, it will fail during `rpmkeys --checksig`.

[1]: https://github.com/rpm-software-management/rpm/blob/4a9b7b5908d8b463a836b51322242677677bd8b7/lib/rpmchecksig.cc#L66 (there is no break statement in the error branch).


---

based on #2291