### PR TITLE
stages/rpm: add support for setting the rpmkeys binary

### DIFF
--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -125,6 +125,24 @@ def remove_unowned_etc_kernel(tree, rpm_args):
         os.rmdir("etc/kernel")
 
 
+def import_gpg_keys(tree, keys, rpmkeys_bin, rpm_args, ignore_failures):
+    for key in keys:
+        with tempfile.NamedTemporaryFile(prefix="gpgkey.", mode="w") as keyfile:
+            keyfile.write(key)
+            keyfile.flush()
+            res = subprocess.run([
+                rpmkeys_bin,
+                *rpm_args,
+                "--root", tree,
+                "--import", keyfile.name
+            ], check=not ignore_failures)
+            if res.returncode != 0:
+                # if rpm doesn't understand some of the keys, it returns the number of such keys
+                print(f"failed to import {res.returncode} keys, ignoring them")
+            else:
+                print("all gpg keys imported successfully")
+
+
 def parse_input(inputs):
     packages = inputs["packages"]
     path = packages["path"]
@@ -144,28 +162,16 @@ def main(tree, inputs, options):
         print(f"dbpath set to '{dbpath}'")
         rpm_args += ["--dbpath", dbpath]
 
-    for key in options.get("gpgkeys", []):
-        with tempfile.NamedTemporaryFile(prefix="gpgkey.", mode="w") as keyfile:
-            ignore_gpg_import_failures = options.get("ignore_gpg_import_failures", False)
-            keyfile.write(key)
-            keyfile.flush()
-            res = subprocess.run([
-                "rpmkeys",
-                *rpm_args,
-                "--root", tree,
-                "--import", keyfile.name
-            ], check=not ignore_gpg_import_failures)
-            if res.returncode != 0:
-                # if rpm doesn't understand some of the keys, it returns the number of such keys
-                print(f"failed to import {res.returncode} keys, ignoring them")
-            else:
-                print("all gpg keys imported successfully")
+    rpmkeys_options = options.get("rpmkeys", {})
+    rpmkeys_bin = rpmkeys_options.get("bin_path", "rpmkeys")
+    ignore_import_failures = rpmkeys_options.get("ignore_import_failures", False)
+    import_gpg_keys(tree, options.get("gpgkeys", []), rpmkeys_bin, rpm_args, ignore_import_failures)
 
     for filename, data in packages.items():
         if data.get("rpm.check_gpg"):
             try:
                 subprocess.run([
-                    "rpmkeys",
+                    rpmkeys_bin,
                     *rpm_args,
                     "--root", tree,
                     "--checksig",
@@ -234,7 +240,7 @@ def main(tree, inputs, options):
         for key in options.get("gpgkeys.fromtree", []):
             path = os.path.join(tree, key.lstrip("/"))
             subprocess.run([
-                "rpmkeys",
+                rpmkeys_bin,
                 *rpm_args,
                 "--root", tree,
                 "--import", path

--- a/stages/org.osbuild.rpm.meta.json
+++ b/stages/org.osbuild.rpm.meta.json
@@ -119,10 +119,21 @@
             "type": "string"
           }
         },
-        "ignore_gpg_import_failures": {
-          "type": "boolean",
-          "description": "Ignore errors when importing gpg keys specified in the `gpgkeys` option",
-          "default": false
+        "rpmkeys": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "bin_path": {
+              "type": "string",
+              "description": "Path to the rpmkeys binary, used for importing gpg keys and verifying rpm signatures",
+              "default": "rpmkeys"
+            },
+            "ignore_import_failures": {
+              "type": "boolean",
+              "description": "Ignore errors when importing gpg keys specified in the `gpgkeys` option",
+              "default": false
+            }
+          }
         },
         "disable_dracut": {
           "description": "Prevent dracut from running",

--- a/stages/test/test_rpm.py
+++ b/stages/test/test_rpm.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from osbuild import testutil
@@ -26,3 +28,17 @@ def test_schema_validation(stage_schema, test_data, expected_err):
     else:
         assert res.valid is False
         testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
+
+
+@pytest.mark.parametrize("ignore_failures", [
+    (False),
+    (True),
+])
+@mock.patch("subprocess.run")
+def test_import_gpg_keys(mock_run, tmp_path, stage_module, ignore_failures):
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    stage_module.import_gpg_keys(tree, ["some-key"], "my-binary", [], ignore_failures)
+    mock_run.assert_called_once()
+    assert mock_run.call_args[0][0][0] == "my-binary"
+    assert mock_run.call_args[1] == {"check": not ignore_failures}


### PR DESCRIPTION
This adds an rpmkeys option in the rpm stage, which allows setting the binary. This is useful on certain platforms where post-quantum crypto keys can only be verified by a patched version of rpm (like `pqrpm` on el9).

Adds a unit test to makes sure both options are respected.

Also see #2301. This technically breaks API but since it hasn't been used anywhere before, and the previous API was made without a full understanding of all the usecases it will need to support, this should be ok.