### PR TITLE
Makefile: new target: rpm-nocheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,6 +310,13 @@ rpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL)
 		--define "_topdir $(CURDIR)/rpmbuild" \
 		$(RPM_SPECFILE)
 
+.PHONY: rpm-nocheck
+rpm-nocheck: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL)
+	rpmbuild -bb \
+		--define "_topdir $(CURDIR)/rpmbuild" \
+		--nocheck \
+		$(RPM_SPECFILE)
+
 #
 # Releasing
 #


### PR DESCRIPTION
It's often desirable to skip all the checks when building the RPM.

---

This came up in Konflux builds for bootc-image-builder.  Some tests have a `root-only` skip check where the decision is made based on `os.getuid()`.  However, the functionality being tested (or the test itself) might require capabilities not provided by the context, even for root.

For example:
https://github.com/osbuild/osbuild/blob/53a068c13f98b28a9ba934533ab545e3a4f5a428/tools/test/test_osbuild_image_info.py#L182-L190
Checks for `os.getuid() == 0` but needs to bind mount, so should instead use [can_bind_mount()](https://github.com/osbuild/osbuild/blob/53a068c13f98b28a9ba934533ab545e3a4f5a428/test/test.py#L131).

Internal MR with link to failures is here, though inaccessible outside of Red Hat: https://gitlab.com/redhat/rhel/containers/bootc-image-builder/-/merge_requests/115#note_3007024114

The following tests failed:
```
FAILED mounts/test/test_bind.py::test_bind_mount_integration
FAILED stages/test/test_coreos_live_artifacts_mono.py::test_make_efi_bootfile
FAILED stages/test/test_write_device.py::test_write_device_integration
FAILED test/mod/test_util_fscache.py::test_cache_load_updates_last_used_on_noatime
FAILED test/mod/test_util_mnt.py::test_mount_failure_msg
FAILED test/mod/test_util_mnt.py::test_mount_guard_failure_msg
FAILED test/mod/test_util_mnt.py::test_osbuild_mount_failure_msg
FAILED test/run/test_exports.py::test_exports_normal
FAILED test/run/test_exports.py::test_exports_with_force_no_preserve_owner
FAILED tools/test/test_osbuild_image_info.py::test_empty_report_fail
FAILED tools/test/test_osbuild_image_info.py::test_analyse_iso_fail_no_tarball
```

I'm going to ask the downstream maintainers to run `make rpm-nocheck` to get the builds unblocked.  We can make the test-skip-conditions more accurate later.