### PR TITLE
packit: Add RHEL10 x86 and ARM COPR builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,6 +42,8 @@ jobs:
   - fedora-all-s390x
   - fedora-all-ppc64le
   - fedora-all
+  - rhel-10-x86_64
+  - rhel-10-aarch64
 - <<: *copr
   trigger: commit
   branch: main


### PR DESCRIPTION
Since we're releasing this into RHEL10, it'd be useful to have the RPMs ready for it for easy testing.