### PR TITLE
test: add a wait to mitigate race condition

### DIFF
--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -7,6 +7,7 @@ import multiprocessing as mp
 import os
 import pathlib
 import tempfile
+import time
 import unittest
 
 import osbuild
@@ -98,6 +99,13 @@ class TestAPI(unittest.TestCase):
             p = _mp_context.Process(target=exception, args=(path, ))
             p.start()
             p.join()
+
+        # Add a small buffer for the background thread to update 'api.error' which
+        # randomly manifests on ppc64 on our CICD.
+        start_time = time.time()
+        while api.error is None and time.time() - start_time < 5:
+            time.sleep(0.1)
+
         self.assertEqual(p.exitcode, 2)
         self.assertIsNotNone(api.error, "Error not set")
         self.assertIn("type", api.error, "Error has no 'type' set")


### PR DESCRIPTION
This failure on PPC64 (running Python 3.14) is a classic race condition exacerbated by the way multiprocessing and threading interact during a fork(). The core issue is that your test process finishes and joins before the API server has finished processing the exception message sent by the child. On PPC64 (which often has different memory ordering and cache behavior than x86_64), the background thread inside osbuild.api.API that listens to the socket might not have context-switched or processed the incoming data by the time p.join() returns in the main thread.

The "correct" long-term fix is to make the osbuild-api compatible with spawn or forkserver but that is not the goal of this quick fix to unblock CICD.