### PR TITLE
bootc.install.config: add ostree.bls-append-except-default option

### DIFF
--- a/stages/org.osbuild.bootc.install.config.meta.json
+++ b/stages/org.osbuild.bootc.install.config.meta.json
@@ -68,6 +68,17 @@
                     "tmp2-luks"
                   ]
                 }
+              },
+              "ostree": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Configuration options for the ostree repository.",
+                "properties": {
+                  "bls-append-except-default": {
+                    "type": "string",
+                    "description": "Kernel arguments to append to Boot Loader Spec entries, except for the default entry. Useful for configuring arguments that should only apply to non-default deployments."
+                  }
+                }
               }
             }
           }

--- a/stages/test/test_bootc_install_config.py
+++ b/stages/test/test_bootc_install_config.py
@@ -70,7 +70,26 @@ STAGE_NAME = "org.osbuild.bootc.install.config"
                     "block": ["tmp2-luks"]
                 }
             }
-        )
+        ),
+        (
+            {
+                "filename": "30-ostree.conf",
+                "config": {
+                    "install": {
+                        "ostree": {
+                            "bls-append-except-default": 'grub_users=""'
+                        }
+                    }
+                }
+            },
+            {
+                "install": {
+                    "ostree": {
+                        "bls-append-except-default": 'grub_users=""'
+                    }
+                }
+            },
+        ),
     ]
 )
 @pytest.mark.tomlwrite
@@ -151,6 +170,19 @@ def test_bootc_install_config(tmp_path, stage_module, options, expected_config):
                 },
             },
             ["'whatever' is not one of ['direct', 'tmp2-luks']"]
+        ),
+        (
+            {
+                "filename": "error.conf",
+                "config": {
+                    "install": {
+                        "ostree": {
+                            "invalid-option": "value",
+                        },
+                    }
+                },
+            },
+            ["Additional properties are not allowed ('invalid-option' was unexpected)"]
         ),
     ]
 )


### PR DESCRIPTION
Add support for the new [install.ostree] configuration section with the bls-append-except-default option, which was introduced in bootc PR [1] (still not yet released, probably >=1.13.0)

This option allows setting the ostree sysroot.bls-append-except-default config key during installation, which appends kernel arguments to Boot Loader Spec entries except for the default entry. A common use case is setting grub_users="" to bypass GRUB password prompts for non-default deployments.

Example usage in manifest:
```
  {
    "type": "org.osbuild.bootc.install.config",
    "options": {
      "filename": "10-custom.toml",
      "config": {
        "install": {
          "ostree": {
            "bls-append-except-default": "grub_users=\"\""
          }
        }
      }
    }
  }
```
[1] https://github.com/bootc-dev/bootc/pull/1909