### PR TITLE
monitor: Report if the runner is running in a vm

### DIFF
--- a/osbuild/monitor.py
+++ b/osbuild/monitor.py
@@ -283,6 +283,8 @@ class LogMonitor(BaseMonitor):
             self.out.write("<host>")
         if pipeline.runner:
             self.out.write(f"\n  runner: {pipeline.runner.name} ({pipeline.runner.exec})")
+            if pipeline.run_in_vm:
+                self.out.write(" in vm")
         source_epoch = pipeline.source_epoch
         if source_epoch is not None:
             timepoint = datetime.datetime.fromtimestamp(source_epoch).strftime('%c')

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -385,6 +385,7 @@ class Pipeline:
         self.stages: List[Stage] = []
         self.assembler = None
         self.source_epoch = source_epoch
+        self.run_in_vm = False
 
     @property
     def id(self):
@@ -520,6 +521,7 @@ class Pipeline:
 
     def run(self, store, monitor, libdir, debug_break="", stage_timeout=None, in_vm=False):
 
+        self.run_in_vm = in_vm
         monitor.begin(self)
 
         results = self.build_stages(store,


### PR DESCRIPTION
This adds "in vm" to the "runner:" line in the log output if that particular pipeline is running in a vm.