### PR TITLE
Revert "test_objectstore: add time.sleep(0.1) to solve flaky tests"

### DIFF
--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -5,7 +5,6 @@
 import contextlib
 import os
 import tempfile
-import time
 from pathlib import Path
 
 import pytest
@@ -197,12 +196,8 @@ def test_host_tree(tmp_path):
 
 
 def test_source_epoch(object_store):
-    """
-    Uses time.sleep(0.1) to ensure time difference on high-resolution timestamp filesystems.
-    """
     tree = object_store.new("a")
     tree.source_epoch = 946688461
-    time.sleep(0.1)
 
     t = Path(tree)
 
@@ -222,7 +217,6 @@ def test_source_epoch(object_store):
 
     # FINALIZING
     tree.finalize()
-    time.sleep(0.1)
 
     for i in (a, d, l, t):
         si = os.stat(i, follow_symlinks=False)
@@ -233,13 +227,11 @@ def test_source_epoch(object_store):
 
     baum = object_store.new("b")
     baum.init(tree)
-    time.sleep(0.1)
 
     assert baum.created == tree.created
 
     b = Path(tree, "B")
     b.touch()
-    time.sleep(0.1)
 
     si = os.stat(b, follow_symlinks=False)
     before = int(si.st_mtime)
@@ -248,8 +240,6 @@ def test_source_epoch(object_store):
 
     # FINALIZING
     baum.finalize()
-    time.sleep(0.1)
-
     si = os.stat(a, follow_symlinks=False)
     after = int(si.st_mtime)
 


### PR DESCRIPTION
Did not help: https://github.com/osbuild/osbuild/issues/2337

This reverts commit f637fca2a9cf7c84cfaa919b1537c6ea0f20058f.