### PR TITLE
stages/module-config: postfix with `.module`

### DIFF
--- a/stages/org.osbuild.dnf.module-config
+++ b/stages/org.osbuild.dnf.module-config
@@ -17,7 +17,7 @@ def main(tree, options):
     # would normally write [a, b]
     inip[name]["profiles"] = ", ".join(conf["profiles"])
 
-    path = pathlib.Path(tree) / "etc/dnf/modules.d" / f"{name}.conf"
+    path = pathlib.Path(tree) / "etc/dnf/modules.d" / f"{name}.module"
     path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(path, "w", encoding="utf-8") as file:

--- a/stages/test/test_dnf_module_config.py
+++ b/stages/test/test_dnf_module_config.py
@@ -39,7 +39,7 @@ def test_dnf_module_config_schema_validation(stage_schema, test_data, expected_e
 
 def test_dnf_module_config_writes_file(tmp_path, stage_module):
     treepath = tmp_path / "tree"
-    confpath = "etc/dnf/modules.d/some-module.conf"
+    confpath = "etc/dnf/modules.d/some-module.module"
 
     fullpath = treepath / confpath
 


### PR DESCRIPTION
DNF actually looks for files ending in `.module`, not `.conf`. This is a bug so let's adjust the stage.