### PR TITLE
stages/bootc.install-to-fs: add bootupd-skip-boot-uuid option

### DIFF
--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -62,6 +62,8 @@ def main(options, inputs, paths):
                 pargs.extend(["--boot-mount-spec="])
             else:
                 pargs.extend(["--boot-mount-spec", boot_spec])
+        if options.get("bootupd-skip-boot-uuid", False):
+            pargs.extend(["--bootupd-skip-boot-uuid"])
 
         # add target and go
         pargs.append(dst)

--- a/stages/org.osbuild.bootc.install-to-filesystem.meta.json
+++ b/stages/org.osbuild.bootc.install-to-filesystem.meta.json
@@ -56,6 +56,10 @@
         "boot-mount-spec": {
           "type": "string",
           "description": "Mount specification for the /boot filesystem. If `/boot` is detected as a mounted partition, then its UUID will be used."
+        },
+        "bootupd-skip-boot-uuid": {
+          "type": "boolean",
+          "description": "Don't pass --write-uuid to bootupd during bootloader installation."
         }
       }
     },

--- a/stages/test/test_bootc_install_to_fs.py
+++ b/stages/test/test_bootc_install_to_fs.py
@@ -60,6 +60,9 @@ FAKE_INPUTS = {
     # boot-mount-spec
     ({"boot-mount-spec": ""}, ["--boot-mount-spec="]),
     ({"boot-mount-spec": "/dev/sda1"}, ["--boot-mount-spec", "/dev/sda1"]),
+    # bootupd-skip-boot-uuid
+    ({"bootupd-skip-boot-uuid": False}, []),
+    ({"bootupd-skip-boot-uuid": True}, ["--bootupd-skip-boot-uuid"]),
     # all
     ({"root-ssh-authorized-keys": ["key1", "key2"],
       "kernel-args": ["arg1", "arg2"],
@@ -67,6 +70,7 @@ FAKE_INPUTS = {
       "stateroot": "/some/stateroot",
       "root-mount-spec": "root-mount-spec",
       "boot-mount-spec": "boot-mount-spec",
+      "bootupd-skip-boot-uuid": True,
       },
      ["--root-ssh-authorized-keys", "/tmp/fake-named-tmpfile-name",
       "--karg", "arg1", "--karg", "arg2",
@@ -74,6 +78,7 @@ FAKE_INPUTS = {
       "--stateroot", "/some/stateroot",
       "--root-mount-spec", "root-mount-spec",
       "--boot-mount-spec", "boot-mount-spec",
+      "--bootupd-skip-boot-uuid",
       ],
      ),
 ])


### PR DESCRIPTION
In [1] bootc made writing the boot UUID stamp optionnal by adding a CLI switch. Wire up the option here to allow creating disk images without that boot stamp. We need them in CoreOS because we randomize the partitions UUIDs at first boot so this flag in unncessary and short- circuits out initramfs services chain.

[1] https://github.com/bootc-dev/bootc/pull/1978