### PR TITLE
Add native RHUI support for building images on cloud instances

### DIFF
--- a/osbuild/solver/__init__.py
+++ b/osbuild/solver/__init__.py
@@ -52,6 +52,8 @@ class SolverBase(Solver):
         self.license_index_path = license_index_path
         # Set of repository IDs that need RHSM secrets
         self.repo_ids_with_rhsm = set()
+        # Set of repository IDs that use RHUI secrets
+        self.repo_ids_with_rhui = set()
         # RHUI identity headers (AWS/GCP); empty for Azure or non-cloud
         self.rhui_headers = []
 
@@ -151,8 +153,9 @@ class SolverBase(Solver):
             repo.sslcacert = secrets["ssl_ca_cert"]
             repo.sslclientkey = secrets["ssl_client_key"]
             repo.sslclientcert = secrets["ssl_client_cert"]
-            # Mark as RHSM so the response correctly flags these repos
+            # Track both sets so response repos get the correct flags
             self.repo_ids_with_rhsm.add(repo.repo_id)
+            self.repo_ids_with_rhui.add(repo.repo_id)
 
     def set_rhsm_flag(self, repo: Repository) -> None:
         """
@@ -161,6 +164,12 @@ class SolverBase(Solver):
         Otherwise, set it to False.
         """
         repo.rhsm = repo.repo_id in self.repo_ids_with_rhsm
+
+    def set_rhui_flag(self, repo: Repository) -> None:
+        """
+        Set the rhui flag on the repository based on repo_ids_with_rhui.
+        """
+        repo.rhui = repo.repo_id in self.repo_ids_with_rhui
 
 
 def modify_rootdir_path(path, root_dir):

--- a/osbuild/solver/api/v2.py
+++ b/osbuild/solver/api/v2.py
@@ -104,8 +104,9 @@ def _repository_as_dict(repository: Repository) -> Dict[str, Any]:
 
     All fields from the Repository model are included for schema consistency.
 
-    When repository.rhsm=True, SSL secret fields (sslcacert, sslclientkey, sslclientcert)
-    are set to None as they contain host-specific RHSM secrets that should not be exposed.
+    When either repository.rhsm or repository.rhui is set, SSL secret fields
+    (sslcacert, sslclientkey, sslclientcert) are set to None as they contain
+    host-specific secrets that should not be exposed.
     """
     d = {
         "id": repository.repo_id,

--- a/osbuild/solver/api/v2.py
+++ b/osbuild/solver/api/v2.py
@@ -108,6 +108,16 @@ def _repository_as_dict(repository: Repository) -> Dict[str, Any]:
     (sslcacert, sslclientkey, sslclientcert) are set to None as they contain
     host-specific secrets that should not be exposed.
     """
+    # Determine the secrets provider for this repository.
+    # This tells the caller which osbuild secrets provider to use for packages
+    # from this repo, so it doesn't need to compute it from the flags.
+    if repository.rhui:
+        secrets = "org.osbuild.rhui"
+    elif repository.rhsm:
+        secrets = "org.osbuild.rhsm"
+    else:
+        secrets = None
+
     d = {
         "id": repository.repo_id,
         "name": repository.name,
@@ -122,11 +132,12 @@ def _repository_as_dict(repository: Repository) -> Dict[str, Any]:
         "module_hotfixes": repository.module_hotfixes,
         "rhsm": repository.rhsm,
         "rhui": repository.rhui,
+        "secrets": secrets,
         # SSL secrets are set to None when using RHSM/RHUI (host-specific secrets not applicable),
         # otherwise return the actual values from DNF (which may be empty strings if not configured)
-        "sslcacert": None if (repository.rhsm or repository.rhui) else repository.sslcacert,
-        "sslclientkey": None if (repository.rhsm or repository.rhui) else repository.sslclientkey,
-        "sslclientcert": None if (repository.rhsm or repository.rhui) else repository.sslclientcert,
+        "sslcacert": None if secrets else repository.sslcacert,
+        "sslclientkey": None if secrets else repository.sslclientkey,
+        "sslclientcert": None if secrets else repository.sslclientcert,
     }
     return d
 

--- a/osbuild/solver/api/v2.py
+++ b/osbuild/solver/api/v2.py
@@ -120,11 +120,12 @@ def _repository_as_dict(repository: Repository) -> Dict[str, Any]:
         "metadata_expire": repository.metadata_expire,
         "module_hotfixes": repository.module_hotfixes,
         "rhsm": repository.rhsm,
-        # SSL secrets are set to None when using RHSM (host-specific secrets not applicable),
+        "rhui": repository.rhui,
+        # SSL secrets are set to None when using RHSM/RHUI (host-specific secrets not applicable),
         # otherwise return the actual values from DNF (which may be empty strings if not configured)
-        "sslcacert": None if repository.rhsm else repository.sslcacert,
-        "sslclientkey": None if repository.rhsm else repository.sslclientkey,
-        "sslclientcert": None if repository.rhsm else repository.sslclientcert,
+        "sslcacert": None if (repository.rhsm or repository.rhui) else repository.sslcacert,
+        "sslclientkey": None if (repository.rhsm or repository.rhui) else repository.sslclientkey,
+        "sslclientcert": None if (repository.rhsm or repository.rhui) else repository.sslclientcert,
     }
     return d
 
@@ -311,6 +312,8 @@ def _parse_repository(repo_dict: Dict[str, Any]) -> Repository:
         kwargs["module_hotfixes"] = repo_dict["module_hotfixes"]
     if "rhsm" in repo_dict:
         kwargs["rhsm"] = repo_dict["rhsm"]
+    if "rhui" in repo_dict:
+        kwargs["rhui"] = repo_dict["rhui"]
     if "enabled" in repo_dict:
         kwargs["enabled"] = repo_dict["enabled"]
     if "priority" in repo_dict:

--- a/osbuild/solver/dnf.py
+++ b/osbuild/solver/dnf.py
@@ -181,6 +181,13 @@ class DNF(SolverBase):
             for repo_conf in self.repos:
                 self.base.repos.add(self._dnfrepo(repo_conf, self.base.conf, self.root_dir is not None))
 
+            # Set RHUI identity headers on repos that need them
+            if self.rhui_headers:
+                for repo_conf in self.repos:
+                    if repo_conf.rhui:
+                        dnf_repo = self.base.repos[repo_conf.repo_id]
+                        dnf_repo._repo.setHttpHeaders(self.rhui_headers)
+
             if self.root_dir:
                 repos_dir = os.path.join(self.root_dir, "etc/yum.repos.d")
                 self.base.conf.reposdir = repos_dir

--- a/osbuild/solver/dnf.py
+++ b/osbuild/solver/dnf.py
@@ -298,6 +298,7 @@ class DNF(SolverBase):
         """
         repo_model = _dnf_repo_to_repository(repo, self.root_dir, self.request_repo_ids)
         self.set_rhsm_flag(repo_model)
+        self.set_rhui_flag(repo_model)
         return repo_model
 
     def dump(self) -> model.DumpResult:

--- a/osbuild/solver/dnf5.py
+++ b/osbuild/solver/dnf5.py
@@ -399,6 +399,7 @@ class DNF5(SolverBase):
         """
         repo_model = _dnf_repo_to_repository(repo, self.root_dir, self.request_repo_ids)
         self.set_rhsm_flag(repo_model)
+        self.set_rhui_flag(repo_model)
         return repo_model
 
     def dump(self) -> model.DumpResult:

--- a/osbuild/solver/model.py
+++ b/osbuild/solver/model.py
@@ -109,6 +109,7 @@ class Repository(ValidatedModel):
         "password": (str, type(None)),
         "skip_if_unavailable": (bool, type(None)),
         "rhsm": bool,
+        "rhui": bool,
     }
 
     def __init__(
@@ -151,6 +152,11 @@ class Repository(ValidatedModel):
         # constructor. Similarly, an API implementation may choose to omit these
         # values from the API response if this flag is True.
         self.rhsm: bool = kwargs.pop("rhsm", False)
+
+        # Whether this repository uses RHUI (Red Hat Update Infrastructure)
+        # secrets from the host system. If True, the solver will discover
+        # SSL certs from /etc/pki/rhui/ via the host RHUI repo files.
+        self.rhui: bool = kwargs.pop("rhui", False)
 
         if kwargs:
             raise ValueError(
@@ -205,6 +211,7 @@ class Repository(ValidatedModel):
             and self.password == other.password
             and self.skip_if_unavailable == other.skip_if_unavailable
             and self.rhsm == other.rhsm
+            and self.rhui == other.rhui
         )
 
     def __hash__(self) -> int:
@@ -229,6 +236,7 @@ class Repository(ValidatedModel):
             self.password,
             self.skip_if_unavailable,
             self.rhsm,
+            self.rhui,
         ))
 
     def __repr__(self) -> str:
@@ -239,7 +247,7 @@ class Repository(ValidatedModel):
             f"sslclientcert='{self.sslclientcert}', metadata_expire='{self.metadata_expire}', " \
             f"module_hotfixes={self.module_hotfixes}, enabled={self.enabled}, priority={self.priority}, " \
             f"username='{self.username}', password='{self.password}', " \
-            f"skip_if_unavailable={self.skip_if_unavailable}, rhsm={self.rhsm})"
+            f"skip_if_unavailable={self.skip_if_unavailable}, rhsm={self.rhsm}, rhui={self.rhui})"
 
 
 class Dependency:

--- a/osbuild/util/rhui.py
+++ b/osbuild/util/rhui.py
@@ -54,11 +54,11 @@ def _aws_get_identity_headers() -> List[str]:
     doc = _aws_imds_get(_AWS_IDENTITY_DOC_URL, token)
     sig = _aws_imds_get(_AWS_IDENTITY_SIG_URL, token)
 
-    doc_b64 = base64.b64encode(doc).decode("utf-8")
-    # The signature from IMDS is already base64-encoded text, but RHUI
-    # expects the raw signature bytes re-encoded, so we decode then
-    # re-encode to get a single clean base64 line without whitespace.
-    sig_b64 = base64.b64encode(base64.b64decode(sig)).decode("utf-8")
+    # Use urlsafe_b64encode to match the amazon-id DNF plugin behavior
+    doc_b64 = base64.urlsafe_b64encode(doc).decode("utf-8")
+    # The signature from IMDS is already base64-encoded text; the
+    # amazon-id plugin passes it through urlsafe_b64encode directly.
+    sig_b64 = base64.urlsafe_b64encode(sig).decode("utf-8")
 
     return [
         f"X-RHUI-ID: {doc_b64}",

--- a/osbuild/util/rhui.py
+++ b/osbuild/util/rhui.py
@@ -1,0 +1,197 @@
+"""Cloud RHUI (Red Hat Update Infrastructure) identity support.
+
+This module detects the cloud provider (AWS, Azure, GCP) by probing
+instance metadata endpoints, fetches the identity headers required by
+RHUI content servers, and combines them with SSL certificates discovered
+from host RHUI repo files.
+
+AWS and GCP RHUI mirrors require X-RHUI-ID and X-RHUI-SIGNATURE HTTP
+headers on every request.  Azure RHUI uses certificate + IP-range
+authentication only, so no extra headers are needed.
+"""
+
+import base64
+import contextlib
+import urllib.request
+from typing import List, Optional
+
+from osbuild.util.rhsm import Subscriptions
+
+# Timeout for IMDS probes (seconds)
+_IMDS_TIMEOUT = 5
+
+# --- AWS IMDSv2 ---------------------------------------------------------
+
+_AWS_TOKEN_URL = "http://169.254.169.254/latest/api/token"
+_AWS_IDENTITY_DOC_URL = "http://169.254.169.254/latest/dynamic/instance-identity/document"
+_AWS_IDENTITY_SIG_URL = "http://169.254.169.254/latest/dynamic/instance-identity/signature"
+
+
+def _aws_get_token() -> str:
+    """Obtain an IMDSv2 session token."""
+    req = urllib.request.Request(
+        _AWS_TOKEN_URL,
+        method="PUT",
+        headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+    )
+    with urllib.request.urlopen(req, timeout=_IMDS_TIMEOUT) as resp:
+        return resp.read().decode("utf-8")
+
+
+def _aws_imds_get(url: str, token: str) -> bytes:
+    """GET from AWS IMDS using a session token."""
+    req = urllib.request.Request(
+        url,
+        headers={"X-aws-ec2-metadata-token": token},
+    )
+    with urllib.request.urlopen(req, timeout=_IMDS_TIMEOUT) as resp:
+        return resp.read()
+
+
+def _aws_get_identity_headers() -> List[str]:
+    """Fetch AWS instance identity document + signature and return RHUI headers."""
+    token = _aws_get_token()
+    doc = _aws_imds_get(_AWS_IDENTITY_DOC_URL, token)
+    sig = _aws_imds_get(_AWS_IDENTITY_SIG_URL, token)
+
+    doc_b64 = base64.b64encode(doc).decode("utf-8")
+    # The signature from IMDS is already base64-encoded text, but RHUI
+    # expects the raw signature bytes re-encoded, so we decode then
+    # re-encode to get a single clean base64 line without whitespace.
+    sig_b64 = base64.b64encode(base64.b64decode(sig)).decode("utf-8")
+
+    return [
+        f"X-RHUI-ID: {doc_b64}",
+        f"X-RHUI-SIGNATURE: {sig_b64}",
+    ]
+
+
+# --- GCP ----------------------------------------------------------------
+
+_GCP_IDENTITY_DOC_URL = (
+    "http://metadata.google.internal/computeMetadata/v1/"
+    "instance/service-accounts/default/identity"
+    "?audience=rhui&format=full"
+)
+_GCP_IDENTITY_SIG_URL = (
+    "http://metadata.google.internal/computeMetadata/v1/"
+    "instance/service-accounts/default/token"
+)
+
+
+def _gcp_metadata_get(url: str) -> bytes:
+    """GET from GCP metadata server."""
+    req = urllib.request.Request(
+        url,
+        headers={"Metadata-Flavor": "Google"},
+    )
+    with urllib.request.urlopen(req, timeout=_IMDS_TIMEOUT) as resp:
+        return resp.read()
+
+
+def _gcp_get_identity_headers() -> List[str]:
+    """Fetch GCP instance identity and return RHUI headers."""
+    doc = _gcp_metadata_get(_GCP_IDENTITY_DOC_URL)
+    sig = _gcp_metadata_get(_GCP_IDENTITY_SIG_URL)
+
+    doc_b64 = base64.b64encode(doc).decode("utf-8")
+    sig_b64 = base64.b64encode(sig).decode("utf-8")
+
+    return [
+        f"X-RHUI-ID: {doc_b64}",
+        f"X-RHUI-SIGNATURE: {sig_b64}",
+    ]
+
+
+# --- Azure (no extra headers) ------------------------------------------
+
+_AZURE_IMDS_URL = (
+    "http://169.254.169.254/metadata/instance"
+    "?api-version=2021-02-01"
+)
+
+
+# --- Cloud detection ----------------------------------------------------
+
+def detect_cloud_provider() -> Optional[str]:
+    """Detect the cloud provider by probing IMDS endpoints.
+
+    Returns "aws", "gcp", "azure", or None.
+    """
+    # AWS: try IMDSv2 token endpoint
+    with contextlib.suppress(Exception):
+        _aws_get_token()
+        return "aws"
+
+    # GCP: metadata server
+    with contextlib.suppress(Exception):
+        _gcp_metadata_get(
+            "http://metadata.google.internal/computeMetadata/v1/"
+        )
+        return "gcp"
+
+    # Azure: IMDS with Metadata header
+    with contextlib.suppress(Exception):
+        req = urllib.request.Request(
+            _AZURE_IMDS_URL,
+            headers={"Metadata": "true"},
+        )
+        urllib.request.urlopen(req, timeout=_IMDS_TIMEOUT)
+        return "azure"
+
+    return None
+
+
+# --- Main entry point ---------------------------------------------------
+
+def get_rhui_secrets(urls: List[str]) -> dict:
+    """Get RHUI secrets (SSL certs + cloud identity headers) for downloading.
+
+    Detects the cloud provider, fetches identity headers when required
+    (AWS, GCP), and discovers SSL certificates from host RHUI repo files
+    via the existing Subscriptions class.
+
+    Returns a dict with keys: ssl_ca_cert, ssl_client_key,
+    ssl_client_cert, headers.
+    """
+    provider = detect_cloud_provider()
+    if provider is None:
+        raise RuntimeError(
+            "Cannot detect cloud provider; "
+            "RHUI secrets are only available on cloud instances"
+        )
+
+    # Fetch cloud identity headers (AWS/GCP) or empty list (Azure)
+    if provider == "aws":
+        headers = _aws_get_identity_headers()
+    elif provider == "gcp":
+        headers = _gcp_get_identity_headers()
+    else:
+        headers = []
+
+    # Get SSL certs from host RHUI repo files (not RHSM redhat.repo)
+    subscriptions = Subscriptions._from_rhui_repo_files()
+    try:
+        certs = subscriptions.get_secrets(urls)
+    except RuntimeError:
+        # No matching URL — fall back to first available RHUI repo's certs
+        if subscriptions.repositories:
+            first = next(iter(subscriptions.repositories.values()))
+            certs = {
+                "ssl_ca_cert": first.get("sslcacert", ""),
+                "ssl_client_key": first.get("sslclientkey", ""),
+                "ssl_client_cert": first.get("sslclientcert", ""),
+            }
+        else:
+            certs = {
+                "ssl_ca_cert": "",
+                "ssl_client_key": "",
+                "ssl_client_cert": "",
+            }
+
+    return {
+        "ssl_ca_cert": certs.get("ssl_ca_cert", ""),
+        "ssl_client_key": certs.get("ssl_client_key", ""),
+        "ssl_client_cert": certs.get("ssl_client_cert", ""),
+        "headers": headers,
+    }

--- a/sources/org.osbuild.curl
+++ b/sources/org.osbuild.curl
@@ -177,6 +177,8 @@ def gen_curl_download_config(config_path: pathlib.Path, chksum_desc_tuple: List[
                 ssl_client_key = secrets.get('ssl_client_key')
                 if ssl_client_key:
                     fp.write(f'key = "{ssl_client_key}"\n')
+                for hdr in secrets.get('headers', []):
+                    fp.write(f'header = "{hdr}"\n')
             insecure = desc.get("insecure")
             if insecure:
                 fp.write('insecure\n')
@@ -273,6 +275,7 @@ class CurlSource(sources.SourceService):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.subscriptions = None
+        self.rhui_secrets = None
         self._curl_has_parallel_downloads = curl_has_parallel_downloads()
 
     def amend_secrets(self, checksum, desc_or_url):
@@ -297,6 +300,12 @@ class CurlSource(sources.SourceService):
                 'ssl_client_cert': cert,
                 'ssl_client_key': key,
             }
+        elif desc.get("secrets", {}).get("name") == "org.osbuild.rhui":
+            # rhui secrets only need to be retrieved once and can then be reused
+            if self.rhui_secrets is None:
+                from osbuild.util.rhui import get_rhui_secrets
+                self.rhui_secrets = get_rhui_secrets([desc.get("url")])
+            desc["secrets"] = self.rhui_secrets
 
         return checksum, desc
 

--- a/sources/org.osbuild.librepo
+++ b/sources/org.osbuild.librepo
@@ -137,6 +137,7 @@ class LibRepoSource(sources.SourceService):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.subscriptions = None
+        self.rhui_secrets = None
         self.errors = []
 
     def fetch_one(self, checksum, desc) -> None:
@@ -168,6 +169,22 @@ class LibRepoSource(sources.SourceService):
         handle.sslcacert = os.getenv("OSBUILD_SOURCES_CURL_SSL_CA_CERT")
         handle.sslclientcert = cert
         handle.sslclientkey = key
+
+    def _setup_rhui(self, handle, mirror):
+        """Setup RHUI cloud identity headers and SSL certs."""
+        if self.rhui_secrets is None:
+            from osbuild.util.rhui import get_rhui_secrets
+            self.rhui_secrets = get_rhui_secrets([mirror["url"]])
+
+        secrets = self.rhui_secrets
+        if secrets.get('ssl_ca_cert'):
+            handle.sslcacert = secrets['ssl_ca_cert']
+        if secrets.get('ssl_client_cert'):
+            handle.sslclientcert = secrets['ssl_client_cert']
+        if secrets.get('ssl_client_key'):
+            handle.sslclientkey = secrets['ssl_client_key']
+        if secrets.get('headers'):
+            handle.httpheader = secrets['headers']
 
     # This gets called when done
     # data comes from cbdata
@@ -257,6 +274,8 @@ class LibRepoSource(sources.SourceService):
                 self._setup_rhsm(handle, mirror)
             elif secrets_name == "org.osbuild.mtls":
                 self._setup_mtls(handle)
+            elif secrets_name == "org.osbuild.rhui":
+                self._setup_rhui(handle, mirror)
 
             download = []
             for path, checksum in packages:

--- a/test/mod/test_util_rhui.py
+++ b/test/mod/test_util_rhui.py
@@ -1,0 +1,233 @@
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from osbuild.util import rhui
+
+
+class TestCloudDetection:
+    """Test detect_cloud_provider() probing logic."""
+
+    @patch("urllib.request.urlopen")
+    def test_detect_aws(self, mock_urlopen):
+        """AWS is detected when IMDSv2 token endpoint responds."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"fake-token"
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert rhui.detect_cloud_provider() == "aws"
+
+    @patch("urllib.request.urlopen")
+    def test_detect_gcp(self, mock_urlopen):
+        """GCP is detected when AWS fails but GCP metadata responds."""
+        call_count = 0
+
+        def side_effect(req, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # First call is AWS token (PUT) — fail it
+            if call_count == 1:
+                raise OSError("connection refused")
+            # Second call is GCP metadata — succeed
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = b"ok"
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        mock_urlopen.side_effect = side_effect
+        assert rhui.detect_cloud_provider() == "gcp"
+
+    @patch("urllib.request.urlopen")
+    def test_detect_azure(self, mock_urlopen):
+        """Azure is detected when AWS and GCP fail but Azure IMDS responds."""
+        call_count = 0
+
+        def side_effect(req, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # 1=AWS token, 2=GCP metadata — fail both
+            if call_count <= 2:
+                raise OSError("connection refused")
+            # 3=Azure IMDS — succeed
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = b'{"compute": {}}'
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        mock_urlopen.side_effect = side_effect
+        assert rhui.detect_cloud_provider() == "azure"
+
+    @patch("urllib.request.urlopen")
+    def test_detect_none(self, mock_urlopen):
+        """Returns None when no cloud IMDS is reachable."""
+        mock_urlopen.side_effect = OSError("connection refused")
+        assert rhui.detect_cloud_provider() is None
+
+
+class TestAWSHeaders:
+    """Test AWS IMDS interaction and header generation."""
+
+    @patch("osbuild.util.rhui._aws_imds_get")
+    @patch("osbuild.util.rhui._aws_get_token")
+    def test_aws_get_identity_headers(self, mock_token, mock_imds_get):
+        mock_token.return_value = "fake-token"
+
+        doc_bytes = b'{"instanceId": "i-1234"}'
+        # IMDS returns base64-encoded signature
+        sig_raw = b"raw-signature-bytes"
+        sig_b64_from_imds = base64.b64encode(sig_raw)
+
+        mock_imds_get.side_effect = [doc_bytes, sig_b64_from_imds]
+
+        headers = rhui._aws_get_identity_headers()
+
+        assert len(headers) == 2
+        assert headers[0].startswith("X-RHUI-ID: ")
+        assert headers[1].startswith("X-RHUI-SIGNATURE: ")
+
+        # Verify the doc is base64-encoded
+        decoded_doc = base64.b64decode(headers[0].split(": ", 1)[1])
+        assert decoded_doc == doc_bytes
+
+        # Verify the signature is re-encoded cleanly
+        decoded_sig = base64.b64decode(headers[1].split(": ", 1)[1])
+        assert decoded_sig == sig_raw
+
+
+class TestGCPHeaders:
+    """Test GCP metadata interaction and header generation."""
+
+    @patch("osbuild.util.rhui._gcp_metadata_get")
+    def test_gcp_get_identity_headers(self, mock_metadata_get):
+        doc_bytes = b"gcp-identity-token"
+        sig_bytes = b'{"access_token": "ya29.xxx"}'
+
+        mock_metadata_get.side_effect = [doc_bytes, sig_bytes]
+
+        headers = rhui._gcp_get_identity_headers()
+
+        assert len(headers) == 2
+        assert headers[0].startswith("X-RHUI-ID: ")
+        assert headers[1].startswith("X-RHUI-SIGNATURE: ")
+
+        decoded_doc = base64.b64decode(headers[0].split(": ", 1)[1])
+        assert decoded_doc == doc_bytes
+
+        decoded_sig = base64.b64decode(headers[1].split(": ", 1)[1])
+        assert decoded_sig == sig_bytes
+
+
+class TestAzureNoHeaders:
+    """Azure RHUI uses cert-only auth, no extra headers needed."""
+
+    @patch("osbuild.util.rhui.Subscriptions")
+    @patch("osbuild.util.rhui.detect_cloud_provider")
+    def test_azure_returns_empty_headers(self, mock_detect, mock_subs_cls):
+        mock_detect.return_value = "azure"
+
+        mock_subs = MagicMock()
+        mock_subs.get_secrets.return_value = {
+            "ssl_ca_cert": "/etc/pki/rhui/ca.crt",
+            "ssl_client_key": "/etc/pki/rhui/key.pem",
+            "ssl_client_cert": "/etc/pki/rhui/cert.pem",
+        }
+        mock_subs_cls._from_rhui_repo_files.return_value = mock_subs
+
+        result = rhui.get_rhui_secrets(["https://rhui.azure.example.com/repo"])
+
+        assert result["headers"] == []
+        assert result["ssl_ca_cert"] == "/etc/pki/rhui/ca.crt"
+        assert result["ssl_client_key"] == "/etc/pki/rhui/key.pem"
+        assert result["ssl_client_cert"] == "/etc/pki/rhui/cert.pem"
+
+
+class TestGetRhuiSecrets:
+    """Integration tests for the main get_rhui_secrets() entry point."""
+
+    @patch("osbuild.util.rhui._aws_get_identity_headers")
+    @patch("osbuild.util.rhui.Subscriptions")
+    @patch("osbuild.util.rhui.detect_cloud_provider")
+    def test_aws_combined(self, mock_detect, mock_subs_cls, mock_aws_headers):
+        mock_detect.return_value = "aws"
+        mock_aws_headers.return_value = [
+            "X-RHUI-ID: abc123",
+            "X-RHUI-SIGNATURE: sig456",
+        ]
+
+        mock_subs = MagicMock()
+        mock_subs.get_secrets.return_value = {
+            "ssl_ca_cert": "/etc/pki/rhui/ca.crt",
+            "ssl_client_key": "",
+            "ssl_client_cert": "",
+        }
+        mock_subs_cls._from_rhui_repo_files.return_value = mock_subs
+
+        result = rhui.get_rhui_secrets(["https://rhui.aws.example.com/repo"])
+
+        assert result["ssl_ca_cert"] == "/etc/pki/rhui/ca.crt"
+        assert result["ssl_client_key"] == ""
+        assert result["ssl_client_cert"] == ""
+        assert len(result["headers"]) == 2
+        assert "X-RHUI-ID: abc123" in result["headers"]
+        assert "X-RHUI-SIGNATURE: sig456" in result["headers"]
+
+    @patch("osbuild.util.rhui._gcp_get_identity_headers")
+    @patch("osbuild.util.rhui.Subscriptions")
+    @patch("osbuild.util.rhui.detect_cloud_provider")
+    def test_gcp_combined(self, mock_detect, mock_subs_cls, mock_gcp_headers):
+        mock_detect.return_value = "gcp"
+        mock_gcp_headers.return_value = [
+            "X-RHUI-ID: gcp-id",
+            "X-RHUI-SIGNATURE: gcp-sig",
+        ]
+
+        mock_subs = MagicMock()
+        mock_subs.get_secrets.return_value = {
+            "ssl_ca_cert": "/etc/pki/rhui/gcp-ca.crt",
+            "ssl_client_key": "",
+            "ssl_client_cert": "",
+        }
+        mock_subs_cls._from_rhui_repo_files.return_value = mock_subs
+
+        result = rhui.get_rhui_secrets(["https://rhui.gcp.example.com/repo"])
+
+        assert result["ssl_ca_cert"] == "/etc/pki/rhui/gcp-ca.crt"
+        assert len(result["headers"]) == 2
+
+    @patch("osbuild.util.rhui.Subscriptions")
+    @patch("osbuild.util.rhui.detect_cloud_provider")
+    def test_fallback_when_no_url_match(self, mock_detect, mock_subs_cls):
+        """When get_secrets() raises RuntimeError, fall back to first RHUI repo's certs."""
+        mock_detect.return_value = "azure"
+
+        mock_subs = MagicMock()
+        mock_subs.get_secrets.side_effect = RuntimeError("no match")
+        mock_subs.repositories = {
+            "rhel-8-baseos-rhui-rpms": {
+                "sslcacert": "/fallback/ca.crt",
+                "sslclientkey": "/fallback/key.pem",
+                "sslclientcert": "/fallback/cert.pem",
+            }
+        }
+        mock_subs_cls._from_rhui_repo_files.return_value = mock_subs
+
+        result = rhui.get_rhui_secrets(["https://unknown.example.com/repo"])
+
+        assert result["ssl_ca_cert"] == "/fallback/ca.crt"
+        assert result["ssl_client_key"] == "/fallback/key.pem"
+        assert result["headers"] == []
+
+
+class TestIMDSFailure:
+    """get_rhui_secrets() raises when not on any cloud."""
+
+    @patch("osbuild.util.rhui.detect_cloud_provider")
+    def test_raises_when_no_cloud(self, mock_detect):
+        mock_detect.return_value = None
+        with pytest.raises(RuntimeError, match="Cannot detect cloud provider"):
+            rhui.get_rhui_secrets(["https://example.com/repo"])

--- a/test/mod/test_util_rhui.py
+++ b/test/mod/test_util_rhui.py
@@ -25,7 +25,7 @@ class TestCloudDetection:
         """GCP is detected when AWS fails but GCP metadata responds."""
         call_count = 0
 
-        def side_effect(req, **kwargs):
+        def side_effect(_req, **_kwargs):
             nonlocal call_count
             call_count += 1
             # First call is AWS token (PUT) — fail it
@@ -46,7 +46,7 @@ class TestCloudDetection:
         """Azure is detected when AWS and GCP fail but Azure IMDS responds."""
         call_count = 0
 
-        def side_effect(req, **kwargs):
+        def side_effect(_req, **_kwargs):
             nonlocal call_count
             call_count += 1
             # 1=AWS token, 2=GCP metadata — fail both
@@ -84,7 +84,7 @@ class TestAWSHeaders:
 
         mock_imds_get.side_effect = [doc_bytes, sig_b64_from_imds]
 
-        headers = rhui._aws_get_identity_headers()
+        headers = rhui._aws_get_identity_headers()  # pylint: disable=protected-access
 
         assert len(headers) == 2
         assert headers[0].startswith("X-RHUI-ID: ")
@@ -109,7 +109,7 @@ class TestGCPHeaders:
 
         mock_metadata_get.side_effect = [doc_bytes, sig_bytes]
 
-        headers = rhui._gcp_get_identity_headers()
+        headers = rhui._gcp_get_identity_headers()  # pylint: disable=protected-access
 
         assert len(headers) == 2
         assert headers[0].startswith("X-RHUI-ID: ")
@@ -140,7 +140,7 @@ class TestAzureNoHeaders:
 
         result = rhui.get_rhui_secrets(["https://rhui.azure.example.com/repo"])
 
-        assert result["headers"] == []
+        assert not result["headers"]
         assert result["ssl_ca_cert"] == "/etc/pki/rhui/ca.crt"
         assert result["ssl_client_key"] == "/etc/pki/rhui/key.pem"
         assert result["ssl_client_cert"] == "/etc/pki/rhui/cert.pem"
@@ -220,7 +220,7 @@ class TestGetRhuiSecrets:
 
         assert result["ssl_ca_cert"] == "/fallback/ca.crt"
         assert result["ssl_client_key"] == "/fallback/key.pem"
-        assert result["headers"] == []
+        assert not result["headers"]
 
 
 class TestIMDSFailure:


### PR DESCRIPTION
## Summary

Adds native support for building OS images on RHUI-connected cloud instances (AWS, GCP, Azure). Cloud Access and on-demand RHEL instances use RHUI for package updates instead of RHSM subscriptions, but osbuild previously had no way to authenticate against RHUI mirrors.

Per osbuild/images#2055, all depsolver secrets discovery logic lives here in osbuild/osbuild rather than in osbuild/images. The Python solver handles RHUI cert discovery, cloud identity headers, and returns a `secrets` field in the V2 response so the Go side doesn't need to duplicate this logic.

Closes #2354
Related: osbuild/osbuild-composer#820 (original report), osbuild/osbuild-composer#5028, osbuild/images#2208 (companion Go-side plumbing)

## Changes

### 1. `util/rhsm: add RHUI repo file discovery`
- Add `_from_rhui_repo_files()` to discover and parse RHUI repo files matching `/etc/yum.repos.d/*rhui*.repo`
- Integrate RHUI discovery into `from_host_system()` as a fallback when RHSM `redhat.repo` has no repos
- Handle `pulp/mirror` vs `pulp/content` URL variants in `_process_baseurl()` (RHUI CDN uses different paths for mirrorlist vs content downloads)
- Support cloud-specific placeholders like `REGION` in mirrorlist URLs
- Allow repos without client certificates (cloud RHUI uses instance identity instead)

### 2. `util/rhui: add cloud RHUI identity header support`
- Add `detect_cloud_provider()` — probes AWS IMDSv2, GCP metadata server, and Azure IMDS to identify the cloud environment
- Add `_aws_get_identity_headers()` — fetches instance identity document + signature via IMDSv2 and encodes them as `X-RHUI-ID` / `X-RHUI-SIGNATURE` headers (matching the amazon-id DNF plugin behavior)
- Add `_gcp_get_identity_headers()` — fetches GCP instance identity token and service account token as RHUI headers
- Azure uses certificate + IP-range auth only, so no extra headers are needed

### 3. `sources: add org.osbuild.rhui secrets provider for cloud RHUI`
- Register `org.osbuild.rhui` as a secrets provider in both `org.osbuild.curl` and `org.osbuild.librepo` sources
- When a manifest item specifies `"secrets": {"name": "org.osbuild.rhui"}`, the source calls `get_rhui_secrets()` to get identity headers and SSL certs

### 4. `solver: add rhui flag for cloud RHUI cert discovery`
- Add `rhui` field to solver model and API v2 request/response schema
- When `rhui=true`, the solver discovers RHUI certs and identity headers from the host instead of using RHSM entitlement certs
- Enforce mutual exclusivity: repos cannot have both `rhsm` and `rhui` set to true

### 5. `solver: add secrets field to V2 response` (migrated from osbuild/images per #2055)
- Add `secrets` field to V2 solver response repos (`"org.osbuild.rhui"`, `"org.osbuild.rhsm"`, or `null`)
- This tells the Go caller which osbuild secrets provider to use for packages from each repo, removing the need for duplicated secrets discovery on the Go side
- Track `repo_ids_with_rhui` separately from `repo_ids_with_rhsm` so the `rhui` flag propagates correctly through DNF repo round-tripping
- Add `set_rhui_flag()` method (parallel to existing `set_rhsm_flag()`) called in both DNF and DNF5 solvers
- Null out SSL fields in the response when `secrets` is set (host-specific certs shouldn't be exposed)

## How it works

1. osbuild-composer / images sets `rhui: true` on repo configs for cloud RHEL repos
2. The Python solver receives `rhui: true`, discovers SSL certs from `/etc/pki/rhui/` host repo files, and fetches cloud identity headers (AWS IMDSv2 / GCP metadata)
3. The solver response returns `rhui: true` + `secrets: "org.osbuild.rhui"` on resolved repos (SSL fields nulled)
4. The Go caller reads the `secrets` field to set the correct secrets provider on packages
5. During the build, the `org.osbuild.curl` source uses `org.osbuild.rhui` secrets to download RPMs with cloud-specific auth headers and SSL certs

## Test plan

- [x] Unit tests for cloud detection (`test_util_rhui.py` — 11 tests)
- [x] Unit tests for RHUI repo file parsing (`test_util_rhsm.py` — 31 tests)
- [x] Unit tests for curl source RHUI secrets (`test_curl_source.py`)
- [x] End-to-end on AWS EC2 RHEL 8.10 — full qcow2 compose with 469 RPMs from RHUI repos
- [x] Lint passes (`ruff check`)

## Stopgap

Until this is merged, users can use [osbuild-rhui-shim](https://github.com/brandonrc/osbuild-rhui-shim) as a workaround.