### PR TITLE
spec: drop typer-slim dependency and use only python3-typer

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -170,11 +170,7 @@ Requires:       python3-dnf
 %if 0%{?fedora}
 Requires:       python3-rich
 Requires:       python3-attrs
-%if 0%{?fedora} > 40
-Requires:       python3dist(typer-slim[standard])
-%else
 Requires:       python3-typer
-%endif
 %endif
 
 %description    tools


### PR DESCRIPTION
typer-slim has been removed in 0.22.0 [1,2].  Fedora 44+ no longer includes it.

Remove the condition for all Fedora versions and revert to using python3-typer everywhere.

This reverts commit 3932cc479cc8c08338fe149246df53f62bb71092.

[1] https://typer.tiangolo.com/#typer-slim
[2] https://github.com/fastapi/typer/releases/tag/0.22.0