### PR TITLE
stages/erofs: quiet stdout

### DIFF
--- a/stages/org.osbuild.erofs
+++ b/stages/org.osbuild.erofs
@@ -24,7 +24,8 @@ def main(args):
 
     target = os.path.join(output_dir, filename)
 
-    cmd = ["mkfs.erofs", target, source]
+    # run quietly so we don't blow up the logs
+    cmd = ["mkfs.erofs", target, source, "--quiet"]
 
     if compression:
         method = compression["method"]

--- a/stages/test/test_erofs.py
+++ b/stages/test/test_erofs.py
@@ -111,6 +111,7 @@ def test_erofs(mock_run, tmp_path, stage_module, test_options, expected):
         "mkfs.erofs",
         f"{os.path.join(tmp_path, filename)}",
         f"{fake_input_tree}",
+        "--quiet",
     ] + expected
     mock_run.assert_called_with(expected, check=True)
 


### PR DESCRIPTION
Pass `--quiet` to `mkfs.erofs` to quiet the stdout output of it. Default behavior is to output each compressed file but this makes build logs extremely large leading to issues in CI.

---

The reason for this is that when compressing large filesystems (such as live media) the output is so large that our GitLab CI truncates the logs, hiding any errors that happen after this stage.