### PR TITLE
qemu: Default to 3GB vm instead of 4GB

### DIFF
--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -464,7 +464,7 @@ class Pipeline:
             if in_vm:
                 buildtree_dir = os.path.join(build_tree.path, "tree")
 
-                qemu = Qemu("4G",
+                qemu = Qemu("3G",
                             buildtree_dir,
                             libdir)
                 qemu.add_virtiofs(object_store.store, "store", readonly=False)


### PR DESCRIPTION
When running with non-kvm on aarch64 I am getting:
```
qemu-kvm: Could not access KVM kernel module: No such file or directory
qemu-kvm: failed to initialize kvm: No such file or directory
qemu-kvm: falling back to tcg
qemu-kvm: Addressing limited to 32 bits, but memory exceeds it by 1073741824 bytes
```

Looking at e.g. https://github.com/kubernetes/minikube/issues/14273 it seems that there is a 32bit limit, which means it can't handle ram above 3GB.

So, lets lower our default from 4GB to 3GB. This is probably generally a good idea to allow building images on smaller machines. We shouldn't need that much ram to copy files around anyway.