### PR TITLE
spec: require proper selinux policy version

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -136,8 +136,8 @@ Osbuild initrd used for in-vm support.
 %package        selinux
 Summary:        SELinux policies
 Requires:       %{name} = %{version}-%{release}
-Requires:       selinux-policy-%{selinuxtype}
-Requires(post): selinux-policy-%{selinuxtype}
+Requires:       selinux-policy-%{selinuxtype} >= %{_selinux_policy_version}
+Requires(post): selinux-policy-%{selinuxtype} >= %{_selinux_policy_version}
 BuildRequires:  selinux-policy-devel
 %{?selinux_requires}
 
@@ -148,9 +148,9 @@ containers it uses to build OS artifacts.
 
 %package        container-selinux
 Summary:        SELinux container policies
-Requires:       selinux-policy-%{selinuxtype}
+Requires:       selinux-policy-%{selinuxtype} >= %{_selinux_policy_version}
 Requires:       container-selinux
-Requires(post): selinux-policy-%{selinuxtype}
+Requires(post): selinux-policy-%{selinuxtype} >= %{_selinux_policy_version}
 Requires(post): container-selinux
 BuildRequires:  selinux-policy-devel
 BuildRequires:  selinux-policy-devel


### PR DESCRIPTION
```
When osbuild-selinux is packaged, the .pp policy module is compiled
using the SELinux toolchain present in the RPM build environment. This
bakes a specific policydb ABI version into the module.

If this package is installed on a target system (the osbuild host)
running an older SELinux runtime, libsemanage will fail to load the
policy. This manifests as an ABI mismatch error during installation
(e.g., `policydb module version 24 does not match my version range
4-23`).

To prevent this, I propose to use the %{_selinux_policy_version} macro.
This automatically extracts the policy version used during the RPM build
and enforces it as a minimum requirement. This ensures that DNF will
correctly update selinux-policy and libsemanage on the target host to a
compatible version before allowing osbuild-selinux to be installed.
```

Edit: Slightly reworded

Edit: This patch is currently not effective on CentOS 10 Stream due to bug in policy dependency constraints, the fix is on the way:

https://gitlab.com/redhat/centos-stream/rpms/selinux-policy/-/merge_requests/255/diffs

---

@achilleas-k this should resolve the issue you were fighting yesterday plus any other similar issue in the future:

```
libsemanage.semanage_pipe_data: Child process /usr/libexec/selinux/hll/pp failed with code: 255. (No data available).
libsemanage.semanage_compile_module: osbuild: libsepol.policydb_read: policydb module version 24 does not match my version range 4-23.
libsemanage.semanage_compile_module: osbuild: libsepol.sepol_module_package_read: invalid module in module package (at section 0).
libsemanage.semanage_compile_module: osbuild: libsepol.sepol_ppfile_to_module_package: Failed to read policy package.
libsemanage.semanage_direct_commit: Failed to compile hll files into cil files. (No data available).
semodule:  Failed!
```

When `osbuild` is installed on a system with old `selinux-policy`, it will be automatically updated as well so our policy will always load fine. I am surprised that we survived that long without this pretty important require, I guess we were good in keeping our systems up to date?!? :-)

I also noticed you mentioned `cockpitd`, we might need to add `Require: cockpit-selinux` into our selinux package in case we need these rules to be present. But that is something different and I am not sure if we need that.