### PR TITLE
stage/xorrisofs: support excluding files (HMS-9966)

### DIFF
--- a/stages/org.osbuild.xorrisofs
+++ b/stages/org.osbuild.xorrisofs
@@ -19,6 +19,7 @@ def grub2(inputs, output_dir, options):
     efi = options.get("efi")
     isolevel = options.get("isolevel")
     grub2mbr = options.get("grub2mbr")
+    excludes = options.get("exclude", [])
 
     cmd = [
         "/usr/bin/xorrisofs",
@@ -96,6 +97,9 @@ def grub2(inputs, output_dir, options):
         "-no-emul-boot"
     ]
 
+    for exclude in excludes:
+        cmd += ["-exclude", exclude]
+
     cmd += [
         '-o', os.path.join(output_dir, filename),
         tree
@@ -118,6 +122,7 @@ def syslinux(inputs, output_dir, options):
     efi = options.get("efi")
     isohybrid = options.get("isohybridmbr")
     isolevel = options.get("isolevel")
+    excludes = options.get("exclude", [])
 
     cmd = [
         "/usr/bin/xorrisofs",
@@ -183,6 +188,9 @@ def syslinux(inputs, output_dir, options):
 
         if isohybrid:
             cmd += ["-isohybrid-gpt-basdat"]
+
+    for exclude in excludes:
+        cmd += ["-exclude", exclude]
 
     cmd += [
         '-o', os.path.join(output_dir, filename),

--- a/stages/org.osbuild.xorrisofs.meta.json
+++ b/stages/org.osbuild.xorrisofs.meta.json
@@ -82,6 +82,12 @@
           "description": "The ISO 9660 version (limits of data size and filenames)",
           "minimum": 1,
           "maximum": 4
+        },
+        "exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/stages/test/test_xorrisofs.py
+++ b/stages/test/test_xorrisofs.py
@@ -55,6 +55,55 @@ def test_xorrisofs_syslinux(mock_run, tmp_path, stage_module):
 
 
 @mock.patch("subprocess.run")
+def test_xorrisofs_syslinux_with_excludes(mock_run, tmp_path, stage_module):
+    fake_input_tree = make_fake_input_tree(tmp_path, {})
+
+    inputs = {
+        "tree": {
+            "path": fake_input_tree,
+        }
+    }
+
+    # default (syslinux)
+    stage_module.main(
+        inputs,
+        tmp_path,
+        {
+            "boot": {
+                "image": "images/eltorito.img",
+                "catalog": "boot.cat",
+            },
+            "filename": "test.iso",
+            "volid": "test",
+            "efi": "images/efiboot.img",
+            "exclude": [
+                "efiboot.img",
+            ],
+        },
+    )
+
+    mock_run.assert_called_with([
+        "/usr/bin/xorrisofs",
+        "-verbose",
+        "-V", "test",
+        "-b", "images/eltorito.img",
+        "-c", "boot.cat",
+        "--boot-catalog-hide",
+        "-boot-load-size", "4",
+        "-boot-info-table",
+        "-no-emul-boot",
+        "-rock",
+        "-joliet",
+        "-eltorito-alt-boot",
+        "-e", "images/efiboot.img",
+        "-no-emul-boot",
+        "-exclude", "efiboot.img",
+        "-o", os.path.join(tmp_path, "test.iso"),
+        fake_input_tree,
+    ], check=True)
+
+
+@mock.patch("subprocess.run")
 @mock.patch("os.path.exists")
 def test_xorrisofs_grub2(mock_exists, mock_run, tmp_path, stage_module):
     mock_exists.return_value = True
@@ -103,6 +152,64 @@ def test_xorrisofs_grub2(mock_exists, mock_run, tmp_path, stage_module):
         "-eltorito-alt-boot",
         "-e", "--interval:appended_partition_2:all::",
         "-no-emul-boot",
+        "-o", os.path.join(tmp_path, "test.iso"),
+        fake_input_tree,
+    ], check=True)
+
+
+@mock.patch("subprocess.run")
+@mock.patch("os.path.exists")
+def test_xorrisofs_grub2_with_excludes(mock_exists, mock_run, tmp_path, stage_module):
+    mock_exists.return_value = True
+
+    fake_input_tree = make_fake_input_tree(tmp_path, {})
+
+    inputs = {
+        "tree": {
+            "path": fake_input_tree,
+        }
+    }
+
+    stage_module.main(
+        inputs,
+        tmp_path,
+        {
+            "boot": {
+                "image": "images/eltorito.img",
+                "catalog": "boot.cat",
+            },
+            "grub2mbr": "/usr/lib/grub/i386-pc/boot_hybrid.img",
+            "filename": "test.iso",
+            "volid": "test",
+            "efi": "images/efiboot.img",
+            "exclude": [
+                "efiboot.img",
+            ],
+        },
+    )
+
+    mock_run.assert_called_with([
+        "/usr/bin/xorrisofs",
+        "-verbose",
+        "-rock",
+        "-joliet",
+        "-V", "test",
+        "--grub2-mbr", "/usr/lib/grub/i386-pc/boot_hybrid.img",
+        "-partition_offset", "16",
+        "-appended_part_as_gpt",
+        "-append_partition", "2", "C12A7328-F81F-11D2-BA4B-00A0C93EC93B", os.path.join(fake_input_tree, "images/efiboot.img"),
+        "-iso_mbr_part_type", "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7",
+        "-b", "images/eltorito.img",
+        "-c", "boot.cat",
+        "--boot-catalog-hide",
+        "-no-emul-boot",
+        "-boot-load-size", "4",
+        "-boot-info-table",
+        "--grub2-boot-info",
+        "-eltorito-alt-boot",
+        "-e", "--interval:appended_partition_2:all::",
+        "-no-emul-boot",
+        "-exclude", "efiboot.img",
         "-o", os.path.join(tmp_path, "test.iso"),
         fake_input_tree,
     ], check=True)


### PR DESCRIPTION
stage/xorrisofs: support excluding files

In another PR [1], [2] I wanted to introduce efiboot.img being sourced from
inputs. However, this was quite a larger sweeping change that might need
more careful consideration (we might use such a change to also switch to
using `xorriso` directly, and to revisit all of our ISO mushing needs).

This PR instead introduces the option to exclude certain files. See the
documentation for `xorrisofs` for the options but it's basically a shell
glob. If it doesn't contain a `/` then the basename of the file is used
instead.

The change allows to achieve the goal of not including `efiboot.img`
without complicating matters.

[1]: https://github.com/osbuild/osbuild/pull/2352
[2]: https://github.com/osbuild/images/pull/2204