### PR TITLE
ci/mock: enable verbose build

### DIFF
--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -423,6 +423,7 @@ sudo usermod -a -G mock "$(whoami)"
 greenprint "🎁 Building RPMs with mock"
 mock -r $MOCK_CONFIG \
     --resultdir $REPO_DIR \
+    -v \
     rpmbuild/SRPMS/*.src.rpm
 sudo chown -R $USER ${REPO_DIR}
 


### PR DESCRIPTION
Since we aren't uploading logs anywhere; let's enable verbose mode for mock as some RPMs are failing to build.