### PR TITLE
Preparatory cleanups for rootless osbuild

### DIFF
--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -5,10 +5,9 @@ import io
 import json
 import os
 import sys
-import tempfile
 import threading
 import traceback
-from typing import ClassVar, Dict, Optional
+from typing import ClassVar, Dict
 
 from .util import jsoncomm
 from .util.types import PathLike
@@ -43,12 +42,11 @@ class BaseAPI(abc.ABC):
     endpoint: ClassVar[str]
     """The name of the API endpoint"""
 
-    def __init__(self, socket_address: Optional[PathLike] = None):
-        self.socket_address = socket_address
+    def __init__(self, rundir: PathLike):
+        self.socket_address = os.path.join(rundir, self.endpoint)
         self.barrier = threading.Barrier(2)
         self.event_loop = None
         self.thread = None
-        self._socketdir = None
 
     @abc.abstractmethod
     def _message(self, msg: Dict, fds: jsoncomm.FdSet, sock: jsoncomm.Socket):
@@ -60,12 +58,6 @@ class BaseAPI(abc.ABC):
 
     def _cleanup(self):
         """Called after the event loop is shut down"""
-
-    @classmethod
-    def _make_socket_dir(cls, rundir: PathLike = "/run/osbuild"):
-        """Called to create the temporary socket dir"""
-        os.makedirs(rundir, exist_ok=True)
-        return tempfile.TemporaryDirectory(prefix="api-", dir=rundir)
 
     def _dispatch(self, sock: jsoncomm.Socket):
         """Called when data is available on the socket"""
@@ -102,11 +94,6 @@ class BaseAPI(abc.ABC):
         # We are not re-entrant, so complain if re-entered.
         assert not self.running
 
-        if not self.socket_address:
-            self._socketdir = self._make_socket_dir()
-            address = os.path.join(self._socketdir.name, self.endpoint)
-            self.socket_address = address
-
         self.event_loop = asyncio.new_event_loop()
         self.thread = threading.Thread(target=self._run_event_loop)
 
@@ -126,11 +113,7 @@ class BaseAPI(abc.ABC):
 
         self.thread = None
         self.event_loop = None
-
-        if self._socketdir:
-            self._socketdir.cleanup()
-            self._socketdir = None
-            self.socket_address = None
+        self.socket_address = None
 
 
 class API(BaseAPI):
@@ -138,8 +121,8 @@ class API(BaseAPI):
 
     endpoint = "osbuild"
 
-    def __init__(self, *, socket_address=None):
-        super().__init__(socket_address)
+    def __init__(self, rundir):
+        super().__init__(rundir)
         self.error = None
 
     def _message(self, msg, fds, sock):

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -14,7 +14,6 @@ import select
 import subprocess
 import tempfile
 import time
-from typing import Set
 
 from osbuild.api import BaseAPI
 
@@ -49,25 +48,6 @@ class CompletedBuild:
         return self.output
 
 
-class ProcOverrides:
-    """Overrides for /proc inside the buildroot"""
-
-    def __init__(self, path) -> None:
-        self.path = path
-        self.overrides: Set["str"] = set()
-
-    @property
-    def cmdline(self) -> str:
-        with open(os.path.join(self.path, "cmdline"), "r", encoding="utf8") as f:
-            return f.read().strip()
-
-    @cmdline.setter
-    def cmdline(self, value) -> None:
-        with open(os.path.join(self.path, "cmdline"), "w", encoding="utf8") as f:
-            f.write(value + "\n")
-        self.overrides.add("cmdline")
-
-
 # pylint: disable=too-many-instance-attributes,too-many-branches
 class BuildRoot(contextlib.AbstractContextManager):
     """Build Root
@@ -86,18 +66,16 @@ class BuildRoot(contextlib.AbstractContextManager):
     are retained.
     """
 
-    def __init__(self, root, runner, libdir, var, *, rundir="/run/osbuild"):
+    def __init__(self, root, runner, libdir, tmpdir):
         self._exitstack = None
         self._rootdir = root
-        self._rundir = rundir
-        self._vardir = var
+        self._tmpdir = tmpdir
         self._libdir = libdir
         self._runner = runner
         self._apis = []
         self.dev = None
+        self._proc_cmdline = None
         self.var = None
-        self.proc = None
-        self.tmp = None
         self.mount_boot = True
         self.caps = None
 
@@ -113,35 +91,32 @@ class BuildRoot(contextlib.AbstractContextManager):
         with self._exitstack:
             # We create almost everything directly in the container as temporary
             # directories and mounts. However, for some things we need external
-            # setup. For these, we create temporary directories which are then
-            # bind-mounted into the container.
+            # setup. For these, we a create temporary directory with:
             #
-            # For now, this includes:
+            #   * dev: Used as /dev in he container. A tmpfs instance *without*
+            #     `nodev` which we then use as `/dev` in the container. This is
+            #     required for the container to create device nodes for
+            #     loop-devices.
             #
-            #   * We create a tmpfs instance *without* `nodev` which we then use
-            #     as `/dev` in the container. This is required for the container
-            #     to create device nodes for loop-devices.
+            #   * var: Used as '/var' in the container. This allows the
+            #     container to create throw-away data that it does not want to
+            #     put into a tmpfs.
             #
-            #   * We create a temporary directory for variable data and then use
-            #     it as '/var' in the container. This allows the container to
-            #     create throw-away data that it does not want to put into a
-            #     tmpfs.
+            #   * cmdline: Overrides /proc/cmdline in the container to not leak
+            #     the host's cmdline.
 
-            os.makedirs(self._rundir, exist_ok=True)
-            dev = tempfile.TemporaryDirectory(prefix="osbuild-dev-", dir=self._rundir)
-            self.dev = self._exitstack.enter_context(dev)
+            tmp = tempfile.TemporaryDirectory(prefix="osbuild-tmp-", dir=self._tmpdir)
+            self._exitstack.enter_context(tmp)
 
-            os.makedirs(self._vardir, exist_ok=True)
-            tmp = tempfile.TemporaryDirectory(prefix="osbuild-tmp-", dir=self._vardir)
-            self.tmp = self._exitstack.enter_context(tmp)
+            self.dev = os.path.join(tmp.name, "dev")
+            os.makedirs(self.dev, exist_ok=True)
 
-            self.var = os.path.join(self.tmp, "var")
+            self.var = os.path.join(tmp.name, "var")
             os.makedirs(self.var, exist_ok=True)
 
-            proc = os.path.join(self.tmp, "proc")
-            os.makedirs(proc)
-            self.proc = ProcOverrides(proc)
-            self.proc.cmdline = "root=/dev/osbuild"
+            self._proc_cmdline = os.path.join(tmp.name, "cmdline")
+            with open(self._proc_cmdline, "w", encoding="utf8") as f:
+                f.write("root=/dev/osbuild\n")
 
             subprocess.run(["mount", "-t", "tmpfs", "-o", "nosuid", "none", self.dev], check=True)
             self._exitstack.callback(lambda: subprocess.run(["umount", "--lazy", self.dev], check=True))
@@ -224,8 +199,13 @@ class BuildRoot(contextlib.AbstractContextManager):
         #  https://github.com/osbuild/bootc-image-builder/issues/223
         os.makedirs(os.path.join(self.var, "tmp"), 0o1777, exist_ok=True)
 
-        # Setup API file-systems.
-        mounts += ["--proc", "/proc"]
+        # Setup /proc. Don't leak /proc/cmdline from the host.
+        mounts += [
+            "--proc", "/proc",
+            "--ro-bind", self._proc_cmdline, "/proc/cmdline"
+        ]
+
+        # Setup /sys
         mounts += ["--ro-bind", "/sys", "/sys"]
         mounts += ["--ro-bind-try", "/sys/fs/selinux", "/sys/fs/selinux"]
 
@@ -259,14 +239,6 @@ class BuildRoot(contextlib.AbstractContextManager):
             modorigin = importlib.util.find_spec("osbuild").origin
             modpath = os.path.dirname(modorigin)
             mounts += ["--ro-bind", f"{modpath}", "/run/osbuild/lib/osbuild"]
-
-        # Setup /proc overrides
-        for override in self.proc.overrides:
-            mounts += [
-                "--ro-bind",
-                os.path.join(self.proc.path, override),
-                os.path.join("/proc", override)
-            ]
 
         # Make caller-provided mounts available as well.
         for b in binds or []:

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -176,7 +176,7 @@ class BuildRoot(contextlib.AbstractContextManager):
 
         for p in imports:
             source = os.path.join(self._rootdir, p)
-            if os.path.isdir(source) and not os.path.islink(source):
+            if os.path.isdir(source):
                 mounts += ["--ro-bind", source, os.path.join("/", p)]
 
         # Create /usr symlinks.

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -194,10 +194,7 @@ class BuildRoot(contextlib.AbstractContextManager):
         mounts += ["--tmpfs", "/run"]
         mounts += ["--tmpfs", "/tmp"]
         mounts += ["--bind", self.var, "/var"]
-
-        # Create a usable /var/tmp, see
-        #  https://github.com/osbuild/bootc-image-builder/issues/223
-        os.makedirs(os.path.join(self.var, "tmp"), 0o1777, exist_ok=True)
+        mounts += ["--perms", "01777", "--dir", "/var/tmp"]
 
         # Setup /proc. Don't leak /proc/cmdline from the host.
         mounts += [

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -184,7 +184,7 @@ def osbuild_cli() -> int:
             pipelines = manifest.depsolve(object_store, exports)
             total_steps = len(manifest.sources) + len(pipelines)
             monitor = osbuild.monitor.make(monitor_name, args.monitor_fd, total_steps)
-            monitor.log(f"starting {args.manifest_path}", origin="osbuild.main_cli")
+            monitor.log(f"starting {args.manifest_path}\n", origin="osbuild.main_cli")
 
             r = manifest.build(
                 object_store,

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -500,8 +500,8 @@ class StoreServer(api.BaseAPI):
 
     endpoint = "store"
 
-    def __init__(self, store: ObjectStore, *, socket_address=None):
-        super().__init__(socket_address)
+    def __init__(self, store: ObjectStore, rundir):
+        super().__init__(rundir)
         self.store = store
         self.tmproot = store.tempdir(prefix="store-server-")
         self._stack = contextlib.ExitStack()

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -300,22 +300,20 @@ class HostTree:
         self._root = self.store.tempdir(prefix="host")
 
         root = self._root.name
-        # Create a bare bones root file system. Starting with just
-        # /usr mounted from the host.
+        # Create a bare bones root file system. Starting with just /usr from
+        # the host. Link it into the root. Bubblewrap will read-only bind it
+        # into the container.
         usr = os.path.join(root, "usr")
-        os.makedirs(usr)
+        os.symlink("/usr", usr)
+
         # Also add in /etc/containers, which will allow us to access
         # /etc/containers/policy.json and enable moving containers
         # (skopeo): https://github.com/osbuild/osbuild/pull/1410
         # If https://github.com/containers/image/issues/2157 ever gets
         # fixed we can probably remove this bind mount.
-        etc_containers = os.path.join(root, "etc", "containers")
-        os.makedirs(etc_containers)
-
-        # ensure / is read-only
-        mount(root, root)
-        mount("/usr", usr)
-        mount("/etc/containers", etc_containers)
+        if os.path.isdir("/etc/containers"):
+            os.makedirs(os.path.join(root, "etc"))
+            os.symlink("/etc/containers", os.path.join(root, "etc", "containers"))
 
     @property
     def tree(self) -> os.PathLike:
@@ -325,7 +323,6 @@ class HostTree:
 
     def cleanup(self):
         if self._root:
-            umount(self._root.name)
             self._root.cleanup()
             self._root = None
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -241,6 +241,9 @@ class Stage:
             tmpdir = store.tempdir(prefix="buildroot-tmp-")
             tmpdir = cm.enter_context(tmpdir)
 
+            rundir = os.path.join(tmpdir, "run")
+            os.makedirs(rundir)
+
             inputs_tmpdir = os.path.join(tmpdir, "inputs")
             os.makedirs(inputs_tmpdir)
             inputs_mapped = "/run/osbuild/inputs"
@@ -281,7 +284,7 @@ class Stage:
                 f"{mounts_tmpdir}:{mounts_mapped}"
             ]
 
-            storeapi = objectstore.StoreServer(store)
+            storeapi = objectstore.StoreServer(store, rundir)
             cm.enter_context(storeapi)
 
             mgr = host.ServiceManager(monitor=monitor)
@@ -303,10 +306,10 @@ class Stage:
 
             self.prepare_arguments(args, args_path)
 
-            api = API()
+            api = API(rundir)
             build_root.register_api(api)
 
-            rls = remoteloop.LoopServer()
+            rls = remoteloop.LoopServer(rundir)
             build_root.register_api(rls)
 
             extra_env = {}

--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -36,8 +36,8 @@ class LoopServer(api.BaseAPI):
 
     endpoint = "remoteloop"
 
-    def __init__(self, *, socket_address=None):
-        super().__init__(socket_address)
+    def __init__(self, rundir):
+        super().__init__(rundir)
         self.devs = []
         self.ctl = None
 

--- a/osbuild/testutil/dnf4.py
+++ b/osbuild/testutil/dnf4.py
@@ -21,6 +21,9 @@ def depsolve_pkgset(
         conf.reposdir = ["/dev/null"]
         conf.pluginconfpath = ["/dev/null"]
         conf.varsdir = ["/dev/null"]
+        # explicitly set arch as our test repos only include x86 metadata
+        conf.substitutions["arch"] = "x86_64"
+        conf.substitutions["basearch"] = "x86_64"
 
         base = dnf.Base(conf)
 

--- a/test/mod/test_api.py
+++ b/test/mod/test_api.py
@@ -4,7 +4,6 @@
 
 import json
 import multiprocessing as mp
-import os
 import pathlib
 import tempfile
 import time
@@ -17,8 +16,8 @@ from osbuild.util import jsoncomm
 class APITester(osbuild.api.BaseAPI):
     """Records the number of messages and if it got cleaned up"""
 
-    def __init__(self, sockaddr):
-        super().__init__(sockaddr)
+    def __init__(self, rundir):
+        super().__init__(rundir)
         self.clean = False
         self.messages = 0
 
@@ -49,10 +48,9 @@ class TestAPI(unittest.TestCase):
     def test_basic(self):
         # Basic API communication and cleanup checks
 
-        socket = os.path.join(self.tmp.name, "socket")
-        api = APITester(socket)
+        api = APITester(self.tmp.name)
         with api:
-            with jsoncomm.Socket.new_client(socket) as client:
+            with jsoncomm.Socket.new_client(api.socket_address) as client:
                 req = {'method': 'echo', 'data': 'Hello'}
                 client.send(req)
                 msg, _, _ = client.recv()
@@ -67,8 +65,7 @@ class TestAPI(unittest.TestCase):
         self.assertIsNone(api.event_loop)
 
     def test_reentrancy_guard(self):
-        socket = os.path.join(self.tmp.name, "socket")
-        api = APITester(socket)
+        api = APITester(self.tmp.name)
         with api:
             with self.assertRaises(AssertionError):
                 with api:
@@ -77,14 +74,13 @@ class TestAPI(unittest.TestCase):
     def test_exception(self):
         # Check that 'api.exception' correctly sets 'API.exception'
         tmpdir = self.tmp.name
-        path = os.path.join(tmpdir, "osbuild-api")
 
         def exception(path):
             with osbuild.api.exception_handler(path):
                 raise ValueError("osbuild test exception")
             assert False, "api.exception should exit process"
 
-        api = osbuild.api.API(socket_address=path)
+        api = osbuild.api.API(tmpdir)
         with api:
             # On macOS and newly non-macOS POSIX systems (since Python 3.14),
             # the default method has been changed to forkserver.
@@ -96,7 +92,7 @@ class TestAPI(unittest.TestCase):
             else:
                 _mp_context = mp.get_context()
 
-            p = _mp_context.Process(target=exception, args=(path, ))
+            p = _mp_context.Process(target=exception, args=(api.socket_address, ))
             p.start()
             p.join()
 
@@ -134,10 +130,9 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(metadata, data)
 
     def test_exception_in_api_message(self):
-        socket = os.path.join(self.tmp.name, "socket")
-        api = APITester(socket)
+        api = APITester(self.tmp.name)
         with api:
-            with jsoncomm.Socket.new_client(socket) as client:
+            with jsoncomm.Socket.new_client(api.socket_address) as client:
                 req = {'method': 'error-trigger'}
                 client.send(req)
                 msg, _, _ = client.recv()

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -158,21 +158,16 @@ def test_selinuxfs_ro(tempdir, runner):
 
 
 @pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")
-def test_proc_overrides(tempdir, runner):
+def test_proc_cmdline(tempdir, runner):
     libdir = os.path.abspath(os.curdir)
     var = pathlib.Path(tempdir, "var")
     var.mkdir()
 
-    cmdline = "is-this-the-real-world"
-
     monitor = NullMonitor(sys.stderr.fileno())
     with BuildRoot("/", runner, libdir, var) as root:
-
-        root.proc.cmdline = cmdline
-
         r = root.run(["cat", "/proc/cmdline"], monitor)
         assert r.returncode == 0
-        assert cmdline in r.output.strip()
+        assert "root=/dev/osbuild" in r.output.strip()
 
 
 @pytest.mark.skipif(not TestBase.can_bind_mount(), reason="root only")

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -258,7 +258,7 @@ def test_store_server(tmp_path):
         tmp = tempfile.TemporaryDirectory()
         tmp = stack.enter_context(tmp)
 
-        server = objectstore.StoreServer(store)
+        server = objectstore.StoreServer(store, tmp)
         stack.enter_context(server)
 
         client = objectstore.StoreClient(server.socket_address)

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -184,11 +184,10 @@ def test_host_tree(tmp_path):
         assert host.tree
         assert os.fspath(host)
 
-        # check we actually cannot write to the path
-        p = Path(host.tree, "osbuild-test-file")
-        with pytest.raises(OSError):
-            p.touch()
-            print("FOO")
+        # /usr should be a symlink pointing to /usr on the host
+        usr = os.path.join(host.tree, "usr")
+        assert os.path.islink(usr)
+        assert os.readlink(usr) == "/usr"
 
     # We cannot access the tree property after cleanup
     with pytest.raises(AssertionError):


### PR DESCRIPTION
Some more preparatory commits towards running osbuild without root privileges.

Most of the simplify the buildroot setup by using bwrap's built-in capabilities instead of reimplementing them. Some of them are just cleanups I stumbled across along the way. (I don't think it's worth spinning up CI for those separately, but please let me know if any of the maintainers prefer a separate PR for those.)

I was already able to drop the root requirement for the buildroot tests.