### PR TITLE
inputs: Move all mounting to bwrap

### DIFF
--- a/inputs/org.osbuild.containers
+++ b/inputs/org.osbuild.containers
@@ -21,7 +21,6 @@ import os
 import sys
 
 from osbuild import inputs
-from osbuild.util.mnt import MountGuard
 
 SCHEMA = r"""
 "definitions": {
@@ -160,62 +159,47 @@ SCHEMA = r"""
 
 class ContainersInput(inputs.InputService):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.mg = MountGuard()
-
-    def map_source_ref(self, source, ref, target):
+    @staticmethod
+    def map_source_ref(source, ref):
         source_archive = os.path.join(source, ref, "image")
-        dest = os.path.join(target, ref)
-
-        # bind mount the input directory to the destination
-        os.makedirs(dest)
-        self.mg.mount(source_archive, dest)
-
-        return ref, "dir"
+        return (source_archive, ref), "dir"
 
     @staticmethod
-    def map_pipeline_ref(store, ref, target):
-        # prepare the mount point
-        os.makedirs(target, exist_ok=True)
-        print("target", target)
-
-        store.read_tree_at(ref, target)
+    def map_pipeline_ref(store, ref):
+        tree = store.read_tree(ref)
+        if not tree:
+            raise RuntimeError(f"No tree at {ref}")
 
         # Find the archive file in target, we use the first alphabetical regular file
-        files = sorted(filter(lambda f: os.path.isfile(os.path.join(target, f)),
-                              os.listdir(target)))
+        files = sorted(filter(lambda f: os.path.isfile(os.path.join(tree, f)),
+                              os.listdir(tree)))
         if len(files) == 0:
             raise RuntimeError("No archive files in source")
 
-        return files[0], "oci-archive"
+        return (os.path.join(tree, files[0]), ref), "oci-archive"
 
     def map(self, store, origin, refs, target, _options):
         source = store.source("org.osbuild.containers")
         images = {}
+        binds = []
 
         for ref, data in refs.items():
             if origin == "org.osbuild.source":
-                ref, container_format = self.map_source_ref(source, ref, target)
+                bind, container_format = self.map_source_ref(source, ref)
             else:
-                ref, container_format = self.map_pipeline_ref(store, ref, target)
+                bind, container_format = self.map_pipeline_ref(store, ref)
+
+            binds.append(bind)
 
             images[ref] = {
                 "format": container_format,
                 "name": data["name"]
             }
-            images[ref]["name"] = data["name"]
 
-        reply = {
-            "path": target,
-            "data": {
-                "archives": images
-            }
+        data = {
+            "archives": images
         }
-        return reply
-
-    def unmap(self):
-        self.mg.umount()
+        return data, binds
 
 
 def main():

--- a/inputs/org.osbuild.containers-storage
+++ b/inputs/org.osbuild.containers-storage
@@ -11,12 +11,10 @@ container store that depends on the availability of the
 resource (the specific container) on the host.
 """
 
-import os
 import sys
 
 from osbuild import inputs
 from osbuild.util import host
-from osbuild.util.mnt import MountGuard
 
 SCHEMA = r"""
 "definitions": {
@@ -88,19 +86,12 @@ class ContainersStorageInput(inputs.InputService):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.mg = MountGuard()
         self.storage_conf = host.get_container_storage()
 
-    def bind_mount_local_storage(self, target):
-        source = self.storage_conf["storage"]["graphroot"]
-        dest = os.path.join(target, "storage")
-
-        # bind mount the input directory to the destination
-        os.makedirs(dest, exist_ok=True)
-        self.mg.mount(source, dest)
-
     def map(self, store, origin, refs, target, _options):
-        self.bind_mount_local_storage(target)
+        binds = [
+            (self.storage_conf["storage"]["graphroot"], "storage")
+        ]
 
         images = {}
         for ref, data in refs.items():
@@ -111,17 +102,10 @@ class ContainersStorageInput(inputs.InputService):
             images[ref]["name"] = data["name"]
             images[ref]["storage"] = self.storage_conf["storage"]
 
-        reply = {
-            "path": target,
-            "data": {
-                "archives": images
-            }
+        data = {
+            "archives": images
         }
-
-        return reply
-
-    def unmap(self):
-        self.mg.umount()
+        return data, binds
 
 
 def main():

--- a/inputs/org.osbuild.files
+++ b/inputs/org.osbuild.files
@@ -15,7 +15,6 @@ schema validation.
 """
 
 import os
-import pathlib
 import sys
 
 from osbuild import inputs
@@ -178,43 +177,39 @@ SCHEMA = r"""
 class FilesInput(inputs.InputService):
 
     @staticmethod
-    def map_pipeline_ref(store, ref, data, target):
-        filepath = data["file"].lstrip("/")
-
-        # prepare the mount point
-        filename = pathlib.Path(target, filepath)
-        os.makedirs(filename.parent, exist_ok=True)
-        filename.touch()
-
-        store.read_tree_at(ref, filename, filepath)
-
-        return filepath, data.get("metadata", {})
-
-    @staticmethod
-    def map_source_ref(source, ref, data, target):
-        os.link(f"{source}/{ref}", f"{target}/{ref}")
-        data = data.get("metadata", {})
-        return ref, data
-
-    def map(self, store, origin, refs, target, _options):
-
-        source = store.source("org.osbuild.files")
-        files = {}
+    def map_pipeline_refs(store, refs):
+        binds = []
 
         for ref, data in refs.items():
-            if origin == "org.osbuild.source":
-                ref, data = self.map_source_ref(source, ref, data, target)
-            else:
-                ref, data = self.map_pipeline_ref(store, ref, data, target)
-            files[ref] = data
+            tree = store.read_tree(ref)
+            if not tree:
+                raise RuntimeError(f"No tree at {ref}")
+            path = data["file"].lstrip("/")
+            binds.append((os.path.join(tree, path), ref))
 
-        reply = {
-            "path": target,
-            "data": {
-                "files": files
-            }
+        return binds
+
+    @staticmethod
+    def map_source_refs(store, refs, target):
+        source = store.source("org.osbuild.files")
+
+        for ref in refs.keys():
+            os.link(os.path.join(source, ref), os.path.join(target, ref))
+
+        return [(target, "")]
+
+    def map(self, store, origin, refs, target, _options):
+        binds = []
+
+        if origin == "org.osbuild.source":
+            binds = self.map_source_refs(store, refs, target)
+        else:
+            binds = self.map_pipeline_refs(store, refs)
+
+        data = {
+            "files": {ref: data.get("metadata", {}) for ref, data in refs.items()}
         }
-        return reply
+        return data, binds
 
 
 def main():

--- a/inputs/org.osbuild.noop
+++ b/inputs/org.osbuild.noop
@@ -26,13 +26,7 @@ class NoopInput(inputs.InputService):
         path = os.path.join(target, uid)
         os.makedirs(path)
 
-        reply = {
-            "path": target,
-            "data": {
-                "refs": refs
-            }
-        }
-        return reply
+        return {"refs": refs}, []
 
 
 def main():

--- a/inputs/org.osbuild.ostree
+++ b/inputs/org.osbuild.ostree
@@ -87,8 +87,7 @@ SCHEMA = """
 def export(checksums, cache, output):
     repo_cache = os.path.join(cache, "repo")
 
-    repo_out = os.path.join(output, "repo")
-    ostree.cli("init", mode="archive", repo=repo_out)
+    ostree.cli("init", mode="archive", repo=output)
 
     refs = {}
     for commit, options in checksums.items():
@@ -96,23 +95,16 @@ def export(checksums, cache, output):
         print(f"exporting {commit}", file=sys.stderr)
 
         ostree.cli("pull-local", repo_cache, commit,
-                   repo=repo_out)
+                   repo=output)
 
         ref = options.get("ref")
         if ref:
             ostree.cli("refs", "--create", ref, commit,
-                       repo=repo_out)
+                       repo=output)
 
         refs[commit] = options
 
-    reply = {
-        "path": repo_out,
-        "data": {
-            "refs": refs
-        }
-    }
-
-    return reply
+    return {"refs": refs}
 
 
 class OSTreeInput(inputs.InputService):
@@ -130,7 +122,7 @@ class OSTreeInput(inputs.InputService):
             source = store.source("org.osbuild.ostree")
             reply = export(refs, source, target)
 
-        return reply
+        return reply, [(target, "")]
 
 
 def main():

--- a/inputs/org.osbuild.ostree.checkout
+++ b/inputs/org.osbuild.ostree.checkout
@@ -112,14 +112,11 @@ class OSTreeCheckoutInput(inputs.InputService):
             source = store.source("org.osbuild.ostree")
             ids = checkout(refs, source, target)
 
-        reply = {
-            "path": target,
-            "data": {
-                "refs": {i: {"path": i} for i in ids}
-            }
+        data = {
+            "refs": {i: {"path": i} for i in ids}
         }
 
-        return reply
+        return data, []
 
 
 def main():

--- a/inputs/org.osbuild.tree
+++ b/inputs/org.osbuild.tree
@@ -79,15 +79,16 @@ class TreeInput(inputs.InputService):
         # and we have exactly one reference, i.e. a pipeline id
         pid, _ = refs.popitem()
 
-        path = None
+        tree = None
         if pid:
-            path = store.read_tree_at(pid, target)
+            tree = store.read_tree(pid)
 
-        if not path:
+        if not tree:
             raise ValueError(f"Unknown pipeline '{pid}'")
 
-        reply = {"path": target}
-        return reply
+        data = {}
+        binds = [(tree, "")]
+        return data, binds
 
 
 def main():

--- a/inputs/test/test_containers.py
+++ b/inputs/test/test_containers.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 import os
-import pathlib
 import subprocess
 import tempfile
 
@@ -43,17 +42,8 @@ def test_containers_local_inputs_integration(tmp_path, inputs_service):
         # not using "tmp_path" here as it will "rm -rf" on cleanup and
         # that is dangerous as during the tests we bind mount the
         # system container storage read-write
-        target = pathlib.Path(tempfile.TemporaryDirectory("cnt-target").name)
-        options = None
-        try:
-            reply = inputs_service.map(store, inputs["origin"], inputs["references"], target, options)
-            assert reply["path"] == target
-            assert len(reply["data"]["archives"]) == 1
-            assert (target / "storage").exists()
-        finally:
-            inputs_service.unmap()
-            # cleanup manually, note that we only remove empty dirs here,
-            # because we only expect a bind mount under "$target/storage"
-            # Anything non-empty here means a umount() failed
-            os.rmdir(target / "storage")
-            os.rmdir(target)
+        with tempfile.TemporaryDirectory("cnt-target") as target:
+            data, binds = inputs_service.map(store, inputs["origin"], inputs["references"], target, None)
+            assert len(data["archives"]) == 1
+            assert len(binds) == 1
+            assert binds[0][1] == "storage"

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -269,10 +269,10 @@ class BuildRoot(contextlib.AbstractContextManager):
             ]
 
         # Make caller-provided mounts available as well.
-        for b in binds or []:
-            mounts += ["--bind"] + b.split(":")
-        for b in readonly_binds or []:
-            mounts += ["--ro-bind"] + b.split(":")
+        for source, target in binds or []:
+            mounts += ["--bind", source, target]
+        for source, target in readonly_binds or []:
+            mounts += ["--ro-bind", source, target]
 
         # Prepare all registered API endpoints: bind mount the address with
         # the `endpoint` name, provided by the API, into the well known path

--- a/osbuild/inputs.py
+++ b/osbuild/inputs.py
@@ -21,7 +21,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from osbuild import host
 from osbuild.util.types import PathLike
@@ -93,9 +93,13 @@ class InputManager:
         self.service_manager = mgr
         self.storeapi = storeapi
         self.root = root
-        self.inputs: Dict[str, Input] = {}
 
-    def map(self, ip: Input) -> Tuple[str, Dict]:
+    def map(self, ip: Input) -> Tuple[Dict, List[Tuple[str, str]]]:
+        """Map an input's sources into a target directory.
+
+        Returns: A tuple containing the input's data dictionary and a list of
+        bind mounts for the stage.
+        """
 
         target = os.path.join(self.root, ip.name)
         os.makedirs(target)
@@ -117,18 +121,7 @@ class InputManager:
         }
 
         client = self.service_manager.start(f"input/{ip.name}", ip.info_path)
-        reply = client.call("map", args)
-
-        path = reply["path"]
-
-        if not path.startswith(self.root):
-            raise RuntimeError(f"returned {path} has wrong prefix")
-
-        reply["path"] = os.path.relpath(path, self.root)
-
-        self.inputs[ip.name] = reply
-
-        return reply
+        return client.call("map", args)
 
 
 class InputService(host.Service):
@@ -137,12 +130,6 @@ class InputService(host.Service):
     @abc.abstractmethod
     def map(self, store, origin, refs, target, options):
         pass
-
-    def unmap(self):
-        pass
-
-    def stop(self):
-        self.unmap()
 
     def dispatch(self, method: str, args, fds):
         if method == "map":

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -524,28 +524,6 @@ class StoreServer(api.BaseAPI):
 
         sock.send({"path": obj.tree})
 
-    def _read_tree_at(self, msg, sock):
-        object_id = msg["object-id"]
-        target = msg["target"]
-        subtree = msg["subtree"]
-
-        obj = self.store.get(object_id)
-        if not obj:
-            sock.send({"path": None})
-            return
-
-        try:
-            source = os.path.join(obj, subtree.lstrip("/"))
-            mount(source, target)
-            self._stack.callback(umount, target)
-
-        # pylint: disable=broad-except
-        except Exception as e:
-            sock.send({"error": str(e)})
-            return
-
-        sock.send({"path": target})
-
     def _mkdtemp(self, msg, sock):
         args = {
             "suffix": msg.get("suffix"),
@@ -565,8 +543,6 @@ class StoreServer(api.BaseAPI):
     def _message(self, msg, _fds, sock):
         if msg["method"] == "read-tree":
             self._read_tree(msg, sock)
-        elif msg["method"] == "read-tree-at":
-            self._read_tree_at(msg, sock)
         elif msg["method"] == "mkdtemp":
             self._mkdtemp(msg, sock)
         elif msg["method"] == "source":
@@ -603,23 +579,6 @@ class StoreClient:
 
         self.client.send(msg)
         msg, _, _ = self.client.recv()
-
-        return msg["path"]
-
-    def read_tree_at(self, object_id: str, target: str, path="/"):
-        msg = {
-            "method": "read-tree-at",
-            "object-id": object_id,
-            "target": os.fspath(target),
-            "subtree": os.fspath(path)
-        }
-
-        self.client.send(msg)
-        msg, _, _ = self.client.recv()
-
-        err = msg.get("error")
-        if err:
-            raise RuntimeError(err)
 
         return msg["path"]
 

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -286,15 +286,14 @@ class Stage:
             }
 
             ro_binds = [
-                f"{self.info_path}:/run/osbuild/bin/{self.name}",
-                f"{inputs_tmpdir}:{inputs_mapped}",
-                f"{args_path}:/run/osbuild/api/arguments"
+                (self.info_path, f"/run/osbuild/bin/{self.name}"),
+                (args_path, "/run/osbuild/api/arguments")
             ]
 
             binds = [
-                tree_path + ":/run/osbuild/tree",
-                meta_name + ":/run/osbuild/meta",
-                f"{mounts_tmpdir}:{mounts_mapped}"
+                (tree_path, "/run/osbuild/tree"),
+                (meta_name, "/run/osbuild/meta"),
+                (mounts_tmpdir, mounts_mapped)
             ]
 
             storeapi = objectstore.StoreServer(store)
@@ -305,8 +304,12 @@ class Stage:
 
             ipmgr = InputManager(mgr, storeapi, inputs_tmpdir)
             for key, ip in self.inputs.items():
-                data_inp = ipmgr.map(ip)
-                inputs[key] = data_inp
+                path = os.path.join(inputs_mapped, ip.name)
+                data, input_binds = ipmgr.map(ip)
+                ro_binds += [
+                    (source, os.path.join(path, target)) for source, target in input_binds
+                ]
+                inputs[key] = {"path": path, "data": data}
 
             devmgr = DeviceManager(mgr, build_root.dev, tree_path)
             for name, dev in self.devices.items():

--- a/test/mod/test_buildroot.py
+++ b/test/mod/test_buildroot.py
@@ -112,7 +112,7 @@ def test_bind_mounts(tempdir, runner):
     monitor = NullMonitor(sys.stderr.fileno())
     with BuildRoot("/", runner, libdir, var) as root:
 
-        ro_binds = [f"{scripts}:/scripts"]
+        ro_binds = [(scripts, "/scripts")]
 
         cmd = ["/scripts/mount_flags.py",
                "/scripts",
@@ -125,7 +125,7 @@ def test_bind_mounts(tempdir, runner):
                "/rw-data",
                "ro"]
 
-        binds = [f"{rw_data}:/rw-data"]
+        binds = [(rw_data, "/rw-data")]
         r = root.run(cmd, monitor, binds=binds, readonly_binds=ro_binds)
         assert r.returncode == 1
 
@@ -147,7 +147,7 @@ def test_selinuxfs_ro(tempdir, runner):
     monitor = NullMonitor(sys.stderr.fileno())
     with BuildRoot("/", runner, libdir, var) as root:
 
-        ro_binds = [f"{scripts}:/scripts"]
+        ro_binds = [(scripts, "/scripts")]
 
         cmd = ["/scripts/mount_flags.py",
                "/sys/fs/selinux",
@@ -211,7 +211,7 @@ def test_env_isolation(tempdir, runner):
 
     with BuildRoot("/", runner, libdir, var) as root:
         cmd = ["/bin/sh", "-c", "/usr/bin/env > /ipc/env.txt"]
-        r = root.run(cmd, monitor, binds=[f"{ipc}:/ipc"])
+        r = root.run(cmd, monitor, binds=[(ipc, "/ipc")])
 
     assert r.returncode == 0
     with open(os.path.join(ipc, "env.txt"), encoding="utf8") as f:
@@ -256,7 +256,7 @@ def test_caps(tempdir, runner):
 
         def run_and_get_caps():
             cmd = ["/bin/sh", "-c", "cat /proc/self/status > /ipc/status"]
-            r = root.run(cmd, monitor, binds=[f"{ipc}:/ipc"])
+            r = root.run(cmd, monitor, binds=[(ipc, "/ipc")])
             assert r.returncode == 0
             return get_caps_from_status(os.path.join(ipc, "status"))
 

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -282,44 +282,28 @@ def test_store_server(tmp_path):
         p.mkdir()
         obj.finalize()
 
-        mountpoint = Path(tmp_path, "mountpoint")
-        mountpoint.mkdir()
-
         assert store.contains("42")
-        path = client.read_tree_at("42", mountpoint)
-        assert Path(path) == mountpoint
-        filepath = Path(mountpoint, "file.txt")
+
+        # read_tree returns the path to the tree directory
+        path = client.read_tree("42")
+        assert path is not None
+        filepath = Path(path, "file.txt")
         assert filepath.exists()
         txt = filepath.read_text(encoding="utf8")
         assert txt == "osbuild"
 
-        # check we can mount subtrees via `read_tree_at`
-
-        filemount = Path(tmp_path, "file")
-        filemount.touch()
-
-        path = client.read_tree_at("42", filemount, "/file.txt")
-        filepath = Path(path)
-        assert filepath.is_file()
-        txt = filepath.read_text(encoding="utf8")
+        # check we can access subtrees via read_tree + path joining
+        file_path = os.path.join(path, "file.txt")
+        assert os.path.isfile(file_path)
+        txt = Path(file_path).read_text(encoding="utf8")
         assert txt == "osbuild"
 
-        dirmount = Path(tmp_path, "dir")
-        dirmount.mkdir()
+        dir_path = os.path.join(path, "directory")
+        assert os.path.isdir(dir_path)
 
-        path = client.read_tree_at("42", dirmount, "/directory")
-        dirpath = Path(path)
-        assert dirpath.is_dir()
-
-        # check proper exceptions are raised for non existent
-        # mount points and sub-trees
-
-        with pytest.raises(RuntimeError):
-            nonexistent = os.path.join(tmp_path, "nonexistent")
-            _ = client.read_tree_at("42", nonexistent)
-
-        with pytest.raises(RuntimeError):
-            _ = client.read_tree_at("42", tmp_path, "/nonexistent")
+        # read_tree for non-existent object returns None
+        path = client.read_tree("nonexistent")
+        assert path is None
 
 
 @pytest.mark.skipif(os.getuid() != 0, reason="needs root")


### PR DESCRIPTION
Refactor input services to return input metadata together with a list of bind mounts for bwrap to perform. This allows using inputs while running osbuild as ordinary user.

This removes all users of ObjectStore.read_tree_at(). Remove that function and the associated IPC methods.

Change BuildRoot.run's `binds` and `ro_binds` parameters to accept tuples instead of colon-separated strings. They were separated with str.split(":"), which breaks for filenames containing colons. This became a problem with this patch, because obuild names object directories `sha256:<id>`.