### PR TITLE
CI: update runners for 9.9 and 10.3 nightlies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,8 +52,12 @@ RPM:
       - RUNNER:
           - aws/rhel-9.8-nightly-x86_64
           - aws/rhel-9.8-nightly-aarch64
+          - aws/rhel-9.9-nightly-x86_64
+          - aws/rhel-9.9-nightly-aarch64
           - aws/rhel-10.2-nightly-x86_64
           - aws/rhel-10.2-nightly-aarch64
+          - aws/rhel-10.3-nightly-x86_64
+          - aws/rhel-10.3-nightly-aarch64
         INTERNAL_NETWORK: "true"
 
 OSTree Images:
@@ -96,8 +100,10 @@ PQC keys:
           - aws/fedora-42-x86_64
           - aws/rhel-9.7-ga-x86_64
           - aws/rhel-9.8-nightly-x86_64
+          - aws/rhel-9.9-nightly-x86_64
           - aws/rhel-10.1-ga-x86_64
           - aws/rhel-10.2-nightly-x86_64
+          - aws/rhel-10.3-nightly-x86_64
         INTERNAL_NETWORK: "true"
 
 Manifests:
@@ -161,10 +167,14 @@ Manifests:
           - aws/rhel-9.7-ga-aarch64
           - aws/rhel-9.8-nightly-x86_64
           - aws/rhel-9.8-nightly-aarch64
+          - aws/rhel-9.9-nightly-x86_64
+          - aws/rhel-9.9-nightly-aarch64
           - aws/rhel-10.1-ga-x86_64
           - aws/rhel-10.1-ga-aarch64
           - aws/rhel-10.2-nightly-x86_64
           - aws/rhel-10.2-nightly-aarch64
+          - aws/rhel-10.3-nightly-x86_64
+          - aws/rhel-10.3-nightly-aarch64
         INTERNAL_NETWORK: "true"
         # Test only the following manifest generation configs
         CONFIG: "empty all-customizations"

--- a/Schutzfile
+++ b/Schutzfile
@@ -181,6 +181,47 @@
       }
     ]
   },
+  "rhel-9.9": {
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/rhel9internal.repo",
+        "x86_64": [
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-BaseOS",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.9-20260331"
+          },
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-AppStream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.9-20260331"
+          },
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-CRB",
+            "name": "crb",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-crb-n9.9-20260331"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-BaseOS",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-baseos-n9.9-20260331"
+          },
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-AppStream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.9-20260331"
+          },
+          {
+            "title": "RHEL-9-RPMREPO-NIGHTLY-CRB",
+            "name": "crb",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-crb-n9.9-20260331"
+          }
+        ]
+      }
+    ]
+  },
   "rhel-10.2": {
     "repos": [
       {
@@ -217,6 +258,47 @@
             "title": "RHEL-10-RPMREPO-NIGHTLY-CRB",
             "name": "crb",
             "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el10/el10-aarch64-crb-n10.2-20260412"
+          }
+        ]
+      }
+    ]
+  },
+"rhel-10.3": {
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/rhel10internal.repo",
+        "x86_64": [
+          {
+            "title": "RHEL-10-RPMREPO-NIGHTLY-BaseOS",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el10/el10-x86_64-baseos-n10.3-20260331"
+          },
+          {
+            "title": "RHEL-10-RPMREPO-NIGHTLY-AppStream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el10/el10-x86_64-appstream-n10.3-20260331"
+          },
+          {
+            "title": "RHEL-10-RPMREPO-NIGHTLY-CRB",
+            "name": "crb",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el10/el10-x86_64-crb-n10.3-20260331"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "RHEL-10-RPMREPO-NIGHTLY-BaseOS",
+            "name": "baseos",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el10/el10-aarch64-baseos-n10.3-20260331"
+          },
+          {
+            "title": "RHEL-10-RPMREPO-NIGHTLY-AppStream",
+            "name": "appstream",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el10/el10-aarch64-appstream-n10.3-20260331"
+          },
+          {
+            "title": "RHEL-10-RPMREPO-NIGHTLY-CRB",
+            "name": "crb",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el10/el10-aarch64-crb-n10.3-20260331"
           }
         ]
       }


### PR DESCRIPTION
Add new rhel-9.9-nightly and 10.3 CI runners to .gitlab-ci.yml
Adds rhel-9.9 and 10.3 to Schutzfile snapshots