### PR TITLE
osbuild.spec: fix version number in the spec file

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -1,7 +1,7 @@
 %global         forgeurl https://github.com/osbuild/osbuild
 %global         selinuxtype targeted
 
-Version:        178
+Version:        179
 %global         osbuild_initrd_version 0.1
 
 %forgemeta


### PR DESCRIPTION
Due to misconfigured branch protection settings, the last github release action failed to push the version bump. This makes sure the next release has the correct version number.