### PR TITLE
depsolve: use json.dump() to avoid full JSON string copy in memory (HMS-10526)

### DIFF
--- a/tools/osbuild-depsolve-dnf
+++ b/tools/osbuild-depsolve-dnf
@@ -118,7 +118,8 @@ def fail(err):
 
 
 def respond(result):
-    print(json.dumps(result))
+    json.dump(result, sys.stdout)
+    sys.stdout.write("\n")
 
 
 def main():


### PR DESCRIPTION
Replace json.dumps() + print() with json.dump() to write the serialized result directly to stdout, eliminating an intermediate in-memory copy of the entire JSON string.

For large repositories like Fedora (~70K packages), the JSON output can exceed 200 MB. json.dumps() forces the full string to live in memory before printing, on top of the already-resident dict tree. json.dump() streams the serialization straight to stdout, removing that layer.

Related: https://redhat.atlassian.net/browse/HMS-10526