### PR TITLE
stages/bootctl.install.root: systemd-boot (HMS-10629)

### DIFF
--- a/stages/org.osbuild.bootctl.install.root
+++ b/stages/org.osbuild.bootctl.install.root
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+
+import osbuild.api
+from osbuild.util import parsing
+
+
+def main(args):
+    options = args["options"]
+
+    cmd = [
+        "bootctl", "install",
+        # no variables as we don't/can't write to the UEFI variables
+        # when building an image
+        "--no-variables",
+        "--root", os.path.normpath(parsing.parse_location(options["root"], args)),
+    ]
+
+    if options.get("esp-path"):
+        cmd += ["--esp-path", options["esp-path"]]
+
+    if options.get("boot-path"):
+        cmd += ["--boot-path", options["boot-path"]]
+
+    env = {}
+    if options.get("relax-esp-checks", False):
+        env["SYSTEMD_RELAX_ESP_CHECKS"] = 1
+
+    subprocess.run(cmd, check=True, env=env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(osbuild.api.arguments()))

--- a/stages/org.osbuild.bootctl.install.root.meta.json
+++ b/stages/org.osbuild.bootctl.install.root.meta.json
@@ -1,0 +1,53 @@
+{
+  "summary": "Run systemd-boot's bootctl install",
+  "description": [
+    "`bootctl install` is the command to install `systemd-boot` into the ESP/XBOOTLDR.",
+    "This stage implements installation with the `--root` argument. Note that systemd",
+    "performs checks on the ESP/XBOOTLDR paths which means that this stage will currently",
+    "only work on a root where those partitions are mounted. Note on a bare filesystem",
+    "tree."
+  ],
+  "schema_2": {
+    "options": {
+      "additionalProperties": false,
+      "required": [
+        "root"
+      ],
+      "properties": {
+        "root": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Filesystem root to operate on, if a mount",
+              "pattern": "^mount://[^/]+/"
+            },
+            {
+              "type": "string",
+              "description": "Filesystem root to operate on, if the tree",
+              "pattern": "^tree:///"
+            }
+          ]
+        },
+        "esp-path": {
+          "type": "string",
+          "description": "Path to the ESP partition"
+        },
+        "boot-path": {
+          "type": "string",
+          "description": "Path to the $BOOT partition"
+        },
+        "relax-esp-checks": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "devices": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "mounts": {
+      "type": "array"
+    }
+  }
+}

--- a/stages/test/test_bootctl_install_root.py
+++ b/stages/test/test_bootctl_install_root.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python3
+from unittest import mock
+
+import pytest
+
+from osbuild import testutil
+
+STAGE_NAME = "org.osbuild.bootctl.install.root"
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # bad
+    ({}, "'root' is a required property"),
+    ({"root": "/foo/bar"}, "'/foo/bar' is not valid under any of the given schemas"),
+    ({"root": "unknown://-/"}, "'unknown://-/' is not valid under any of the given schemas"),
+    ({"root": "mount://-/", "unknown": "property"}, "Additional properties are not allowed ('unknown' was unexpected)"),
+    ({"root": "input://-/"}, "'input://-/' is not valid under any of the given schemas"),
+    # good
+    ({"root": "mount://-/"}, ""),
+    ({"root": "tree:///"}, ""),
+    ({"root": "tree:///with/subpath"}, ""),
+    ({"root": "mount://-/", "esp-path": "/foo/bar"}, ""),
+    ({"root": "mount://-/", "boot-path": "/foo/bar"}, ""),
+])
+def test_bootctl_install_root_schema_validation(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "options": {
+        }
+    }
+    test_input["options"].update(test_data)
+    res = stage_schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
+
+
+@mock.patch("subprocess.run")
+def test_bootctl_install_root_plain(mock_run, tmp_path, stage_module):
+    options = {
+        "root": "tree:///",
+    }
+
+    fake_tree = tmp_path / "tree"
+
+    stage_module.main({
+        "tree": fake_tree,
+        "options": options,
+    })
+
+    mock_run.assert_called_with([
+        "bootctl", "install",
+        "--no-variables",
+        "--root", str(fake_tree),
+    ],
+        check=True,
+        env={},
+    )
+
+
+@mock.patch("subprocess.run")
+def test_bootctl_install_root_with_options(mock_run, tmp_path, stage_module):
+    options = {
+        "root": "tree:///",
+        "esp-path": "/efi",
+        "boot-path": "/boot",
+        "relax-esp-checks": True,
+    }
+
+    fake_tree = tmp_path / "tree"
+
+    stage_module.main({
+        "tree": fake_tree,
+        "options": options,
+    })
+
+    mock_run.assert_called_with([
+        "bootctl", "install",
+        "--no-variables",
+        "--root", str(fake_tree),
+        "--esp-path", "/efi",
+        "--boot-path", "/boot",
+    ],
+        check=True,
+        env={"SYSTEMD_RELAX_ESP_CHECKS": 1},
+    )


### PR DESCRIPTION
A stage that calls `bootctl install` on a root. The root directory is assumed to have set up mount points as `systemd-boot` will verify that the ESP path (and potentially XBOOTLDR path) are roots of filesystems even if `--no-variables` *and* `SYSTEMD_RELAX_ESP_CHECKS` is set.

I've opened an upstream PR [1] to `systemd` to relax this further. This means that currently this stage must be called inside `images`'s `image` pipeline where we loopback mount the partitions into the tree. In the future this stage might migrate to the `os` pipeline when it can run on a filesystem tree without having to set up mounts.

This stage is called `.root` as I can maybe see a future where we also have a `.image` to call it directly on the image without setting up mountpoints; I'd prefer not to clash then.

[1]: https://github.com/systemd/systemd/pull/41708