### PR TITLE
bootc.install-to-filesystem: additional options (bootloader, composefs-backend)

### DIFF
--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -66,6 +66,8 @@ def main(options, inputs, paths):
             pargs.extend(["--bootupd-skip-boot-uuid"])
         if options.get("bootloader", None):
             pargs.extend(["--bootloader", options["bootloader"]])
+        if options.get("composefs", False):
+            pargs.extend(["--composefs-backend"])
 
         # add target and go
         pargs.append(dst)

--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -8,7 +8,7 @@ import osbuild.api
 from osbuild.util import containers
 
 
-def main(options, inputs, paths):
+def main(options, inputs, paths):  # pylint: disable=too-many-branches
     images = containers.parse_containers_input(inputs)
     assert len(images) == 1
     image = list(images.values())[0]

--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -64,6 +64,8 @@ def main(options, inputs, paths):
                 pargs.extend(["--boot-mount-spec", boot_spec])
         if options.get("bootupd-skip-boot-uuid", False):
             pargs.extend(["--bootupd-skip-boot-uuid"])
+        if options.get("bootloader", None):
+            pargs.extend(["--bootloader", options["bootloader"]])
 
         # add target and go
         pargs.append(dst)

--- a/stages/org.osbuild.bootc.install-to-filesystem.meta.json
+++ b/stages/org.osbuild.bootc.install-to-filesystem.meta.json
@@ -60,6 +60,14 @@
         "bootupd-skip-boot-uuid": {
           "type": "boolean",
           "description": "Don't pass --write-uuid to bootupd during bootloader installation."
+        },
+        "bootloader": {
+          "type": "string",
+          "enum": [
+            "grub",
+            "systemd",
+            "none"
+          ]
         }
       }
     },

--- a/stages/org.osbuild.bootc.install-to-filesystem.meta.json
+++ b/stages/org.osbuild.bootc.install-to-filesystem.meta.json
@@ -68,6 +68,11 @@
             "systemd",
             "none"
           ]
+        },
+        "composefs": {
+          "description": "Use the compsefs backend instead of the ostree backend",
+          "type": "boolean",
+          "default": "false"
         }
       }
     },

--- a/stages/test/test_bootc_install_to_fs.py
+++ b/stages/test/test_bootc_install_to_fs.py
@@ -67,6 +67,9 @@ FAKE_INPUTS = {
     ({"bootloader": "none"}, ["--bootloader", "none"]),
     ({"bootloader": "systemd"}, ["--bootloader", "systemd"]),
     ({"bootloader": "grub"}, ["--bootloader", "grub"]),
+    # composefs
+    ({"composefs": False}, []),
+    ({"composefs": True}, ["--composefs-backend"]),
     # all
     ({"root-ssh-authorized-keys": ["key1", "key2"],
       "kernel-args": ["arg1", "arg2"],

--- a/stages/test/test_bootc_install_to_fs.py
+++ b/stages/test/test_bootc_install_to_fs.py
@@ -63,6 +63,10 @@ FAKE_INPUTS = {
     # bootupd-skip-boot-uuid
     ({"bootupd-skip-boot-uuid": False}, []),
     ({"bootupd-skip-boot-uuid": True}, ["--bootupd-skip-boot-uuid"]),
+    # bootloader
+    ({"bootloader": "none"}, ["--bootloader", "none"]),
+    ({"bootloader": "systemd"}, ["--bootloader", "systemd"]),
+    ({"bootloader": "grub"}, ["--bootloader", "grub"]),
     # all
     ({"root-ssh-authorized-keys": ["key1", "key2"],
       "kernel-args": ["arg1", "arg2"],


### PR DESCRIPTION
I've been tinkering with sealed images. `bootc install to-filesystem` doesn't always select the appropriate options for all containers; or they need to be user selectable in the general case.

Let's plumb these options through so we can expose them eventually in `image-builder`.