### PR TITLE
stages/oci-archive: accept variant

### DIFF
--- a/stages/org.osbuild.oci-archive
+++ b/stages/org.osbuild.oci-archive
@@ -141,6 +141,9 @@ def create_oci_dir(inputs, output_dir, options, create_time):
         "history": []
     }
 
+    if options.get("variant", None):
+        config["variant"] = options["variant"]
+
     manifest = {
         "schemaVersion": 2,
         "config": None,

--- a/stages/org.osbuild.oci-archive.meta.json
+++ b/stages/org.osbuild.oci-archive.meta.json
@@ -40,6 +40,10 @@
           "description": "The CPU architecture of the image",
           "type": "string"
         },
+        "variant": {
+          "description": "The CPU architecture variant of the image",
+          "type": "string"
+        },
         "filename": {
           "description": "Resulting image filename",
           "type": "string"


### PR DESCRIPTION
In this issue [1] it was found that we incorrectly set the architecture used for OCI archives. However; it was also discovered that there's an optional `variant` field that we might want to set.

Let's prepare the stage to allow passing it along from images when we decide to implement this there.

[1]: https://github.com/osbuild/images/issues/2306