### PR TITLE
workflows: Limit tests to main branch and PRs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,13 @@
+---
 name: Checks
 
-on: [pull_request, push]
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,6 +1,13 @@
+---
 name: Generate
 
-on: [pull_request, push]
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
 
 jobs:
   generate_documentation:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
+---
 name: Tests
 
-on: [pull_request, push]
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Previously it was also trying to run the PR tests on the submitter's
push to their fork. This will run the tests on PR creation, and when pushed
to main, not when pushed to some random user's branch.
