### PR TITLE
stages/bootc.install-to-fs: remount /dev

### DIFF
--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -71,7 +71,17 @@ def main(options, inputs, paths):  # pylint: disable=too-many-branches
 
         # add target and go
         pargs.append(dst)
-        subprocess.run(pargs, env=env, check=True)
+
+        # The composefs backend wants to manage loopback devices. It needs access to
+        # /dev/loop-control and any /dev/loopXpY devices that appear. `bootc` may opt
+        # to use the `composefs` backend based on the input container; we can't control
+        # this so we should always be prepared.
+        subprocess.check_call(['mount', '-t', 'devtmpfs', 'devtmpfs', '/dev/'])
+
+        try:
+            subprocess.run(pargs, env=env, check=True)
+        finally:
+            subprocess.check_call(['umount', '/dev/'])
 
 
 if __name__ == "__main__":

--- a/stages/test/test_bootc_install_to_fs.py
+++ b/stages/test/test_bootc_install_to_fs.py
@@ -90,7 +90,8 @@ FAKE_INPUTS = {
      ),
 ])
 @patch("subprocess.run")
-def test_bootc_install_to_fs(mock_run, mocked_named_tmp, mocked_temp_dir, stage_module, options, expected_args):  # pylint: disable=unused-argument
+@patch("subprocess.check_call")
+def test_bootc_install_to_fs(_mock_check_call, mock_run, mocked_named_tmp, mocked_temp_dir, stage_module, options, expected_args):  # pylint: disable=unused-argument
     inputs = {
         "images": {
             "path": "/input/images/path",
@@ -123,7 +124,8 @@ def test_bootc_install_to_fs(mock_run, mocked_named_tmp, mocked_temp_dir, stage_
 
 
 @patch("subprocess.run")
-def test_bootc_install_to_fs_write_root_ssh_keys(mock_run, stage_module):  # pylint: disable=unused-argument
+@patch("subprocess.check_call")
+def test_bootc_install_to_fs_write_root_ssh_keys(_mock_check_call, mock_run, stage_module):  # pylint: disable=unused-argument
     paths = {
         "mounts": "/path/to/mounts",
     }

--- a/stages/test/test_bootc_install_to_fs.py
+++ b/stages/test/test_bootc_install_to_fs.py
@@ -2,7 +2,7 @@
 
 import tempfile
 from contextlib import contextmanager
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 
@@ -91,7 +91,7 @@ FAKE_INPUTS = {
 ])
 @patch("subprocess.run")
 @patch("subprocess.check_call")
-def test_bootc_install_to_fs(_mock_check_call, mock_run, mocked_named_tmp, mocked_temp_dir, stage_module, options, expected_args):  # pylint: disable=unused-argument
+def test_bootc_install_to_fs(mock_check_call, mock_run, mocked_named_tmp, mocked_temp_dir, stage_module, options, expected_args):  # pylint: disable=unused-argument
     inputs = {
         "images": {
             "path": "/input/images/path",
@@ -121,6 +121,12 @@ def test_bootc_install_to_fs(_mock_check_call, mock_run, mocked_named_tmp, mocke
     )
     assert kwargs["check"] is True
     assert kwargs["env"]["BOOTC_SKIP_SELINUX_HOST_CHECK"] == "true"
+
+    assert mock_check_call.call_count == 2
+    mock_check_call.assert_has_calls([
+        call(['mount', '-t', 'devtmpfs', 'devtmpfs', '/dev/']),
+        call(['umount', '/dev/']),
+    ])
 
 
 @patch("subprocess.run")


### PR DESCRIPTION
When the composefs backend is used by `bootc` it wants to manage loopback devices. There is prior art for executables that want to do this and that is to remount `/dev` as `devtmpfs`.

This allows `bootc` to progress further.

---

Partially resolves https://github.com/osbuild/image-builder/issues/2427