### PR TITLE
stages/bootctl.install.root: additional options

### DIFF
--- a/stages/org.osbuild.bootctl.install.root
+++ b/stages/org.osbuild.bootctl.install.root
@@ -17,6 +17,9 @@ def main(args):
         "--root", os.path.normpath(parsing.parse_location(options["root"], args)),
     ]
 
+    if options.get("random-seed"):
+        cmd += ["--random-seed", options["random-seed"]]
+
     if options.get("esp-path"):
         cmd += ["--esp-path", options["esp-path"]]
 

--- a/stages/org.osbuild.bootctl.install.root
+++ b/stages/org.osbuild.bootctl.install.root
@@ -23,6 +23,9 @@ def main(args):
     if options.get("make-entry-directory"):
         cmd += ["--make-entry-directory", options["make-entry-directory"]]
 
+    if options.get("entry-token"):
+        cmd += ["--entry-token", options["entry-token"]]
+
     if options.get("esp-path"):
         cmd += ["--esp-path", options["esp-path"]]
 

--- a/stages/org.osbuild.bootctl.install.root
+++ b/stages/org.osbuild.bootctl.install.root
@@ -20,6 +20,9 @@ def main(args):
     if options.get("random-seed"):
         cmd += ["--random-seed", options["random-seed"]]
 
+    if options.get("make-entry-directory"):
+        cmd += ["--make-entry-directory", options["make-entry-directory"]]
+
     if options.get("esp-path"):
         cmd += ["--esp-path", options["esp-path"]]
 

--- a/stages/org.osbuild.bootctl.install.root.meta.json
+++ b/stages/org.osbuild.bootctl.install.root.meta.json
@@ -39,6 +39,13 @@
         "relax-esp-checks": {
           "type": "boolean",
           "default": false
+        },
+        "random-seed": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no"
+          ]
         }
       }
     },

--- a/stages/org.osbuild.bootctl.install.root.meta.json
+++ b/stages/org.osbuild.bootctl.install.root.meta.json
@@ -53,6 +53,15 @@
             "yes",
             "no"
           ]
+        },
+        "entry-token": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "machine-id",
+            "os-id",
+            "os-image-id"
+          ]
         }
       }
     },

--- a/stages/org.osbuild.bootctl.install.root.meta.json
+++ b/stages/org.osbuild.bootctl.install.root.meta.json
@@ -46,6 +46,13 @@
             "yes",
             "no"
           ]
+        },
+        "make-entry-directory": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no"
+          ]
         }
       }
     },

--- a/stages/test/test_bootctl_install_root.py
+++ b/stages/test/test_bootctl_install_root.py
@@ -15,12 +15,14 @@ STAGE_NAME = "org.osbuild.bootctl.install.root"
     ({"root": "unknown://-/"}, "'unknown://-/' is not valid under any of the given schemas"),
     ({"root": "mount://-/", "unknown": "property"}, "Additional properties are not allowed ('unknown' was unexpected)"),
     ({"root": "input://-/"}, "'input://-/' is not valid under any of the given schemas"),
+    ({"root": "tree:///", "random-seed": "false"}, "'false' is not one of ['yes', 'no']"),
     # good
     ({"root": "mount://-/"}, ""),
     ({"root": "tree:///"}, ""),
     ({"root": "tree:///with/subpath"}, ""),
     ({"root": "mount://-/", "esp-path": "/foo/bar"}, ""),
     ({"root": "mount://-/", "boot-path": "/foo/bar"}, ""),
+    ({"root": "mount://-/", "random-seed": "no"}, ""),
 ])
 def test_bootctl_install_root_schema_validation(stage_schema, test_data, expected_err):
     test_input = {
@@ -68,6 +70,7 @@ def test_bootctl_install_root_with_options(mock_run, tmp_path, stage_module):
         "esp-path": "/efi",
         "boot-path": "/boot",
         "relax-esp-checks": True,
+        "random-seed": "no",
     }
 
     fake_tree = tmp_path / "tree"
@@ -81,6 +84,7 @@ def test_bootctl_install_root_with_options(mock_run, tmp_path, stage_module):
         "bootctl", "install",
         "--no-variables",
         "--root", str(fake_tree),
+        "--random-seed", "no",
         "--esp-path", "/efi",
         "--boot-path", "/boot",
     ],

--- a/stages/test/test_bootctl_install_root.py
+++ b/stages/test/test_bootctl_install_root.py
@@ -17,6 +17,8 @@ STAGE_NAME = "org.osbuild.bootctl.install.root"
     ({"root": "input://-/"}, "'input://-/' is not valid under any of the given schemas"),
     ({"root": "tree:///", "random-seed": "false"}, "'false' is not one of ['yes', 'no']"),
     ({"root": "tree:///", "make-entry-directory": "false"}, "'false' is not one of ['yes', 'no']"),
+    ({"root": "tree:///", "entry-token": "broken"},
+     "'broken' is not one of ['auto', 'machine-id', 'os-id', 'os-image-id']"),
     # good
     ({"root": "mount://-/"}, ""),
     ({"root": "tree:///"}, ""),
@@ -25,6 +27,7 @@ STAGE_NAME = "org.osbuild.bootctl.install.root"
     ({"root": "mount://-/", "boot-path": "/foo/bar"}, ""),
     ({"root": "mount://-/", "random-seed": "no"}, ""),
     ({"root": "mount://-/", "make-entry-directory": "yes"}, ""),
+    ({"root": "mount://-/", "entry-token": "os-id"}, ""),
 ])
 def test_bootctl_install_root_schema_validation(stage_schema, test_data, expected_err):
     test_input = {
@@ -74,6 +77,7 @@ def test_bootctl_install_root_with_options(mock_run, tmp_path, stage_module):
         "relax-esp-checks": True,
         "random-seed": "no",
         "make-entry-directory": "yes",
+        "entry-token": "os-id"
     }
 
     fake_tree = tmp_path / "tree"
@@ -89,6 +93,7 @@ def test_bootctl_install_root_with_options(mock_run, tmp_path, stage_module):
         "--root", str(fake_tree),
         "--random-seed", "no",
         "--make-entry-directory", "yes",
+        "--entry-token", "os-id",
         "--esp-path", "/efi",
         "--boot-path", "/boot",
     ],

--- a/stages/test/test_bootctl_install_root.py
+++ b/stages/test/test_bootctl_install_root.py
@@ -16,6 +16,7 @@ STAGE_NAME = "org.osbuild.bootctl.install.root"
     ({"root": "mount://-/", "unknown": "property"}, "Additional properties are not allowed ('unknown' was unexpected)"),
     ({"root": "input://-/"}, "'input://-/' is not valid under any of the given schemas"),
     ({"root": "tree:///", "random-seed": "false"}, "'false' is not one of ['yes', 'no']"),
+    ({"root": "tree:///", "make-entry-directory": "false"}, "'false' is not one of ['yes', 'no']"),
     # good
     ({"root": "mount://-/"}, ""),
     ({"root": "tree:///"}, ""),
@@ -23,6 +24,7 @@ STAGE_NAME = "org.osbuild.bootctl.install.root"
     ({"root": "mount://-/", "esp-path": "/foo/bar"}, ""),
     ({"root": "mount://-/", "boot-path": "/foo/bar"}, ""),
     ({"root": "mount://-/", "random-seed": "no"}, ""),
+    ({"root": "mount://-/", "make-entry-directory": "yes"}, ""),
 ])
 def test_bootctl_install_root_schema_validation(stage_schema, test_data, expected_err):
     test_input = {
@@ -71,6 +73,7 @@ def test_bootctl_install_root_with_options(mock_run, tmp_path, stage_module):
         "boot-path": "/boot",
         "relax-esp-checks": True,
         "random-seed": "no",
+        "make-entry-directory": "yes",
     }
 
     fake_tree = tmp_path / "tree"
@@ -85,6 +88,7 @@ def test_bootctl_install_root_with_options(mock_run, tmp_path, stage_module):
         "--no-variables",
         "--root", str(fake_tree),
         "--random-seed", "no",
+        "--make-entry-directory", "yes",
         "--esp-path", "/efi",
         "--boot-path", "/boot",
     ],


### PR DESCRIPTION
Plumb through a few more useful options to `bootctl.install.root`: `make-entry-directory`, `random-seed`, `entry-token`.