### PR TITLE
erofs: avoid tmpfs for compression

### DIFF
--- a/stages/org.osbuild.erofs
+++ b/stages/org.osbuild.erofs
@@ -45,7 +45,11 @@ def main(args):
         for e in exclude_paths:
             cmd += ["--exclude-regex", e]
 
-    subprocess.run(cmd, check=True)
+    subprocess.run(
+        cmd,
+        check=True,
+        env={**os.environ, "TMPDIR": "/var/tmp"},
+    )
 
     return 0
 

--- a/stages/test/test_erofs.py
+++ b/stages/test/test_erofs.py
@@ -113,7 +113,9 @@ def test_erofs(mock_run, tmp_path, stage_module, test_options, expected):
         f"{fake_input_tree}",
         "--quiet",
     ] + expected
-    mock_run.assert_called_with(expected, check=True)
+    mock_run.assert_called_once()
+    assert mock_run.call_args[0][0] == expected
+    assert mock_run.call_args[1]["env"]["TMPDIR"] == "/var/tmp"
 
 
 @pytest.mark.parametrize("test_data,expected_err", [


### PR DESCRIPTION
Compression can use large temp files; default TMPDIR is often tmpfs (/tmp). This patch sets TMPDIR to /var/tmp to avoid this.

---

On `tmpfs`:

```
real	7m18.660s
user	0m0.044s
sys	0m0.114s
```

On `ext4 (rw,noatime)`

```
real	8m11.313s
user	0m0.038s
sys	0m0.103s
```

It is a difference I am not sure about this. I feel like there is a better solution, some global flag that allows for avoiding tmpfs globally?

Or we can simply issue a warning if there is not enough swap, we would do this in the CLI not here obviously.