### PR TITLE
Allow use of template variables in custom menus

### DIFF
--- a/stages/org.osbuild.grub2.iso
+++ b/stages/org.osbuild.grub2.iso
@@ -141,8 +141,12 @@ def main(root, options):
 
     if len(custom):
         for entry in custom:
-            custom_tmpl = string.Template(CUSTOM_ENTRY_TEMPLATE)
-            customentry = custom_tmpl.safe_substitute(entry)
+            entry_tmpl = string.Template(CUSTOM_ENTRY_TEMPLATE)
+            entry_string = entry_tmpl.safe_substitute(entry)
+
+            # Substitute any of the standard variables used in the custom entry
+            custom_tmpl = string.Template(entry_string)
+            customentry = custom_tmpl.safe_substitute(tplt_variables)
             tplt_variables["customentries"] += customentry
 
     if test:

--- a/stages/org.osbuild.grub2.iso.legacy
+++ b/stages/org.osbuild.grub2.iso.legacy
@@ -126,8 +126,12 @@ def main(root, options):
 
     if len(custom):
         for entry in custom:
-            custom_tmpl = string.Template(CUSTOM_ENTRY_TEMPLATE)
-            customentry = custom_tmpl.safe_substitute(entry)
+            entry_tmpl = string.Template(CUSTOM_ENTRY_TEMPLATE)
+            entry_string = entry_tmpl.safe_substitute(entry)
+
+            # Substitute any of the standard variables used in the custom entry
+            custom_tmpl = string.Template(entry_string)
+            customentry = custom_tmpl.safe_substitute(tplt_variables)
             tplt_variables["customentries"] += customentry
 
     if test:

--- a/stages/test/test_grub2_iso.py
+++ b/stages/test/test_grub2_iso.py
@@ -93,6 +93,13 @@ CONFIG_DEFAULT = """set default="1"
     # custom entries
     (
         {
+            "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                    "root=hd:LABEL=root",
+                    "rhgb"
+                ]
+            },
             "troubleshooting": False,
             "test": False,
             "install": False,
@@ -107,6 +114,11 @@ CONFIG_DEFAULT = """set default="1"
                     "linux": "/bar/foo root=baz quiet",
                     "initrd": "/bar/foo",
                 },
+                {
+                    "name": "label 2",
+                    "linux": "${kernelpath} ${root}",
+                    "initrd": "${initrdpath}",
+                },
             ]
         },
         CONFIG_PART_1 +
@@ -119,6 +131,11 @@ CONFIG_DEFAULT = """set default="1"
             name="label 1",
             linux="/bar/foo root=baz quiet",
             initrd="/bar/foo",
+        ) +
+        CONFIG_TMPL_CUSTOM.format(
+            name="label 2",
+            linux="/images/pxeboot/vmlinuz root=hd:LABEL=root rhgb",
+            initrd="/images/pxeboot/initrd.img",
         ) +
         "\n\n\n\n\n",
     ),

--- a/stages/test/test_grub2_iso_legacy.py
+++ b/stages/test/test_grub2_iso_legacy.py
@@ -114,6 +114,11 @@ CONFIG_DEFAULT = """set default="1"
                     "linux": "/bar/foo root=baz quiet",
                     "initrd": "/bar/foo",
                 },
+                {
+                    "name": "label 2",
+                    "linux": "${kernelpath} ${root}",
+                    "initrd": "${initrdpath}",
+                },
             ]
         },
         CONFIG_PART_1 +
@@ -126,6 +131,11 @@ CONFIG_DEFAULT = """set default="1"
             name="label 1",
             linux="/bar/foo root=baz quiet",
             initrd="/bar/foo",
+        ) +
+        CONFIG_TMPL_CUSTOM.format(
+            name="label 2",
+            linux="/images/pxeboot/vmlinuz inst.ks=hd:LABEL=Fedora-41-X86_64:/install.ks",
+            initrd="/images/pxeboot/initrd.img",
         ) +
         "\n\n\n\n\n",
     ),


### PR DESCRIPTION
Previously you would have to reconstruct the menu entry in the manifest. This allows using the template variables so that we don't have to duplicate the stage logic outside the stage (eg. in the manifest).