### PR TITLE
runners: `eln11` (HMS-10652, HMS-10652)

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,6 +43,10 @@ jobs:
   #- fedora-all-s390x
   - fedora-all-ppc64le
   - fedora-all
+  - fedora-eln-x86_64
+  - fedora-eln-aarch64
+  - fedora-eln-s390x
+  - fedora-eln-ppc64le
   - rhel-10-x86_64
   - rhel-10-aarch64
 - <<: *copr

--- a/runners/org.osbuild.eln11
+++ b/runners/org.osbuild.eln11
@@ -1,0 +1,1 @@
+org.osbuild.fedora38


### PR DESCRIPTION
Introduce an `eln-11` runner so that builds can be performed on ELN. Also enable ELN builds in COPR.

See https://github.com/fedora-eln/eln/issues/524, closes #2445.