### PR TITLE
test: don't mark no buffer as failure

### DIFF
--- a/test/mod/test_util_jsoncomm.py
+++ b/test/mod/test_util_jsoncomm.py
@@ -238,7 +238,12 @@ class TestUtilJsonComm(unittest.TestCase):
         a, b = jsoncomm.Socket.new_pair()
 
         ping = {"data": "tons" * 1_000_000}
-        a.send(ping)
+        try:
+            a.send(ping)
+        except OSError as e:
+            if e.errno == errno.ENOBUFS:
+                pytest.skip("kernel could not allocate socket buffer space")
+            raise
         pong, _, _ = b.send_and_recv(ping)
         self.assertEqual(ping, pong)
         pong, _, _ = a.recv()


### PR DESCRIPTION
Our tests downstream commonly fail due to the kernel being unable to allocate enough buffer space to send the 4 MiB message; even *if* `wmem_max` says it supposedly should be able to.

Either this is a real bug; or we should skip when ENOBUFS, or we should take the send_via_fd path for large messages or on error. I did the middle one.

---

See #2342.