### PR TITLE
org.osbuild.ovf: support setting virtual hardware version (HMS-3248)

### DIFF
--- a/stages/org.osbuild.ovf
+++ b/stages/org.osbuild.ovf
@@ -33,7 +33,7 @@ OVF_TEMPLATE = """<?xml version="1.0"?>
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
         <vssd:InstanceID>0</vssd:InstanceID>
         <vssd:VirtualSystemIdentifier>image</vssd:VirtualSystemIdentifier>
-        <vssd:VirtualSystemType>vmx-15</vssd:VirtualSystemType>
+        <vssd:VirtualSystemType>{vmware_virtual_hardware_version}</vssd:VirtualSystemType>
       </System>
       <Item>
         <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
@@ -164,6 +164,7 @@ def write_template(vmdk, options):
         vmdk_size=os.stat(vmdk).st_size,
         vmdk_capacity=virtual_size(vmdk),
         vmware_os_type=options.get("vmware", {}).get("os_type", "other26xLinux64Guest"),
+        vmware_virtual_hardware_version=options.get("vmware", {}).get("virtual_hardware_version", "vmx-15"),
         vbox_machine_uuid=str(uuid.uuid4()),
         vbox_disk_uuid=str(uuid.uuid4()),
         vbox_os_type=options.get("virtualbox", {}).get("os_type", "OtherLinux_64"),

--- a/stages/org.osbuild.ovf.meta.json
+++ b/stages/org.osbuild.ovf.meta.json
@@ -27,6 +27,11 @@
             "os_type": {
               "type": "string",
               "default": "other26xLinux64Guest"
+            },
+            "virtual_hardware_version": {
+              "type": "string",
+              "default": "vmx-15",
+              "pattern": "^vmx-[0-9]+$"
             }
           }
         },

--- a/stages/test/test_ovf.py
+++ b/stages/test/test_ovf.py
@@ -17,9 +17,12 @@ STAGE_NAME = "org.osbuild.ovf"
     ({"vmdk": "imagename.vmdk", "virtualbox": {"os_type": 1}}, "is not of type 'string'"),
     ({"vmdk": "imagename.vmdk", "virtualbox": {"mac_address": 1}}, "is not of type 'string'"),
     ({"vmdk": "imagename.vmdk", "virtualbox": {"mac_address": "1"}}, "'1' does not match '^[a-fA-F0-9]{12}$'"),
+    ({"vmdk": "imagename.vmdk", "vmware": {"virtual_hardware_version": 1}}, "is not of type 'string'"),
+    ({"vmdk": "imagename.vmdk", "vmware": {"virtual_hardware_version": "21"}}, "'21' does not match '^vmx-[0-9]+$'"),
     # Good API parameters
     ({"vmdk": "imagename.vmdk"}, ""),
-    ({"vmdk": "imagename.vmdk", "vmware": {"os_type": "OtherGuest"}, "virtualbox": {"os_type": "OtherGuest"}}, ""),
+    ({"vmdk": "imagename.vmdk", "vmware": {"os_type": "OtherGuest",
+     "virtual_hardware_version": "vmx-21"}, "virtualbox": {"os_type": "OtherGuest"}}, ""),
 ])
 # This test validates only API calls using correct and incorrect queries
 def test_schema_validation_ovf(stage_schema, test_data, expected_err):


### PR DESCRIPTION
The hardware version determines what features are available to VMs on vmware platforms, and can impact performance and security.