### PR TITLE
osbuild: /var/cache/osbuild as default cache for root

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ To build an image:
 
 Every osbuild run uses a cache for downloaded files (sources) and, optionally,
 checkpoints of artifacts built by stages and pipelines. By default, this is
-kept in `.osbuild` (in the current working directory). The location of this
-directory can be specified using the `--cache` option.
+kept in `/var/cache/osbuild` when running as root, or `.osbuild` (in the current
+working directory) when running as a regular user. The location of this directory
+can be specified using the `--cache` option.
 
 For more information about the options and arguments, read [man pages](/docs).
 

--- a/docs/osbuild.1.rst
+++ b/docs/osbuild.1.rst
@@ -40,7 +40,8 @@ is not listed here, **osbuild** will deny startup and exit with an error.
 -h, --help                      print usage information and exit immediately
 --version                       print version information and exit immediately
 --cache=DIR, --store=DIR        directory where intermediary sources and file
-                                system trees are stored
+                                system trees are stored (default: /var/cache/osbuild
+                                when running as root, .osbuild otherwise)
 -l DIR, --libdir=DIR            directory containing stages, assemblers, and
                                 the osbuild library
 --cache-max-size=SIZE           maximum size of the cache (bytes) or 'unlimited'

--- a/osbuild.spec
+++ b/osbuild.spec
@@ -287,6 +287,9 @@ install -D -p -m 0644 selinux/osbuild.if %{buildroot}%{_datadir}/selinux/devel/i
 mkdir -p %{buildroot}%{_udevrulesdir}
 install -p -m 0755 data/10-osbuild-inhibitor.rules %{buildroot}%{_udevrulesdir}
 
+# Cache directory for root
+mkdir -p %{buildroot}%{_localstatedir}/cache/osbuild
+
 # Remove `osbuild-dev` on non-fedora systems
 %{!?fedora:rm %{buildroot}%{_bindir}/osbuild-dev}
 
@@ -403,6 +406,7 @@ done
 %{pkgdir}
 %exclude %{pkgdir}/initrd
 %{_udevrulesdir}/*.rules
+%dir %{_localstatedir}/cache/osbuild
 # the following files are in the lvm2 sub-package
 %exclude %{pkgdir}/devices/org.osbuild.lvm2*
 %exclude %{pkgdir}/stages/org.osbuild.lvm2*

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -67,10 +67,12 @@ def parse_arguments(sys_argv: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="osbuild",
                                      description="Build operating system images")
 
+    default_cache = "/var/cache/osbuild" if os.geteuid() == 0 else ".osbuild"
+
     parser.add_argument("manifest_path", metavar="MANIFEST",
                         help="json file containing the manifest that should be built, or a '-' to read from stdin")
     parser.add_argument("--cache", "--store", metavar="DIRECTORY", type=os.path.abspath,
-                        default=".osbuild",
+                        default=default_cache,
                         help="directory where sources and intermediary os trees are stored")
     parser.add_argument("-l", "--libdir", metavar="DIRECTORY", type=os.path.abspath, default="/usr/lib/osbuild",
                         help="directory containing stages, assemblers, and the osbuild library")


### PR DESCRIPTION
Having .osbuild created in current working directory when executing osbuild (typically via sudo) is not great. This change brings the behavior to typical *NIX app - root uses /var/cache.