### PR TITLE
stages/org.osbuild.bfb: Update BFB Stage to use up to date capsule file for secure boot

### DIFF
--- a/stages/org.osbuild.bfb
+++ b/stages/org.osbuild.bfb
@@ -17,7 +17,28 @@ import osbuild.api
 #
 # Hardcode some firmware file paths in constants that we use below
 DEFAULT_BFB_PATH = "/lib/firmware/mellanox/boot/default.bfb"
-BOOT_CAPSULE_PATH = "/lib/firmware/mellanox/boot/capsule/boot_update2.cap"
+
+CAPSULE_PRESETS = {
+    "default": {
+        "path": "/lib/firmware/mellanox/boot/capsule/boot_update2.cap",
+        "default_args_v2": [
+            "console=hvc0",
+            "console=ttyAMA0",
+            "earlycon=pl011,0x13010000",
+            "initrd=initramfs",
+            "modprobe.blacklist=mlxbf_pmc",
+        ],
+    },
+    "redhat": {
+        "path": "/usr/share/redhat-cap/RedHat.cap",
+        "default_args_v2": [
+            "console=hvc0",
+            "console=ttyAMA0",
+            "earlycon=pl011,0x13010000",
+            "initrd=initramfs",
+        ],
+    },
+}
 
 
 def parse_input(inputs, name):
@@ -43,23 +64,11 @@ def main(inputs, output, options):
                     out.write(f.read())
         initramfs = combined
 
-    # We don't plan to support BF1/BF2 hardware where v0 args are used
+    preset = CAPSULE_PRESETS[options.get("capsule", "default")]
+
     default_args_v0 = []
-    # Sourced from https://github.com/Mellanox/bfb-build
-    # - console=hvc0: rshim virtual console (/dev/rshim0/console)
-    # - console=ttyAMA0: IPMI serial console
-    # - earlycon=pl011,0x13010000: early serial output on BF3
-    # - initrd=initramfs: initramfs selection
-    # - modprobe.blacklist=mlxbf_pmc: avoid PMC driver conflicts on BF3
-    default_args_v2 = [
-        "console=hvc0",
-        "console=ttyAMA0",
-        "earlycon=pl011,0x13010000",
-        "initrd=initramfs",
-        "modprobe.blacklist=mlxbf_pmc"
-    ]
     boot_args_v0 = " ".join(options.get("boot_args_v0", default_args_v0))
-    boot_args_v2 = " ".join(options.get("boot_args_v2", default_args_v2))
+    boot_args_v2 = " ".join(options.get("boot_args_v2", preset["default_args_v2"]))
     boot_path = options.get("boot_path", "VenHw(F019E406-8C9C-11E5-8797-001ACA00BFC4)/Image")
     boot_desc = options.get("boot_desc", "Linux from rshim")
 
@@ -67,7 +76,7 @@ def main(inputs, output, options):
         "/usr/bin/mlx-mkbfb",
         "--image", kernel,
         "--initramfs", initramfs,
-        "--capsule", BOOT_CAPSULE_PATH,
+        "--capsule", preset["path"],
         "--boot-args-v0", f"={boot_args_v0}",
         "--boot-args-v2", f"={boot_args_v2}",
         "--boot-path", f"={boot_path}",

--- a/stages/org.osbuild.bfb.meta.json
+++ b/stages/org.osbuild.bfb.meta.json
@@ -40,6 +40,15 @@
           "type": "string",
           "description": "Output BFB filename"
         },
+        "capsule": {
+          "type": "string",
+          "description": "Boot capsule preset. 'default' uses the Mellanox capsule for RHEL 9.6/9.7/10.0/10.1. 'redhat' uses the Red Hat CA-8 capsule for RHEL 9.8/10.2.",
+          "default": "default",
+          "enum": [
+            "default",
+            "redhat"
+          ]
+        },
         "boot_args_v0": {
           "type": "array",
           "items": {

--- a/stages/test/test_bfb.py
+++ b/stages/test/test_bfb.py
@@ -46,9 +46,14 @@ DEFAULT_BOOT_ARGS_V2 = (
     " initrd=initramfs modprobe.blacklist=mlxbf_pmc"
 )
 
+REDHAT_BOOT_ARGS_V2 = (
+    "console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000"
+    " initrd=initramfs"
+)
+
 
 @pytest.mark.parametrize("inputs,options,expected_cmd_parts", [
-    # Basic test - kernel + initramfs only
+    # Basic test - kernel + initramfs only (default capsule)
     (
         FAKE_INPUTS,
         {"filename": "test.bfb"},
@@ -73,6 +78,30 @@ DEFAULT_BOOT_ARGS_V2 = (
             "--boot-args-v0", "=",
             "--boot-args-v2", f"={DEFAULT_BOOT_ARGS_V2}",
             "/lib/firmware/mellanox/boot/default.bfb",
+        ]
+    ),
+    # Test with redhat capsule preset (RHEL 9.8/10.2)
+    (
+        FAKE_INPUTS,
+        {"filename": "test.bfb", "capsule": "redhat"},
+        [
+            "/usr/bin/mlx-mkbfb",
+            "--image", "/input/kernel/path/kernel-file",
+            "--initramfs", "/input/initramfs/path/initramfs-file",
+            "--capsule", "/usr/share/redhat-cap/RedHat.cap",
+            "--boot-args-v0", "=",
+            "--boot-args-v2", f"={REDHAT_BOOT_ARGS_V2}",
+            "/lib/firmware/mellanox/boot/default.bfb",
+        ]
+    ),
+    # Test redhat capsule with explicit boot_args_v2 override
+    (
+        FAKE_INPUTS,
+        {"filename": "test.bfb", "capsule": "redhat", "boot_args_v2": ["console=hvc0"]},
+        [
+            "/usr/bin/mlx-mkbfb",
+            "--capsule", "/usr/share/redhat-cap/RedHat.cap",
+            "--boot-args-v2", "=console=hvc0",
         ]
     ),
 ])


### PR DESCRIPTION
This PR updates the BFB stage to use the new `RedHat.cap` capsule, which includes the `CA-5`, `CA-6`, and `CA-8` certificates required for RHEL9 and RHEL10 secure boot.
Another small change is the removal of the blacklisting of the `mlxbf_pmc` kernel module, which has been fixed in recent RHEL10 kernels.

Linked PR: https://github.com/coreos/coreos-assembler/pull/4575 