### PR TITLE
stages/org.osbuild.bfb: BFB boot grub shims

### DIFF
--- a/stages/org.osbuild.bfb
+++ b/stages/org.osbuild.bfb
@@ -6,10 +6,14 @@ Buildhost commands used: `mlx-mkbfb`
 """
 
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 
 import osbuild.api
+import osbuild.remoteloop as remoteloop
+from osbuild.util import makeefi
 
 # BlueField enablement software is typically from these RPMs:
 # - mlxbf-bfscripts: provides /usr/bin/mlx-mkbfb tool
@@ -17,7 +21,27 @@ import osbuild.api
 #
 # Hardcode some firmware file paths in constants that we use below
 DEFAULT_BFB_PATH = "/lib/firmware/mellanox/boot/default.bfb"
+
 BOOT_CAPSULE_PATH = "/lib/firmware/mellanox/boot/capsule/boot_update2.cap"
+
+DEFAULT_KERNEL_ARGS = [
+    "console=hvc0",            # rshim virtual console (/dev/rshim0/console)
+    "console=ttyAMA0",         # IPMI serial console
+    "earlycon=pl011,0x13010000",  # early serial output on BF3
+]
+
+
+def make_grub_cfg(kernel_args):
+    args_str = " ".join(kernel_args)
+    return f"""
+set timeout=5
+set default=0
+
+menuentry "RHCOS Live" {{
+    linux /EFI/BOOT/vmlinuz {args_str}
+    initrd /EFI/BOOT/initramfs.img
+}}
+"""
 
 
 def parse_input(inputs, name):
@@ -28,60 +52,63 @@ def parse_input(inputs, name):
     return os.path.join(data["path"], filename)
 
 
-def main(inputs, output, options):
+def main(inputs, output, options, loop_client):
     filename = options["filename"].lstrip("/")
     kernel = parse_input(inputs, "kernel")
     initramfs = parse_input(inputs, "initramfs")
 
-    # Combine initramfs + rootfs if rootfs provided
-    if "rootfs" in inputs:
-        rootfs = parse_input(inputs, "rootfs")
-        combined = os.path.join(output, "combined.img")
-        with open(combined, "wb") as out:
-            for path in [initramfs, rootfs]:
-                with open(path, "rb") as f:
-                    out.write(f.read())
-        initramfs = combined
+    with tempfile.TemporaryDirectory(dir=output) as workdir:
+        # Optionally combine initramfs + rootfs
+        if "rootfs" in inputs:
+            rootfs = parse_input(inputs, "rootfs")
+            combined_initramfs = os.path.join(workdir, "combined.img")
+            with open(combined_initramfs, "wb") as out:
+                for path in [initramfs, rootfs]:
+                    with open(path, "rb") as f:
+                        shutil.copyfileobj(f, out)
+            initramfs = combined_initramfs
 
-    # We don't plan to support BF1/BF2 hardware where v0 args are used
-    default_args_v0 = []
-    # Sourced from https://github.com/Mellanox/bfb-build
-    # - console=hvc0: rshim virtual console (/dev/rshim0/console)
-    # - console=ttyAMA0: IPMI serial console
-    # - earlycon=pl011,0x13010000: early serial output on BF3
-    # - initrd=initramfs: initramfs selection
-    # - modprobe.blacklist=mlxbf_pmc: avoid PMC driver conflicts on BF3
-    default_args_v2 = [
-        "console=hvc0",
-        "console=ttyAMA0",
-        "earlycon=pl011,0x13010000",
-        "initrd=initramfs",
-        "modprobe.blacklist=mlxbf_pmc"
-    ]
-    boot_args_v0 = " ".join(options.get("boot_args_v0", default_args_v0))
-    boot_args_v2 = " ".join(options.get("boot_args_v2", default_args_v2))
-    boot_path = options.get("boot_path", "VenHw(F019E406-8C9C-11E5-8797-001ACA00BFC4)/Image")
-    boot_desc = options.get("boot_desc", "Linux from rshim")
+        # Copy in all files needed for EFI booting into a tmpdir
+        # We'll pull the files from the buildroot "/".
+        efidir = os.path.join(workdir, 'efidir')
+        makeefi.mkefidir(efidir=efidir, source_tree="/")
 
-    cmd = [
-        "/usr/bin/mlx-mkbfb",
-        "--image", kernel,
-        "--initramfs", initramfs,
-        "--capsule", BOOT_CAPSULE_PATH,
-        "--boot-args-v0", f"={boot_args_v0}",
-        "--boot-args-v2", f"={boot_args_v2}",
-        "--boot-path", f"={boot_path}",
-        "--boot-desc", f"={boot_desc}",
-        DEFAULT_BFB_PATH,
-        os.path.join(output, filename)
-    ]
+        # Create the grub.cfg
+        kernel_args = options.get("kernel_args", DEFAULT_KERNEL_ARGS)
+        grub_cfg = make_grub_cfg(kernel_args)
+        with open(os.path.join(efidir, "BOOT", "grub.cfg"), "w", encoding='utf8') as fh:
+            fh.write(grub_cfg)
 
-    subprocess.run(cmd, check=True)
+        # Copy in the kernel+initramfs
+        shutil.copy2(kernel, os.path.join(efidir, "BOOT", "vmlinuz"))
+        shutil.copy2(initramfs, os.path.join(efidir, "BOOT", "initramfs.img"))
+
+        # Create the efiboot.img file
+        ramdisk = os.path.join(workdir, "ramdisk.img")
+        makeefi.mkefiboot(efidir=efidir,
+                          output_efiboot_img=ramdisk,
+                          loop_client=loop_client)
+
+        boot_path = options.get("boot_path", "VenHw(F019E406-8C9C-11E5-8797-001ACA00BFC4)/EFI/BOOT/BOOTAA64.EFI")
+        boot_desc = options.get("boot_desc", "Linux via EFI+GRUB")
+
+        cmd = [
+            "/usr/bin/mlx-mkbfb",
+            "--ramdisk", ramdisk,
+            "--capsule", options.get("capsule", BOOT_CAPSULE_PATH),
+            "--boot-path", f"={boot_path}",
+            "--boot-desc", f"={boot_desc}",
+            DEFAULT_BFB_PATH,
+            os.path.join(output, filename)
+        ]
+
+        subprocess.run(cmd, check=True)
 
     return 0
 
 
 if __name__ == '__main__':
     args = osbuild.api.arguments()
-    r = main(args["inputs"], args["tree"], args["options"])
+    r = main(args["inputs"], args["tree"], args["options"],
+             loop_client=remoteloop.LoopClient("/run/osbuild/api/remoteloop"))
     sys.exit(r)

--- a/stages/org.osbuild.bfb.meta.json
+++ b/stages/org.osbuild.bfb.meta.json
@@ -4,7 +4,7 @@
     "Packages Linux live artifacts into NVIDIA BFB format for BlueField DPUs.",
     "Takes kernel, initramfs, and optionally rootfs as inputs.",
     "If rootfs is provided, it is concatenated with initramfs.",
-    "Provides hardware-specific boot arguments for BlueField DPUs.",
+    "Boots via GRUB shims discovered from the buildroot EFI paths.",
     "Buildhost commands used: `mlx-mkbfb`"
   ],
   "schema_2": {
@@ -40,27 +40,21 @@
           "type": "string",
           "description": "Output BFB filename"
         },
-        "boot_args_v0": {
+        "kernel_args": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Boot arguments for older DPU firmware (BF1/BF2). Empty by default as BF1/BF2 support is not planned.",
-          "default": []
-        },
-        "boot_args_v2": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Boot arguments for newer DPU firmware (BF3). Defaults include essential hardware-specific arguments (console, earlycon, initrd).",
+          "description": "Kernel command-line arguments.",
           "default": [
             "console=hvc0",
             "console=ttyAMA0",
-            "earlycon=pl011,0x13010000",
-            "initrd=initramfs",
-            "modprobe.blacklist=mlxbf_pmc"
+            "earlycon=pl011,0x13010000"
           ]
+        },
+        "capsule": {
+          "type": "string",
+          "description": "Path to UEFI capsule for firmware update, passed to mlx-mkbfb --capsule."
         },
         "boot_path": {
           "type": "string",

--- a/stages/test/test_bfb.py
+++ b/stages/test/test_bfb.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
+# pylint: disable=redefined-outer-name
 
+import contextlib
 import copy
-import unittest.mock
-from unittest.mock import patch
+import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -41,12 +43,34 @@ FAKE_INPUTS_WITH_ROOTFS = {
 }
 
 
-DEFAULT_BOOT_ARGS_V2 = (
-    "console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000"
-    " initrd=initramfs modprobe.blacklist=mlxbf_pmc"
-)
+@pytest.fixture
+def mock_makeefi(stage_module):
+    def fake_mkefidir(efidir, source_tree):  # pylint: disable=unused-argument
+        os.makedirs(os.path.join(efidir, "BOOT"), exist_ok=True)
+
+    def fake_mkefiboot(efidir, output_efiboot_img, loop_client):  # pylint: disable=unused-argument
+        with open(output_efiboot_img, "wb") as f:
+            f.write(b"fake_efiboot")
+
+    with patch.object(stage_module.makeefi, "mkefidir",
+                      side_effect=fake_mkefidir), \
+            patch.object(stage_module.makeefi, "mkefiboot",
+                         side_effect=fake_mkefiboot):
+        yield
 
 
+@pytest.fixture
+def mock_loop_client():
+    client = MagicMock()
+
+    @contextlib.contextmanager
+    def _fake_device(_path):
+        yield "/dev/loop99"
+    client.device = MagicMock(side_effect=_fake_device)
+    return client
+
+
+@pytest.mark.usefixtures("mock_makeefi")
 @pytest.mark.parametrize("inputs,options,expected_cmd_parts", [
     # Basic test - kernel + initramfs only
     (
@@ -54,69 +78,108 @@ DEFAULT_BOOT_ARGS_V2 = (
         {"filename": "test.bfb"},
         [
             "/usr/bin/mlx-mkbfb",
-            "--image", "/input/kernel/path/kernel-file",
-            "--initramfs", "/input/initramfs/path/initramfs-file",
-            "--capsule", "/lib/firmware/mellanox/boot/capsule/boot_update2.cap",
-            "--boot-args-v0", "=",
-            "--boot-args-v2", f"={DEFAULT_BOOT_ARGS_V2}",
+            "--ramdisk",
+            "--capsule",
+            "--boot-path",
+            "--boot-desc",
             "/lib/firmware/mellanox/boot/default.bfb",
         ]
     ),
-    # Test with rootfs (should use combined file)
+    # Test with rootfs
     (
         FAKE_INPUTS_WITH_ROOTFS,
         {"filename": "test.bfb"},
         [
             "/usr/bin/mlx-mkbfb",
-            "--image", "/input/kernel/path/kernel-file",
-            "--capsule", "/lib/firmware/mellanox/boot/capsule/boot_update2.cap",
-            "--boot-args-v0", "=",
-            "--boot-args-v2", f"={DEFAULT_BOOT_ARGS_V2}",
+            "--ramdisk",
+            "--capsule",
+            "--boot-path",
+            "--boot-desc",
             "/lib/firmware/mellanox/boot/default.bfb",
         ]
     ),
 ])
 @patch("subprocess.run")
-@patch("builtins.open", new_callable=unittest.mock.mock_open)
 def test_bfb_command_generation(
-        _mock_file,
         mock_run,
+        tmp_path,
         stage_module,
+        mock_loop_client,
         inputs,
         options,
         expected_cmd_parts):
     """Test that stage generates correct mlx-mkbfb command"""
 
-    output_dir = "/fake/output"
+    output_dir = str(tmp_path / "output")
+    os.makedirs(output_dir)
 
-    # Deep copy to prevent parse_input()'s popitem() from mutating shared test data
-    stage_module.main(copy.deepcopy(inputs), output_dir, options)
+    # Create fake input files so file I/O works
+    test_inputs = copy.deepcopy(inputs)
+    for name in test_inputs:
+        inp = test_inputs[name]
+        files = inp["data"]["files"]
+        fname = list(files.keys())[0]
+        inp["path"] = str(tmp_path / name)
+        os.makedirs(inp["path"], exist_ok=True)
+        with open(os.path.join(inp["path"], fname), "wb") as f:
+            f.write(b"fake")
 
-    mock_run.assert_called_once()
-    actual_cmd = mock_run.call_args[0][0]
+    stage_module.main(test_inputs, output_dir, options, mock_loop_client)
+
+    actual_cmd = mock_run.call_args_list[-1][0][0]
 
     for part in expected_cmd_parts:
         assert part in actual_cmd, f"Expected {part!r} in command: {actual_cmd}"
     assert f"{output_dir}/{options['filename']}" in actual_cmd
 
 
+@pytest.mark.usefixtures("mock_makeefi")
 @patch("subprocess.run")
-def test_bfb_rootfs_combination(mock_run, tmp_path, stage_module):
+def test_bfb_rootfs_combination(mock_run, tmp_path, mock_loop_client, stage_module):
     """Test that initramfs and rootfs are combined when rootfs is provided"""
 
     options = {"filename": "test.bfb"}
-    output_dir = str(tmp_path)
+    output_dir = str(tmp_path / "output")
+    os.makedirs(output_dir)
 
-    with patch("builtins.open", unittest.mock.mock_open(read_data=b"fake_data")) as mock_file:
-        stage_module.main(copy.deepcopy(FAKE_INPUTS_WITH_ROOTFS), output_dir, options)
+    test_inputs = copy.deepcopy(FAKE_INPUTS_WITH_ROOTFS)
+    for name in test_inputs:
+        inp = test_inputs[name]
+        fname = list(inp["data"]["files"].keys())[0]
+        inp["path"] = str(tmp_path / name)
+        os.makedirs(inp["path"], exist_ok=True)
+        with open(os.path.join(inp["path"], fname), "wb") as f:
+            f.write(b"fake_data")
 
-    mock_file.assert_called()
-    mock_run.assert_called_once()
+    stage_module.main(test_inputs, output_dir, options, mock_loop_client)
 
-    actual_cmd = mock_run.call_args[0][0]
-    initramfs_idx = actual_cmd.index("--initramfs") + 1
-    initramfs_path = actual_cmd[initramfs_idx]
-    assert "combined.img" in initramfs_path
+    # mlx-mkbfb is the last call
+    actual_cmd = mock_run.call_args_list[-1][0][0]
+    assert "--ramdisk" in actual_cmd
+
+
+@pytest.mark.usefixtures("mock_makeefi")
+@patch("subprocess.run")
+def test_bfb_no_rootfs(mock_run, tmp_path, mock_loop_client, stage_module):
+    """Test that initramfs is used directly when rootfs is not provided"""
+
+    options = {"filename": "test.bfb"}
+    output_dir = str(tmp_path / "output")
+    os.makedirs(output_dir)
+
+    test_inputs = copy.deepcopy(FAKE_INPUTS)
+    for name in test_inputs:
+        inp = test_inputs[name]
+        fname = list(inp["data"]["files"].keys())[0]
+        inp["path"] = str(tmp_path / name)
+        os.makedirs(inp["path"], exist_ok=True)
+        with open(os.path.join(inp["path"], fname), "wb") as f:
+            f.write(b"fake_data")
+
+    stage_module.main(test_inputs, output_dir, options, mock_loop_client)
+
+    actual_cmd = mock_run.call_args_list[-1][0][0]
+    assert "--ramdisk" in actual_cmd
 
 
 def test_parse_input(stage_module):


### PR DESCRIPTION
This PR modifies the boot process for BlueField Boot (BFB) images. Instead of booting the kernel directly and relying on a capsule file to establish the secure boot chain of trust, the BFB image will now boot GRUB. Because this Red Hat GRUB path is ultimately authenticated and trusted via Microsoft's UEFI keys, this simplifies and secures the verification process.

