### PR TITLE
stages: add org.osbuild.grub2.d

### DIFF
--- a/stages/org.osbuild.grub2.d
+++ b/stages/org.osbuild.grub2.d
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+"""Write a GRUB2 drop-in configuration file.
+
+This stage writes a grub2 configuration snippet to a configurable
+location (tree:// or mount://). The primary use case is writing
+console.cfg for bootupd-managed bootloaders, but the path is
+configurable to support other drop-in files.
+
+The config options support serial, terminal_input, and
+terminal_output settings matching the org.osbuild.grub2 stage.
+"""
+import os
+import sys
+
+import osbuild.api
+from osbuild.util import parsing
+
+
+def generate_grub2_dropin(config, file_path):
+    """Write grub2 commands derived from config to file_path."""
+    cmds = []
+    serial = config.get("serial")
+    if serial:
+        cmds.append(serial)
+    terminal_input = config.get("terminal_input")
+    if terminal_input:
+        cmds.append("terminal_input " + " ".join(terminal_input))
+    terminal_output = config.get("terminal_output")
+    if terminal_output:
+        cmds.append("terminal_output " + " ".join(terminal_output))
+
+    content = "\n".join(cmds) + "\n" if cmds else ""
+
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with open(file_path, 'w', encoding="utf8") as f:
+        f.write(content)
+
+
+def main(args, options):
+    config = options.get("config", {})
+    file_path = parsing.parse_location(options["path"], args)
+
+    generate_grub2_dropin(config, file_path)
+    return 0
+
+
+if __name__ == "__main__":
+    _args = osbuild.api.arguments()
+    r = main(_args, _args["options"])
+    sys.exit(r)

--- a/stages/org.osbuild.grub2.d.meta.json
+++ b/stages/org.osbuild.grub2.d.meta.json
@@ -1,0 +1,72 @@
+{
+  "summary": "Write a GRUB2 drop-in configuration file",
+  "description": [
+    "Write a GRUB2 configuration snippet to a drop-in file.",
+    "The path is specified as a location URL (tree:// or mount://).",
+    "",
+    "Examples:",
+    "  - 'tree:///boot/grub2/console.cfg' for bootupd-managed bootloaders",
+    "  - 'mount://root/etc/grub.d/99-serial.cfg' for grub2-mkconfig setups",
+    "",
+    "The config options support the same serial, terminal_input,",
+    "and terminal_output fields as the org.osbuild.grub2 stage."
+  ],
+  "schema_2": {
+    "definitions": {
+      "terminal": {
+        "description": "Terminal device list",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "options": {
+      "additionalProperties": false,
+      "required": [
+        "config",
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "description": "Location URL for the drop-in file (tree:// or mount://)",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^mount://[^/]+/"
+            },
+            {
+              "type": "string",
+              "pattern": "^tree:///"
+            }
+          ]
+        },
+        "config": {
+          "description": "GRUB2 configuration to write",
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "terminal_input": {
+              "$ref": "#/definitions/terminal"
+            },
+            "terminal_output": {
+              "$ref": "#/definitions/terminal"
+            },
+            "serial": {
+              "description": "The grub serial command (e.g. 'serial --speed=115200')",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "devices": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "mounts": {
+      "type": "array"
+    }
+  }
+}

--- a/stages/test/test_grub2_d.py
+++ b/stages/test/test_grub2_d.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python3
+
+import re
+
+import pytest
+
+from osbuild.testutil import assert_jsonschema_error_contains
+
+STAGE_NAME = "org.osbuild.grub2.d"
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # good - tree:// paths
+    ({"config": {"serial": "serial --speed=115200"}, "path": "tree:///boot/grub2/console.cfg"}, ""),
+    ({"config": {"terminal_input": ["serial", "console"]}, "path": "tree:///boot/grub2/console.cfg"}, ""),
+    ({"config": {"terminal_output": ["serial", "console"]}, "path": "tree:///boot/grub2/console.cfg"}, ""),
+    ({"config": {
+        "serial": "serial --speed=115200",
+        "terminal_input": ["serial", "console"],
+        "terminal_output": ["serial", "console"],
+    }, "path": "tree:///boot/grub2/console.cfg"}, ""),
+    # good - mount:// paths
+    ({"config": {"serial": "serial --speed=115200"}, "path": "mount://root/boot/grub2/custom.cfg"}, ""),
+    ({"config": {"serial": "serial --speed=115200"}, "path": "mount://root/etc/grub.d/99-serial.cfg"}, ""),
+    # bad - missing required config
+    ({"path": "tree:///boot/grub2/console.cfg"}, "'config' is a required property"),
+    # bad - missing required path
+    ({"config": {"serial": "serial --speed=115200"}}, "'path' is a required property"),
+    # bad - empty config
+    ({"config": {}, "path": "tree:///boot/grub2/console.cfg"},
+     re.compile(r"{} should be non-empty|{} does not have enough properties")),
+    # bad - unknown property in config
+    ({"config": {"unknown": "value"}, "path": "tree:///boot/grub2/console.cfg"}, "Additional properties are not allowed"),
+    # bad - wrong types
+    ({"config": {"serial": 123}, "path": "tree:///boot/grub2/console.cfg"}, "123 is not of type 'string'"),
+    ({"config": {"terminal_input": "not-an-array"}, "path": "tree:///boot/grub2/console.cfg"},
+     "'not-an-array' is not of type 'array'"),
+    ({"config": {"terminal_output": "not-an-array"}, "path": "tree:///boot/grub2/console.cfg"},
+     "'not-an-array' is not of type 'array'"),
+    ({"config": {"terminal_input": [123]}, "path": "tree:///boot/grub2/console.cfg"},
+     "123 is not of type 'string'"),
+    # bad - unknown top-level option
+    ({"config": {"serial": "serial"}, "unknown": "value", "path": "tree:///x"}, "Additional properties are not allowed"),
+    # bad - bare path (no scheme)
+    ({"config": {"serial": "serial"}, "path": "boot/grub2/console.cfg"}, "is not valid under any of the given schemas"),
+    ({"config": {"serial": "serial"}, "path": "/boot/grub2/console.cfg"}, "is not valid under any of the given schemas"),
+])
+def test_schema_validation(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "options": {},
+    }
+    test_input["options"].update(test_data)
+    res = stage_schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        assert_jsonschema_error_contains(res, expected_err)
+
+
+@pytest.mark.parametrize("config,expected_lines", [
+    # empty config produces empty file
+    ({}, []),
+    # serial only
+    (
+        {"serial": "serial --speed=115200"},
+        ["serial --speed=115200"],
+    ),
+    # terminal_input only
+    (
+        {"terminal_input": ["serial", "console"]},
+        ["terminal_input serial console"],
+    ),
+    # terminal_output only
+    (
+        {"terminal_output": ["serial"]},
+        ["terminal_output serial"],
+    ),
+    # all three
+    (
+        {
+            "serial": "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
+            "terminal_input": ["serial", "console"],
+            "terminal_output": ["serial", "console"],
+        },
+        [
+            "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
+            "terminal_input serial console",
+            "terminal_output serial console",
+        ],
+    ),
+])
+def test_generate_grub2_dropin(tmp_path, stage_module, config, expected_lines):
+    dropin_path = tmp_path / "test.cfg"
+    stage_module.generate_grub2_dropin(config, dropin_path)
+
+    content = dropin_path.read_text(encoding="utf8")
+    if expected_lines:
+        assert content == "\n".join(expected_lines) + "\n"
+    else:
+        assert content == ""
+
+
+def test_main_tree_path(tmp_path, stage_module):
+    """main() writes to the specified tree:// location."""
+    args = {"tree": str(tmp_path)}
+    options = {
+        "path": "tree:///boot/grub2/console.cfg",
+        "config": {
+            "serial": "serial --speed=115200",
+            "terminal_input": ["serial", "console"],
+            "terminal_output": ["serial", "console"],
+        },
+    }
+    stage_module.main(args, options)
+
+    cfg_path = tmp_path / "boot" / "grub2" / "console.cfg"
+    assert cfg_path.exists()
+    content = cfg_path.read_text(encoding="utf8")
+    assert "serial --speed=115200\n" in content
+    assert "terminal_input serial console\n" in content
+    assert "terminal_output serial console\n" in content
+
+
+def test_main_creates_parent_dirs(tmp_path, stage_module):
+    """main() creates parent directories if they don't exist."""
+    args = {"tree": str(tmp_path)}
+    options = {
+        "path": "tree:///boot/grub2/console.cfg",
+        "config": {
+            "serial": "serial --speed=115200",
+        },
+    }
+    stage_module.main(args, options)
+
+    cfg_path = tmp_path / "boot" / "grub2" / "console.cfg"
+    assert cfg_path.exists()


### PR DESCRIPTION
Add a new stage to write a GRUB2 drop-in configuration file at a configurable path relative to the filesystem root.

Allowed inputs are matching the `org.osbuild.grub2` stage on purpose. The primary intent of this stage is to write `/boot/grub2/console.cfg`, a config drop-in that is set by bootupd on bootc distros.

The path defaults to `boot/grub2/console.cfg` but can be set to any location, e.g. `etc/grub.d/99-serial.cfg` for grub2-mkconfig setups.

The config options reuse the same terminal_input, terminal_output, and serial fields as the org.osbuild.grub2 stage.

Assisted-by: OpenCode.ai <Opus 4.6>