### PR TITLE
runners: Add Oracle Linux 9 runner symlinked to CentOS9

### DIFF
--- a/runners/org.osbuild.ol9
+++ b/runners/org.osbuild.ol9
@@ -1,0 +1,1 @@
+org.osbuild.centos9


### PR DESCRIPTION
[osbuild/images PR #2404](https://github.com/osbuild/images/pull/2404) has been submitted to add support for Oracle Linux.

Add an associated runner in osbuild for OL9 symlinked to CentOS9