### PR TITLE
ci: fix `test_qemu`

### DIFF
--- a/test/run/test_assemblers.py
+++ b/test/run/test_assemblers.py
@@ -156,7 +156,7 @@ def test_ostree(osbuild):
 @pytest.mark.skipif(not test.TestBase.have_tree_diff(), reason="tree-diff missing")
 @pytest.mark.skipif(not test.TestBase.have_test_data(), reason="no test-data access")
 @pytest.mark.skipif(not test.TestBase.can_bind_mount(), reason="root-only")
-@pytest.mark.parametrize("fmt,", ["raw", "raw.xz", "qcow2", "vmdk", "vdi"])
+@pytest.mark.parametrize("fmt", ["raw", "raw.xz", "qcow2", "vmdk", "vdi"])
 @pytest.mark.parametrize("fs_type", ["ext4", "xfs", "btrfs"])
 def test_qemu(osbuild, fmt, fs_type):
     loctl = loop.LoopControl()


### PR DESCRIPTION
I assume this has to do with a newer version of `pytest` that interprets things differently. CI started failing on `main` and PRs a day or so ago; don't really want to dig in.