### PR TITLE
many: replace `images` -> `image-builder` (HMS-10891)

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -4,10 +4,8 @@ This document is a guide to help understand the osbuild manifest. It follows the
 
 In addition to osbuild contributors, this guide is useful for:
 - Developers of and contributors to manifest generator tools:
-    - [osbuild/images](https://github.com/osbuild/images) (the osbuild image definition library) and the projects that use it:
+    - [osbuild/image-builder](https://github.com/osbuild/image-builder) (the osbuild image library and executables (`image-builder`, `bootc-image-builder`) and the projects that use it:
         - [osbuild-composer](https://github.com/osbuild/osbuild-composer).
-        - [image-builder-cli](https://github.com/osbuild/image-builder-cli).
-        - [bootc-image-builder](https://github.com/osbuild/bootc-image-builder).
     - [osbuild-mpp](https://github.com/osbuild/blob/main/tools/osbuild-mpp)
 - Authors of osbuild modules ([stages](https://github.com/osbuild/osbuild/tree/main/stages), [sources](https://github.com/osbuild/osbuild/tree/main/sources), [inputs](https://github.com/osbuild/osbuild/tree/main/inputs), [mounts](https://github.com/osbuild/osbuild/tree/main/mounts), [devices](https://github.com/osbuild/osbuild/tree/main/devices)).
 

--- a/osbuild/solver/request.py
+++ b/osbuild/solver/request.py
@@ -39,7 +39,7 @@ class DepsolveTransaction:
     ):
         # pylint: disable=fixme
         # XXX: We can't enforce this, because there is a "bug" in the osbuild/images "os" pipeline implementation.
-        # https://github.com/osbuild/images/commit/8b779619aa0c3a9b8537f6bb79324303cb87909c introduced three
+        # https://github.com/osbuild/image-builder/commit/8b779619aa0c3a9b8537f6bb79324303cb87909c introduced three
         # transactions, but the "customizations" package set is added to the "chain" unconditionally, even if it
         # is empty. This is the case for "container" and "wsl" image types. Other image types enable at least
         # SELinux, which adds the "selinux-policy-targeted" package to the list.

--- a/test/cases/utils.py
+++ b/test/cases/utils.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 
-OSBUILD_IMAGES_REPO_URL = os.environ.get("OSBUILD_IMAGES_REPO_URL", "https://github.com/osbuild/images.git")
+OSBUILD_IMAGES_REPO_URL = os.environ.get("OSBUILD_IMAGES_REPO_URL", "https://github.com/osbuild/image-builder.git")
 
 
 def checkout_images_repo(ref, workdir: os.PathLike) -> str:

--- a/test/mod/test_solver_request.py
+++ b/test/mod/test_solver_request.py
@@ -41,7 +41,7 @@ class TestDepsolveTransaction:
         ),
         # Invalid requests
         # We can't enforce this, because there is a "bug" in the osbuild/images "os" pipeline implementation.
-        # https://github.com/osbuild/images/commit/8b779619aa0c3a9b8537f6bb79324303cb87909c introduced three
+        # https://github.com/osbuild/image-builder/commit/8b779619aa0c3a9b8537f6bb79324303cb87909c introduced three
         # transactions, but the "customizations" package set is added to the "chain" unconditionally, even if it
         # is empty. This is the case for "container" and "wsl" image types. Other image types enable at least
         # SELinux, which adds the "selinux-policy-targeted" package to the list.


### PR DESCRIPTION
Replace all references, even if they still worked it's just nicer to have them be correct.