### PR TITLE
stages/bootc.install-to-fs: remount /dev/shm in addition to /dev/shm

### DIFF
--- a/stages/org.osbuild.bootc.install-to-filesystem
+++ b/stages/org.osbuild.bootc.install-to-filesystem
@@ -77,10 +77,13 @@ def main(options, inputs, paths):  # pylint: disable=too-many-branches
         # to use the `composefs` backend based on the input container; we can't control
         # this so we should always be prepared.
         subprocess.check_call(['mount', '-t', 'devtmpfs', 'devtmpfs', '/dev/'])
+        os.makedirs('/dev/shm', exist_ok=True)
+        subprocess.check_call(['mount', '-t', 'tmpfs', 'tmpfs', '/dev/shm'])
 
         try:
             subprocess.run(pargs, env=env, check=True)
         finally:
+            subprocess.check_call(['umount', '/dev/shm'])
             subprocess.check_call(['umount', '/dev/'])
 
 

--- a/stages/test/test_bootc_install_to_fs.py
+++ b/stages/test/test_bootc_install_to_fs.py
@@ -122,9 +122,11 @@ def test_bootc_install_to_fs(mock_check_call, mock_run, mocked_named_tmp, mocked
     assert kwargs["check"] is True
     assert kwargs["env"]["BOOTC_SKIP_SELINUX_HOST_CHECK"] == "true"
 
-    assert mock_check_call.call_count == 2
+    assert mock_check_call.call_count == 4
     mock_check_call.assert_has_calls([
         call(['mount', '-t', 'devtmpfs', 'devtmpfs', '/dev/']),
+        call(['mount', '-t', 'tmpfs', 'tmpfs', '/dev/shm']),
+        call(['umount', '/dev/shm']),
         call(['umount', '/dev/']),
     ])
 


### PR DESCRIPTION
In commit c1f5f50d8ce6340dae98fb2d3604dcfc65ce546e we introduced the remounting of /dev. However, wit this /dev, podman, as started from image-builder ends up with this error:

```
Error: failed to get new shm lock manager: failed to create 2048 locks in /libpod_lock: no such file or directory
```

This is due to the lack of /dev/shm, so mount it as well