### PR TITLE
utils: add utils.makeefi library

### DIFF
--- a/osbuild/util/makeefi.py
+++ b/osbuild/util/makeefi.py
@@ -32,7 +32,23 @@ def find_efi_source_paths(tree):
     return [os.path.join(tree, 'usr/lib/bootupd/updates/EFI')]
 
 
-def find_efi_vendor_dir_name(efidir):
+def find_efi_vendor_dir_name(efidir=None, source_tree=None):
+    """
+    Searches either an EFI directory structure (efidir) or a source tree
+    (source_tree) for an EFI vendor directory name (usually fedora,
+    redhat, or centos). If source_tree is given the efidir will be found
+    first using find_efi_source_paths().
+    """
+    if source_tree and efidir:
+        raise ValueError("find_efi_vendor_dir_name: cannot pass both efidir and source_tree")
+    if not source_tree and not efidir:
+        raise ValueError("find_efi_vendor_dir_name: must pass either efidir or source_tree")
+    # If the user provided a source_tree and not an efidir then
+    # we must first find the efidir within the source_tree.
+    if source_tree:
+        # To find the string for the vendor ID we only need to inspect one
+        # of the source EFI directories. Grab one here.
+        efidir = find_efi_source_paths(source_tree)[0]
     # Find name of vendor directory for this distro. i.e. "fedora" or "redhat".
     dirs = [n for n in os.listdir(efidir) if n != "BOOT"]
     if len(dirs) != 1:
@@ -49,7 +65,7 @@ def mkefidir(efidir, source_tree):
     for path in find_efi_source_paths(source_tree):
         shutil.copytree(path, efidir, dirs_exist_ok=True)
 
-    vendor_id = find_efi_vendor_dir_name(efidir)
+    vendor_id = find_efi_vendor_dir_name(efidir=efidir)
 
     # Delete fallback and its CSV file.  Its purpose is to create
     # EFI boot variables, which we don't want when booting from

--- a/osbuild/util/makeefi.py
+++ b/osbuild/util/makeefi.py
@@ -15,10 +15,10 @@ from osbuild.util.path import ensure_glob
 
 # This function finds the source EFI paths to copy from /usr/ to the EFI/
 # directory. Historically this was just the usr/lib/bootupd/updates/EFI/
-# directory (populated by bootupd), but as part of BootLoaderUpdatesPhase1 [1]
-# the shim and grub packages started delivering files in
-# /usr/lib/efi/(grub|shim)/<version>/EFI/ directly. Lets prefer the
-# new paths and fallback to the legacy path if those don't exist.
+# directory (populated by bootupd) or boot/efi/EFI (package mode), but
+# as part of BootLoaderUpdatesPhase1 [1] the shim and grub packages started
+# delivering files in /usr/lib/efi/(grub|shim)/<version>/EFI/ directly.
+# Lets prefer the new paths and fallback to the legacy paths.
 #
 # [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
 def find_efi_source_paths(tree):
@@ -28,8 +28,14 @@ def find_efi_source_paths(tree):
         # Let's ensure there's only 2 dirs that match (i.e. one for grub
         # one for shim) and return that list.
         return ensure_glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI'), n=2)
-    # Legacy path. Just return a single entry list with the old path.
-    return [os.path.join(tree, 'usr/lib/bootupd/updates/EFI')]
+    # Legacy paths:
+    #   - 'usr/lib/bootupd/updates/EFI' - on Image Mode systems
+    #   - 'boot/efi/EFI'                - on Package Mode systems
+    for path in ['usr/lib/bootupd/updates/EFI', 'boot/efi/EFI']:
+        fullpath = os.path.join(tree, path)
+        if os.path.exists(fullpath):
+            return [fullpath]
+    raise ValueError(f'No EFI source paths found in {tree}')
 
 
 def find_efi_vendor_dir_name(efidir=None, source_tree=None):

--- a/osbuild/util/makeefi.py
+++ b/osbuild/util/makeefi.py
@@ -13,15 +13,17 @@ import tempfile
 from osbuild.util.path import ensure_glob
 
 
-# This function finds the source EFI paths to copy from /usr/ to the EFI/
-# directory. Historically this was just the usr/lib/bootupd/updates/EFI/
-# directory (populated by bootupd) or boot/efi/EFI (package mode), but
-# as part of BootLoaderUpdatesPhase1 [1] the shim and grub packages started
-# delivering files in /usr/lib/efi/(grub|shim)/<version>/EFI/ directly.
-# Lets prefer the new paths and fallback to the legacy paths.
-#
-# [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
 def find_efi_source_paths(tree):
+    """
+    This function finds the source EFI paths to copy from /usr/ to the EFI/
+    directory. Historically this was just the usr/lib/bootupd/updates/EFI/
+    directory (populated by bootupd) or boot/efi/EFI (package mode), but
+    as part of BootLoaderUpdatesPhase1 [1] the shim and grub packages started
+    delivering files in /usr/lib/efi/(grub|shim)/<version>/EFI/ directly.
+    Lets prefer the new paths and fallback to the legacy paths.
+
+    [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
+    """
     if glob.glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI')):
         # BootLoaderUpdatesPhase1 has been implemented and we should
         # be able to pick up files from usr/lib/efi/(grub|shim)/<version>/EFI/

--- a/osbuild/util/makeefi.py
+++ b/osbuild/util/makeefi.py
@@ -119,6 +119,10 @@ def mkefiboot(efidir, output_efiboot_img, loop_client):
     # Create the efiboot image file. Determine the size we should make
     # it by taking the tarball size and adding 2MiB for fs overhead.
     size = os.path.getsize(efitarfile.name) + 2 * 1024 * 1024
+    # Align to 512 byte boundary. Some firmeware (like nvidiabluefield)
+    # derives block device sector size from image size; unaligned sizes
+    # produce sector size 1 which GRUB cannot handle
+    size = (size + 511) & ~511
     with open(output_efiboot_img, "wb") as out:
         out.truncate(size)
 

--- a/osbuild/util/makeefi.py
+++ b/osbuild/util/makeefi.py
@@ -1,0 +1,126 @@
+"""EFI boot image utilities
+
+Functions for building EFI boot directory layouts and
+FAT filesystem images suitable for ISO / removable-media boot.
+"""
+import glob
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+
+from osbuild.util.path import ensure_glob
+
+
+# This function finds the source EFI paths to copy from /usr/ to the EFI/
+# directory. Historically this was just the usr/lib/bootupd/updates/EFI/
+# directory (populated by bootupd), but as part of BootLoaderUpdatesPhase1 [1]
+# the shim and grub packages started delivering files in
+# /usr/lib/efi/(grub|shim)/<version>/EFI/ directly. Lets prefer the
+# new paths and fallback to the legacy path if those don't exist.
+#
+# [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
+def find_efi_source_paths(tree):
+    if glob.glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI')):
+        # BootLoaderUpdatesPhase1 has been implemented and we should
+        # be able to pick up files from usr/lib/efi/(grub|shim)/<version>/EFI/
+        # Let's ensure there's only 2 dirs that match (i.e. one for grub
+        # one for shim) and return that list.
+        return ensure_glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI'), n=2)
+    # Legacy path. Just return a single entry list with the old path.
+    return [os.path.join(tree, 'usr/lib/bootupd/updates/EFI')]
+
+
+def find_efi_vendor_dir_name(efidir):
+    # Find name of vendor directory for this distro. i.e. "fedora" or "redhat".
+    dirs = [n for n in os.listdir(efidir) if n != "BOOT"]
+    if len(dirs) != 1:
+        raise ValueError(f"did not find exactly one EFI vendor ID: {dirs}")
+    vendor_id = dirs[0]
+    return vendor_id
+
+
+def mkefidir(efidir, source_tree):
+    """
+    Searches the source_tree for files used for EFI booting and copies
+    these files into the specified efidir.
+    """
+    for path in find_efi_source_paths(source_tree):
+        shutil.copytree(path, efidir, dirs_exist_ok=True)
+
+    vendor_id = find_efi_vendor_dir_name(efidir)
+
+    # Delete fallback and its CSV file.  Its purpose is to create
+    # EFI boot variables, which we don't want when booting from
+    # removable media.
+    #
+    # A future shim release will merge fallback.efi into the main
+    # shim binary and enable the fallback behavior when the CSV
+    # exists.  But for now, fail if fallback.efi is missing.
+    for path in ensure_glob(os.path.join(efidir, "BOOT", "fb*.efi")):
+        os.unlink(path)
+    for path in ensure_glob(os.path.join(efidir, vendor_id, "BOOT*.CSV")):
+        os.unlink(path)
+
+    # Drop vendor copies of shim; we already have it in BOOT*.EFI in
+    # BOOT
+    for path in ensure_glob(os.path.join(efidir, vendor_id, "shim*.efi")):
+        os.unlink(path)
+
+    # Consolidate remaining files into BOOT.  shim needs GRUB to be
+    # there, and the rest doesn't hurt.
+    for path in ensure_glob(os.path.join(efidir, vendor_id, "*")):
+        shutil.move(path, os.path.join(efidir, "BOOT"))
+    os.rmdir(os.path.join(efidir, vendor_id))
+
+
+def mkefiboot(efidir, output_efiboot_img, loop_client):
+    """
+    Creates an efi boot image file at output_efiboot_img (usually named efiboot.img),
+    which is required for EFI booting. This is a fat32 formatted filesystem that
+    contains all the files needed for EFI boot.
+    """
+
+    # In restrictive environments, setgid, setuid and ownership changes
+    # may be restricted. This sets the file ownership to root and
+    # removes the setgid and setuid bits in the tarball.
+    def strip_tar(tarinfo):
+        tarinfo.uid = 0
+        tarinfo.gid = 0
+        if tarinfo.isdir():
+            tarinfo.mode = 0o755
+        elif tarinfo.isfile():
+            tarinfo.mode = 0o0644
+        return tarinfo
+
+    # Install binaries from the efidir
+    # Manually construct the tarball to ensure proper permissions and ownership
+    efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")
+    with tarfile.open(efitarfile.name, "w:", dereference=True) as tar:
+        tar.add(efidir, arcname="/EFI", filter=strip_tar)
+
+    # Create the efiboot image file. Determine the size we should make
+    # it by taking the tarball size and adding 2MiB for fs overhead.
+    size = os.path.getsize(efitarfile.name) + 2 * 1024 * 1024
+    with open(output_efiboot_img, "wb") as out:
+        out.truncate(size)
+
+    # Make loopback device; mkfs; populate with files
+    with loop_client.device(output_efiboot_img) as loopdev:
+        # On RHEL 8, when booting from a disk device (rather than a CD),
+        # https://github.com/systemd/systemd/issues/14408 causes the
+        # hybrid ESP to race with the ISO9660 filesystem for the
+        # /dev/disk/by-label symlink unless the ESP has its own label,
+        # so set EFI-SYSTEM for consistency with the metal image.
+        # This should not be needed on Fedora or RHEL 9, but seems like
+        # a good thing to do anyway.
+        label = 'EFI-SYSTEM'
+        # NOTE: the arguments to mkfs here match how virt-make-fs calls mkfs
+        subprocess.check_call(['mkfs', '-t', 'vfat', '-I', '--mbr=n', '-n', label, loopdev])
+        with tempfile.TemporaryDirectory() as d:
+            try:
+                subprocess.check_call(['mount', '-o', 'utf8', loopdev, d])
+                subprocess.check_call(['tar', '-C', d, '-xf', efitarfile.name])
+            finally:
+                subprocess.check_call(['umount', d])

--- a/osbuild/util/path.py
+++ b/osbuild/util/path.py
@@ -1,5 +1,6 @@
 """Path handling utility functions"""
 import errno
+import glob
 import os
 import os.path
 from typing import Optional, Union
@@ -56,3 +57,16 @@ def join_abs(root: Union[str, os.PathLike], *paths: Union[str, os.PathLike]) -> 
         else:
             final_path = os.path.join(final_path, path)
     return os.path.normpath(os.path.join(os.sep, final_path))
+
+
+def ensure_glob(pathname, n="", **kwargs):
+    """
+    Call glob.glob() and fail if there are no results or
+    if the number of results doesn't match provided n
+    """
+    ret = glob.glob(pathname, **kwargs)
+    if not ret:
+        raise ValueError(f'No matches for {pathname}')
+    if n != "" and len(ret) != int(n):
+        raise ValueError(f'Matches for {pathname} does not match expected ({n})')
+    return ret

--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -377,8 +377,24 @@ def gen_live_artifacts(paths, tree, filenames, deployed_tree, loop_client, versi
 
     # For x86_64 and aarch64 UEFI booting
     if basearch in ("x86_64", "aarch64"):
-        efiboot_path = mkefiboot(paths, deployed_tree, volid, loop_client)
-        genisoargs += ['-eltorito-alt-boot', '-efi-boot', efiboot_path, '-no-emul-boot']
+        # extract a few directories from paths dict
+        efidir = paths["efi"]
+        output_efiboot_img = paths["iso/images/efiboot.img"]
+        # Copy out the EFI files found from the source_tree to the specified
+        # directory: efidir
+        mkefidir(efidir=efidir, source_tree=deployed_tree)
+        # Discover the vendor ID (can be different on Fedora/RHEL/CentOS)
+        vendor_id = find_efi_vendor_dir_name(efidir)
+        # Get the grub configuration for booting from the ISO and write it out
+        # to $efidir/BOOT/grub.cfg. See the comment in the function for explanation
+        # of config used.
+        # Write out the grub config into $efidir/BOOT/grub.cfg
+        with open(os.path.join(efidir, "BOOT", "grub.cfg"), "w", encoding='utf8') as fh:
+            fh.write(get_grub_cfg_string(volid, vendor_id))
+        # Create the efiboot.img file
+        mkefiboot(efidir, output_efiboot_img, loop_client)
+        # And add arguments to include it in when creating the ISO
+        genisoargs += ['-eltorito-alt-boot', '-efi-boot', 'images/efiboot.img', '-no-emul-boot']
 
     # We've done everything that might affect kargs, so filter out any files
     # that no longer exist and write out the kargs JSON if it lists any files
@@ -483,28 +499,35 @@ def update_image_offsets_s390x(paths, kargs_json, igninfo_json):
     })
 
 
-def mkefiboot(paths, deployed_tree, volid, loop_client):
-    """
-    Creates an efi boot image (efiboot.img) file, required for EFI
-    booting the ISO. This is a fat32 formatted filesystem that contains
-    all the files needed for EFI boot from an ISO.
+def get_grub_cfg_string(volid, vendor_id):
+    # Inject a stub grub.cfg pointing to the one in the main ISO image.
+    #
+    # When booting via El Torito, this stub is not used; GRUB reads
+    # the ISO image directly using its own ISO support.  This
+    # happens when booting from a CD device, or when the ISO is
+    # copied to a USB stick and booted on EFI firmware which prefers
+    # to boot a hard disk from an El Torito image if it has one.
+    # EDK II in QEMU behaves this way.
+    #
+    # This stub is used with EFI firmware which prefers to boot a
+    # hard disk from an ESP, or which cannot boot a hard disk via El
+    # Torito at all.  In that case, GRUB thinks it booted from a
+    # partition of the disk (a fake ESP created by isohybrid,
+    # pointing to efiboot.img) and needs a grub.cfg there.
+    return f'''search --label "{volid}" --set root --no-floppy
+set prefix=($root)/EFI/{vendor_id}
+echo "Booting via ESP..."
+configfile $prefix/grub.cfg
+boot
+'''
 
-    Returns the path to the image file.
-    """
-    # In restrictive environments, setgid, setuid and ownership changes
-    # may be restricted. This sets the file ownership to root and
-    # removes the setgid and setuid bits in the tarball.
-    def strip(tarinfo):
-        tarinfo.uid = 0
-        tarinfo.gid = 0
-        if tarinfo.isdir():
-            tarinfo.mode = 0o755
-        elif tarinfo.isfile():
-            tarinfo.mode = 0o0644
-        return tarinfo
 
-    efidir = paths["efi"]
-    for path in find_efi_source_paths(deployed_tree):
+def mkefidir(efidir, source_tree):
+    """
+    Searches the source_tree for files used for EFI booting and copies
+    these files into the specified efidir.
+    """
+    for path in find_efi_source_paths(source_tree):
         shutil.copytree(path, efidir, dirs_exist_ok=True)
 
     vendor_id = find_efi_vendor_dir_name(efidir)
@@ -532,39 +555,36 @@ def mkefiboot(paths, deployed_tree, volid, loop_client):
         shutil.move(path, os.path.join(efidir, "BOOT"))
     os.rmdir(os.path.join(efidir, vendor_id))
 
-    # Inject a stub grub.cfg pointing to the one in the main ISO image.
-    #
-    # When booting via El Torito, this stub is not used; GRUB reads
-    # the ISO image directly using its own ISO support.  This
-    # happens when booting from a CD device, or when the ISO is
-    # copied to a USB stick and booted on EFI firmware which prefers
-    # to boot a hard disk from an El Torito image if it has one.
-    # EDK II in QEMU behaves this way.
-    #
-    # This stub is used with EFI firmware which prefers to boot a
-    # hard disk from an ESP, or which cannot boot a hard disk via El
-    # Torito at all.  In that case, GRUB thinks it booted from a
-    # partition of the disk (a fake ESP created by isohybrid,
-    # pointing to efiboot.img) and needs a grub.cfg there.
-    with open(os.path.join(efidir, "BOOT", "grub.cfg"), "w", encoding='utf8') as fh:
-        fh.write(f'''search --label "{volid}" --set root --no-floppy
-set prefix=($root)/EFI/{vendor_id}
-echo "Booting via ESP..."
-configfile $prefix/grub.cfg
-boot
-''')
+
+def mkefiboot(efidir, output_efiboot_img, loop_client):
+    """
+    Creates an efi boot image file at output_efiboot_img (usually named efiboot.img),
+    which is required for EFI booting. This is a fat32 formatted filesystem that
+    contains all the files needed for EFI boot.
+    """
+
+    # In restrictive environments, setgid, setuid and ownership changes
+    # may be restricted. This sets the file ownership to root and
+    # removes the setgid and setuid bits in the tarball.
+    def strip_tar(tarinfo):
+        tarinfo.uid = 0
+        tarinfo.gid = 0
+        if tarinfo.isdir():
+            tarinfo.mode = 0o755
+        elif tarinfo.isfile():
+            tarinfo.mode = 0o0644
+        return tarinfo
 
     # Install binaries from boot partition
     # Manually construct the tarball to ensure proper permissions and ownership
     efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")
     with tarfile.open(efitarfile.name, "w:", dereference=True) as tar:
-        tar.add(efidir, arcname="/EFI", filter=strip)
+        tar.add(efidir, arcname="/EFI", filter=strip_tar)
 
     # Create the efiboot.img file in the images/ dir
-    efibootfile = paths["iso/images/efiboot.img"]
-    make_efi_bootfile(loop_client, input_tarball=efitarfile.name, output_efiboot_img=efibootfile)
-    return "images/efiboot.img"
-
+    make_efi_bootfile(loop_client,
+                      input_tarball=efitarfile.name,
+                      output_efiboot_img=output_efiboot_img)
 
 def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
     """

--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -171,33 +171,6 @@ def find_efi_vendor_dir_name(efidir):
     return vendor_id
 
 
-# This creates efiboot.img, which is a FAT filesystem.
-def make_efi_bootfile(loop_client, input_tarball, output_efiboot_img):
-    # Create the efiboot image file. Determine the size we should make
-    # it by taking the tarball size and adding 2MiB for fs overhead.
-    size = os.path.getsize(input_tarball) + 2 * 1024 * 1024
-    with open(output_efiboot_img, "wb") as out:
-        out.truncate(size)
-    # Make loopback device; mkfs; populate with files
-    with loop_client.device(output_efiboot_img) as loopdev:
-        # On RHEL 8, when booting from a disk device (rather than a CD),
-        # https://github.com/systemd/systemd/issues/14408 causes the
-        # hybrid ESP to race with the ISO9660 filesystem for the
-        # /dev/disk/by-label symlink unless the ESP has its own label,
-        # so set EFI-SYSTEM for consistency with the metal image.
-        # This should not be needed on Fedora or RHEL 9, but seems like
-        # a good thing to do anyway.
-        label = 'EFI-SYSTEM'
-        # NOTE: the arguments to mkfs here match how virt-make-fs calls mkfs
-        subprocess.check_call(['mkfs', '-t', 'vfat', '-I', '--mbr=n', '-n', label, loopdev])
-        with tempfile.TemporaryDirectory() as d:
-            try:
-                subprocess.check_call(['mount', '-o', 'utf8', loopdev, d])
-                subprocess.check_call(['tar', '-C', d, '-xf', input_tarball])
-            finally:
-                subprocess.check_call(['umount', d])
-
-
 def parse_metal_inputs(inputs):
     def get_filepath_from_input(name):
         files = inputs[name]["data"]["files"]
@@ -575,16 +548,37 @@ def mkefiboot(efidir, output_efiboot_img, loop_client):
             tarinfo.mode = 0o0644
         return tarinfo
 
-    # Install binaries from boot partition
+    # Install binaries from the efidir
     # Manually construct the tarball to ensure proper permissions and ownership
     efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")
     with tarfile.open(efitarfile.name, "w:", dereference=True) as tar:
         tar.add(efidir, arcname="/EFI", filter=strip_tar)
 
-    # Create the efiboot.img file in the images/ dir
-    make_efi_bootfile(loop_client,
-                      input_tarball=efitarfile.name,
-                      output_efiboot_img=output_efiboot_img)
+    # Create the efiboot image file. Determine the size we should make
+    # it by taking the tarball size and adding 2MiB for fs overhead.
+    size = os.path.getsize(efitarfile.name) + 2 * 1024 * 1024
+    with open(output_efiboot_img, "wb") as out:
+        out.truncate(size)
+
+    # Make loopback device; mkfs; populate with files
+    with loop_client.device(output_efiboot_img) as loopdev:
+        # On RHEL 8, when booting from a disk device (rather than a CD),
+        # https://github.com/systemd/systemd/issues/14408 causes the
+        # hybrid ESP to race with the ISO9660 filesystem for the
+        # /dev/disk/by-label symlink unless the ESP has its own label,
+        # so set EFI-SYSTEM for consistency with the metal image.
+        # This should not be needed on Fedora or RHEL 9, but seems like
+        # a good thing to do anyway.
+        label = 'EFI-SYSTEM'
+        # NOTE: the arguments to mkfs here match how virt-make-fs calls mkfs
+        subprocess.check_call(['mkfs', '-t', 'vfat', '-I', '--mbr=n', '-n', label, loopdev])
+        with tempfile.TemporaryDirectory() as d:
+            try:
+                subprocess.check_call(['mount', '-o', 'utf8', loopdev, d])
+                subprocess.check_call(['tar', '-C', d, '-xf', efitarfile.name])
+            finally:
+                subprocess.check_call(['umount', d])
+
 
 def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
     """

--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -27,6 +27,7 @@ import osbuild.api
 import osbuild.remoteloop as remoteloop
 from osbuild.util import checksum, osrelease
 from osbuild.util.chroot import Chroot
+from osbuild.util.path import ensure_glob
 
 # Size of file used to embed an Ignition config within a CPIO.
 IGNITION_IMG_SIZE = 256 * 1024
@@ -128,19 +129,6 @@ def make_stream_hash(src, dest):
                 if not buf:
                     break
                 outf.write(hashlib.sha256(buf).hexdigest() + '\n')
-
-
-def ensure_glob(pathname, n="", **kwargs):
-    """
-    Call glob.glob() and fail if there are no results or
-    if the number of results doesn't match provided n
-    """
-    ret = glob.glob(pathname, **kwargs)
-    if not ret:
-        raise ValueError(f'No matches for {pathname}')
-    if n != "" and len(ret) != int(n):
-        raise ValueError(f'Matches for {pathname} does not match expected ({n})')
-    return ret
 
 
 # This function finds the source EFI paths to copy from /usr/ to the EFI/

--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -277,7 +277,7 @@ def gen_live_artifacts(paths, tree, filenames, deployed_tree, loop_client, versi
     test_fixture = check_for_test_fixture(deployed_tree)
     basearch = os.uname().machine
 
-    kargs_json = copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid)
+    kargs_json = copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid, basearch)
 
     # Add placeholder for Ignition CPIO file.  This allows an external tool,
     # `coreos-installer iso ignition embed`, to modify an existing ISO image
@@ -316,7 +316,7 @@ def gen_live_artifacts(paths, tree, filenames, deployed_tree, loop_client, versi
         # directory: efidir
         makeefi.mkefidir(efidir=efidir, source_tree=deployed_tree)
         # Discover the vendor ID (can be different on Fedora/RHEL/CentOS)
-        vendor_id = makeefi.find_efi_vendor_dir_name(efidir)
+        vendor_id = makeefi.find_efi_vendor_dir_name(source_tree=deployed_tree)
         # Get the grub configuration for booting from the ISO and write it out
         # to $efidir/BOOT/grub.cfg. See the comment in the function for explanation
         # of config used.
@@ -553,7 +553,7 @@ def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
 
 
 # pylint: disable=too-many-branches
-def copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid):
+def copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid, basearch):
     # Filter kernel arguments for substituting into ISO bootloader
     kargs_array = [karg for karg in blsentry_kargs
                    if karg.split('=')[0] not in LIVE_EXCLUDE_KARGS]
@@ -620,12 +620,8 @@ def copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid
     # [1] https://github.com/coreos/fedora-coreos-config/tree/testing-devel/live/EFI/fedora
     # [2] https://github.com/openshift/os/tree/master/live/EFI/vendor
     # [3] https://github.com/openshift/os/issues/954
-    #
-    # To find the string for the vendor ID we only need to inspect one
-    # of the source EFI directories. Grab one here.
-    efidir = makeefi.find_efi_source_paths(deployed_tree)[0]
-    if os.path.exists(efidir):
-        vendor_id = makeefi.find_efi_vendor_dir_name(efidir)
+    if basearch in ("x86_64", "aarch64"):
+        vendor_id = makeefi.find_efi_vendor_dir_name(source_tree=deployed_tree)
         grubfilepath = ensure_glob(os.path.join(paths["iso"], 'EFI/*/grub.cfg'), n=1)[0]
         srcdir = os.path.dirname(grubfilepath)
         dstdir = os.path.join(paths["iso"], f"EFI/{vendor_id}")

--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -18,14 +18,13 @@ import shutil
 import struct
 import subprocess
 import sys
-import tarfile
 import tempfile
 
 import yaml
 
 import osbuild.api
 import osbuild.remoteloop as remoteloop
-from osbuild.util import checksum, osrelease
+from osbuild.util import checksum, makeefi, osrelease
 from osbuild.util.chroot import Chroot
 from osbuild.util.path import ensure_glob
 
@@ -129,34 +128,6 @@ def make_stream_hash(src, dest):
                 if not buf:
                     break
                 outf.write(hashlib.sha256(buf).hexdigest() + '\n')
-
-
-# This function finds the source EFI paths to copy from /usr/ to the EFI/
-# directory. Historically this was just the usr/lib/bootupd/updates/EFI/
-# directory (populated by bootupd), but as part of BootLoaderUpdatesPhase1 [1]
-# the shim and grub packages started delivering files in
-# /usr/lib/efi/(grub|shim)/<version>/EFI/ directly. Lets prefer the
-# new paths and fallback to the legacy path if those don't exist.
-#
-# [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
-def find_efi_source_paths(tree):
-    if glob.glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI')):
-        # BootLoaderUpdatesPhase1 has been implemented and we should
-        # be able to pick up files from usr/lib/efi/(grub|shim)/<version>/EFI/
-        # Let's ensure there's only 2 dirs that match (i.e. one for grub
-        # one for shim) and return that list.
-        return ensure_glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI'), n=2)
-    # Legacy path. Just return a single entry list with the old path.
-    return [os.path.join(tree, 'usr/lib/bootupd/updates/EFI')]
-
-
-def find_efi_vendor_dir_name(efidir):
-    # Find name of vendor directory for this distro. i.e. "fedora" or "redhat".
-    dirs = [n for n in os.listdir(efidir) if n != "BOOT"]
-    if len(dirs) != 1:
-        raise ValueError(f"did not find exactly one EFI vendor ID: {dirs}")
-    vendor_id = dirs[0]
-    return vendor_id
 
 
 def parse_metal_inputs(inputs):
@@ -343,9 +314,9 @@ def gen_live_artifacts(paths, tree, filenames, deployed_tree, loop_client, versi
         output_efiboot_img = paths["iso/images/efiboot.img"]
         # Copy out the EFI files found from the source_tree to the specified
         # directory: efidir
-        mkefidir(efidir=efidir, source_tree=deployed_tree)
+        makeefi.mkefidir(efidir=efidir, source_tree=deployed_tree)
         # Discover the vendor ID (can be different on Fedora/RHEL/CentOS)
-        vendor_id = find_efi_vendor_dir_name(efidir)
+        vendor_id = makeefi.find_efi_vendor_dir_name(efidir)
         # Get the grub configuration for booting from the ISO and write it out
         # to $efidir/BOOT/grub.cfg. See the comment in the function for explanation
         # of config used.
@@ -353,7 +324,7 @@ def gen_live_artifacts(paths, tree, filenames, deployed_tree, loop_client, versi
         with open(os.path.join(efidir, "BOOT", "grub.cfg"), "w", encoding='utf8') as fh:
             fh.write(get_grub_cfg_string(volid, vendor_id))
         # Create the efiboot.img file
-        mkefiboot(efidir, output_efiboot_img, loop_client)
+        makeefi.mkefiboot(efidir, output_efiboot_img, loop_client)
         # And add arguments to include it in when creating the ISO
         genisoargs += ['-eltorito-alt-boot', '-efi-boot', 'images/efiboot.img', '-no-emul-boot']
 
@@ -481,91 +452,6 @@ echo "Booting via ESP..."
 configfile $prefix/grub.cfg
 boot
 '''
-
-
-def mkefidir(efidir, source_tree):
-    """
-    Searches the source_tree for files used for EFI booting and copies
-    these files into the specified efidir.
-    """
-    for path in find_efi_source_paths(source_tree):
-        shutil.copytree(path, efidir, dirs_exist_ok=True)
-
-    vendor_id = find_efi_vendor_dir_name(efidir)
-
-    # Delete fallback and its CSV file.  Its purpose is to create
-    # EFI boot variables, which we don't want when booting from
-    # removable media.
-    #
-    # A future shim release will merge fallback.efi into the main
-    # shim binary and enable the fallback behavior when the CSV
-    # exists.  But for now, fail if fallback.efi is missing.
-    for path in ensure_glob(os.path.join(efidir, "BOOT", "fb*.efi")):
-        os.unlink(path)
-    for path in ensure_glob(os.path.join(efidir, vendor_id, "BOOT*.CSV")):
-        os.unlink(path)
-
-    # Drop vendor copies of shim; we already have it in BOOT*.EFI in
-    # BOOT
-    for path in ensure_glob(os.path.join(efidir, vendor_id, "shim*.efi")):
-        os.unlink(path)
-
-    # Consolidate remaining files into BOOT.  shim needs GRUB to be
-    # there, and the rest doesn't hurt.
-    for path in ensure_glob(os.path.join(efidir, vendor_id, "*")):
-        shutil.move(path, os.path.join(efidir, "BOOT"))
-    os.rmdir(os.path.join(efidir, vendor_id))
-
-
-def mkefiboot(efidir, output_efiboot_img, loop_client):
-    """
-    Creates an efi boot image file at output_efiboot_img (usually named efiboot.img),
-    which is required for EFI booting. This is a fat32 formatted filesystem that
-    contains all the files needed for EFI boot.
-    """
-
-    # In restrictive environments, setgid, setuid and ownership changes
-    # may be restricted. This sets the file ownership to root and
-    # removes the setgid and setuid bits in the tarball.
-    def strip_tar(tarinfo):
-        tarinfo.uid = 0
-        tarinfo.gid = 0
-        if tarinfo.isdir():
-            tarinfo.mode = 0o755
-        elif tarinfo.isfile():
-            tarinfo.mode = 0o0644
-        return tarinfo
-
-    # Install binaries from the efidir
-    # Manually construct the tarball to ensure proper permissions and ownership
-    efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")
-    with tarfile.open(efitarfile.name, "w:", dereference=True) as tar:
-        tar.add(efidir, arcname="/EFI", filter=strip_tar)
-
-    # Create the efiboot image file. Determine the size we should make
-    # it by taking the tarball size and adding 2MiB for fs overhead.
-    size = os.path.getsize(efitarfile.name) + 2 * 1024 * 1024
-    with open(output_efiboot_img, "wb") as out:
-        out.truncate(size)
-
-    # Make loopback device; mkfs; populate with files
-    with loop_client.device(output_efiboot_img) as loopdev:
-        # On RHEL 8, when booting from a disk device (rather than a CD),
-        # https://github.com/systemd/systemd/issues/14408 causes the
-        # hybrid ESP to race with the ISO9660 filesystem for the
-        # /dev/disk/by-label symlink unless the ESP has its own label,
-        # so set EFI-SYSTEM for consistency with the metal image.
-        # This should not be needed on Fedora or RHEL 9, but seems like
-        # a good thing to do anyway.
-        label = 'EFI-SYSTEM'
-        # NOTE: the arguments to mkfs here match how virt-make-fs calls mkfs
-        subprocess.check_call(['mkfs', '-t', 'vfat', '-I', '--mbr=n', '-n', label, loopdev])
-        with tempfile.TemporaryDirectory() as d:
-            try:
-                subprocess.check_call(['mount', '-o', 'utf8', loopdev, d])
-                subprocess.check_call(['tar', '-C', d, '-xf', efitarfile.name])
-            finally:
-                subprocess.check_call(['umount', d])
 
 
 def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
@@ -737,9 +623,9 @@ def copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid
     #
     # To find the string for the vendor ID we only need to inspect one
     # of the source EFI directories. Grab one here.
-    efidir = find_efi_source_paths(deployed_tree)[0]
+    efidir = makeefi.find_efi_source_paths(deployed_tree)[0]
     if os.path.exists(efidir):
-        vendor_id = find_efi_vendor_dir_name(efidir)
+        vendor_id = makeefi.find_efi_vendor_dir_name(efidir)
         grubfilepath = ensure_glob(os.path.join(paths["iso"], 'EFI/*/grub.cfg'), n=1)[0]
         srcdir = os.path.dirname(grubfilepath)
         dstdir = os.path.join(paths["iso"], f"EFI/{vendor_id}")

--- a/stages/test/test_coreos_live_artifacts_mono.py
+++ b/stages/test/test_coreos_live_artifacts_mono.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
-import contextlib
 import os
-import random
 import subprocess as sp
 import textwrap
 
@@ -115,53 +113,3 @@ def test_make_stream_hash(tmp_path, stage_module):
         "stream-hash sha256 2097152",
         *hashes,
     ]
-
-
-@pytest.mark.skipif(os.getuid() != 0, reason="needs root")
-def test_make_efi_bootfile(tmp_path, stage_module):
-
-    tar_files_path = tmp_path / "tar_files"
-    tar_files_path.mkdir()
-
-    tar_files = []
-
-    for fnum in range(99):
-        name = f"rand_file_{fnum:02d}.bin"
-        rand_file = tar_files_path / name
-        filesize = random.randrange(100, 500)
-        rand_file.write_bytes(random.getrandbits(filesize * 8).to_bytes(filesize, 'little'))
-        tar_files.append(rand_file.relative_to(tar_files_path))
-
-    input_tarball = tmp_path / "files.tar"
-    sp.check_call(["tar", "-C", tar_files_path, "-cf", input_tarball, "."])
-
-    output_efiboot_img = tmp_path / "efiboot.img"
-
-    class TestLoopClient:
-        """
-        Implements only the device() context manager method from the remoteloop.LoopClient class that is used in the
-        make_efi_bootfile() function.
-        """
-
-        @contextlib.contextmanager
-        def device(self, path):
-            output = sp.check_output(["losetup", "--find", "--show", path])
-            device = output.strip()
-            yield device
-            sp.check_call(["losetup", "--detach", device])
-
-    mountpoint = tmp_path / "mnt"
-    mountpoint.mkdir()
-    loop_client = TestLoopClient()
-    stage_module.make_efi_bootfile(loop_client, input_tarball, output_efiboot_img)
-
-    with loop_client.device(output_efiboot_img) as loopdev:
-        try:
-            sp.check_call(["mount", "-o", "utf8", loopdev, mountpoint])
-            files_in_image = []
-            for f in mountpoint.iterdir():
-                files_in_image.append(f.relative_to(mountpoint))
-        finally:
-            sp.check_call(["umount", loopdev])
-
-    assert sorted(files_in_image) == sorted(tar_files)

--- a/test/mod/test_util_makeefi.py
+++ b/test/mod/test_util_makeefi.py
@@ -1,0 +1,64 @@
+#
+# Tests for the 'osbuild.util.makeefi' module
+#
+import contextlib
+import os
+import random
+import subprocess as sp
+
+import pytest
+
+from osbuild.util.makeefi import mkefiboot
+
+
+class TestLoopClient:
+    """
+    Implements only the device() context manager method from the
+    remoteloop.LoopClient class that is used in mkefiboot().
+    """
+
+    @contextlib.contextmanager
+    def device(self, path):
+        output = sp.check_output(["losetup", "--find", "--show", path])
+        device = output.strip()
+        yield device
+        sp.check_call(["losetup", "--detach", device])
+
+
+@pytest.mark.skipif(os.getuid() != 0, reason="needs root")
+def test_mkefiboot(tmp_path):
+
+    efidir = tmp_path / "efidir"
+    efidir.mkdir()
+
+    efi_files = []
+
+    for fnum in range(99):
+        name = f"rand_file_{fnum:02d}.bin"
+        rand_file = efidir / name
+        filesize = random.randrange(100, 500)
+        rand_file.write_bytes(random.getrandbits(filesize * 8).to_bytes(filesize, 'little'))
+        efi_files.append(rand_file.relative_to(efidir))
+
+    output_efiboot_img = tmp_path / "efiboot.img"
+
+    loop_client = TestLoopClient()
+    mkefiboot(efidir, output_efiboot_img, loop_client)
+
+    # Verify the image size is aligned to a 512 byte boundary
+    assert output_efiboot_img.stat().st_size % 512 == 0
+
+    # Verify the image contains the expected files under /EFI/
+    mountpoint = tmp_path / "mnt"
+    mountpoint.mkdir()
+
+    with loop_client.device(output_efiboot_img) as loopdev:
+        try:
+            sp.check_call(["mount", "-o", "utf8", loopdev, mountpoint])
+            files_in_image = []
+            for f in (mountpoint / "EFI").iterdir():
+                files_in_image.append(f.relative_to(mountpoint / "EFI"))
+        finally:
+            sp.check_call(["umount", loopdev])
+
+    assert sorted(files_in_image) == sorted(efi_files)


### PR DESCRIPTION
These are functions related to making EFI bootable images that can
be shared among stages that need to do that. These are factored out
of the org.osbuild.coreos.live-artifacts.mono stage at this point.

See individual commit messages.

This refactor should make the implementation for
https://github.com/osbuild/osbuild/pull/2471 much simpler.
