### PR TITLE
containers-storage: Handle missing `storage.conf` values

### DIFF
--- a/inputs/org.osbuild.containers-storage
+++ b/inputs/org.osbuild.containers-storage
@@ -86,13 +86,18 @@ SCHEMA = r"""
 
 class ContainersStorageInput(inputs.InputService):
 
+    # Default values matching containers/storage library defaults for root
+    # c.f. https://github.com/podman-container-tools/container-libs/blob/main/storage/storage.conf
+    DEFAULT_GRAPHROOT = "/var/lib/containers/storage"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.mg = MountGuard()
         self.storage_conf = host.get_container_storage()
 
     def bind_mount_local_storage(self, target):
-        source = self.storage_conf["storage"]["graphroot"]
+        storage = self.storage_conf.get("storage", {})
+        source = storage.get("graphroot", self.DEFAULT_GRAPHROOT)
         dest = os.path.join(target, "storage")
 
         # bind mount the input directory to the destination

--- a/sources/org.osbuild.containers-storage
+++ b/sources/org.osbuild.containers-storage
@@ -43,6 +43,12 @@ class ContainersStorageSource(sources.SourceService):
 
     content_type = "org.osbuild.containers-storage"
 
+    # Default values matching containers/storage library defaults for root
+    # c.f. https://github.com/podman-container-tools/container-libs/blob/main/storage/storage.conf
+    DEFAULT_DRIVER = "overlay"
+    DEFAULT_GRAPHROOT = "/var/lib/containers/storage"
+    DEFAULT_RUNROOT = "/run/containers/storage"
+
     storage_conf = None
 
     def local_image_name(self, imagename):
@@ -51,9 +57,10 @@ class ContainersStorageSource(sources.SourceService):
         """
         if self.storage_conf is None:
             self.storage_conf = host.get_container_storage()
-        driver = self.storage_conf["storage"]["driver"]
-        graphroot = self.storage_conf["storage"]["graphroot"]
-        runroot = self.storage_conf["storage"]["runroot"]
+        storage = self.storage_conf.get("storage", {})
+        driver = storage.get("driver", self.DEFAULT_DRIVER)
+        graphroot = storage.get("graphroot", self.DEFAULT_GRAPHROOT)
+        runroot = storage.get("runroot", self.DEFAULT_RUNROOT)
 
         return f"containers-storage:[{driver}@{graphroot}+{runroot}]{imagename}"
 


### PR DESCRIPTION
Since `containers-common` >= 0.68.0, the `graphroot`, `runroot`, and `driver` values are commented out by default in `storage.conf`. The `containers/storage` library handles this by using built-in defaults, but osbuild's `containers-storage` input and source were directly accessing these keys and raising `KeyError` when they were absent.

Use `.get()` with default values matching the `containers/storage` library defaults for root: `overlay` driver,
`/var/lib/containers/storage` for `graphroot`, and `/run/containers/storage` for `runroot`.

This complements the fix in commit 1ef3d52 #2357 which addressed the same issue in `osbuild/qemu.py` for the `--in-vm` path.

Closes: https://github.com/osbuild/osbuild/issues/2500

Assisted-by: OpenCode (Claude Opus 4.5)