### PR TITLE
vm: Mount cgroup2 filesystem for Podman 6+ compatibility

### DIFF
--- a/osbuild/vm.py
+++ b/osbuild/vm.py
@@ -276,6 +276,14 @@ mounts = {
 subprocess.run(["mount", "-t", "tmpfs", "tmpfs", "/tmp"], check=True)
 subprocess.run(["mount", "-t", "tmpfs", "tmpfs", "/var"], check=True)
 
+# Mount cgroup2 for Podman 6+ which requires cgroups v2
+# This is needed because the initrd may not have been able to move the mount
+# to the sysroot if /sys/fs/cgroup didn't exist in the rootfs
+cgroup_path = "/sys/fs/cgroup"
+if not os.path.ismount(cgroup_path):
+    os.makedirs(cgroup_path, exist_ok=True)
+    subprocess.run(["mount", "-t", "cgroup2", "cgroup2", cgroup_path], check=True)
+
 for subdir in os.listdir("/sys/fs/virtiofs"):
     tagfile = os.path.join("/sys/fs/virtiofs", subdir, "tag")
     with open(tagfile, "r", encoding="utf8") as file:


### PR DESCRIPTION
Podman 6 removed cgroups v1 support (containers/podman#27271). Specifically, commit [e860773c0d](https://github.com/podman-container-tools/podman/commit/e860773c0d) added a mandatory check at startup that verifies `/sys/fs/cgroup` is mounted as `cgroup2`. If the check fails, Podman exits with: "Cgroups v1 not supported".

Prior to Podman 6, this worked because there was no such verification - Podman would simply run without cgroups if none were mounted.

The initrd attempts to mount cgroup2 and move it during switchRoot, but this fails if `/sys/fs/cgroup` doesn't exist in the read-only rootfs. This change ensures cgroup2 is mounted in vm.py if it wasn't already mounted by the initrd.

Note: osbuild does not actually need cgroup functionality - this is only to satisfy Podman 6+'s mandatory startup check.

Closes: https://github.com/osbuild/osbuild/issues/2502

Assisted-by: OpenCode (Claude Opus 4)