### PR TITLE
runner: use minimal_passwd() in rhel7 stage (HMS-11012)

### DIFF
--- a/runners/org.osbuild.rhel7
+++ b/runners/org.osbuild.rhel7
@@ -8,6 +8,7 @@ from osbuild.util import runners
 
 if __name__ == "__main__":
     with api.exception_handler():
+        runners.minimal_passwd()
         runners.ldconfig("/usr/lib64/iscsi")
         runners.nsswitch()
 


### PR DESCRIPTION
This commit uses a helper minimal_passwd() to create a minimal /etc/passwd. This has been an issue in the past (bdc1d85), where a psswd entry for uid=0 was required or a HOME environment set. This should resolve the failure of builds: "Error loading trust policy: unable to resolve HOME directory: user: unknown userid 0"

Relevant: HMS-11012