### PR TITLE
eln: gets its own runner

### DIFF
--- a/runners/org.osbuild.eln11
+++ b/runners/org.osbuild.eln11
@@ -1,1 +1,20 @@
-org.osbuild.fedora38
+#!/usr/bin/python3
+
+import subprocess
+import sys
+
+from osbuild import api
+from osbuild.util import runners
+
+if __name__ == "__main__":
+    with api.exception_handler():
+        runners.minimal_passwd()
+        runners.ldconfig()
+        runners.sysusers()
+        with runners.create_machine_id_if_needed():
+            runners.tmpfiles()
+            runners.nsswitch()
+            runners.sequoia()
+            r = subprocess.run(sys.argv[1:], check=False)
+
+        sys.exit(r.returncode)


### PR DESCRIPTION
Since we setup sysusers in the fedora38 runner (that eln symlinks to) we really should have a user 0 I think so this *might* get resolved by https://github.com/osbuild/image-builder/pull/2535 instead if it doesn't then this PR is the likely next step.

---

Drop the eln11 -> fedora38 symlink and add the `minimal_passwd` step to sort out issues with `skopeo` seemingly expecting [1] [2] it in eln:

```
time="2026-07-17T08:52:33Z" level=fatal msg="Error loading trust policy: unable to resolve HOME directory: user: unknown userid 0"
```

[1]: https://github.com/osbuild/image-builder/pull/2511
[2]: https://gitlab.com/redhat/services/products/image-builder/ci/images/-/jobs/15395421229#L3283

---

cc @achilleas-k / @croissanne / @avitova 