### PR TITLE
ci: enable allow-unsafe-pr-checkout

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - uses: octokit/request-action@v2.x
         id: fetch_pulls


### PR DESCRIPTION
Github introduced a bakcport which introduces a new flag we have to use: allow-unsafe-pr-checkout, in order to opt in for check outing fork pull request code by default.

#2514 failed on this, I think