### PR TITLE
buildroot: bind-mount `/dev/fuse` into bwrap sandbox

### DIFF
--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -152,6 +152,7 @@ class BuildRoot(contextlib.AbstractContextManager):
             self._bind_dev(self.dev, "urandom")
             self._bind_dev(self.dev, "tty")
             self._bind_dev(self.dev, "zero")
+            self._bind_dev(self.dev, "fuse")
 
             # Prepare all registered API endpoints
             for api in self._apis:


### PR DESCRIPTION
On older kernels with overlayfs < v6.7, the kernel overlay driver cannot create whiteout devices in a bwrap sandbox without `--unshare-user`. When Podman tests native overlay support via `supportsOverlay()`, it performs an `os.RemoveAll()` inside an overlay merged directory. This triggers `unlinkat(AT_REMOVEDIR)` which returns EIO because the kernel cannot create the whiteout in the upperdir in this "hybrid" context (mount namespace isolated, user namespace shared with the host).

As a result, Podman falls back to fuse-overlayfs, but `/dev/fuse` is not available in the sandbox, causing the `org.osbuild.container-deploy` stage to fail with:

    fuse: device not found, try 'modprobe fuse' first
    fuse-overlayfs: cannot mount: No such file or directory

Bind-mounting `/dev/fuse` allows fuse-overlayfs to work as a fallback on these older kernels.

Closes: https://github.com/osbuild/osbuild/issues/2509

Assisted-by: OpenCode (Claude Opus 4.5)