### PR TITLE
add Oracle as datasource to cloud init

### DIFF
--- a/stages/org.osbuild.cloud-init.meta.json
+++ b/stages/org.osbuild.cloud-init.meta.json
@@ -97,6 +97,7 @@
               "enum": [
                 "Azure",
                 "Ec2",
+                "Oracle",
                 "NoCloud",
                 "WSL",
                 "None"


### PR DESCRIPTION
These changes go hand in hand with https://github.com/osbuild/image-builder/pull/2559. 

In order to use Oracle as a datasource for cloudinit in RHEL image definitions, we need to add Oracle as a datasource in the stage meta.json file. 