### PR TITLE
stage/rpm: general env options

### DIFF
--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -165,6 +165,29 @@ def main(tree, inputs, options):
         print(f"dbpath set to '{dbpath}'")
         rpm_args += ["--dbpath", dbpath]
 
+    generic_env = options.get("generic_env", {})
+    kernel_install_env = options.get("kernel_install_env", {})
+
+    kernel_install_env_map = {
+        "boot_root": "BOOT_ROOT",
+        "conf_root": "KERNEL_INSTALL_CONF_ROOT",
+        "plugins": "KERNEL_INSTALL_PLUGINS",
+        "machine_id": "MACHINE_ID",
+    }
+
+    resolved_kernel_env = {}
+    for opt_key, env_key in kernel_install_env_map.items():
+        value = kernel_install_env.get(opt_key)
+        if value:
+            resolved_kernel_env[env_key] = value
+
+    conflicts = set(generic_env) & set(resolved_kernel_env)
+    if conflicts:
+        raise ValueError(
+            f"environment variable(s) set in both generic_env and "
+            f"kernel_install_env: {', '.join(sorted(conflicts))}"
+        )
+
     rpmkeys_options = options.get("rpmkeys", {})
     rpmkeys_bin = rpmkeys_options.get("bin_path", "rpmkeys")
     ignore_import_failures = rpmkeys_options.get("ignore_import_failures", False)
@@ -220,12 +243,8 @@ def main(tree, inputs, options):
             ]
 
         env = os.environ.copy()
-        # update the environment with variables for kernel-install if any are defined
-        kernel_install_env = options.get("kernel_install_env", {})
-        if kernel_install_env:
-            boot_root = kernel_install_env.get("boot_root")
-            if boot_root:
-                env["BOOT_ROOT"] = boot_root
+        env.update(generic_env)
+        env.update(resolved_kernel_env)
 
         with tempfile.NamedTemporaryFile(prefix="manifest.", mode='w') as manifest:
             manifest.writelines(c + '\n' for c in packages)

--- a/stages/org.osbuild.rpm.meta.json
+++ b/stages/org.osbuild.rpm.meta.json
@@ -173,6 +173,13 @@
           "type": "boolean",
           "description": "Create the '/run/ostree-booted' marker"
         },
+        "generic_env": {
+          "description": "Set generic environment variables",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "kernel_install_env": {
           "description": "Set environment variables understood by kernel-install and plugins (kernel-install(8))",
           "type": "object",
@@ -182,6 +189,20 @@
               "type": "string",
               "pattern": "^\\/?(?!\\.\\.)((?!\\/\\.\\.\\/).)+$",
               "description": "Sets $BOOT_ROOT for kernel-install to override $KERNEL_INSTALL_BOOT_ROOT, the installation location for boot entries"
+            },
+            "conf_root": {
+              "type": "string",
+              "pattern": "^\\/?(?!\\.\\.)((?!\\/\\.\\.\\/).)+$",
+              "description": "Sets $KERNEL_INSTALL_CONF_ROOT to override the location of configuration files read by kernel-install"
+            },
+            "plugins": {
+              "type": "string",
+              "description": "Sets $KERNEL_INSTALL_PLUGINS to override the list of plugins executed by kernel-install"
+            },
+            "machine_id": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{32}$",
+              "description": "Sets $MACHINE_ID for kernel-install to override $KERNEL_INSTALL_MACHINE_ID"
             }
           }
         }

--- a/stages/test/test_rpm.py
+++ b/stages/test/test_rpm.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import pytest
@@ -7,22 +8,33 @@ from osbuild import testutil
 STAGE_NAME = "org.osbuild.rpm"
 
 
-@pytest.mark.parametrize("test_data,expected_err", [
-    # bad
-    ({"kernel_install_env": {"boot_root": "../rel"}}, "'../rel' does not match "),
-    ({"nodeps": "yes"}, "is not of type 'boolean'"),
-    # good
-    ({}, ""),
-    ({"kernel_install_env": {"boot_root": "/boot"}}, ""),
-    ({"nodeps": True}, ""),
-    ({"nodeps": False}, ""),
-])
+@pytest.mark.parametrize(
+    "test_data,expected_err",
+    [
+        # bad
+        ({"kernel_install_env": {"boot_root": "../rel"}}, "'../rel' does not match "),
+        ({"kernel_install_env": {"conf_root": "../rel"}}, "'../rel' does not match "),
+        ({"kernel_install_env": {"machine_id": "not-a-valid-id"}}, "'not-a-valid-id' does not match "),
+        ({"kernel_install_env": {"machine_id": "ABCD0123abcd0123abcd0123abcd0123"}}, "does not match "),
+        ({"nodeps": "yes"}, "is not of type 'boolean'"),
+        ({"generic_env": "not-an-object"}, "is not of type 'object'"),
+        ({"generic_env": {"FOO": 123}}, "is not of type 'string'"),
+        # good
+        ({}, ""),
+        ({"kernel_install_env": {"boot_root": "/boot"}}, ""),
+        ({"kernel_install_env": {"conf_root": "/etc/kernel"}}, ""),
+        ({"kernel_install_env": {"plugins": "/usr/lib/kernel/install.d/50-depmod.install"}}, ""),
+        ({"kernel_install_env": {"plugins": ":"}}, ""),
+        ({"kernel_install_env": {"machine_id": "abcd0123abcd0123abcd0123abcd0123"}}, ""),
+        ({"nodeps": True}, ""),
+        ({"nodeps": False}, ""),
+        ({"generic_env": {}}, ""),
+        ({"generic_env": {"FOO": "bar"}}, ""),
+        ({"generic_env": {"FOO": "bar", "BAZ": "qux"}}, ""),
+    ],
+)
 def test_schema_validation(stage_schema, test_data, expected_err):
-    test_input = {
-        "type": STAGE_NAME,
-        "options": {
-        }
-    }
+    test_input = {"type": STAGE_NAME, "options": {}}
     test_input["options"].update(test_data)
     res = stage_schema.validate(test_input)
 
@@ -33,10 +45,42 @@ def test_schema_validation(stage_schema, test_data, expected_err):
         testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
 
 
-@pytest.mark.parametrize("ignore_failures", [
-    (False),
-    (True),
-])
+@pytest.mark.parametrize(
+    "generic_env,kernel_install_env,expected_err",
+    [
+        ({"BOOT_ROOT": "/other"}, {"boot_root": "/boot"}, "BOOT_ROOT"),
+        (
+            {"MACHINE_ID": "abcd0123abcd0123abcd0123abcd0123"},
+            {"machine_id": "abcd0123abcd0123abcd0123abcd0123"},
+            "MACHINE_ID",
+        ),
+        (
+            {"BOOT_ROOT": "/a", "MACHINE_ID": "abcd0123abcd0123abcd0123abcd0123"},
+            {"boot_root": "/b", "machine_id": "abcd0123abcd0123abcd0123abcd0123"},
+            "BOOT_ROOT.*MACHINE_ID",
+        ),
+    ],
+)
+@mock.patch("subprocess.run")
+def test_env_conflict_detection(tmp_path, stage_module, generic_env, kernel_install_env, expected_err):
+    tree = str(tmp_path / "tree")
+    os.makedirs(tree)
+    inputs = {"packages": {"path": str(tmp_path), "data": {"files": {}}}}
+    options = {
+        "generic_env": generic_env,
+        "kernel_install_env": kernel_install_env,
+    }
+    with pytest.raises(ValueError, match=expected_err):
+        stage_module.main(tree, inputs, options)
+
+
+@pytest.mark.parametrize(
+    "ignore_failures",
+    [
+        (False),
+        (True),
+    ],
+)
 @mock.patch("subprocess.run")
 def test_import_gpg_keys(mock_run, tmp_path, stage_module, ignore_failures):
     tree = tmp_path / "tree"
@@ -47,123 +91,130 @@ def test_import_gpg_keys(mock_run, tmp_path, stage_module, ignore_failures):
     assert mock_run.call_args[1] == {"check": not ignore_failures}
 
 
-@pytest.mark.parametrize("rpm_output,expected_packages", [
-    # all optional fields present
-    (
-        '{\n'
-        '"name": "bash",\n'
-        '"version": "5.2.26",\n'
-        '"release": "3.fc40",\n'
-        '"epoch": "0",\n'
-        '"arch": "x86_64",\n'
-        '"sigmd5": "abc123",\n'
-        '"sha1header": "da39a3ee5e6b4b0d3255bfef95601890afd80709",\n'
-        '"sha256header": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",\n'
-        '"sha3_256header": "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",\n'
-        '"sigpgp": "deadbeef",\n'
-        '"siggpg": null\n'
-        '},\n',
-        [{
-            "name": "bash",
-            "version": "5.2.26",
-            "release": "3.fc40",
-            "epoch": "0",
-            "arch": "x86_64",
-            "sigmd5": "abc123",
-            "sha1header": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
-            "sha256header": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-            "sha3_256header": "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",
-            "sigpgp": "deadbeef",
-            "siggpg": None,
-        }],
-    ),
-    # all optional fields null (including new header digests)
-    (
-        '{\n'
-        '"name": "coreutils",\n'
-        '"version": "9.4",\n'
-        '"release": "1.fc40",\n'
-        '"epoch": null,\n'
-        '"arch": null,\n'
-        '"sigmd5": null,\n'
-        '"sha1header": null,\n'
-        '"sha256header": null,\n'
-        '"sha3_256header": null,\n'
-        '"sigpgp": null,\n'
-        '"siggpg": null\n'
-        '},\n',
-        [{
-            "name": "coreutils",
-            "version": "9.4",
-            "release": "1.fc40",
-            "epoch": None,
-            "arch": None,
-            "sigmd5": None,
-            "sha1header": None,
-            "sha256header": None,
-            "sha3_256header": None,
-            "sigpgp": None,
-            "siggpg": None,
-        }],
-    ),
-    # multiple packages, sorted by name in output
-    (
-        '{\n'
-        '"name": "zsh",\n'
-        '"version": "5.9",\n'
-        '"release": "1.fc40",\n'
-        '"epoch": null,\n'
-        '"arch": "x86_64",\n'
-        '"sigmd5": null,\n'
-        '"sha1header": null,\n'
-        '"sha256header": "abc",\n'
-        '"sha3_256header": null,\n'
-        '"sigpgp": null,\n'
-        '"siggpg": null\n'
-        '},\n'
-        '{\n'
-        '"name": "bash",\n'
-        '"version": "5.2",\n'
-        '"release": "1.fc40",\n'
-        '"epoch": null,\n'
-        '"arch": "x86_64",\n'
-        '"sigmd5": null,\n'
-        '"sha1header": "def",\n'
-        '"sha256header": null,\n'
-        '"sha3_256header": null,\n'
-        '"sigpgp": null,\n'
-        '"siggpg": null\n'
-        '},\n',
-        [
-            {
-                "name": "bash",
-                "version": "5.2",
-                "release": "1.fc40",
-                "epoch": None,
-                "arch": "x86_64",
-                "sigmd5": None,
-                "sha1header": "def",
-                "sha256header": None,
-                "sha3_256header": None,
-                "sigpgp": None,
-                "siggpg": None,
-            },
-            {
-                "name": "zsh",
-                "version": "5.9",
-                "release": "1.fc40",
-                "epoch": None,
-                "arch": "x86_64",
-                "sigmd5": None,
-                "sha1header": None,
-                "sha256header": "abc",
-                "sha3_256header": None,
-                "sigpgp": None,
-                "siggpg": None,
-            },
-        ],
-    ),
-])
+@pytest.mark.parametrize(
+    "rpm_output,expected_packages",
+    [
+        # all optional fields present
+        (
+            "{\n"
+            '"name": "bash",\n'
+            '"version": "5.2.26",\n'
+            '"release": "3.fc40",\n'
+            '"epoch": "0",\n'
+            '"arch": "x86_64",\n'
+            '"sigmd5": "abc123",\n'
+            '"sha1header": "da39a3ee5e6b4b0d3255bfef95601890afd80709",\n'
+            '"sha256header": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",\n'
+            '"sha3_256header": "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",\n'
+            '"sigpgp": "deadbeef",\n'
+            '"siggpg": null\n'
+            "},\n",
+            [
+                {
+                    "name": "bash",
+                    "version": "5.2.26",
+                    "release": "3.fc40",
+                    "epoch": "0",
+                    "arch": "x86_64",
+                    "sigmd5": "abc123",
+                    "sha1header": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                    "sha256header": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                    "sha3_256header": "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",
+                    "sigpgp": "deadbeef",
+                    "siggpg": None,
+                }
+            ],
+        ),
+        # all optional fields null (including new header digests)
+        (
+            "{\n"
+            '"name": "coreutils",\n'
+            '"version": "9.4",\n'
+            '"release": "1.fc40",\n'
+            '"epoch": null,\n'
+            '"arch": null,\n'
+            '"sigmd5": null,\n'
+            '"sha1header": null,\n'
+            '"sha256header": null,\n'
+            '"sha3_256header": null,\n'
+            '"sigpgp": null,\n'
+            '"siggpg": null\n'
+            "},\n",
+            [
+                {
+                    "name": "coreutils",
+                    "version": "9.4",
+                    "release": "1.fc40",
+                    "epoch": None,
+                    "arch": None,
+                    "sigmd5": None,
+                    "sha1header": None,
+                    "sha256header": None,
+                    "sha3_256header": None,
+                    "sigpgp": None,
+                    "siggpg": None,
+                }
+            ],
+        ),
+        # multiple packages, sorted by name in output
+        (
+            "{\n"
+            '"name": "zsh",\n'
+            '"version": "5.9",\n'
+            '"release": "1.fc40",\n'
+            '"epoch": null,\n'
+            '"arch": "x86_64",\n'
+            '"sigmd5": null,\n'
+            '"sha1header": null,\n'
+            '"sha256header": "abc",\n'
+            '"sha3_256header": null,\n'
+            '"sigpgp": null,\n'
+            '"siggpg": null\n'
+            "},\n"
+            "{\n"
+            '"name": "bash",\n'
+            '"version": "5.2",\n'
+            '"release": "1.fc40",\n'
+            '"epoch": null,\n'
+            '"arch": "x86_64",\n'
+            '"sigmd5": null,\n'
+            '"sha1header": "def",\n'
+            '"sha256header": null,\n'
+            '"sha3_256header": null,\n'
+            '"sigpgp": null,\n'
+            '"siggpg": null\n'
+            "},\n",
+            [
+                {
+                    "name": "bash",
+                    "version": "5.2",
+                    "release": "1.fc40",
+                    "epoch": None,
+                    "arch": "x86_64",
+                    "sigmd5": None,
+                    "sha1header": "def",
+                    "sha256header": None,
+                    "sha3_256header": None,
+                    "sigpgp": None,
+                    "siggpg": None,
+                },
+                {
+                    "name": "zsh",
+                    "version": "5.9",
+                    "release": "1.fc40",
+                    "epoch": None,
+                    "arch": "x86_64",
+                    "sigmd5": None,
+                    "sha1header": None,
+                    "sha256header": "abc",
+                    "sha3_256header": None,
+                    "sigpgp": None,
+                    "siggpg": None,
+                },
+            ],
+        ),
+    ],
+)
 @mock.patch("subprocess.run")
 def test_generate_package_metadata(mock_run, tmp_path, stage_module, rpm_output, expected_packages):
     mock_run.return_value = mock.Mock(stdout=rpm_output)


### PR DESCRIPTION
We had a specific stage option to allow setting specific environment variables that are set for `kernel-install`. This commit generalizes this and allows setting *any* environment variable.

This is duplicate for backwards compatibility (can't just get rid of the `kernel_install_env` option).

Some RPMs perform extra actions in `%post` or `%posttrans` based on environment variables; specifically I have RPMs that want to write `IMAGE_ID` and `IMAGE_VERSION` into `/usr/lib/os-release` and they want to do this based on environment variables.