### PR TITLE
stages/tree-delta: produce delta trees

### DIFF
--- a/stages/org.osbuild.tree-delta
+++ b/stages/org.osbuild.tree-delta
@@ -1,0 +1,129 @@
+#!/usr/bin/python3
+"""Compute the delta between an overlay tree and a reference tree, keeping only new or changed files."""
+
+import filecmp
+import os
+import stat
+import subprocess
+import sys
+
+import osbuild.api
+
+
+def is_same_entry(overlay_path, ref_path):
+    """Check if two files are identical (type, content, symlink target)."""
+    try:
+        ostat = os.lstat(overlay_path)
+        rstat = os.lstat(ref_path)
+    except OSError:
+        return False
+
+    if ostat.st_mode != rstat.st_mode:
+        return False
+
+    if stat.S_ISLNK(ostat.st_mode):
+        return os.readlink(overlay_path) == os.readlink(ref_path)
+
+    if stat.S_ISREG(ostat.st_mode):
+        if ostat.st_size != rstat.st_size:
+            return False
+        return filecmp.cmp(overlay_path, ref_path, shallow=False)
+
+    return False
+
+
+def copy_entry(src, dest):
+    """Copy a single file, symlink, or directory (non-recursively) preserving attributes."""
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    subprocess.run(["cp", "-a", "--reflink=auto", src, dest], check=True)
+
+
+def is_excluded(rel_path, exclude_set):
+    """Check if a canonical path starts with any of the exclude prefixes."""
+    canonical = os.path.normpath("/" + rel_path)
+    for excl in exclude_set:
+        if canonical.startswith(excl):
+            return True
+    return False
+
+
+def has_excluded_descendants(rel_path, exclude_set):
+    """Check if any exclude prefix falls under this directory."""
+    prefix = os.path.normpath("/" + rel_path) + "/"
+    for excl in exclude_set:
+        if excl.startswith(prefix):
+            return True
+    return False
+
+
+def trim_tree(overlay_root, ref_root, output_root, paths_filter=None, exclude_paths=None):
+    """Walk overlay_root and copy entries not present or different in ref_root."""
+    for dirpath, dirnames, filenames in os.walk(overlay_root):
+        rel_dir = os.path.relpath(dirpath, overlay_root)
+
+        if paths_filter and rel_dir == ".":
+            dirnames[:] = [d for d in dirnames if f"/{d}" in paths_filter]
+            filenames = [f for f in filenames if f"/{f}" in paths_filter]
+
+        for name in filenames:
+            rel_path = os.path.join(rel_dir, name)
+
+            if exclude_paths and is_excluded(rel_path, exclude_paths):
+                continue
+
+            overlay_path = os.path.join(overlay_root, rel_path)
+            ref_path = os.path.join(ref_root, rel_path)
+            dest_path = os.path.join(output_root, rel_path)
+
+            if not is_same_entry(overlay_path, ref_path):
+                copy_entry(overlay_path, dest_path)
+
+        for name in list(dirnames):
+            rel_path = os.path.join(rel_dir, name)
+
+            if exclude_paths and is_excluded(rel_path, exclude_paths):
+                dirnames.remove(name)
+                continue
+
+            overlay_path = os.path.join(overlay_root, rel_path)
+            ref_path = os.path.join(ref_root, rel_path)
+
+            if os.path.islink(overlay_path):
+                dest_path = os.path.join(output_root, rel_path)
+                if not is_same_entry(overlay_path, ref_path):
+                    copy_entry(overlay_path, dest_path)
+                dirnames.remove(name)
+            elif not (os.path.lexists(ref_path) and stat.S_ISDIR(os.lstat(ref_path).st_mode)):
+                if exclude_paths and has_excluded_descendants(rel_path, exclude_paths):
+                    continue
+                dest_path = os.path.join(output_root, rel_path)
+                os.makedirs(dest_path, exist_ok=True)
+                subprocess.run(
+                    ["cp", "-a", "--reflink=auto", f"{overlay_path}/.", f"{dest_path}/"],
+                    check=True,
+                )
+                dirnames.remove(name)
+
+
+def main(args):
+    overlay = args["inputs"]["overlay"]["path"]
+    reference = args["inputs"]["reference"]["path"]
+    tree = args["tree"]
+
+    options = args.get("options", {})
+    paths_filter = options.get("paths")
+    if paths_filter:
+        paths_filter = set(paths_filter)
+
+    exclude_paths = options.get("exclude_paths")
+    if exclude_paths:
+        exclude_paths = set(exclude_paths)
+
+    trim_tree(overlay, reference, tree, paths_filter, exclude_paths)
+
+    return 0
+
+
+if __name__ == '__main__':
+    _args = osbuild.api.arguments()
+    sys.exit(main(_args))

--- a/stages/org.osbuild.tree-delta.meta.json
+++ b/stages/org.osbuild.tree-delta.meta.json
@@ -1,0 +1,71 @@
+{
+  "capabilities": [
+    "CAP_MAC_ADMIN"
+  ],
+  "description": [
+    "Takes two tree inputs: a 'reference' layer (e.g. a base OS tree)",
+    "and an 'overlay' layer (e.g. a different tree). Walks the overlay",
+    "and copies only files that are either absent from or different from",
+    "the corresponding file in the reference layer, trimming away",
+    "everything the reference already provides.",
+    "This is useful for building delta trees that contain only the files",
+    "not already present in the reference tree.",
+    "",
+    "An optional 'paths' filter restricts which top-level directories",
+    "are considered (e.g. [\"/usr\", \"/opt\"]). Files outside those",
+    "paths are ignored. An optional 'exclude_paths' filter skips any",
+    "path that starts with one of the given prefixes (e.g.",
+    "[\"/usr/share/doc\"]).",
+    "",
+    "File attributes (permissions, ownership, timestamps, symlinks,",
+    "extended attributes) are preserved via 'cp -a'.",
+    "",
+    "The comparison is content-based: files are considered identical if",
+    "they have the same type, permission bits, and content (or symlink",
+    "target). Metadata-only changes (ownership, timestamps, xattrs)",
+    "will not cause a file to appear in the delta. Hardlink",
+    "relationships between files are also not preserved in the output."
+  ],
+  "schema_2": {
+    "inputs": {
+      "additionalProperties": false,
+      "properties": {
+        "overlay": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "reference": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "required": [
+        "reference",
+        "overlay"
+      ],
+      "type": "object"
+    },
+    "options": {
+      "additionalProperties": false,
+      "properties": {
+        "paths": {
+          "description": "List of top-level paths to include (e.g. [\"/usr\", \"/opt\"]). If omitted, the entire tree is trimmed.",
+          "items": {
+            "pattern": "^/",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "exclude_paths": {
+          "description": "List of canonical paths to exclude. Any path starting with an entry is skipped (e.g. [\"/usr/share/doc\"]).",
+          "items": {
+            "pattern": "^/",
+            "type": "string"
+          },
+          "type": "array"
+        }
+      }
+    }
+  },
+  "summary": "Compute the delta between an overlay tree and a reference layer"
+}

--- a/stages/test/test_tree_delta.py
+++ b/stages/test/test_tree_delta.py
@@ -1,0 +1,403 @@
+#!/usr/bin/python3
+
+import os
+import stat
+
+import pytest
+
+from osbuild import testutil
+from osbuild.testutil import make_fake_tree
+
+STAGE_NAME = "org.osbuild.tree-delta"
+
+
+def make_tree(tmp_path, name, content):
+    tree = tmp_path / name
+    make_fake_tree(tree, content)
+    return os.fspath(tree)
+
+
+def make_args(tmp_path, reference, overlay, options=None):
+    output = tmp_path / "output"
+    output.mkdir(exist_ok=True)
+    args = {
+        "tree": os.fspath(output),
+        "inputs": {
+            "reference": {"path": reference},
+            "overlay": {"path": overlay},
+        },
+    }
+    if options:
+        args["options"] = options
+    return args
+
+
+def test_new_file_copied(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {})
+    overlay = make_tree(tmp_path, "overlay", {
+        "/usr/bin/hello": "hello world",
+    })
+    args = make_args(tmp_path, ref, overlay)
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/bin/hello").read_text() == "hello world"
+
+
+def test_identical_file_excluded(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {
+        "/usr/lib/libc.so": "base content",
+    })
+    overlay = make_tree(tmp_path, "overlay", {
+        "/usr/lib/libc.so": "base content",
+    })
+    args = make_args(tmp_path, ref, overlay)
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert not (output / "usr/lib/libc.so").exists()
+
+
+def test_modified_file_copied(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {
+        "/etc/config": "old",
+    })
+    overlay = make_tree(tmp_path, "overlay", {
+        "/etc/config": "new",
+    })
+    args = make_args(tmp_path, ref, overlay)
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "etc/config").read_text() == "new"
+
+
+def test_symlink_new(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {})
+    overlay_dir = tmp_path / "overlay"
+    overlay_dir.mkdir()
+    (overlay_dir / "usr" / "lib").mkdir(parents=True)
+    (overlay_dir / "usr" / "lib" / "libfoo.so.1").write_text("lib")
+    os.symlink("libfoo.so.1", overlay_dir / "usr" / "lib" / "libfoo.so")
+    overlay = os.fspath(overlay_dir)
+
+    args = make_args(tmp_path, ref, overlay)
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/lib/libfoo.so").is_symlink()
+    assert os.readlink(output / "usr/lib/libfoo.so") == "libfoo.so.1"
+
+
+def test_symlink_same_excluded(tmp_path, stage_module):
+    for name in ("reference", "overlay"):
+        d = tmp_path / name
+        d.mkdir()
+        (d / "usr" / "lib").mkdir(parents=True)
+        (d / "usr" / "lib" / "libfoo.so.1").write_text("lib")
+        os.symlink("libfoo.so.1", d / "usr" / "lib" / "libfoo.so")
+
+    args = make_args(
+        tmp_path,
+        os.fspath(tmp_path / "reference"),
+        os.fspath(tmp_path / "overlay"),
+    )
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert not (output / "usr/lib/libfoo.so").exists()
+
+
+def test_symlink_different_copied(tmp_path, stage_module):
+    for name, target in (("reference", "libfoo.so.1"), ("overlay", "libfoo.so.2")):
+        d = tmp_path / name
+        d.mkdir()
+        (d / "usr" / "lib").mkdir(parents=True)
+        os.symlink(target, d / "usr" / "lib" / "libfoo.so")
+
+    args = make_args(
+        tmp_path,
+        os.fspath(tmp_path / "reference"),
+        os.fspath(tmp_path / "overlay"),
+    )
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/lib/libfoo.so").is_symlink()
+    assert os.readlink(output / "usr/lib/libfoo.so") == "libfoo.so.2"
+
+
+def test_new_directory_copied_wholesale(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {})
+    overlay = make_tree(tmp_path, "overlay", {
+        "/opt/app/bin/run": "#!/bin/sh\necho hi",
+        "/opt/app/lib/data": "data",
+    })
+    args = make_args(tmp_path, ref, overlay)
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "opt/app/bin/run").read_text() == "#!/bin/sh\necho hi"
+    assert (output / "opt/app/lib/data").read_text() == "data"
+
+
+def test_paths_filter(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {})
+    overlay = make_tree(tmp_path, "overlay", {
+        "/usr/bin/hello": "hello",
+        "/opt/app/run": "run",
+        "/etc/config": "config",
+        "/var/log/messages": "log",
+    })
+    args = make_args(tmp_path, ref, overlay, options={"paths": ["/usr", "/opt"]})
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/bin/hello").exists()
+    assert (output / "opt/app/run").exists()
+    assert not (output / "etc").exists()
+    assert not (output / "var").exists()
+
+
+def test_exclude_paths(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {})
+    overlay = make_tree(tmp_path, "overlay", {
+        "/usr/bin/hello": "hello",
+        "/usr/share/doc/readme": "docs",
+        "/usr/share/doc/sub/notes": "notes",
+        "/usr/share/man/man1/hello.1": "man page",
+        "/opt/app/run": "run",
+    })
+    args = make_args(tmp_path, ref, overlay, options={
+        "exclude_paths": ["/usr/share/doc"],
+    })
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/bin/hello").exists()
+    assert (output / "usr/share/man/man1/hello.1").exists()
+    assert (output / "opt/app/run").exists()
+    assert not (output / "usr/share/doc").exists()
+
+
+def test_exclude_paths_with_paths_filter(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {})
+    overlay = make_tree(tmp_path, "overlay", {
+        "/usr/bin/hello": "hello",
+        "/usr/share/doc/readme": "docs",
+        "/opt/app/run": "run",
+        "/etc/config": "config",
+    })
+    args = make_args(tmp_path, ref, overlay, options={
+        "paths": ["/usr", "/opt"],
+        "exclude_paths": ["/usr/share/doc"],
+    })
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/bin/hello").exists()
+    assert (output / "opt/app/run").exists()
+    assert not (output / "usr/share/doc").exists()
+    assert not (output / "etc").exists()
+
+
+def test_exclude_paths_exact_file(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {})
+    overlay = make_tree(tmp_path, "overlay", {
+        "/usr/lib/libfoo.so": "lib",
+        "/usr/lib/libbar.so": "lib",
+    })
+    args = make_args(tmp_path, ref, overlay, options={
+        "exclude_paths": ["/usr/lib/libfoo.so"],
+    })
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/lib/libbar.so").exists()
+    assert not (output / "usr/lib/libfoo.so").exists()
+
+
+def test_empty_overlay(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {
+        "/usr/lib/libc.so": "content",
+    })
+    overlay = make_tree(tmp_path, "overlay", {})
+    args = make_args(tmp_path, ref, overlay)
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert len(list(output.iterdir())) == 0
+
+
+def test_mode_difference_copied(tmp_path, stage_module):
+    ref_dir = tmp_path / "reference"
+    overlay_dir = tmp_path / "overlay"
+    for d in (ref_dir, overlay_dir):
+        d.mkdir()
+        (d / "usr" / "bin").mkdir(parents=True)
+        (d / "usr" / "bin" / "tool").write_text("same content")
+
+    os.chmod(ref_dir / "usr/bin/tool", 0o644)
+    os.chmod(overlay_dir / "usr/bin/tool", 0o755)
+
+    args = make_args(tmp_path, os.fspath(ref_dir), os.fspath(overlay_dir))
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/bin/tool").exists()
+    result_mode = stat.S_IMODE(os.lstat(output / "usr/bin/tool").st_mode)
+    assert result_mode == 0o755
+
+
+def test_hardlink_new(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {})
+    overlay_dir = tmp_path / "overlay"
+    overlay_dir.mkdir()
+    (overlay_dir / "usr" / "lib").mkdir(parents=True)
+    (overlay_dir / "usr" / "lib" / "libfoo.so.1").write_text("lib content")
+    os.link(overlay_dir / "usr" / "lib" / "libfoo.so.1",
+            overlay_dir / "usr" / "lib" / "libfoo.so.1.0")
+
+    args = make_args(tmp_path, ref, os.fspath(overlay_dir))
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/lib/libfoo.so.1").read_text() == "lib content"
+    assert (output / "usr/lib/libfoo.so.1.0").read_text() == "lib content"
+
+
+def test_hardlink_same_excluded(tmp_path, stage_module):
+    for name in ("reference", "overlay"):
+        d = tmp_path / name
+        d.mkdir()
+        (d / "usr" / "lib").mkdir(parents=True)
+        (d / "usr" / "lib" / "libfoo.so.1").write_text("lib content")
+        os.link(d / "usr" / "lib" / "libfoo.so.1",
+                d / "usr" / "lib" / "libfoo.so.1.0")
+
+    args = make_args(
+        tmp_path,
+        os.fspath(tmp_path / "reference"),
+        os.fspath(tmp_path / "overlay"),
+    )
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert not (output / "usr/lib/libfoo.so.1").exists()
+    assert not (output / "usr/lib/libfoo.so.1.0").exists()
+
+
+def test_hardlink_different_copied(tmp_path, stage_module):
+    for name in ("reference", "overlay"):
+        d = tmp_path / name
+        d.mkdir()
+        (d / "usr" / "lib").mkdir(parents=True)
+        (d / "usr" / "lib" / "libfoo.so.1").write_text(f"{name} content")
+
+    args = make_args(
+        tmp_path,
+        os.fspath(tmp_path / "reference"),
+        os.fspath(tmp_path / "overlay"),
+    )
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/lib/libfoo.so.1").read_text() == "overlay content"
+
+
+def test_dir_replaces_symlink_to_dir(tmp_path, stage_module):
+    ref_dir = tmp_path / "reference"
+    ref_dir.mkdir()
+    (ref_dir / "usr" / "lib").mkdir(parents=True)
+    (ref_dir / "usr" / "lib" / "real.so").write_text("lib")
+    os.symlink("lib", ref_dir / "usr" / "lib64")
+
+    overlay_dir = tmp_path / "overlay"
+    overlay_dir.mkdir()
+    (overlay_dir / "usr" / "lib64").mkdir(parents=True)
+    (overlay_dir / "usr" / "lib64" / "new.so").write_text("new lib")
+
+    args = make_args(tmp_path, os.fspath(ref_dir), os.fspath(overlay_dir))
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/lib64/new.so").read_text() == "new lib"
+    assert (output / "usr/lib64").is_dir()
+    assert not (output / "usr/lib64").is_symlink()
+
+
+def test_new_subdir_in_shared_parent(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {
+        "/usr/lib/existing.so": "lib content",
+    })
+    overlay = make_tree(tmp_path, "overlay", {
+        "/usr/lib/existing.so": "lib content",
+        "/usr/lib/newpkg/data.txt": "new data",
+        "/usr/lib/newpkg/sub/deep.txt": "deep",
+    })
+    args = make_args(tmp_path, ref, overlay)
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert not (output / "usr/lib/existing.so").exists()
+    assert (output / "usr/lib/newpkg/data.txt").read_text() == "new data"
+    assert (output / "usr/lib/newpkg/sub/deep.txt").read_text() == "deep"
+
+
+def test_deep_nested_only_changed_leaf_copied(tmp_path, stage_module):
+    ref = make_tree(tmp_path, "reference", {
+        "/usr/share/app/data/a.txt": "same",
+        "/usr/share/app/data/b.txt": "same",
+        "/usr/share/app/data/sub/c.txt": "same",
+    })
+    overlay = make_tree(tmp_path, "overlay", {
+        "/usr/share/app/data/a.txt": "same",
+        "/usr/share/app/data/b.txt": "same",
+        "/usr/share/app/data/sub/c.txt": "changed",
+    })
+    args = make_args(tmp_path, ref, overlay)
+
+    stage_module.main(args)
+
+    output = tmp_path / "output"
+    assert (output / "usr/share/app/data/sub/c.txt").read_text() == "changed"
+    assert not (output / "usr/share/app/data/a.txt").exists()
+    assert not (output / "usr/share/app/data/b.txt").exists()
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # good
+    ({}, ""),
+    ({"paths": ["/usr"]}, ""),
+    ({"paths": ["/usr", "/opt"]}, ""),
+    ({"exclude_paths": ["/usr/share/doc"]}, ""),
+    ({"exclude_paths": ["/usr/share/doc", "/usr/share/man"]}, ""),
+    ({"paths": ["/usr"], "exclude_paths": ["/usr/share/doc"]}, ""),
+    # bad
+    ({"paths": ["usr"]}, "does not match"),
+    ({"exclude_paths": ["usr/share/doc"]}, "does not match"),
+    ({"extra_field": True}, "'extra_field' was unexpected"),
+])
+def test_schema_validation(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+    }
+    if test_data:
+        test_input["options"] = test_data
+    res = stage_schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)


### PR DESCRIPTION
This new stage takes two inputs and compares them against eachother. The reference input contains the 'base' tree and the overlay input contains the tree we want to remove anything from that's already in the reference tree.

The stage is useful for the production of systemd system extensions which should only contain files that are not already present on a base system.

With this implementation it should be possible to build for example a disk image and a bunch of sysexts that target it directly. The base tree can be a given os tree or a mounted bootc container, or anything that we can provide as an input.