### PR TITLE
objectstore: prune leftover directories under store/tmp

### DIFF
--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -8,7 +8,7 @@ import time
 from pathlib import Path
 from typing import Any, Optional, Set, Union
 
-from osbuild.util import jsoncomm
+from osbuild.util import jsoncomm, rmrf
 from osbuild.util.fscache import FsCache, FsCacheInfo
 from osbuild.util.mnt import mount, umount
 from osbuild.util.path import clamp_mtime
@@ -454,6 +454,29 @@ class ObjectStore(contextlib.AbstractContextManager):
 
         self.cache.store_tree(object_id, obj.path + "/.")
 
+    def prune_tmp(self):
+        """Remove leftover files under store/tmp.
+
+        Stage TemporaryDirectory objects normally clean up on exit, but
+        crashed or interrupted builds can leave orphans (for example
+        buildroot-tmp-*) that fill the disk and break later builds.
+        """
+        if self._read_only:
+            return
+
+        try:
+            with os.scandir(self.tmp) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            rmrf.rmtree(entry.path)
+                        else:
+                            os.unlink(entry.path)
+                    except OSError:
+                        pass
+        except FileNotFoundError:
+            os.makedirs(self.tmp, exist_ok=True)
+
     def cleanup(self):
         """Cleanup all created Objects that are still alive"""
         if self._host_tree:
@@ -462,6 +485,7 @@ class ObjectStore(contextlib.AbstractContextManager):
 
         self._stack.close()
         self._objs = set()
+        self.prune_tmp()
 
     # export active floating objects so another store can load them,
     # typically in a VM
@@ -492,6 +516,9 @@ class ObjectStore(contextlib.AbstractContextManager):
     def __enter__(self):
         assert not self.active
         self._stack.enter_context(self.cache)
+        # Drop leftovers from previous crashed/interrupted runs before
+        # allocating new temporary buildroots under store/tmp.
+        self.prune_tmp()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/test/mod/test_objectstore.py
+++ b/test/mod/test_objectstore.py
@@ -92,6 +92,38 @@ def test_cleanup(tmp_path):
         assert object_store.get("A") is None
 
 
+def test_prune_tmp_removes_orphans_on_enter(tmp_path):
+    orphan = tmp_path / "tmp" / "buildroot-tmp-orphan"
+    orphan.mkdir(parents=True)
+    (orphan / "leftover").write_text("x", encoding="utf-8")
+
+    with objectstore.ObjectStore(tmp_path) as object_store:
+        assert not orphan.exists()
+        assert os.path.isdir(object_store.tmp)
+
+    assert os.path.isdir(tmp_path / "tmp")
+    assert not os.listdir(tmp_path / "tmp")
+
+
+def test_prune_tmp_removes_orphans_on_exit(tmp_path):
+    with objectstore.ObjectStore(tmp_path) as object_store:
+        orphan = Path(object_store.tmp) / "buildroot-tmp-orphan"
+        orphan.mkdir()
+        (orphan / "leftover").write_text("x", encoding="utf-8")
+
+    assert not os.listdir(tmp_path / "tmp")
+
+
+def test_prune_tmp_skips_read_only_store(tmp_path):
+    orphan = tmp_path / "tmp" / "buildroot-tmp-orphan"
+    orphan.mkdir(parents=True)
+    (orphan / "leftover").write_text("x", encoding="utf-8")
+
+    with objectstore.ObjectStore(tmp_path, read_only=True) as object_store:
+        assert orphan.exists()
+        assert os.path.isdir(object_store.tmp)
+
+
 def test_metadata(tmp_path):
 
     # test metadata object directly first


### PR DESCRIPTION
## Summary
- Prune orphaned directories under `$store/tmp` (e.g. `buildroot-tmp-*`) when an `ObjectStore` is opened and when it is cleaned up.
- Prevents leftover temp dirs from crashed/interrupted builds from filling the disk and breaking later runs (including `org.osbuild.xorrisofs` free-space failures).
- Skips pruning for read-only stores; uses `osbuild.util.rmrf` for removal.

Fixes: https://github.com/osbuild/osbuild/issues/2531
Related: https://github.com/osbuild/osbuild/issues/2276