### PR TITLE
stage/rpm: remove new header digests

### DIFF
--- a/stages/org.osbuild.rpm
+++ b/stages/org.osbuild.rpm
@@ -58,9 +58,6 @@ def generate_package_metadata(tree, rpm_args):
     "epoch": %|EPOCH?{"%{EPOCH}"}:{null}|,
     "arch": %|ARCH?{"%{ARCH}"}:{null}|,
     "sigmd5": %|SIGMD5?{"%{SIGMD5}"}:{null}|,
-    "sha1header": %|SHA1HEADER?{"%{SHA1HEADER}"}:{null}|,
-    "sha256header": %|SHA256HEADER?{"%{SHA256HEADER}"}:{null}|,
-    "sha3_256header": %|SHA3_256HEADER?{"%{SHA3_256HEADER}"}:{null}|,
     "sigpgp": %|SIGPGP?{"%{SIGPGP}"}:{null}|,
     "siggpg": %|SIGGPG?{"%{SIGGPG}"}:{null}|
     \},

--- a/test/data/stages/rpm/metadata.json
+++ b/test/data/stages/rpm/metadata.json
@@ -9,9 +9,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c59f020adb317d654fa251ca65482199",
-          "sha1header": "5b809b5f3bfedf91935268598c52d1cc0c0f655c",
-          "sha256header": "1a09807db6d0c705bdbe42d03bf8f37fb096506d7d9d64c070026ba4830c9a9f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -22,9 +19,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "2cdad0b5cd4d8dd70ef4e41152e143d0",
-          "sha1header": "155b3bd9a679983102ed6792a719f8c0112b767f",
-          "sha256header": "d3193af0be71b60d3b20b5430cbfa167cc0b027e1f81fc9d2d2d8d926b849807",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -35,9 +29,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "a9a56d797754ae1783b208ffc0bfec7a",
-          "sha1header": "e0f9876742564729675d027a1be04c843d7c5bed",
-          "sha256header": "fd8f437b5cb99fcc8c4939b2a8c292c1f2c86ad90a747f7debc27cb1a7b5994e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -48,9 +39,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "0219a1603dd38ac5439413ad81cfa6fb",
-          "sha1header": "7b5feaa098b2607e63523d88f9238c2cbdaf67e5",
-          "sha256header": "112452e0928fc6d066b22c44cd0fdd8812d8fbecf90b911e3de1801a441fd23a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -61,9 +49,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "16bc0cbfc728e67b5675e3cfa82371e7",
-          "sha1header": "55d5af5c5b846e75c05695ceff99d975b74f41bd",
-          "sha256header": "94d38a5d131addffe96e30b36de414c165984c3563a317f6544245b31915353d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -74,9 +59,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "219b6e36958a35a1766393624d486913",
-          "sha1header": "e5d6578c2268fa4ca57d6ec45f2a572a2cbf4b2c",
-          "sha256header": "7b91758638d779ed890e26579c4bbbddc94462b36f881ac639fca073026a7591",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -87,9 +69,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c20ad50d6d887d0e408354e23ca9b945",
-          "sha1header": "e3e59d4c91d662dbfb5c8fc5d3257617faf4bdbc",
-          "sha256header": "a37976f9eee6f3616d01c40708a1c1cf27476d09baea816c5592c6b96e5f07ac",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -100,9 +79,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5b6ab51beabd5a94bfd28bf8c069c4bb",
-          "sha1header": "89740fe1cc4e1010a7ceeda72c233534481c7684",
-          "sha256header": "a3ebfd6fbc1653cc6cc3c10ea7b6e28d9800626648d85328632798cbb307a5b3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -113,9 +89,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "367c03f044ec65e1e1269d6d815a0ce9",
-          "sha1header": "73f607289b309dafa583e11c037d9c0f9250035e",
-          "sha256header": "f1e839f1441ac4aa70446c3db027a83acc3fefe8d918b1b4e5aec6fdc830fb97",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -126,9 +99,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "7980fc6b712fee9a8cabf7c1574163b1",
-          "sha1header": "7a689c497c7498cbb0d6847492342c7a2f2271e1",
-          "sha256header": "3a6a4ee8406e84cf0f8f3aa41637384eba469332b08ca59a8cd31595c7e86b0d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -139,9 +109,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "c1956af2d534ba0aa54f6da2b8ab63d7",
-          "sha1header": "88ea59bb7baac8450aa253431407b63286d16f93",
-          "sha256header": "d02bd0dfaf0d2831655efd48450a466fd84b30765a4009a24cd949f4e9fca615",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -152,9 +119,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "033bf1d9cb4c75276573b337b7330705",
-          "sha1header": "2a35a61af48a8762c6fb8d373b167c14c7abfcee",
-          "sha256header": "ba1d48eb12c8c4d34ad872faf472520a09dac91cd523c7f6a99576e6566f9de4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -165,9 +129,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1cb84077ef4687c1e41deb50b6f21f77",
-          "sha1header": "f9781c80c4b429d799c0509ff7f5a0330bdc6468",
-          "sha256header": "93c263a36c14b55cef37a933c6a2d0844f31f3197ed99357682d5a7e775bdaee",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -178,9 +139,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "a22a73c1e40695b93b18a43c85b1579a",
-          "sha1header": "7cd7c569f34cd6453b65740861b3bc0ee2fc28f2",
-          "sha256header": "f3b3fb19da6dd3058a240e256079e85127c567478cd78ea9501da698c3606649",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -191,9 +149,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a0ab8e5feadcea1b0423128d37ccce99",
-          "sha1header": "3ebbdb716f060f2084433a9bf6c1928386eb48e6",
-          "sha256header": "0a16049dfab49d4924cf6d909c4be761c6893b03c8337bd21cde7bb183187bf1",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -204,9 +159,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1296ce36b0f30cf632306b983067c9a5",
-          "sha1header": "eb243c7f71f3556db26f729fef1d09664533e61c",
-          "sha256header": "6fd642da8b4bbb31c16abf945fe5b1b7059248648d43a15c8a633a9e2039e4e5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -217,9 +169,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d669d86b2d2fdd2b8d5a1229c4fa6a76",
-          "sha1header": "ce954e9a4fe895ab8181c8c5007dc962b88b2d59",
-          "sha256header": "e3e1513475b64eebc5d3b2e0d42761ad304ae63eca4bf64116c803a32aca5aee",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -230,9 +179,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d3dbf2a684201d7497a1d917db44660a",
-          "sha1header": "aa78c1d9a49fc1c6d39c0203210ad2558c4727e7",
-          "sha256header": "e2338393794032feea8c179d5e70a61a1bc3f6416a3af33555b44b2877b4e61b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -243,9 +189,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "179bc915e9f2d48e40466ff87b2439e5",
-          "sha1header": "fb439edbcd9b42caee75c2d960f0630fc95091cd",
-          "sha256header": "ea553a8f38e817a36e8146e05af3589e38bb8a34f780fec115679536b01d4a69",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -256,9 +199,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6f2ecb632399684d40ea7ce8d61100d9",
-          "sha1header": "0840142cf29fd6b42b81d992d59c0097a78ff751",
-          "sha256header": "fcfcbe4e2418998e54ff81e4ebffdbac69e81c1735eb41ae39eb5d1854332d15",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -269,9 +209,6 @@
           "epoch": "1",
           "arch": "noarch",
           "sigmd5": "74e4a6dd06bec3a9eb57beb8eb85fd1c",
-          "sha1header": "ad7e08f7c002dcfd85b8ffbef396491e75fe71eb",
-          "sha256header": "e9d3d16023e9c2ed698e9239f1f7b36d0842e6cd9426b1d31bdfe2c156b9b410",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -282,9 +219,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7b4b879b3bbc49b2a6dc70228a2a2970",
-          "sha1header": "531af5377a41f0a4190e156434340a26ac865b87",
-          "sha256header": "fe22aa7818283ff0dd13a6c8847f5bc805ce3768b777f232a6e86d6e8fb59ea3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -295,9 +229,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3382bd00fe2a3a9cae51f608f7c3de8a",
-          "sha1header": "c4cd94faa68615638d459c6b88c8a8c5091ac0d2",
-          "sha256header": "313c0a4bfc4c539beb502501473962784badc19efdc991249e7e3489ba478a87",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -308,9 +239,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "11dc5f2c5eb97e4524c7d1bb7e0eb09f",
-          "sha1header": "81ff32cbb9005d64ebc7f2baabad4c79da377449",
-          "sha256header": "e348b780512f0bea49973e3b705c9ae0bffb2d415ede2e8d2ce9cb29ee08acdf",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -321,9 +249,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b9a853ce2c8277921a2cff0d6eadd2d3",
-          "sha1header": "edf70bbc0fa929e6b637ec0f52d18d1625940d38",
-          "sha256header": "ee3524eaffad6fa997753f09dab3d1997659a916e47ab1fc2de4a9156e663019",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -334,9 +259,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "eb2c8382cf9ed8db2311e33cfd7cbff9",
-          "sha1header": "bf4c4851e392e5a3e3bbb4fbe3b0609413f0a85d",
-          "sha256header": "48e1f97cebe4b8c72fe4d3e6eafa2a901b92a111dce89377fd7e2dd3ee76e5e4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -347,9 +269,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e952ab99f3bd5601fa99d0fb061eaa8c",
-          "sha1header": "0f0199a50cbf1599bb7c63e1f47abdb80e528c3d",
-          "sha256header": "f264159b1d94dbaaa28b80df45417baf323060867c33ad68d20680587519fa9f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -360,9 +279,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "0e56e4be4e3bb78f4d6d8087ca874ab9",
-          "sha1header": "812981ebb957bc592ca03216fedcb6521e1d1127",
-          "sha256header": "d8420f0a55cd4e2698c74c93d7c75eb6288ef7504b72b0f3ec2183352e18b6ef",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -373,9 +289,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "42cea577770bd9fd2b9b0b943c7b386e",
-          "sha1header": "cb828f7faa8e755731a6a366e3059178ecec6101",
-          "sha256header": "f507649ee0820e7915664149c0d8c5cb36bd61eee127778e36a78de616453108",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -386,9 +299,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b5a65197be7746d78c21cf4425eb87c1",
-          "sha1header": "15059011d50e13abab8ff79231aa9b4e79c0d6cb",
-          "sha256header": "9f62271b968aa82067752d46151c2040a215c2ab1b9a2174e871c0be35e60712",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -399,9 +309,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "61bf545fe8fcfeb848e573771da12576",
-          "sha1header": "82e0974b0d96b9f7208bc05199e41b7c20684e56",
-          "sha256header": "f21a35ede1dd1e641f09e34306d0498c92f134caa44c7b47fa42f91342c10a28",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -412,9 +319,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "24581fdc0af2627bc50398358dbd6961",
-          "sha1header": "7eac806b6afc5974c53dcd2e7fc4b6f78cc954a1",
-          "sha256header": "782018ca114479773ddf8a91fc0568e6f8f10293ecccd34b8ab4ab7508e60b62",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -425,9 +329,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5afcc1f77aaf2520c1495e968cf9df97",
-          "sha1header": "f6dd59f594b6058eadcacdd6516e585ee5f85065",
-          "sha256header": "cb9fafc84889e45b73fb110f8ebf4e805c02b60a503b1910f3730a0fa473237c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -438,9 +339,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d929cc755a28308f49710e9bf1afff86",
-          "sha1header": "bd89002abc01118de6c893fd5517e2c76804762a",
-          "sha256header": "1586428f601defcd7894c288187c65f26eaa4b5078776419a80229ac636080de",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -451,9 +349,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "0a9957441095f620db659c9fa7299f31",
-          "sha1header": "468b040eefd41a8b935ff4cf28a07f4d2482509c",
-          "sha256header": "8d76395198f6e94cdeab3d58b8f7e6cba8c3358a6a1ce731ac94ed4646615c12",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -464,9 +359,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f28cd7c598cdfbc1ac19c779d37905c7",
-          "sha1header": "3bfdac8d876255fe43d8b31dc9fe54083a9c9d46",
-          "sha256header": "3cd4abb7b957fc3b9dae771829221f43b725d6be6d56bd6f8689bd43df9f9370",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -477,9 +369,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ee98327dc3e5bee8f6797d72c38591b6",
-          "sha1header": "15342f5a6eee256f36ee04a2fd2511fbd6c46f8c",
-          "sha256header": "f9f7118d8fa089bd01de6e1656b65d64e91c4088afefeea662fff916c19506a6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -490,9 +379,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "e4f266373a1a3b13a0d6b2778245fb6a",
-          "sha1header": "0dcc8f01bae4e8032b4e0daa64d92bae649093d8",
-          "sha256header": "df5ff3b9679721bc8b9eb8535b5c53d56edcc50196c24458ecbeb736f05d7369",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -503,9 +389,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3e76756c41874dc3f8672fca05478445",
-          "sha1header": "59f6464181e4fc5fd5fabc8df8ad13624c9ad44e",
-          "sha256header": "150f3b0510385af5b97169a57278af222b5d1f782ebae33290a3b01715600886",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -516,9 +399,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ff5707f4127cbd3bca48cd32c1efa06a",
-          "sha1header": "3dc0ea7f17e2f48bd8c16d08e7783cb208a79135",
-          "sha256header": "2d100c144dfee1af7dbe89a4e38943988b84d8f62bc35f356b6f0e4a37fac586",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -529,9 +409,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "8f5c264badcf966982712baf087ca4f0",
-          "sha1header": "23522c5e3beb4353d21e2d72772a1d8e0f86c480",
-          "sha256header": "9e7c807bbdeadcde82246e925b071aeb5dcf346907274c3a368b7a34b20f7b53",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -542,9 +419,6 @@
           "epoch": "4",
           "arch": "noarch",
           "sigmd5": "cc3ce993068388993ae604ba9366549b",
-          "sha1header": "3c4a241aec6046ebc9d28e7150a01d6419acbab7",
-          "sha256header": "98fe55f2543916f51548e612a5b32a90a9acad8ad9986ac23ece498a3362e870",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -555,9 +429,6 @@
           "epoch": "5",
           "arch": "noarch",
           "sigmd5": "c9ac6581ec4288a35e1450f6aebf38c2",
-          "sha1header": "f3b09a2b604bed77a8af3e28d0e6756775d4c771",
-          "sha256header": "4e4759796696e1e845aa7267e645d18ad1ea856be2a854d1d42bf3b564c1193d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -568,9 +439,6 @@
           "epoch": "5",
           "arch": "noarch",
           "sigmd5": "2184a4fc037653af8bc098992ec0ada5",
-          "sha1header": "79ceb805102e707e0bd74a8bcba94d66e779052c",
-          "sha256header": "5d36bda3fa4fce71d39c118cf87021e095b95c5fd00b557c60dc254126404164",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -581,9 +449,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "fbc0f9baeed2486a044022b20bdec3de",
-          "sha1header": "68bc408f370e8a2825aafd5b12356407dff1485d",
-          "sha256header": "312366adac6449224d0a01ad3efa8d46f47c5c42636d470408ceb7351a9862c6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -594,9 +459,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "fd4c5f50ee15ebee774b53963991ddbd",
-          "sha1header": "254fc27208b41d7780927149f0050cd8eb36976b",
-          "sha256header": "59a30d270e6939e2b7fe8ec998ab758ae101f31ded9180532438e733b5767084",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -607,9 +469,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c78c2dc07057a3698604caf604bb6a13",
-          "sha1header": "a99b88b2411243e2acc63165e375c844fb961c42",
-          "sha256header": "102bf6c7e5f8b5ed09474ecda9f5628329faf9254b96527a6aa1cba428b5723e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -620,9 +479,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9ed30d7a792781b582af6b9620b6cfb7",
-          "sha1header": "3d3966d04a81393313dacfe6a713524d14b6f01e",
-          "sha256header": "8012006e5ddb3c8d61914f136344a88dac519b3fe7388d24a1b71b1b35478e0a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -633,9 +489,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c2500a2b8bee94ea707d9aba528cf1d7",
-          "sha1header": "504c9ea360159eabf4bd6cd7c2ef3bc2f9ffa896",
-          "sha256header": "d080fcb3234334933907c32a011496282240d3ca0d22413c3e47acfc2f001926",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -646,9 +499,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "550873ad10f215003790ff76943f55f3",
-          "sha1header": "14a30c7c128a0ea28d241e1c69e26a695c9085a2",
-          "sha256header": "48da7f6b86bd88aad84970e77693e158aa5da80258a508e72ca53653a239aaf3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -659,9 +509,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f0a8a5a35e774e81a48f6e41a3d3e9d9",
-          "sha1header": "2648c2e75695c1d1ed33c4d2588a91d066a10fb3",
-          "sha256header": "874c502d33e902cfaea76c95843fb34c1beb1ac083a0cd13b1178fa213c79bd9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -672,9 +519,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7502ae9532440ef9a2f622b3c94998be",
-          "sha1header": "a0a0d4313b209ac219fd79ccadffe45141d41472",
-          "sha256header": "df1932c38067bba655d8d414a714e587a7594c28749c215aa5ac45752fc33767",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -685,9 +529,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "768b2339658e62d8ba721b332b1d8d62",
-          "sha1header": "a202f5023d19512fc11b55d8f05ab8e8acf8a7be",
-          "sha256header": "69f02227bf20f0c0039245b7a664e6be488cc44fcad9fe0ae3e08521dfa5d6cb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -698,9 +539,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "a3adecdebc91395d474018a8a75d4bd9",
-          "sha1header": "bdaede53e1cc0f996975db2c5619836b2aa8ff6d",
-          "sha256header": "c4cacc168828afc3b7891f418104415b813993531956802583ed1dfe499fd38a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -711,9 +549,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6cb56221d861ecd538b7ee04eaeba4f1",
-          "sha1header": "0d04e7fb69f2b392246b49d15491c28ca93f3dad",
-          "sha256header": "b448cbd22a4fd0d5ac6ef3407c6b3e362be75f5e4cbc3010152eca376bd88321",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -724,9 +559,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9cceb53f70b102836fa709ae43ac735a",
-          "sha1header": "b960c5f1bfba8a8e998ed41fadea03b7692b4692",
-          "sha256header": "75b5a82871b2f53957c4117300349b5140aec8aa36e45049f4b0f2860d49e104",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -737,9 +569,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "30e8b027347987d77dc998f9e14a8fdb",
-          "sha1header": "f7b26514bd5d1e66227355f6c2ea1932220e1fb1",
-          "sha256header": "0be1b8b9f8643d8ca81cb0530a2989cb501c33ee38e22dec06e1ee22b62b3ff8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -750,9 +579,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4bebe0f10ac11d214dad727e90e33bc0",
-          "sha1header": "07a6511e6296493fb9788cf4b00520ca9b70835c",
-          "sha256header": "db7ff7d5fba37f353b4d7d92cf394b4da9c05f148052c85edd40e5676bdd679f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -763,9 +589,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "3f96218236228d19427c53611901ee59",
-          "sha1header": "aa517fcd440bd97ebf693d594f46f8c49f39b156",
-          "sha256header": "5f6b3d18e707ba7f1acdebca5d1e9f180e671eeb200c41623e36e90688410f69",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -776,9 +599,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d989309245cd3bd11bb302459ad1e25f",
-          "sha1header": "ac248a724b69fb68a28ec22049037cc660a48b26",
-          "sha256header": "af1e48490d8d95dde01bb16c4722c4054fec874547a0958284d9dfb82bea72f9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -789,9 +609,6 @@
           "epoch": "1",
           "arch": "noarch",
           "sigmd5": "e5bd6f9dc2ec4b8d8963b357113bbd11",
-          "sha1header": "cc6b49c1a9ff0db849f8074f91d4b99d7165b08c",
-          "sha256header": "a644ce8fb8ad77a9bb4232723c82123bdd172ba24aff94ae620ff23dd65589bd",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -802,9 +619,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "8a689f832f236d8187628f4f709acdd1",
-          "sha1header": "c8b97b83d051f8b211609817daed2088b134fe06",
-          "sha256header": "3a63326fa358ab7ac20c2f05b783d1a9c533c1be4a30713629cf8d3f38bf3035",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -815,9 +629,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "187a02439df8e3b745ec4ff3dccba2a2",
-          "sha1header": "1c54312c6b145f3bc6f314176558801aae6abef8",
-          "sha256header": "0bf6650906f4484a188afbe7d3a0911d4a66055572fc07a54053f26bf4d3d4be",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -828,9 +639,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ff74ab526f562758741710895e3c1e3f",
-          "sha1header": "d4682c7772d09083da515bc543ad3196423e1c5c",
-          "sha256header": "b5df86ebdc8af793ef9a4d9ad7b565ab05f137297133165eff7fbe2fffe13635",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -841,9 +649,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "07f890fdd2b807ca262e17eeb90ecc3d",
-          "sha1header": "e0ac5806fdd9b057c47b0ee1c656aa5602b990d4",
-          "sha256header": "901ad4bca6c73016356b42a6e33e7c0542959d045ae960fda4ef41e1f45ffbe4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -854,9 +659,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9e633920bfe3b1021613af57d9143651",
-          "sha1header": "2f25febd1a37e2734e2df5efc65708d80325060e",
-          "sha256header": "eb89c3460101fa99bd167ca3eff2a84da67b9a89d2a7bda25a437cf520ca1c7f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -867,9 +669,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ed33a5abb172ff7a46d4de348ae6690d",
-          "sha1header": "af16487421947bbc80066118a543a954e88103a0",
-          "sha256header": "0d8075d7d72ac91c40effde9d9bb72edadd414c554d996a7f724080ac50dc335",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -880,9 +679,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f807baf66f9713a8d39a0f3bb2f5a715",
-          "sha1header": "cde43bf6f7ed20791986af755a14d17a1685a292",
-          "sha256header": "8bca2288ca8d50b437ea51b703e29cb97ed172779d60e4ad04f17eee2fc579a6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -893,9 +689,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1644a4d3715ad0119331df4541c3b98e",
-          "sha1header": "91f41d4c4ee3e830e0d90594e5c7c82cada1c892",
-          "sha256header": "2e901e94a5ff28966a5b678991fdd4d6b4763014bed32ab3939e0979d55287e7",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -906,9 +699,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "79f846cd1b141db4b8cce4c42ec7beb2",
-          "sha1header": "4617059620c855bfbe45009c0c22ea2c5125d2f8",
-          "sha256header": "76717746718a89dd1ba49950cd879c956ebf4e672938c0f37c04cf209c67b03b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -919,9 +709,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ed1f7f3aeb99b9ee528e02fcd4981fd4",
-          "sha1header": "d5c0972b1762938b3ede0eff3f9a7b161b2e8a90",
-          "sha256header": "0df6c21349bd697c72541ae90965873de78ada492ad1624af0a946c4d87b17e4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -932,9 +719,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "976f61354ecdd7e0d9865e517e4c7086",
-          "sha1header": "45654896dbd29ebee7db799e302c69c44d7f23f4",
-          "sha256header": "c009e03535aac0e349ea3699b417667ab9f28a8f10b6d7502d6d46062366c201",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -945,9 +729,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ed3550fe7131219ff94963399d58558f",
-          "sha1header": "e081f76b6554ab718e5781da8446ed9f94a8d595",
-          "sha256header": "c27a0ac8fe2d06e8c0fa6275fa0dfaf740a6295b42b60592ab2241967224810a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -958,9 +739,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "98452e6b100657eab24015ee917f0549",
-          "sha1header": "01313dc7573c2b91eb9f3a4113860e54011cadc3",
-          "sha256header": "0c02123a05790be5a0fe28c00bbb0caeaead243b78bd3c60f34e0e011fe06f6e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -971,9 +749,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cd01c0e5e2b7631b69727f06b231cf4c",
-          "sha1header": "7de4e6943e25b60e069ab16ffa787d9133b149da",
-          "sha256header": "189fb004d2c8c795a3090395754f33d8f33ed3ec144da2a4936d4d0287f9dcf2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -984,9 +759,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "142b9a7483c5de88ae05f24beb523a29",
-          "sha1header": "0613ea42e4181609e01aa0a392d91cb2bad19817",
-          "sha256header": "fba5a2c8f9727f30e7c57570af78b203f4c3b50d85a941a086d3d88e5a53780e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -997,9 +769,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "22c34956dd0de2e829286ac8e3182b45",
-          "sha1header": "2347f56cb06ee667627f854f110a3aa42afd6e81",
-          "sha256header": "f302e369d75d2a21b53d04ebf291f7bfaf551f1b07446422af537b283a206240",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1010,9 +779,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2e67ba7983274020ed7531fe7bd52a71",
-          "sha1header": "e704093eb5249bfaa752a6d70d670b77da9305f6",
-          "sha256header": "48875a293c2965e3ee851ea7c24a6eb4e6d889b57609400381c48b19b9c1d024",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1023,9 +789,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "16694e6d5d9630fe58701dd9f4a5f31c",
-          "sha1header": "f4d4e324c6815910031f8997f333936ee54baa9e",
-          "sha256header": "f44128a3f252f3c07754ff55dd191dc0cf29923b3261f17685a2a8a4fb71ed95",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1036,9 +799,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cbf8e095b310ad6d5b71f81f4409b526",
-          "sha1header": "4bcd195ed7a76a677fa8fbca49b0e8f9402237ce",
-          "sha256header": "3612810c21748cbb115358415e66bf7634e176b4c208187ee774dd143b42d789",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1049,9 +809,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b615393cbf2eff8985124b6b6d6ca3cc",
-          "sha1header": "cb14cc78ec0922a59b64adbec7e025b5ac7691d0",
-          "sha256header": "4d0d03bb46b4f80fd422fbb0356ca26568122f7de1654353574fcb57ae47d01e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1062,9 +819,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "f620feb8571ddff748153c8f0920539d",
-          "sha1header": "5b46076e624aaebd024aa0082f5ea06137b41a65",
-          "sha256header": "5c7a988a6dff7d2da47d0f937909a23e97a147747fa509a6f4ada522a18cc068",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1075,9 +829,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "4e289d8ca99d375160020333374c3e82",
-          "sha1header": "56fb5bf7b14cd51b6da33c2fb03415517ddbd497",
-          "sha256header": "9126287d287816733dac08d20b12275a00b521bd1ac66153af0b02592a3ee678",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1088,9 +839,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "db8b5ee6cf5c77763fc87d50781c25a5",
-          "sha1header": "f94786a7066d7aaf5b35d4c2878937501753bc14",
-          "sha256header": "2cbbb5607e57f1655c77f61257cb88c65faa09fd8e6dde2ff6f6adc17b1ca5b0",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1101,9 +849,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c271d03bb83893094166b5663582969c",
-          "sha1header": "68323057eb31643c85e86cc007194b7dd0a90743",
-          "sha256header": "c1a2c7840d2ee0842613f4a725f5677399f1422aaedd1fcba5631538ce597489",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1114,9 +859,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "85c4df6cdda569396437a5b088dc0db2",
-          "sha1header": "20d31a5afdeb47eba8ff878f0707a1682421bbb2",
-          "sha256header": "1940474f985581553e89a943fd7083aa7f120de3bcc4ddc7e31df51d11fe1f97",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1127,9 +869,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a428a3d6e6f261be7b263524959f5966",
-          "sha1header": "ffe7a372ab2fe578653d325d0f49ae0fee1b81d3",
-          "sha256header": "7215ec4ee43f67c793b36744ac65d4122fad137a8001ffadb83cdea14e611086",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1140,9 +879,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "58d777d735162435297df3ef494ac41c",
-          "sha1header": "eab3bb3118f29da0f8db247854f1a448a51d5419",
-          "sha256header": "8df5616a8b06f7fe98ce0c9b903cb230172adc0ab4da4cfbc61b20acc27415e5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1153,9 +889,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5d58b0a06f772af3191691d90cadb2b2",
-          "sha1header": "9f1a5b3e3511dfafdbc61d7067421aca6fa7ba9f",
-          "sha256header": "ac7c784ba0ebc97c45ee1a4d6d8097b16aaccb01f4ec5cd92eb5335366b03178",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1166,9 +899,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "98b2cd01ae5c9d17935243adbf83eac6",
-          "sha1header": "2d8daa4db4f35a45c980f0af9e8d19deecd5fc86",
-          "sha256header": "013f46d4542f8ab625e2711c5d1fa371a228756ecdc117e468115f72fb94dafa",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1179,9 +909,6 @@
           "epoch": "1",
           "arch": "noarch",
           "sigmd5": "249cf627a322d2371f7fdd13363e7772",
-          "sha1header": "df503340e2b62fa51b4722cbb3803294a218ed60",
-          "sha256header": "adcc739f4a652f31e2eae03305b4573eb72d38d1ad9ed9e2682c735d7d4988b7",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1192,9 +919,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "42edd81823e8fe0f340fe9f9d14725d9",
-          "sha1header": "089bd7767a379f44a699813f512821dac530235f",
-          "sha256header": "5aaad78c2e9c902d2512def467de4fd3f5adb352f353be053f295903627fdf4f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1205,9 +929,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "aca0cb4c0bc92abaf5952c5d94b933e5",
-          "sha1header": "d68cd085e70459591ac5a7f51e8f56a2c42bee1e",
-          "sha256header": "c0b86bee7475da836b90ce44624ff5958ab7b95549c847ec7e8f21252f6cb335",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1218,9 +939,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3363d3dba619fa1220a062cc9a1ed2e5",
-          "sha1header": "c765a5544b37b62b4471adeaa57a81d4889d589e",
-          "sha256header": "deb3cabfe43377d129bc311a67e43dca28c8993e0e1f934fc7d572b471cd8853",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1231,9 +949,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "eab8fa9bc728a79b2a7414d9e24f726d",
-          "sha1header": "480c7644d807630d9e71e695a3cbf01aa9390902",
-          "sha256header": "250b7948fe82696f69b661e65dcda27efabe7a3da03efa1191d47d792dff3d6d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1244,9 +959,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f7c267893d2fdcec808d10013c39de6d",
-          "sha1header": "a1f53054dc2ccdcae209267a5849adc8971078ca",
-          "sha256header": "2b860169dadbbfd47ae3f2eff91e767f049ac069c8d110ad15bf280531c297cf",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1257,9 +969,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "09e2809fc5f22dc6302d74d10f6ae05f",
-          "sha1header": "110a7f70c1187f68684c29f7c31fd676020be79c",
-          "sha256header": "a7109e1857a151935a3857ee49a02166c3ccdd149da638fe692c5f82a0e65c53",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1270,9 +979,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "5d11b2158529b688d1ba39e4bb40751a",
-          "sha1header": "3ace728041a84bab99d32c96fc297e0d875934ce",
-          "sha256header": "3ca4cbbeedc50afb5ca6b31b436216febc15e5214e6d82bcffc1e2ce66ad864c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1283,9 +989,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "0ca346bad6eda9af02a54598fdc08466",
-          "sha1header": "d74c3b259cae46eeda95294ffac10bcb279343e2",
-          "sha256header": "e38718606bb8d7ddee02b57c7fd2e7f96ac6e0c50b17d321f33a15a327dcb896",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1296,9 +999,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "2b298ab79b33797efc1ee992d74dd6a7",
-          "sha1header": "603ad79bb418d4e1e9046c9268a9ea63c29a09a4",
-          "sha256header": "12b455af51bcbca4c171a455bc1c1350e9fa411c94556524e5098e9a28770c05",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1309,9 +1009,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "6eab1408ad49d7b48b783d6bc3799426",
-          "sha1header": "f921c1403baa0deb24473f9912960484c73aa78b",
-          "sha256header": "42781bf2f422272bde70f1d73f46772126e4eae96f96fdd0892e8ce794379f85",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1322,9 +1019,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b53c84a64f21f06b21c05603005de1dc",
-          "sha1header": "fe591855f0d252bb866691fbf20346bd4d2dbe08",
-          "sha256header": "5931acdd887d1bbfa377b77d564c9cbec582ceb3acdfc5fa25cb1587ee221e37",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1335,9 +1029,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1dccdeb613a787f3e1d9840288d2671e",
-          "sha1header": "c0c5aac7d4a5203664d9336e628eac83802443ac",
-          "sha256header": "ccd98587cb5263676db9517287c046b42e59e12260caa6700e7228f0a112c112",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1348,9 +1039,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "8b112e7fb03b109c85558c75907dfb07",
-          "sha1header": "bde96efec44a083130e23030a195f4bcba13f874",
-          "sha256header": "6a4f52095306279b171f6f57172562dd691fca3a6afcd1943f3519e3c4991868",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1361,9 +1049,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ae7dfec82f04ecbfadbc75c5798126e8",
-          "sha1header": "9ba88a6fa6657435c95dd0bc8a9e98d17a8485f3",
-          "sha256header": "3bc68a8f289b121ba7904a4118fd37fe628bf0b1986bab2094dbbfc9e8e5164f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1374,9 +1059,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "1d619a2ed9797a97d5be0dfa8f15a587",
-          "sha1header": "136cac2c55b75bf470d9ec30ecbb5f06fad5d626",
-          "sha256header": "16dda9c6aea79bc873fa0d0bbf6705c2535e0055d60aa9861f9ad5e2a477adf5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1387,9 +1069,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "b73c30e2ef4d986826adadd9b894d967",
-          "sha1header": "c1d04a99985ac25554f4786ec27d104edefba13d",
-          "sha256header": "67009706a2ffe030839789b9b591c2c990039683f1ce489e91c2165e2b2e9da2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1400,9 +1079,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "dbe2c6bc8888a6fc1434a205823bc134",
-          "sha1header": "a80ca1cd138fee34d87df4a86cec7fac9dd6ef5d",
-          "sha256header": "7b159254db989b3ca3ec14f0fc79babfce3326582eb7a99e5d581de6dcdca367",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1413,9 +1089,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9feba1d0421dc8155509e878d8ec0211",
-          "sha1header": "c9196d77dd50177034de83dc73207e596f8af704",
-          "sha256header": "805b26ff15a398a57eea347eb67ef8eb8e757da0b2432a56ec648030c122b5ee",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1426,9 +1099,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "043395c60c74d97615e10309748bc45f",
-          "sha1header": "008c3a67aa1323b2f3cef03f720942ca4c821ba4",
-          "sha256header": "f594e51a787490750f0782b198ffc614fd4e2b8e9249bc6f1ad24f7dc84c6bd6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1439,9 +1109,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2f1db34c39a537d71bbba11e2406937e",
-          "sha1header": "9956c3c6d538aa878887fb4d4bfc6ac2cad67c29",
-          "sha256header": "8e8ec7d0513b02dd6ea03eeac18c91a4113439f46d2d573de3c5218a4d1c180c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1452,9 +1119,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e729c5f8033c2d977d5ebf1e8b33cc6f",
-          "sha1header": "40fe368ee61f18a3e655683de658004809335d61",
-          "sha256header": "114d19e1647fda8b42593b683eef81b1814195e5ca16809ddf3e32d0553f7cf8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1465,9 +1129,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "69235012ed0a903800bd9c4fcbaf8761",
-          "sha1header": "6db25f970b009a2dac84ef8efb6800ef29f0791b",
-          "sha256header": "cdbed8db3464ff3f15c1b75e9945b65adcdd58441b7124ff6b0dbdce6829134e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1478,9 +1139,6 @@
           "epoch": "1",
           "arch": "noarch",
           "sigmd5": "b44c2ab75a5d88f9308d73ddcef14b6c",
-          "sha1header": "b4951b4bd3ecfc274bb2fecbd8758c845052ad76",
-          "sha256header": "0bab2bf340a42c66338f4ec6adbf69cf6c7ec8f4e02a76b055b4a23c1c658047",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1491,9 +1149,6 @@
           "epoch": "1",
           "arch": "noarch",
           "sigmd5": "e5fa98e0d2b0510788b0bf5e31a45e4a",
-          "sha1header": "60ed83ac20a52f89e785e7075d30ff45deb18733",
-          "sha256header": "671212a59ff76ff5f11bbaf29f77a480e9c24f83cf05cf5211e3d6be3f060573",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1504,9 +1159,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "84111e859cbb0c83fef9f7795603d441",
-          "sha1header": "4605a39bdf5b5a78d9017b006526ccce5d81a8d2",
-          "sha256header": "967a939e20594954a51c49c66889f7f91dcd502d4193ee213d970f01c954ad74",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1517,9 +1169,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "f9f0e6b7d3099455104cf4853e2c0f53",
-          "sha1header": "66168d5e34903c583bc057d2d7838cef28e79754",
-          "sha256header": "e27e6a133c0e4c7c9a7f37c557e12d2dcf23e2e7d3cad65570d6a0a1261f6724",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1530,9 +1179,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e62abb15fc1e4fd32e375efeab22bbb2",
-          "sha1header": "b327a8cdee41951886902306d71d1f4026276278",
-          "sha256header": "3404e33f9feb16ebb80607d2e08de421e37b3d081ef73bb98351323ff7050f08",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1543,9 +1189,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "982e565ac49980615506b41d16f1ca4d",
-          "sha1header": "04414ff87e534ea8e647a07c8529fd571734966b",
-          "sha256header": "b74528f9638ff7a390955b52ee611f3e1c5a29f39f1d5170ff3adc9206c2b740",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1556,9 +1199,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4ba76ad8907145ee15d2f812df0dadf4",
-          "sha1header": "75d086b000623ad4bbe71935a52cf1214aa7ddd8",
-          "sha256header": "eb189eb43b95817a5002d7e7ddb5976b2b524f37e73741257ddc425f3bf2c7dc",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1569,9 +1209,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7c57c55271f2331a2e04d50714134d72",
-          "sha1header": "c8677eadc29f9b1f698bc38f60f77e897890ac05",
-          "sha256header": "bccfac4d8dd3406f18895fe4ceee219bf975a149b3238708305e17c1622bab30",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1582,9 +1219,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "39f50cd41960b46b104acbb215e1f9da",
-          "sha1header": "3ac25bca6b81ca7742c9b24e9d42007fc3f4c749",
-          "sha256header": "bb2cd9554aa777f119ae22a6399447b603f08a2f9bc6d99d25cd5cd609428e6e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1595,9 +1229,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "072b11037e3f709ecb73875e2ea92966",
-          "sha1header": "ab71de1b734444dbb7b14b21d0fbad2e7f226874",
-          "sha256header": "24a56d3eadfc012952eb5a8d4c48dcbe3d1a15bc42467ea805a453dbad3f4f7a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1608,9 +1239,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "50973d72267a2efa4d4dad3097ddc160",
-          "sha1header": "7fce65bbd14ca626f14c67d54d717de31426ff65",
-          "sha256header": "d3561a720bf96a62bea6415c98100684d2036a3067caa92daa91f15ecf22d30f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1621,9 +1249,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2ea05efa72a4c6987729995a507592b3",
-          "sha1header": "832db7773a11dc6708c2a2baa8cbdbad2f5689d5",
-          "sha256header": "24b28e6bc70c0c9a9ad97609ee4a3ec73e7ed3620cad04ff5b5ea3c977374148",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1634,9 +1259,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a3eb19dc9cfa5a2fa198408ccdc31494",
-          "sha1header": "a68600079f2dd5f9eaa9f0b57a24cf3c3d4acecb",
-          "sha256header": "15433379983e9517e6949dda9b92678ba82bc4fff92291ef8754d04737911b5f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1647,9 +1269,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "92a66b5a8124ba5305a9e9dc06f15c1d",
-          "sha1header": "2a0fdee2301f45398e9761b97054833755e9bc2f",
-          "sha256header": "570786f44def5ffc8b7977cc19d6985349b4f1e0e2ac579336db540429042065",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1660,9 +1279,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "62bdd5ca0a3992795c0475fea47383f0",
-          "sha1header": "fd85ccf6d03cb8ec684c34dd5e7fc97d41fbef91",
-          "sha256header": "8f07417cdb00c9d8066431aacab7b11f1fae2d98f997044b4916f81c3715f62e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1673,9 +1289,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "7dab7388e85de7f9db6bff61037ff351",
-          "sha1header": "76165c38aa052dd59e6c7e5cb8e1de702bbb5d57",
-          "sha256header": "6a7c7d6d9281b5a8a8e676e1c2b05f915cff5635791f8e011aef755b0f1e77ef",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1686,9 +1299,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "31f70956a56fa88003cb0954df97de35",
-          "sha1header": "4df395d70a2ea5c81a5e6e256bafb60db44fff40",
-          "sha256header": "4df68b3c822f27817d52a5f41d5423d8080e6b8b460a68ac2dcea1b21843355b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1699,9 +1309,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9803b43db63e9ecd1380c41c7c26dec2",
-          "sha1header": "2e02f6a968421cf229db5baabe68b36a17725f45",
-          "sha256header": "1698217f3e65f2a7f6dc89d29ab94cbcb36ace367a5326cbc3c208a34b3a5454",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1712,9 +1319,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1877d4e92408444c262141638f84b872",
-          "sha1header": "f09eafff7407ba679ed2a535d7dfce752b1e1f80",
-          "sha256header": "63ad56404dc7c6056531d20b63b5b3024967a8d5c2b456906c30a78fd26d8e82",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1725,9 +1329,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "fca8ecb6ad0779bfb665a9418e76f5ac",
-          "sha1header": "eb87d4c5f706c7741bc22532a747a121eecc0fce",
-          "sha256header": "e057a971f1e396c999f6e8f5fa74ae03cbeb561fab69196436f170053ec19fa8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1738,9 +1339,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "764a53d85e371955db0b6daed857ff85",
-          "sha1header": "64c3be7c6ec73f8d568b936d430dc243e055b50b",
-          "sha256header": "3cbe2cee66da58d6521d146084c70b0c23df61983fe4f601ae4ff9f38ecd2869",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1751,9 +1349,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4c95ffa913c03c43c44cca53815e0423",
-          "sha1header": "529d212635a6479a9bf8536dbe0d057ccc170559",
-          "sha256header": "7e1fed15a40e653319aa9255299249a710960968e6bc939a8978bf4f0bf88271",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1764,9 +1359,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "da411826f5efbadf8780d167ba437178",
-          "sha1header": "aebb8a1f57cdfaae1043baafdf25d5c8fda62335",
-          "sha256header": "d51812cd8203a65bddc2092a1fdb501013a43b33e9b8bdcc760c2601951661cb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1777,9 +1369,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "06292b63c7d00c75f3d727fc923f699e",
-          "sha1header": "146c44637c0bc167a2eb15866568318c73eb1f1b",
-          "sha256header": "71177a54f9d52a8afe2d3866092e088e7c42c18a061be5b808aacf1e34b2dba5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1790,9 +1379,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3c8e5cb5827cae6a18a33bf537143374",
-          "sha1header": "e89351eed5910cf9b771a5d34bdb35c2cf2aacd6",
-          "sha256header": "40d1ae7f0de7d21d3f3d4dd75e4fe22425ddd71c2a9b02cfcf30046376ace86d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1803,9 +1389,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b839fc87c244246b4b4b1ccaba68fb6f",
-          "sha1header": "cac61ef934e4c62613051787b24a5d42b2a2b3f5",
-          "sha256header": "fa2654d6db0c5b09bd1e09133fec7deeddf250cb06dcc7d1153bc2935ef28390",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1816,9 +1399,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d4d24ca1fa08981fe028ca02a109c941",
-          "sha1header": "06b4cee0ef13eb500501123241ec49b14357f7df",
-          "sha256header": "5035d7c6fb05fcb466610287b17e2e6c62ede61215cb960ebb5adb5ea8e1f8ea",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1829,9 +1409,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "eb0c48004939752d989591f7a68f3106",
-          "sha1header": "13a96f4df03c9e4f212a07cf85aa4eb220d9989b",
-          "sha256header": "351c9ae58ec7b07039737c72f6c4c7d1a11c84b64658ac55ac51be2610d15901",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1842,9 +1419,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "24b84df05465b6ceba9ea2604a238738",
-          "sha1header": "19319d7fc90cd33f0438997c0396645f04aa4899",
-          "sha256header": "f28cf88a12b4ddbfe5612fbc74b8417127d5aedffa32601174bf85d7301a1fe3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1855,9 +1429,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c19fb6eba7d41637fd25b85c80e7be28",
-          "sha1header": "f94bf46c4eda6b5f79243eaf5cc2eb78d76f60dc",
-          "sha256header": "410b5b3ffcad239b4677dbbbe34e0d7c131e5ac49238fb4ac60792cb4ad03bcd",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1868,9 +1439,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5158ac22556893218d13638e6f675960",
-          "sha1header": "9fbae2933e474de667ef0de743ac6b7f00902e14",
-          "sha256header": "5ac6ccd84f3488dd5ebe2a3d16f7107aaa0b7f21f03d8edf2ad8d0116a7c0885",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1881,9 +1449,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4d310ec9a8454d832f9661c681019233",
-          "sha1header": "e59a99a7dd0bb4ac9230b4262f4f808b5f783686",
-          "sha256header": "0229beba8737f0b1c14802e529eda2c0a9ce0f1a9d0acff26aed7bcd42891f94",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1894,9 +1459,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "196c6c25fd80fc9b8247562f1f9f3bfb",
-          "sha1header": "9037ad1f00c8043b5a5c63dea435e08ebf748c3c",
-          "sha256header": "44a86d8257b3f56212f3a7db716733ca77a28a094db9775ae376240d18c12596",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1907,9 +1469,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "af4504b8db8a9e0ba65a4884970477be",
-          "sha1header": "35eec72feadb608fff4376cf2103020cbb23a9a5",
-          "sha256header": "2538ff9bd960c4c595636309a16538f9eb0c8543f535f8579e90cb562ca856f8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1920,9 +1479,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "a2c5b14ad65247c82e824ee522224f4a",
-          "sha1header": "097067e520167921ba29a9d5b66e2dfef2b672b1",
-          "sha256header": "f675a229dec1e003eead9d3ffdcf29752036fb7d202847fe6b5a7c4075b683ef",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1933,9 +1489,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c5650a3ea92a9afed15478c887afa2ae",
-          "sha1header": "33a81b6f713a5f3effa7195f7a54048f23435035",
-          "sha256header": "75cbd14e3f6eeee7d6908e11cb9cc490346d3d6c5b74a53b69d95d0d51349a7f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1946,9 +1499,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a31fb9bb23c0b7ae4fbf1e1c589c0ccc",
-          "sha1header": "32734afa208df63f0403230f3632d76bf847fc91",
-          "sha256header": "e6c2b4c9ca85f9a90fd069c71a27479a163d6fa321188094ef3947c2ba9ee908",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1959,9 +1509,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7c53572660c72a580f0956083c2fad6a",
-          "sha1header": "0c6edc1081c3a1f18e7e83cbbfddfed540e336a4",
-          "sha256header": "1e347a35388a1ae9a8280f880fab10d1b69b56a55291bd6df7300f8f6c170884",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1972,9 +1519,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7f65484bd2e48764ccdb696b4d4d64b8",
-          "sha1header": "bde611899495516d466896b94ec78c055babcd75",
-          "sha256header": "bf8e673028c64525766b088204aad907a4fc6e056a19265072e8677dd9e2a368",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1985,9 +1529,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "691c5ee4c5150a51a33b1824bad74089",
-          "sha1header": "726ad37a63f7fb2e0feef1188191a2d7139f75e9",
-          "sha256header": "429ecebfbcf71595fb8af7cea05f4431220723fd7fd8261fac358b478e7fb488",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -1998,9 +1539,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "8f95446e5b942b261cc96c6f877c01c1",
-          "sha1header": "001914dcee6446a5d4247e4fa07018ec79d5ec94",
-          "sha256header": "a9b545bbeeab8d68084659c286c062ee2d045fe2d7fedd9dc90a45fa6483a796",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2011,9 +1549,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f88a5a63ae36f74decdaaa11a8ec42ab",
-          "sha1header": "2477b25b31468aa8b75aaabaff7fa418576da02e",
-          "sha256header": "b0cf5ba2e8a147fa41ce0e13f7248237402a9185bb97dad558697187c1a2f59c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2024,9 +1559,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "eec8c623a5fd070e08badb9e5d1d197c",
-          "sha1header": "afe5a78b9e79f80a5052f0a9cf3adfc789615f75",
-          "sha256header": "6ffe3a4f1129b393418085130ea43ace4020e4f63749ed9726b5d7e6101ec963",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2037,9 +1569,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "0e4098f1a3dc2358a9f50702a94cc6ef",
-          "sha1header": "a939bc20cba5d62e1c8d818ca8381d4ebc14f2f7",
-          "sha256header": "d59fc42c9db4dba604f20c0d3120b2482fe82d1848ae65fb1879cd1fa6e738b4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2050,9 +1579,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "9dadd0f5008f47e7c8f679ddb40918f2",
-          "sha1header": "21cc51eba96965ed233d9da9cf444d20b0208682",
-          "sha256header": "9c1b541e7eece57e9094b6e4141e184125ecef12ae7aa8f8a81b7955e385bbe8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2063,9 +1589,6 @@
           "epoch": null,
           "arch": null,
           "sigmd5": null,
-          "sha1header": "d487d50c2f29ad851e3839b4e3fba5b98a80f334",
-          "sha256header": "2e55c7b02910e0ccf51771630979b450ce2d63e8e72171988bc57b26a156faed",
-          "sha3_256header": "12f62bb7d55572dcefd9cc04904f208cf4917319632de249ad21505d41503c9f",
           "sigpgp": null,
           "siggpg": null
         },
@@ -2076,9 +1599,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "677e4e7424972099328b994e7bb6c162",
-          "sha1header": "cc9a1c865443979db99863126c6496888fb3ea1f",
-          "sha256header": "649efb66a5197789706fdef0c1fe24d57b85c32b6d2d6168bbb206f972b008ef",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2089,9 +1609,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "394da93cad0ebcfa7e61d8fa63f90180",
-          "sha1header": "c6d49a19a9ac6e30ce56899e8243f13915e7cf12",
-          "sha256header": "22c37e8a4fd71c6f5e133fcf8c3677be432404f3f275da41b798e6799fdcba59",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2102,9 +1619,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5bb27ccb30fa1c12652583be61671c04",
-          "sha1header": "61fa4fe4e4ec38d5cfe349cc889e092fa1913e0e",
-          "sha256header": "8a30500c7a952511de5948edcad1852b7f6948955329da00f4c444727d1eccb8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2115,9 +1629,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a0f98157f1cc2aea27a8141bf7873859",
-          "sha1header": "7b5497124a1f5bf6a789f52383957556a6b2fe37",
-          "sha256header": "1c6813d8fff01cde30ff7215d350327ad9a133545bf56349538cdf79fb2d2dae",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2128,9 +1639,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2f9647fe83818fcb1d4a23a2a59de01d",
-          "sha1header": "e8cfce11ccd628a4d4548af46818bc99c5f414d6",
-          "sha256header": "1f4be4be44315b2dea7a946f5bc9d43648e3837ee18b4d88c05249b09bee5eb5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2141,9 +1649,6 @@
           "epoch": "1",
           "arch": "noarch",
           "sigmd5": "f91b04c003b7ca20807f1407d7cbc156",
-          "sha1header": "26f6870a405191ce6bdf8bc53e0a5581a19c1ed8",
-          "sha256header": "ddbff0ae8ed4fd64ff79ecce97907834f913da209302f706244dea9886ce5c3c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2154,9 +1659,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "0c731fb7592a11dca31f08628025ac20",
-          "sha1header": "672d1c16c47ccef60b6467931a8f08ab31f615c2",
-          "sha256header": "86127f2b02c8accb39551e5ccd48dc531e51e49dc4acb78363d2a94432b72eb5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2167,9 +1669,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "219de7fc7d9629c7677321c59ebdbb91",
-          "sha1header": "6c5ee0c196e9a61e457bcfa1e590b3063d4fd715",
-          "sha256header": "e49b8432a87028811c6723ebffba5074def4bbbb2440deb3ba368d691b728052",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2180,9 +1679,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "bc72c5f5e8bcbb18f02871cb64ddfce6",
-          "sha1header": "af823f9026c75e9a868297a5545f6a05690743a3",
-          "sha256header": "ca6d5bfab2c160d314acf98310a71e3e75e27e8fc81ca2be2d133bb0e97aab60",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2193,9 +1689,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "2b42c02023f904f0612232dbdacc7f2d",
-          "sha1header": "c97b516e77c4d253fe6128ca20e728119cf0a39d",
-          "sha256header": "4746650b75a236c25af33d68ff9d76c1517dd21b67741e0fbc4fc73b37821669",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2206,9 +1699,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "d908264c76bf5fc4963beee64986bf7c",
-          "sha1header": "080f174e6b0114623ff12255d960924cc5547212",
-          "sha256header": "e856174143fc36bfbec9bdff42f3576a4adb7ef80e6555f911fd910008e9c0a2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2219,9 +1709,6 @@
           "epoch": "1",
           "arch": "noarch",
           "sigmd5": "ba2f4dfa21c56ade0d8ad03e37f0531b",
-          "sha1header": "2f25880a16a1c9dbf4d9c5dbd8a5d7a81bfd9385",
-          "sha256header": "179822de62aacd8e8f5300cd935d5f7ddfebebf19f9306062938e393f6b3fe88",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2232,9 +1719,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "d69d431a75e469945ce88794c868f0cb",
-          "sha1header": "a4e408f6b64d15e109e9a7ded8ca6f69b2065df0",
-          "sha256header": "a4a39920b76f98eef7bf92847ad6882441f36b0b3b912dc69de862732fcbd8ac",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2245,9 +1729,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "9436637a49fc3458dc822c5a6d1b54ae",
-          "sha1header": "42c2dd0e1ddc32bbb5742d0dd18b12a44a57d1a7",
-          "sha256header": "15d630b10c979ccc96220f5b3408fb6119ffd406fe0b845f73425f2fcbe8e224",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2258,9 +1739,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "73815578b58706b5e9d3a6f8e672d382",
-          "sha1header": "754110a3261600e0d2697e636fbfbab65da561fe",
-          "sha256header": "5cd98cfce8890ef487fdd791aeac0bba1111087b441013e6a071d56a0aae9285",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2271,9 +1749,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "0ddee6486be20282c8850c2a6ca92b91",
-          "sha1header": "10e77ceccc85ef36833d55791f094099ba9d7248",
-          "sha256header": "5f376ce369f898d1520264e34f4fa396cbd9594e0126871c8ea304a636ebc3a9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2284,9 +1759,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "52b2999ce0a85f7a6e89bec36e8c553b",
-          "sha1header": "c1e115bbd72b4763746929f5a1ccfb43df311d4d",
-          "sha256header": "4310371cd4e26bd911825efe9777e1fcbe5f1ef6c6c697544ece19015574480d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2297,9 +1769,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b2edfdb6dd35cf868181ba6a0657b9cf",
-          "sha1header": "9b501206fac88230949ad62223c7dfde9e9427ac",
-          "sha256header": "6ccd63889f25b90644b89ec9fe93a212608dc430cac0ce5d9495b917bd498b4d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2310,9 +1779,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "878765d4ef45f38460c852b547ca5a0c",
-          "sha1header": "51126d72f3b18c5440f528a2cae70ef559d47656",
-          "sha256header": "79621eea42879517a927482dc37c580e63c02fbdd899e8171a52a111aeebcae2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2323,9 +1789,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f3ef1250e4806e74c3f16bac56b5b0d6",
-          "sha1header": "f5fc0551a7d1bd23c2d9a8d92c930d19c02e1d7f",
-          "sha256header": "abdaf36e7a3bdce4700a3f5acf2eb7128679595c063ce3c1500b05bb87e51301",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2336,9 +1799,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "fc88f9e63f5dd9476ff661f0b17c22e2",
-          "sha1header": "6cd89b6ef8ebb0cf2c84a9a0ea2e2d0d747bb6ed",
-          "sha256header": "80d128f5543a4f70c12ce3cd5dde7e75a63c7562566abe8ebdbf243f07a4e9d3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2349,9 +1809,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "39579b7745dc69a44d6d2ee8ab1ee284",
-          "sha1header": "b9ecd4f9f375b3e7449dadee798c22109ddb0362",
-          "sha256header": "fb67b5714dfab0cd68b9305ad57d76dd1a8265670a1747a250e98f4c2a355a94",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2362,9 +1819,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "8a164999779c609eb9e354bda628ff20",
-          "sha1header": "a75c79ea22a0de7b6eaacf3c463e05b009b2ab17",
-          "sha256header": "f17426b7f775e1b8ea1992505e2823ada825f033fa20a055f34359952ab2f5c5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2375,9 +1829,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cf08c6269720f757019671e5b1f5ce59",
-          "sha1header": "c57e094dafb034d8392fdb1ad10ddcd77c2c81d6",
-          "sha256header": "0ef3fdd09d356b01c8d32c58e389657a9f6d74ccef6f31c515159a207a5469c9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2388,9 +1839,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f10966eab801cc6c2a1aeb96248cb514",
-          "sha1header": "9e71630be9df52ab38ec812707fe2732060958e7",
-          "sha256header": "ada5ddccc6e401f84874724d751eed7274378875794e04e29ea32c7f7eaba6de",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2401,9 +1849,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "0659b52f5bbf0fb86864f68dfacad408",
-          "sha1header": "1545d7ebe47b6446e85f97f27db455e00b69b64e",
-          "sha256header": "170bd8b8902a9c9262764a0aea2fec166519b36c7dd902be049e04374a93077f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2414,9 +1859,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "bb31ab2305d6a59696b4dc0241c30b45",
-          "sha1header": "f03eb4410aeacf72a03355ae526f36d83eeeb679",
-          "sha256header": "17a6faa91ac7fbdf84b5470db163be67f873bfbe257386005ab3bece89cdcbda",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2427,9 +1869,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "63a4871a51a56b6f0f0b49a23369167a",
-          "sha1header": "e437e90e7671e00fb8a97f96953c721045dc960e",
-          "sha256header": "c6ab0b6cc0f47935bb6f30d16ae5f9da22ee74e2eb1b6d6aa8853362ce8ce0c0",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2440,9 +1879,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2048c8250766c30d55973c721825ad21",
-          "sha1header": "494e900e44cecc84a952da120f5ef0a7d079b46c",
-          "sha256header": "0d0cf88bd81c3e112ab0b402b334bbf54f35d0a1e23111accb500de95513d13a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2453,9 +1889,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "819da6244c0c665a65166e8f85b25745",
-          "sha1header": "110bf70375d05edfa02a61a676f69017b69bebad",
-          "sha256header": "d191321920436991bdba01aebd8d08ecdf0f3031da69afa4cbd35b3d20995a1c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2466,9 +1899,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "cf9ff2002c240bb5df00bdae9df37cd7",
-          "sha1header": "ffa1c154d20883ebde491b3abb834b5f96bfbadf",
-          "sha256header": "c087b1ecf3811d4388b566e643156c42386c2e639b455c98c5be52ff16a26420",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2479,9 +1909,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a58d8ae46b474a3be2032b6b7f9061d7",
-          "sha1header": "4b012aac691f3d2b2dd802a5852f6d003f972e06",
-          "sha256header": "3f7675e98c284eb573092c86fde75731a6c4a1486d89238cc0cb3065c674eca0",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2492,9 +1919,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c4110568e45ba4ae39dc1279ad3abcab",
-          "sha1header": "29896012c430bbf632fbe5af7cd35a042557762b",
-          "sha256header": "9c890c9c06b96dd361b70691f002624103f3920f8ce5c081fbd544c8de32bf2c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2505,9 +1929,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "d4ef0fdebe4ff233d13372c0f5ec68e2",
-          "sha1header": "0891f548c5c10b929df940cfbc721b1faec72cfa",
-          "sha256header": "af1724fbe00adffeb5da95f4bdcd1e1822d8d3e553b050e31dfb576fc42cd7af",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2518,9 +1939,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "93f38e7b9433ebf75a0d60e87a4e36c8",
-          "sha1header": "92b80c31407e71985da1e52a102b80ebd94ca391",
-          "sha256header": "b1df406f4ee8f33d96a9bbbe821337c190e846590f406a720776b6a0e43d1a05",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2531,9 +1949,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b3c6ec8aa374b55ef6f0620248adbe40",
-          "sha1header": "8c452bd61a3ad1202b0a7acd3a6791600b4596a9",
-          "sha256header": "6032e2094106656ca955161581e1f28149cae482cf42f376989838d3433c1b09",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2544,9 +1959,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "5376f248393da14b558a3f493272287d",
-          "sha1header": "e5584245ea16318493bb368cd449989db09ebf73",
-          "sha256header": "5f75094f440bf61e8e3e30df7fc6981d0e150d77829c9aa06f388df4512c1a65",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2557,9 +1969,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "061312e29a3232292f707fadc44b5aa7",
-          "sha1header": "4c779c6cb373b749f57babdf634ddd09e0398757",
-          "sha256header": "7a8bbd4cdffacec34417425f1b624e64479f358cf702258110d1412356807266",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2570,9 +1979,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f450e540f30c3841a4164f0dde10fd5e",
-          "sha1header": "471b27aa19875c36addea0a3836b2f5c9a900775",
-          "sha256header": "f64cb44232c815892ce107a5a93b2b5ac4e48207fa44d161f417f8da6016ed0c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2583,9 +1989,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7a59d015056a11299dfad1a400198dd5",
-          "sha1header": "b0510f14f62ef50ffcf6ca856d9357ef20a29060",
-          "sha256header": "eb3a27eccfd69bb9a1ec0e7aa2349d4de219d9ec96825272e6d996bf395bbaab",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2596,9 +1999,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "9451e885156a363474cb84fc0b46cec0",
-          "sha1header": "9b373f0dac0edf14fa5854c2bfa16001bb291b3b",
-          "sha256header": "7d9c2135147e4fddc68c564a8ed3be1a64ed19aaacfdf864b53dcb23bd446ead",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2609,9 +2009,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "c2cde41b496b7a77750d40d1b649f999",
-          "sha1header": "d58f5a201ede5aa697a706cea9793ff73d6509f7",
-          "sha256header": "a9c823b0cfaa972717bbd5cfb701977638bc0ad6746b4d2b0ff46c32a0ef8db0",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2622,9 +2019,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "aad613572918a344cccf474ff7fa53b6",
-          "sha1header": "bd6143cb5a03d6641ae621f5cec1d7369da18eb9",
-          "sha256header": "cef0f1fb2c10b5e1547cc61dd3e6461f6b9bdf123a9ab035fe1f53c5cbaeb180",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2635,9 +2029,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "14b1673d8249e3e17ab5686c435c590c",
-          "sha1header": "68065281e5f43c6426d3e042968a7c05612d95f9",
-          "sha256header": "885036866e2b05609de54661137ae81f0b2fc97500723055b62e8f6b4b445cee",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2648,9 +2039,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2d7b0b9ae1d27976169d0b680beba8f1",
-          "sha1header": "490480afcb0d39e62302f077c085223d3871f60e",
-          "sha256header": "0f7c3c2979829304baf7bf0ee01247c17133a828d9fedf4cef3e9395e83943e5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2661,9 +2049,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "3e099d92bfd3dd9111646c0b886138a9",
-          "sha1header": "aa77daa0ee38ed0edce9de1256789b6fa60b5200",
-          "sha256header": "d684c387bc34d314d22de9cba52aa02b21b8724dbc9c79014eeaaa9bf856125f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2674,9 +2059,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "202f6981047dd8bad82f93ccf7a4869f",
-          "sha1header": "50971c9c1e11d06bde22522804c6a4556bc58616",
-          "sha256header": "41cb6ce2009c742bee963e8838c8e35fe0ff61e4673986d8abe74ab04156f9e8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2687,9 +2069,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1e9f00048de447a36bae2ebadad45312",
-          "sha1header": "f6bbc40222338fc071c8a0a31ecb14a5ecb0f210",
-          "sha256header": "b2d42a448584f686aa3fbbc81c5ce46eeab93a7e3ad080f46deed9e73a813c73",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2700,9 +2079,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cb73c09161a23a1474992b49112574c5",
-          "sha1header": "7ca684a290b3c1188251be2623ff3d3515cd3931",
-          "sha256header": "cacc3dc94b50198fc14c0ad591263eecb824df7e51bade35633ae5dcffe1c533",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2713,9 +2089,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "69b6666b7453606fa6383fede9500d44",
-          "sha1header": "080f8484bfa063fd502fe1863bbd742a9b1e8f25",
-          "sha256header": "cc9e73779ad1437feb5759955a3edd9d25025ae6d1895402dff6e918ab893dbd",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2726,9 +2099,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f0ef0eee7c3081bf2bbfe2099e352fc2",
-          "sha1header": "f0c9f5a898e617ebc846545b2edbfc8a91bb7b21",
-          "sha256header": "180cc0029f59f6fa06f1be7804f838fd50eea8f7530fbc9c5cd48d1f97145f4a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2739,9 +2109,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "13648fe37e7006d8a81e54262d30167b",
-          "sha1header": "8792bdc177645cd1fb3b96e5060bcce14f34bd75",
-          "sha256header": "1629fa46acf61e0b01636b0d9c96ab609c754a6d99e74e595ffa75116e0c4ff0",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2752,9 +2119,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "164a44e993e1f6fa5cfdf125d05257e3",
-          "sha1header": "5188be8c05c74f4329ddff38e0af7e14036a078e",
-          "sha256header": "5c77956d065d746de0b0eacd4350340d0100f885071d48b92db0bdeadaa7eb03",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2765,9 +2129,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7fa7ff913d7fc4aa6d53090cff43a588",
-          "sha1header": "7051fa3d0bad53c1f30ed31e161d79d8312ce06c",
-          "sha256header": "0aa92e61598f8171e43a572c4bde9d27d756545bdc8ce5f11dfa67c1a09de888",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2778,9 +2139,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "fbac3fcd9ff109ef339309eeab134d86",
-          "sha1header": "8f3453ea02c11b9595268ec00c283a2d0b954a9a",
-          "sha256header": "7dc44a6114dd4e40fd8ac19366903554a29351ace268eefda88471f03dcff03c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2791,9 +2149,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "0eee23d2779486b4bdab6875bc610aff",
-          "sha1header": "079a94d867bc62c372e3e996154d4ee8765e0dee",
-          "sha256header": "781acc75da9292fa96d00cd539e7ca15bb5df94fe325eedbf67277545b6f474c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2804,9 +2159,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ac29dba6326e350f03a633234f58e8eb",
-          "sha1header": "ddb5f185872f732ddc74aa7c261ba1cc23c55021",
-          "sha256header": "55b88c6f52cd87b49667ff6a535176632d76deb25d07734976e8bfe674ff722f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2817,9 +2169,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "bff25850110d7d1134a5f0673a3c0354",
-          "sha1header": "b23a6e152192e449a470a3f8343f05332084b8a7",
-          "sha256header": "b6ab4ac7f32fc9b52bc4ece3c8da7a6d515d3e78ca7ec26b14e0eccb64d2ad40",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2830,9 +2179,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a7969f7746cff5ff1dc47a4dd36f70ff",
-          "sha1header": "58f62a7b803696cde925f3101bc3a7a6b28b8394",
-          "sha256header": "d00ba1172758fa0859a6910a7b7f45f2a4cd368aab4ec71bfbcdd9f01fe02da2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2843,9 +2189,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e37df5db39982ba1142643b65bbc37a4",
-          "sha1header": "95cb9aece93c939172f7aa35b5b6417fbfa1da4b",
-          "sha256header": "e9fae5ef85eef40e9c8d2518d4e2afa689537f593a59297b3850bec80cb49969",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2856,9 +2199,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d63879e80d61a075ebc0f2bcf83c5e80",
-          "sha1header": "4cf51f8d6487bd4d2e28350c3ddcb844eb3e95aa",
-          "sha256header": "52c6d435ce76ab70a099d24acbf31291d19142eb0ba3a8e59637ce9f7d6b2c69",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2869,9 +2209,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "54cbaedd569e31754ec44c7f7e9b9896",
-          "sha1header": "624d8fa91cfc3ba1a1481245c4b85d6a13f2e164",
-          "sha256header": "53a0e3b062b39e3083ee7181bd35ca9d793299101c7422315b5ae89186b7b0d1",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2882,9 +2219,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d1346fa55aada0fb897a2c2b91b44f1d",
-          "sha1header": "a21cdf35040a44edd413b661eaedd3e48eace0d2",
-          "sha256header": "120b295517ff1dd9bffe5b24fe180a199edf4a9c1b234abed1d815f5698297d2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2895,9 +2229,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a683743796070fc9e63cca4069ff691a",
-          "sha1header": "9efa89b2fdd7cac1022401d253eebb60b39601aa",
-          "sha256header": "491f34876ef267b2dfc0e33f4865779c63fdd4eb8e9c57e7542425eca621369d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2908,9 +2239,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2ac771d894df7cdc585b8eec021d5709",
-          "sha1header": "b433b40461dd532038ea29240f55d920b57bd566",
-          "sha256header": "3c1d56d7b942eb8ba573a8492ff148436b75bf7997fdd58662d6016af49cf83f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2921,9 +2249,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5ce63962ed57005afe11e3be159d50ed",
-          "sha1header": "1b841a6c4c5d32b0bc870280f5eab98d03221ad6",
-          "sha256header": "b770635d599385d47e654120502c17dd469abcd42a3751c76e861ed8c8e143fb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2934,9 +2259,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "aa76f9003cf98cfc820caee291eb27cd",
-          "sha1header": "cba3156efaa006fb77bc88cd12d013ae938dd17d",
-          "sha256header": "34c4ccfde99e827a2b29bb821d2237b8e06c610b21262592accb15f026b8c9c3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2947,9 +2269,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7439cc1fe88c988714d8723ace6ac354",
-          "sha1header": "a030d0e737e8092ffc2bd053d0754e7cabd99dd4",
-          "sha256header": "dd21bcdf14bed6c40819ad0b03d5e0bff7bcf2c7ad9d2e9d303da7ddebb00b02",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2960,9 +2279,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7840cec75a6ca99968a2fee8e739b867",
-          "sha1header": "cf78420f43b7f893e2307dc7519f943dbbd3ec7a",
-          "sha256header": "4c92b58b897bdf4bd2b597fb88888c840eba2740fa1faba9a49fb2a9fb732439",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2973,9 +2289,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e239ebf083af19ddcdc1368e3125e2eb",
-          "sha1header": "f12d66dbc377ab06988b87228546962827e5a112",
-          "sha256header": "d9008d8009d98914010dfef0d522d6aa81f883d82926468461c0a9221e7eda71",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2986,9 +2299,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d3b6e3bc2bdefaa4b772c844a128cf26",
-          "sha1header": "98b040f8fadbc0e136327df41fd0c885dcbe2e47",
-          "sha256header": "74005bab6ac4b616265406967433e74680e287b0823a7eca06893e5e0a7b625a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -2999,9 +2309,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "623915b1cc55c52dce05457f697f9d68",
-          "sha1header": "8c7404cca652d75f840b3817fc051d314b4a6c4a",
-          "sha256header": "501f97471e18551a5625bdfa90ad48d801bf5b6acaf1dea1012073d987953458",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3012,9 +2319,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "ca8b3a0cc829cc53c29828c8d2898bca",
-          "sha1header": "9ae0b3a5e5742e634e7c5aad93ff8e2bec500022",
-          "sha256header": "7b234d8933cae6c9c95df9759da950e16e2ba293d791140e118f04240148d843",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3025,9 +2329,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d3ff723aae48f838e7de60338fade8fa",
-          "sha1header": "170228781f0dfffdcafaf557a61a5b593f8051ac",
-          "sha256header": "2772f9a50d2790dbebd6465e981b75ad8263468dceccd8e4a2f2ee61bd86bd1d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3038,9 +2339,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7510017fd28b430e6cc2ba86ebd0b44e",
-          "sha1header": "b040f256c098737caac85b21ae3da6d94dd52908",
-          "sha256header": "76ec1d17716b350c25c567821051696df1d48e799228c76f286fc8e6fdfe55da",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3051,9 +2349,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "51d9c1cd910a2af9aca16d08d1ef423c",
-          "sha1header": "55cb848c3e6bb914a377c971600de0feb0fedf55",
-          "sha256header": "5f360aa33ffd66edfb3dda72a3f543be838f6045a7305c7916026e50034664a7",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3064,9 +2359,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6dcc6c3857705847a50ff919ebd56192",
-          "sha1header": "e14a29e5d3d4f88664863e06589f617057d88d4e",
-          "sha256header": "42beac95fd5fb7933afe7cf06dbcede94aee95b296a15c9434d580bb4afa1993",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3077,9 +2369,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a84e72110f3ddb665e352c1dbf3617c5",
-          "sha1header": "0b7dc21f24fee7d0320f8c9cf282d7eb6e7ce236",
-          "sha256header": "838389bb4f6ca9834390a987d554866f80d19d236841214527eff5acc1955c84",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3090,9 +2379,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a212b8c48baf00eb3fbf38c0dae75224",
-          "sha1header": "749fc57ed3e7a7e7964e077674642ed2b57aaaa4",
-          "sha256header": "ee97cd594172e204bb23d2bda6e60f31312af8a3fa72b425a34515ac33a10ed1",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3103,9 +2389,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3af170800c0dfce15dd32e477b3b9efe",
-          "sha1header": "076d4d233fa79b91d46a3041d8745e30801acdf3",
-          "sha256header": "aecb3d6fd5ae0c9ef0b85a99e2479ab5d8ceec2a3130312dce79dc3acccea82e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3116,9 +2399,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "74484494c860c994936fd51f1cfb61b8",
-          "sha1header": "0af19f9b229a72155cb5433b0f5814fda461f8c2",
-          "sha256header": "8591d31db4aa8e65a28ca6d1a2de1191fab476d8ca9234931a7989ccdac84de5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3129,9 +2409,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "324e12234ad1db3ebc3b8890495dca02",
-          "sha1header": "a7b86ca037cb60040db73275d76a5ff4d6491bad",
-          "sha256header": "50020c10c53f664c45c8f86cc066157b4605ee2e90ae8261f76c6b475cc86af5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3142,9 +2419,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "52609c2575ed14288145d72369387643",
-          "sha1header": "2c21cfe457d5bf178903e1ae221171f0cf82b40b",
-          "sha256header": "bcc1dfea5a51e7dec943f995fe991e0d944dd5663d8ab11e3eea0d3f9d879be8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3155,9 +2429,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6d2acb70cce501224406639b90ada13a",
-          "sha1header": "8b0f89cc0b89df176b127a7a69846d84ca26809a",
-          "sha256header": "346e2a5aac1f1c9361db943c952227c0717b6edd567366f8c292591e29702590",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3168,9 +2439,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d4891495893b987f468dc692c5a48e13",
-          "sha1header": "1192222d3f68eb0b0f3e3b9381b4455d6bdd97a3",
-          "sha256header": "84cd1a595f9721dda4a52c3e1c6b6ff8437bacca71bb90bdca030ba076642f32",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3181,9 +2449,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "eed63b000553ce120a986d786f1ddcde",
-          "sha1header": "62599b60b5c701bd2a95d5e00fa93d3952ad67d3",
-          "sha256header": "f20dff1e27210e27aa6e1eaa0f9ec9d21fe3fb07f12c545f33289bf071b3b8ad",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3194,9 +2459,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e14a05cce859aaed99faad9962d6d8f0",
-          "sha1header": "206dbf7d7650db0eeb0cadd0ced6a8650f7f1bb8",
-          "sha256header": "aee1139e2b2ef37aca56236d0567aaf402a3ba52904a25b438fc84c01c5927bf",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3207,9 +2469,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f02ec7f61c23fa253757915f31a1d3f6",
-          "sha1header": "46a8bcc07669e8396e0532153ff7a99dd6b0da1c",
-          "sha256header": "a2fb9dac8b703e1eee53047b72174e2b680afda5de7649931a656dd7e76d246e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3220,9 +2479,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e0d9aabc9e1befb1210051ba2cacd8ff",
-          "sha1header": "32789debc349954f354708817ef35c24d3132225",
-          "sha256header": "f03177a8cf713a9d88cd8a128c1e26224897285078dd447d8b9d16a43e96dd4b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3233,9 +2489,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e944b6933ac4ef3ab8a25fedce112595",
-          "sha1header": "61d788546feb6d3f9909243792e547705eb8979f",
-          "sha256header": "6b855e236dae5c1240aa3e186d469526bc22972a3749d05805d21532fe65f500",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3246,9 +2499,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f06888658a3315718422798ccacf1672",
-          "sha1header": "67ae944da9e920a069347e716bb2f954131a58c5",
-          "sha256header": "14f25ea9a4a36144e3303f5f5c7d0e3428af590477a2100b1fc272b93e9a0eb4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3259,9 +2509,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "69c0857d53e55ede0bf0f58b9ee290a0",
-          "sha1header": "4137e49a4f2daeacf97fdec8b38a4b9b7ecbfb00",
-          "sha256header": "6061e09cfd3094ab83c0b13fb8a55252075e5bf7995e707a85589dd30273cf1d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3272,9 +2519,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "87dd06e058edba6a08beca62b861659a",
-          "sha1header": "d01758c1313260f1b146548875fc2b0f7cffcbd3",
-          "sha256header": "7c38ae9dcc72eae579abb20c43888639fc5232fbcc6736766e0e6ee9d749fd5a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3285,9 +2529,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4eca46f500365cab31261bbf79b260e9",
-          "sha1header": "dfcc1190c8e67c3d82301dbf80f37dde987c2d2f",
-          "sha256header": "3e2c350cdbee13a775a7044021b8c4c2d892803bb7355bb004c8e0745296b6dd",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3298,9 +2539,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cb7b066aa122a64bdb594490343847a4",
-          "sha1header": "9247be83fa866e69dd4cedde0c521f7788f34e3b",
-          "sha256header": "e5cc913cf667a754d18edfdc28ea3b9397a92364ab0614b8441a0dd1f6eeaa68",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3311,9 +2549,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "58a1218b6d634a8c0639a51dba899ff9",
-          "sha1header": "7f0b1fe3922fc6749b4f8e2b420ad9be7f09c67e",
-          "sha256header": "7e6ba206093a2487fdbd4efa372a4cbe075bb80944aa2e8bf2b9e5c65043c5a5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3324,9 +2559,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a60d6065c0e5f500381a9d264991df95",
-          "sha1header": "11e6f033ca80fa70839f383de84f61151b4263e9",
-          "sha256header": "57e1c4b4d1b96b3114cca1f9c6cb2a7fabba3d40b80737e31e73e7ed3a14b827",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3337,9 +2569,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d7960a3f395612cd1f7d94567fdf32ff",
-          "sha1header": "0c34c003085ce5f881582ddf4d7363ec2dbe6001",
-          "sha256header": "29ad61080081af35fca70d72feb3318efa5da22e5218bcf8df392979fba5131e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3350,9 +2579,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1ccd1d0087f412571a4d23c2d75e5608",
-          "sha1header": "9960b9fee23c4524248ef5e5df6b514a68c72133",
-          "sha256header": "2db0ad88ffbb2f1ca45bb4274258b0ecc660ee257975abbd78f0a60bf3a2ec75",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3363,9 +2589,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2ba1fe0fa24e3b81c3f801873e8e65f8",
-          "sha1header": "0a60f5bc900800b7321235a16fd670dd66dd26c8",
-          "sha256header": "99d30d6444f0357273082e251f4b753efe71ee86bf90bbacbd59111045e378c0",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3376,9 +2599,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "40ef5b3ada6e74e9d2bda4d1d41c5662",
-          "sha1header": "76ddc035e580d8f036311213d3ca90900b736d36",
-          "sha256header": "7cec999cc4bb99fc747b35bb99d40611a995f3ff72e3a7995e14b97e0a910fbb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3389,9 +2609,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "323b949f9571f6aae2eed9dd2644c43e",
-          "sha1header": "23e25f10de0aa8daa670f2d07306436734ac6ed9",
-          "sha256header": "aa4414e1dea764fee5a114649ae9063274914d0b0b026c8d212af525235a09c9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3402,9 +2619,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3b7c7611a6ac4f3abed3984ce1f26b07",
-          "sha1header": "4b3529990a2792d86f31b8a2ad88e220b2141b6b",
-          "sha256header": "697418d1575bb40033649e1ce42366444839ff4cc7cf39325dede7a846efb29c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3415,9 +2629,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cd54505327e16ff566fa216cd691c8b9",
-          "sha1header": "1fac4e108445737b17652fcb52211ef3060cf318",
-          "sha256header": "211e22e4c69ed5ee5454d4ea55e7c85cebb22bb1206ce1536c5139f28a58311f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3428,9 +2639,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "33d6b9d76af3348d5618adc22a943072",
-          "sha1header": "65c034ee2f76c3fcedc4bce107163aef53f3b3ff",
-          "sha256header": "00c1b4b2ce2acf88e574fdfc030daf5d69dcd1236c6c627322408fece8f7e999",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3441,9 +2649,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "e63b7e90dc2484d4dab495986d9c5889",
-          "sha1header": "cfefc77dd8f3db99cd13df107d4be784cd59f9f6",
-          "sha256header": "1552d510ead1f8eae30b316519679a16ff3fd33f9084f397d4d611b0d98db23c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3454,9 +2659,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "37a8c697683964211cf6a1a61e72c5fc",
-          "sha1header": "9d8adf996a94bb0dd43daf584c930d7493f372b5",
-          "sha256header": "e1a30aecce59cb92b82a85d0f3f30dada83446c4c4230f97fd14a94550cf4dd2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3467,9 +2669,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b10baf51257ac4b8d9fff873a9912357",
-          "sha1header": "069067999ed712cf7f469c460cb75177965d293a",
-          "sha256header": "3e5073b79d3fad700f3b238bc7f9cb23f09894e68c9ac4a7a1a3802b738140ac",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3480,9 +2679,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6029824a09340f947f1ad9305b9fb42c",
-          "sha1header": "b47ca1bc17124756befb743161fa6ae1488f9b85",
-          "sha256header": "7f2085ee1856965afa3ac0ce9ae8e13bd3a625f697fd01ddff346e52ce4a0d78",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3493,9 +2689,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b52fb6f2d73da86c33551ae60ca91f81",
-          "sha1header": "275d64beaa36ad3f73a2e133a0b42c9ccef00520",
-          "sha256header": "2f944191f7c66dcb916358486ec64583268c664cb8130ca1e63f23d803fb683d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3506,9 +2699,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "faa5461427b976647a8329ad229b8f76",
-          "sha1header": "4912caee17eea07f8c7eaee8f04d631d4ff03bdc",
-          "sha256header": "b8a27f516b203598504543c2103ea0bb24e2b444bbeef31d7bc925beab38a0bb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3519,9 +2709,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f155e43479412b9d85f77b449584de9c",
-          "sha1header": "72792afe6f4330d260b2e6a77b6970f99714766b",
-          "sha256header": "57055964a6ed4ce1c2cbca914342315680c45aa1e3cdc1ccbcb9f31f92e40ccb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3532,9 +2719,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d39e301464bae1847e0ee36b649b1921",
-          "sha1header": "b86a7f53a753af97e5995feaaa57504b83e70630",
-          "sha256header": "f60edc9018e14697ec74b413dbe441e3ee67fd7312c3c5212c6329affe223ca7",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3545,9 +2729,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3ecbebd3c1cac09ab2b5fced14f53f1e",
-          "sha1header": "aed3e8379ce50146489813b1de1d8789ededaf6e",
-          "sha256header": "65c0543e98e41929b8e65b4a2312ace92dbdc59fc1a02acbcff032d52ab89646",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3558,9 +2739,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9fca4b33e2f514329313e6fa04191282",
-          "sha1header": "d3a1686b78286dab4b72cf02e43c6396089c5566",
-          "sha256header": "81a816af1acb59b585ede4b391c859522c40a7ee3943a564a3ee76bfab2cff43",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3571,9 +2749,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "c68bf8e4ee41232efa0f793a881aed3b",
-          "sha1header": "c1116f5077feed2e19a0c6192548601189e3c619",
-          "sha256header": "c157e6a7865c91eab15dfddd86032619881c97c8271749b7d8e8dbcfd647eae6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3584,9 +2759,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3c84bf08c6e006c579d5b0be41eeb5ec",
-          "sha1header": "eeded814b7e95a5322b79e76a9847be5537b0a6d",
-          "sha256header": "45b791d7cdcf9e5aee4cf5c69b23d959459a8876906bb6a019921b71f091d203",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3597,9 +2769,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "161fc3a2918ff346e4e7cbe31f244fb8",
-          "sha1header": "336ad190b873535b22fd9dd4a482aebfad00c859",
-          "sha256header": "ae3c9f68bcbdb6435296b6f26f9925a015024cc92b473654b8de1d5a52a53ea7",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3610,9 +2779,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a62172008087e9f294c675c8a0407977",
-          "sha1header": "43b113f008f8f2851af4b6e1a5f354d5bfdf6d4c",
-          "sha256header": "de311300fc08f16ed057dc77304e44a4d5ac7d243edd9bea919197cceb5a8ecc",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3623,9 +2789,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6c3e11e97b81ea66734fd72167bfd9dd",
-          "sha1header": "67a81269b56f495db67912ee63afbcad6b631c68",
-          "sha256header": "cc5b74c7f8734e482cc1daca1f0979d0c44f94f4845a1fc0378cc69077700d1f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3636,9 +2799,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3aa419ba3850408a722e3c9c7ca5aff3",
-          "sha1header": "47a36cb33a7eb6d3a514f0711269f93a4aad5685",
-          "sha256header": "44e2852cac69cca06bafceccf5586c73e221d9406eb5d48d1adbdcd4488fd485",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3649,9 +2809,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "68dac868c8f5b221dd3b18b9d4a7f870",
-          "sha1header": "c974e476f9544d650681fcf4f113f63ee8002397",
-          "sha256header": "b8ffec0fe321acc5f2dfbe45f18a89d64ddb3bde1db74786cc5e286fa16aaa97",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3662,9 +2819,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4be63ca9a99ee7e1fad4b302e699a694",
-          "sha1header": "b227ecc422a2029b84356b2a356566e0d2acacb1",
-          "sha256header": "217331bde72afdf97cab8df6539dbcaba6cdd1c8e424d14d9a99f939b0c72a96",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3675,9 +2829,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1fb89fc7f812075a484d202b68334b2d",
-          "sha1header": "493c9487e1d67847898d571ef18120fc5109bcee",
-          "sha256header": "da6a4d53fc5600b8f293585c2736735a95d22548dd327fc8f4bc04c8a168b072",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3688,9 +2839,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3fb835c6c3b33ea1c950f53a57dc7484",
-          "sha1header": "841163e09c61a8d24eeb463a78ca38acb3d9859c",
-          "sha256header": "d41c8305f0f96282adeb21798663502d11f1c8c9eb1f5dbba25cfa798c96058d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3701,9 +2849,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d4adcbaad41e2cc440f32554228d6980",
-          "sha1header": "c0929dd9ed9ddd347a93269e687855fb2421e255",
-          "sha256header": "850715ff469c4f3936f3493f9071f3b1d8b5de97bf9a67074e3396d2b06ba77c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3714,9 +2859,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "0f2f898805bdcb48eda398adaddb2728",
-          "sha1header": "4e7e7273876271446cbd8edcc890cbaa0dd4abe0",
-          "sha256header": "c14c2b360241f0c5667afc37112bd8c0ed16d270b02acbf4d2a8e0ac0e024d28",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3727,9 +2869,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7b2ca3d60d07973cad4eb390ee34183d",
-          "sha1header": "6d3f358378cf69355db15510ba7d9849b11cf71a",
-          "sha256header": "ccf595fe83726017ea77cf4ef67cc09ac27a6565524d951bf4fb22f859d3ab7b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3740,9 +2879,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "0495a0557d6c97267825cc73a9c6a40c",
-          "sha1header": "54894bd67022f333fa905f9307f8926828af4c29",
-          "sha256header": "13844e6b4d5eb90637ba14ee999d75fb58a53c302c504204e10db7f3f899b498",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3753,9 +2889,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cbf3be98a257db0c39f07b59ca5916e9",
-          "sha1header": "b97d0315182e4166c5af35b86846ec3c7bde6885",
-          "sha256header": "be0e9d2884babfff8e7086e18446298be5cbbc8ef43c2b8bf084f1b73bb081de",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3766,9 +2899,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a906be3b702871ae382604a42ff6d4ce",
-          "sha1header": "fd07e1ead998ed531e13361045e3bd5efc405977",
-          "sha256header": "2a7c69d1c371e94cf6c0d75560bcf39614aed9ad6bd58d063d58adc352fae9b7",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3779,9 +2909,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "136470c75dfe99d2ef1f65ea9675dd5b",
-          "sha1header": "2d609a795a22f17738e43c61ec0607d64aaa64db",
-          "sha256header": "e9fd68479bbb462ac6acec54eeb88e8683ee6f2a4a960e4f0dfae20cdccfbc55",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3792,9 +2919,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6325d6f1e8bb4cef76bffae8cac8b4fe",
-          "sha1header": "5b4e073f92593de689e7fe4b7cce91efae1344f5",
-          "sha256header": "caefb1ffa116e70c2cca3188d0554095bb6664547d64f5646591d7c79f21a01c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3805,9 +2929,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9dd71a5d5f4188c31066852dda56a626",
-          "sha1header": "d74f94b5e339a8700761149510a86de7da273225",
-          "sha256header": "dfe60d68c742b5f641d9a2878a0d9d1624d24764a12e1e712ae69a7b99d76b9e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3818,9 +2939,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "917ff691b0df5d51a1d72ff6d0a3082a",
-          "sha1header": "5e60dbfe6d2ea94bc95adfcb09d52f14de036c28",
-          "sha256header": "850fe07174a94c52787b69ffe009ae318758b79bc258af0229f08c814f6ad949",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3831,9 +2949,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "09b114fd7f3d992c00812a4adb6ac1bb",
-          "sha1header": "c397dc2874c6b3f24c55ab61fc263b9c13a59331",
-          "sha256header": "ecb0fba65dd0ec739c231ec474627a73e3ba790bfadfaa2d8950525e868fa596",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3844,9 +2959,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f003c5b84ddbd8c200999f252c5ca388",
-          "sha1header": "c697a2ac71e00523fb5b13c98f1167fe82a1cffe",
-          "sha256header": "03454790900c7900d6c05769d5d68597f51aaaf540c9b46ea9c8fd7f62fef77a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3857,9 +2969,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4aec50eb3e0b84106f9c962e998aead3",
-          "sha1header": "62c7809cd3dbfcc37f34a004c277493f06a7f0f5",
-          "sha256header": "8e5081538cdb217d1369f73f8cc0afa085b3ad0f82dc05e06fb9e29a0d591f89",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3870,9 +2979,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cc0d0edb1497b75268b5966548d299c3",
-          "sha1header": "6e53e6ccb31d893f7f02f4cf28f0a7c24685ff7e",
-          "sha256header": "a929f2963d042df48090df599191f9bbb1912d97557677701f6a6ad07638e7dc",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3883,9 +2989,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "c6513158bb8ab63f0fa51aedbf6d1a9a",
-          "sha1header": "4870e341cf5e557eec2415953b7cf84ab5cd8bce",
-          "sha256header": "4e2c637337e10e8eacd78c84dabef431dc831fffa69010c722d984fdc88cdf90",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3896,9 +2999,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "41a10b7ec82cd67e24251b90356d1079",
-          "sha1header": "97dbc02f9439d54d9738ee5e78e830859f3336ad",
-          "sha256header": "26086a5985eb28f40ac5e1d5a1050932a7f1ac95eeaaeb32d6bffc63b4ccf769",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3909,9 +3009,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cbd850e54754bf42b7577c7389d017db",
-          "sha1header": "7ed57cc8c37b400a49375ede4fbeca65a9ce4fa0",
-          "sha256header": "15b456774674e728cd3f9aa89ba24fb9e36763921849f7661efcb236f0588887",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3922,9 +3019,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "8c6f9b60ee480bd858586df76848e439",
-          "sha1header": "2e3eb1cf3bb27fb4ce112b5aa1344d6c902746dc",
-          "sha256header": "a07e4e3e3f38636466d9b38659c194cac133d86ff0234fe71f7e5bb2a09926d9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3935,9 +3029,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1f804a8b05f213fe25ae4a842473bf7a",
-          "sha1header": "307172ef42d6ab4bb56c253d8907d1d1c02ac996",
-          "sha256header": "90c34225852ceee8eb1d7868aa3950861296500f57a06f838724724bafeba023",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3948,9 +3039,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e317a0f67acaf571296a48f76f690d3d",
-          "sha1header": "224afed8ef9ffb9e279ac9bf0787928bbf4d11f9",
-          "sha256header": "c5dfce9ed1ae90ed5ce41268667bfe9df7ca47c48a80ecd49a62c79b76a7a70c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3961,9 +3049,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b0be701b0a5591fc5e272fae1999763b",
-          "sha1header": "bf41e8b30e887d5593cefc9254538222ab91f654",
-          "sha256header": "2a9d2382f99c3735a1bda2e23da36549246eda1c5924b559c7d4318f806e1564",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3974,9 +3059,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "15d3c8e80d4310660ccddb1e67bad19c",
-          "sha1header": "6a9ac9e3c4d916a0199827e6d184db53eefd5e8e",
-          "sha256header": "27e82d8a8e1a064c94f539583dc48df98caac34cab67be671a4aa68dac802bab",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -3987,9 +3069,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cf8faf7143932903d9569219ff56422e",
-          "sha1header": "cb8a889351ae011d5f6e34661b87e5fbb882b736",
-          "sha256header": "0210178a3c9360d9c0ab6e87f58a9fb305ea4ee844b0d38d79fc84b122c6d1df",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4000,9 +3079,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f2e36b26c04a449b95b0cac4cd9e7450",
-          "sha1header": "5e4581bcf6ab848445b8434a7e70fe7914253f98",
-          "sha256header": "6e0b308f2f617781b0b59af634cb126cca81be16149ea584882b9e22d618f893",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4013,9 +3089,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6624da4baafd5e076eb2b5cd7b79a5d0",
-          "sha1header": "fdbafad6ea4567334704c5187f83b4e8d2e2b4f0",
-          "sha256header": "2adc9d5539c0a8927b6c4f4bf70c07e928a14888b526372651d3a55abe789c89",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4026,9 +3099,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1f26ad76cd64d62e7f93fe096e65fe1a",
-          "sha1header": "19427e78899343aec4c3fe5789892a7d5f0caf2c",
-          "sha256header": "8afce90da9661504ca48c1b690456300fb71141af3a1531ad64e01eb207f1554",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4039,9 +3109,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d7dfc0daf8f9957f93b4fc1473b11ed9",
-          "sha1header": "847f50191e356b467b429b41e97729e6cc58ea7b",
-          "sha256header": "45986f5c70d0b497e88e7e3416b984426750072bf8fa5457f9235b2c41726e2a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4052,9 +3119,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4c9519fa9e4c8b3951305869b91e222c",
-          "sha1header": "c4823685beb9ee0d128252f62a0dd01de780d3dc",
-          "sha256header": "1275f16a1bff16c752af4adafd68f127b2d2deec4e1d7dc0d688d0a56cc93135",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4065,9 +3129,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "be5e5e545a81102ec911f05160b5031a",
-          "sha1header": "a5f1f10cd3b107bb5cc9ea3fd23746bdc2f48a34",
-          "sha256header": "55b29bc1f1473cf519bcc36474a9a718fef5b5a9db675b5d72939b42ae59b277",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4078,9 +3139,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "89bb349440975a582fc2b24670786808",
-          "sha1header": "8808cb2c720853982eff3b5ae508c9cc007551ed",
-          "sha256header": "ea0df0401858edac69025fb629160b21f5bf9ff4dc16e8f19dcf2611a616a1da",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4091,9 +3149,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "85a69a6202f2e63d8040cfef0dacffd9",
-          "sha1header": "2bc02b4dcd6da6affd78f8efcd94079ae305da8e",
-          "sha256header": "276d2e25a87b51682ff8861c5679b21af8dbd9dbd154fac9f7c2f9a62bf60077",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4104,9 +3159,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "757e21830bf85c71e276f4e99188f646",
-          "sha1header": "06d05d866529daec6e299c7a23ef2a4b2d6c5e42",
-          "sha256header": "0355f9239b78da7d84b6433c46d71a9b76400f299a10674bca37a6192ff0f621",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4117,9 +3169,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e4af29b5dd5307c4e6af2eb9bf8e2004",
-          "sha1header": "4180cca15cbbaf7edccfa3f4a3b01e6a75f60ff2",
-          "sha256header": "cd5f49fb890f3aec2bb40fc13dbbf183eb1fb6b69a4d2782e2cfa87fedd8fd41",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4130,9 +3179,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "51220ff0b3b32c662c7f5e188ab68375",
-          "sha1header": "f40277baf2cdaa66ad7159a1872d27a3643804c8",
-          "sha256header": "9fca4d2c4aa5eb270785cb717c84dd037b51b2446773671dc73162a7afe96cd5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4143,9 +3189,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f6a6debbeb84ebfc5c1765b94166b01e",
-          "sha1header": "cd579635f148ce143262f70e5552b3d4482b8e25",
-          "sha256header": "f3b67cf753aed360141cbd2ed585247093b9e3178e578dca6a393755351b433d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4156,9 +3199,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6a90e2e0bb76278b8a48ead8efab1af0",
-          "sha1header": "1ab5347aee93dbabcdab12d16004ba3231a075bc",
-          "sha256header": "9c5f5529476b9337a97f904319019b8d76e028fae5f4d2adb7286316a89f6302",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4169,9 +3209,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "725b5751071b13550c7b0540dbcbe6f0",
-          "sha1header": "752b08566141ce70cb579d569e16e6ec18acd629",
-          "sha256header": "e6ed33250feaa58adc977418dff09717016165490e1324a28d518666cd3a6f5e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4182,9 +3219,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ec1517ca1b47625e1a80b88d7f8e2925",
-          "sha1header": "7eb0210de2e917d17c6fb1c7a8b7ffe6c9907ed5",
-          "sha256header": "381b2b31d7fb9fda3a282f0a9ba6f54385f6b4c59913f0558c4937f88c1ca6a2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4195,9 +3229,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "8948cb585a99e818837777d7bbec5974",
-          "sha1header": "38c9f1748b4fa9722358b49ce38910ce28261f3d",
-          "sha256header": "ca09cf479705221357fbe2e422488c83c030f18dfa1de7d421e74604b1d2037f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4208,9 +3239,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "149446b24120712b82b67e2fa0322038",
-          "sha1header": "e23a52fddc4fdc200896025517165dd23b8dad6e",
-          "sha256header": "c7b4fc6e0ed8814b8e168684edb0bf90c9f57b6245e45691a23760cc84ddd572",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4221,9 +3249,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cc10f9a70a6fe450e653f907147de2ed",
-          "sha1header": "36ee980d0d4a7f96bc833b607e75b293a028ee1a",
-          "sha256header": "757a67cc7f7e002c65990accf6e33932696e9f40f401274e9650961292dee679",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4234,9 +3259,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5bbfb9cbee492d6577df8e36634396e5",
-          "sha1header": "27f02d920c1fde3c4de66c39080082176ea54cac",
-          "sha256header": "233992ea9f338c37164327dccb391b9227db53bae792a79f215ba5488260d13c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4247,9 +3269,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c818185f1f2b5b20fb22be95829e6b67",
-          "sha1header": "b30295a547d46b251dc069f7cb417b6adc5a762f",
-          "sha256header": "5dc16767ffede2a41dd80add850a18d8d3a2a716a606940160f13cd04601332c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4260,9 +3279,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "aa96661d406ac9f7d3fe4a7bef4bc862",
-          "sha1header": "ca8d07d056c395fd9b3e907ec5d54da823d0d992",
-          "sha256header": "262bf370d55f9c0b4591ac99f09b9790b6a7942c64820e108b38b50c98e05adc",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4273,9 +3289,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2961963ca12d15ad1a4f03e0f3ada33a",
-          "sha1header": "60af50d74596112218e9b1f0e5e32f5715318617",
-          "sha256header": "e7a4ae78220651d83d9dc072e836ec7f9ffc77014f2c00d4a5f5bed02e9a206f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4286,9 +3299,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5fb39615013ffbf388d9342694dcadd6",
-          "sha1header": "08dd0425d43b1ec7c8fe24fa119b9b203e358ec9",
-          "sha256header": "1cc42ae47232a727eb1ce9c232d2d3053e0bb4f1a625fb75eb37a4a245b43259",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4299,9 +3309,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "314b268e2a604e5af33343d66e890ca0",
-          "sha1header": "c9d4a9428c3a8e02c72f631aef4ecfb8946c6c58",
-          "sha256header": "f8e9aae0d41f60ca67ac376e000f058eeb0487b731fc51592583f540e201a38a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4312,9 +3319,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4729e2e2de8463b69a8d271ee0864c1f",
-          "sha1header": "4271fdac33342f1a651db4e7d84745106160ff12",
-          "sha256header": "cb893c13af23bdb7087969f1e14f89979e23c03c4950de0642b943ab45dda9fb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4325,9 +3329,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b87906ef9fc639c22db03d07bb7975f7",
-          "sha1header": "b8fd443e392166bfb01b761293e606df52ccd0da",
-          "sha256header": "1fac3c21628058434d58b8a6c5aab083e7ccfcb4560fe1b6e2df11642b85a094",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4338,9 +3339,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2abe5766e7239127d11c9b296c9a8513",
-          "sha1header": "9a61e413588ee88a249334c24a1294d898d3c9a1",
-          "sha256header": "bc59ab323d123ba0d76f941c91fb377dc784dc8c5f81d2a11a879ef7d25084ca",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4351,9 +3349,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "38c595b079ce4c71eb716d76b1ae19d4",
-          "sha1header": "4828d7a7daa7ec0ecc9f80e1532265f8a735c5c0",
-          "sha256header": "631cbc70fa62dd19da5ba38919b66869ee4edcf3909deda6a74da3f30372983a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4364,9 +3359,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "edcdadcb34471b5564173dd313779032",
-          "sha1header": "702328899bc0e046d6502365e56220a9e40c73f2",
-          "sha256header": "bd0f2e9c29893a66d2edc17c74f2f03d033339c1384749960c7db92f14a1337e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4377,9 +3369,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "58803718fbd6b61ac2a191f428efdc99",
-          "sha1header": "d2398742c6b1d0fa09ce2cd9b50e4679b53aea6f",
-          "sha256header": "e58a3b57c1ff01a0d46a97a03b7f05158c2f6b4008cc8f694931dc788ff3f485",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4390,9 +3379,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b64a0b515f398d67a71ee5d4a9546488",
-          "sha1header": "fe2004d3d2910dcbe33d6fa0fea74ec8c87a24f9",
-          "sha256header": "770e3890db5f8b3d78254c325a331c32d7bec2b96b4212582b6d5e062a5cf909",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4403,9 +3389,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "98374b98ecbd69c4f395f7020729eaae",
-          "sha1header": "69812964880aeb7d81a6128f51d64eaa992e5e61",
-          "sha256header": "715397aaa3c7336d223f11d7f86e3924494ccc49ccf8737920d17c260ca6b220",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4416,9 +3399,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c8faae3bd8cfa97c538631bcf3039a16",
-          "sha1header": "71fba12737ed573621310f7b3d96d7af0ba5a3f3",
-          "sha256header": "92a08018eed3a8edcb1df91d85cb9c8d79dfd626096a97f56da8b6f59ffab5c5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4429,9 +3409,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3612973e6d8820649a76ef589a6d4c35",
-          "sha1header": "c40fabfddf4ecab5a9349a941b9d179d701c5a47",
-          "sha256header": "5204b4fbe7c67c0bb21cc80d0fa9eac639b88e98ed727e0c94673e6dbe11f8f2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4442,9 +3419,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a1fe8d4da94d87ea49baf70f572206ee",
-          "sha1header": "637e248fe368049139108f780fb3614508d6db67",
-          "sha256header": "1825610b707777ca4de76f3e035d542af4c680a26fb903dbe63e12af7dfcd892",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4455,9 +3429,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "44c57e00d1904d4e1903080bcbbb7481",
-          "sha1header": "5227fab1aeb5e9dfdfcf61d9f7d7a31c7e9f9d36",
-          "sha256header": "5408b960e003f866c0be3bad30f2cdea4f0332ec39c8a998aa7c356786c0cf64",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4468,9 +3439,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b6e41d00a80cd78541a679f972ea11c7",
-          "sha1header": "18b5545e179d0af20f98f59640ade54c81906021",
-          "sha256header": "8c26553b8ea0c6f09e16a66a0d02701ba1f110e256aee03d2ff39bb77d698a51",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4481,9 +3449,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5b82408fd44614615eab3abd360fde9f",
-          "sha1header": "b6a6fe35f60d8bb8bcfd505d070c844e5033cda3",
-          "sha256header": "ca661536c3f46f8861cf362992fd727e6b647239fcaec90c59ae88e37466bda4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4494,9 +3459,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c358ff051bcf5a94b66618894f2427ac",
-          "sha1header": "f72d75c3405ca4ca176e21b0f72efa1d55a8b6ae",
-          "sha256header": "fc01586a049aaa49bf62247f399248ba3b01c0142a2fdff154e3fda829253819",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4507,9 +3469,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b4516f04e968a7a5a54ddcf6aa01cce8",
-          "sha1header": "e2495142c8c6d5e2cdcf01af16a7bf308e30149e",
-          "sha256header": "9a361f15674498871939fc59c80afbf8d96292759e252b3c180570921bcd9c19",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4520,9 +3479,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b667022b02944c57cf8e53429d2181cd",
-          "sha1header": "5a3cc38e0a8e2c9ed3e61b2cd956b59aea63bdee",
-          "sha256header": "4dbac8d3f62b44e8ee8d1643c24cb8edb521e0f8e80793407350be707f33d076",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4533,9 +3489,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4ce5e62e672b5b0ad50a2361c9188475",
-          "sha1header": "bc460d78c1dd3ffffd285c38f4c4255549e7271d",
-          "sha256header": "b89563a1638768c0c12f71d86554a4e43a3da0fc429535df9367c8d17be60745",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4546,9 +3499,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "04aef34d496424134959de1349cbb938",
-          "sha1header": "f4fc3ad8ab38096ff6dc4b25621cec3743f7e1fe",
-          "sha256header": "087dce95763da75b88805d30823105619dee43854f3f22c5ac5ee3e3685119c4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4559,9 +3509,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "43177517bfea6d52bd3aedcd27681c15",
-          "sha1header": "dba60121e66fe08c6ec02f9de0813cb2d679a1d0",
-          "sha256header": "51161089ca4bb5cdd09028f7dc98702e8f278d254926597f2db001dd22704bf6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4572,9 +3519,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "8e744fe96eed0382edc9e43117dfd3c2",
-          "sha1header": "53d05c8b7dd5e2a5930dff2ca1fc4962825a3fdd",
-          "sha256header": "9af5c268d664201ed0492418c1cbb6ed31c3d871c120fece8be80a28a04012f2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4585,9 +3529,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "dcaffc1abad158bb70b6c721ec1f122c",
-          "sha1header": "45ce0b30b7d1968011c52e38f49af6cd1ea89e84",
-          "sha256header": "52f2514da04ba84d01dd2113c8929dac4a8626c04998ae91c351d120a36b79a8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4598,9 +3539,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "8a2a9c1b56b2be97a146664e9f767f52",
-          "sha1header": "98e694f604721891f85f8be3db44d19db65d03a7",
-          "sha256header": "08c34b3955cda67d253287f84f583718f26fa81aff2045692d7a5cfaddfc47ff",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4611,9 +3549,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "2ffa5f89abf62aa553813d26a2d71dff",
-          "sha1header": "e20e044fd1cd6dbf22dc363c71b95b4f50da432d",
-          "sha256header": "6ba19b09d8161bba0c06bba78e5b128c343df2881859d751fbe8a47502aa3792",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4624,9 +3559,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "8d4c998f6f8eded14e22f8d2c6a29c25",
-          "sha1header": "0a1c047efe2e7b9bba5210b17ed997b44e9b921b",
-          "sha256header": "6e88cf1e41d7fc828fc1e4241a7ccc632a557be0f7fd59651def2417628acc78",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4637,9 +3569,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6d2bff5a97ee98c481756268ffcf3f21",
-          "sha1header": "d83098cbcc595f3e1bee10559b88896e48a693eb",
-          "sha256header": "32c2de8d454eb0fb58a97c8347e43148aac3cce5c690205618a35381bff26704",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4650,9 +3579,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "baffeb46ece5301591be7946d8f3a8df",
-          "sha1header": "8aa6efbc14147f96c04d48b9f59049cbecab3b77",
-          "sha256header": "1ece8fa1917dbfdfeae114bb34611df50af7f2de95a0181f39b2f9ffa2592437",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4663,9 +3589,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "49ed3e213d8ac48dd1909569d0266a4c",
-          "sha1header": "e928e3010399b1428bd7042ca19c47f9532ec9b2",
-          "sha256header": "c8edcff75663505b52000399291afad0cf1bcfa223eb8e2e9d732ef1ee55e290",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4676,9 +3599,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "250f8aae42243fde974dfa4d12c40762",
-          "sha1header": "aa1ba5736421e3ea60667f5ec705408624012c65",
-          "sha256header": "a41a9d3cb0c9637aee5fee1455c2e9fe7ea5a654c63c77c1dabe435c2c42f0ad",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4689,9 +3609,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b4f8455d236fcb4a4e119bcdb5654592",
-          "sha1header": "17e428c5f45e32ca3faa0f1c56a84ee63a3ad7ad",
-          "sha256header": "e2394368e12d363597143d1bef11d0d6c4fb3c63daa129e8774a06212cb13b28",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4702,9 +3619,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6024e5e5b0c1fc48e40ae52e8133426b",
-          "sha1header": "7c534a82ea6a0846048c4c728f64c36981a12c5d",
-          "sha256header": "0b77ce083fb990fd79744dbfcc0da67602d750584b760ab8584001908f93ff24",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4715,9 +3629,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b8d8cadd16ff6dd2fbe647b36d11388d",
-          "sha1header": "96f8d1ed6e4459976e17277cb616d1a474778508",
-          "sha256header": "576c38aae8b51fb525681ee6cc3e559a45bae78b5364d1399e91cec8aa12005a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4728,9 +3639,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "55a12cb7db24eeda5d706c94d1da9607",
-          "sha1header": "0a61d6e4dbe5415b3619ddef8b276a1bf6a94cfa",
-          "sha256header": "226cbee9efb53ab28119b362dbec9c8d82b0dadc98d4a8b3716f3983bc43b97b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4741,9 +3649,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5f6fa3642a8b68d76b144db0888f421b",
-          "sha1header": "c1a104318e363bdbd9e693495a6ed5325080b320",
-          "sha256header": "0bf70afc556bbbd741af9bc9f230784ae39c29e9073ba355056aefddd0da2897",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4754,9 +3659,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "df97060eb8b1468379655917cffe54e3",
-          "sha1header": "de7b96c4d2846fc6cd504bd65cb911d7983e2ee1",
-          "sha256header": "1e2853778fce3fd0d150ff524644bdab71e59c73c5ad89cb34ed623a0162784b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4767,9 +3669,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "08151d4093dd7b57215d2bc6c861878b",
-          "sha1header": "e715cce0d27e6b696e23780191ada6596f5d4c30",
-          "sha256header": "887aef2927814022837b823fbeb8af41e43a766777ab2ac504f6e93f77f5f715",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4780,9 +3679,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cc4d62b4c02fe4fe52693a0ac440d4a1",
-          "sha1header": "3436b4b388fb3e9b39798ebc6b99132b4ff55e3c",
-          "sha256header": "730077d51a89503c506ef4f9d73ab674698217f87b46ca2c50bdeef46d860cd9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4793,9 +3689,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "991565f1283268e230c6b852d8a707eb",
-          "sha1header": "7d20f34811b30fc90826f4a3f64afb7beb3ab326",
-          "sha256header": "00918d92f620d8ebc66f4228fbee8775a74bb27ce41b860d021019ff01e7323c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4806,9 +3699,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "822d8ee3d7981432f4ba19dc9691c682",
-          "sha1header": "777036d798538d8de59ee5cb8e6357f766c03815",
-          "sha256header": "3d56614736c8a5de75229710e2c793bd903f532e3a94f453c5f257ae84aa0e90",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4819,9 +3709,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a032b22fa36d676603a8dd2a230255a6",
-          "sha1header": "53a287e984881c652c94e86598fb7ac1a0bc7b58",
-          "sha256header": "48f14117cfd9134a9d5668a8d8aef420ff116d5d7731142b88978e31df192b12",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4832,9 +3719,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "8fcecf9fb64f9e337c41d7411413b005",
-          "sha1header": "acd99072a0dc89af21b429790033807feeca1989",
-          "sha256header": "f3572272a9e8e85b2e9f12872888a488733a92a64218dfd8de766bfca3996405",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4845,9 +3729,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "80670e7ef5e21448f211c01ca2cbfb0b",
-          "sha1header": "a40817f17daba2f9dfe3e2724a5519c9d875fba3",
-          "sha256header": "33c7bee1e5f4c282b8a669406842dbbd1eecb8707a805ce650bae38535ae372c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4858,9 +3739,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b381720e98484301bd973e670e7bfce7",
-          "sha1header": "594fade2942dac6191be81b489a753a71f7cdb6a",
-          "sha256header": "680b0900524a564e114b4e033fd3ebf19a6a2771925d90821223a5074afed1c3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4871,9 +3749,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9741be77b0148dd8ed113db27bb9a091",
-          "sha1header": "8144b9f65afc06ecd447536848adb0f928fd035d",
-          "sha256header": "9b724584c9eda02062b29ce53ca53602e997df76d997e089d87ed3c1c2d7c1bb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4884,9 +3759,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "be1197ce1970d80f80e525c8475d64a1",
-          "sha1header": "cfbbb32f35ed708267008eb50385ed96d3f73a2e",
-          "sha256header": "c01bd54b82bdabc26c183b0cf7a62c8adf78259b613a9d68937e865b8a251f7d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4897,9 +3769,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "055f8282857f9e935367b4a52eaa0539",
-          "sha1header": "570041099d0323935a958ff051d2f82a5168801f",
-          "sha256header": "023e15359cdc6060dcda9da5316c941c0345daf5a5b66b84638b08dc8aa8d669",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4910,9 +3779,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "92c2b0e81cf5866b7c888646b5679772",
-          "sha1header": "d962cecb240e6ade557dc850ca38ecf3235dfcca",
-          "sha256header": "f97aede27abf9efd0f56a703d7bac99c08f44007a05e909bafee353c5b4452d7",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4923,9 +3789,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1a77cd7d794a12a1921e08b16a3df969",
-          "sha1header": "9118acc604a58e9287163163df29bb717d6f1580",
-          "sha256header": "f9b20238c6cad8982d85c409cd8f9ce94ff383be1f1e9938911fd674b940bf74",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4936,9 +3799,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d17dc7adefff5255fdbb3e7682dddf28",
-          "sha1header": "30e451d54fb0b9926f3e1e09fe6fec7191f0bb4b",
-          "sha256header": "109a0c134e35507b4528564528199ab3e7ecd4a53c1f349e53ddc8dc1d78db83",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4949,9 +3809,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "50426757342966991e034b245694835d",
-          "sha1header": "ba5372389744a813539f8be71a39d5aba4041c7e",
-          "sha256header": "b0cf6ea3d322bee70b75c1461710af371d41735a6fb04c7c59df05c28477af8b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4962,9 +3819,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "0a0d2727d951a2f7c91ca4a251d540d5",
-          "sha1header": "e530a1afb813dc36637ce21b2d81ee99eb167f61",
-          "sha256header": "d7425396648a39ef9fc49f37e4cd9a5012d4a121722cb4e67672ae92d42efc6c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4975,9 +3829,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5c64707b3a85e195fbd41e4addc62a22",
-          "sha1header": "62254f011da39167a4312eaf755315081d7506a1",
-          "sha256header": "5066d9925ffa99a8c4c7323c61424b34133f494b21118f92b0a9ff0637da1365",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -4988,9 +3839,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "98023553b45fea30de59d434a6abf45e",
-          "sha1header": "ad50733f4e926b8c33ab92fc290e3975eec9bc61",
-          "sha256header": "5fbd1604c7582e8ac8f1e97922f573e4a3793db277c58abec149819e8d1657ab",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5001,9 +3849,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "382388c5203d38ed4316f5e3f6e451de",
-          "sha1header": "5ce30c639e963d85f17275c82a9675267d39a0bb",
-          "sha256header": "097565e4ee808d6c6105c5ffd524854d1434c03a0fc26a35a3365c5110e802ee",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5014,9 +3859,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "26cf8f6f8a5f6d243e451a66d2d8d45a",
-          "sha1header": "2706007b7d5b2282d831ba69f00ae2ca31de00ef",
-          "sha256header": "08d03e9979524749d6e8daeac9f60b60b366962af955881b145ba7461111458f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5027,9 +3869,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6f4ab73b37527429454d460ac4ba3fea",
-          "sha1header": "867c72c9b2312a8fcf13b80113742ce3f3ae15e1",
-          "sha256header": "4ab12de2ee68d136ec0a4767d7679e474ed039c7a44915fb2ad0ff98cfb38d5f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5040,9 +3879,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "89a16f396650c632a13b9e627ce72e4d",
-          "sha1header": "23d8ef5103262c319d2a626578e432c9787ecf6f",
-          "sha256header": "46f46596e4bb8c5f4242d5c1bd717b2d5f180f695ba398a557c125646dfa8e84",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5053,9 +3889,6 @@
           "epoch": "1",
           "arch": "noarch",
           "sigmd5": "11b07dfe1d9459eabc92e52617cd558f",
-          "sha1header": "0cca65ce77b7a2c5fcd683647bcab5b2cc630733",
-          "sha256header": "8053a69a904faa308a039bc658b6ee08d93aec73d1c6f1393a1c20fd43743378",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5066,9 +3899,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "35a18d756b1893d732e07cda7065e532",
-          "sha1header": "4bd9a7de89148b7032964067084e0004fb23b925",
-          "sha256header": "136c5533417adc75f85b9fdeb8dc58fa4a940b04666d5a850b5e5464b3ec121f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5079,9 +3909,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d70d3e454860c1a00410a959a7480509",
-          "sha1header": "4ae7d765ae80c3101b685d109ce16e2058140116",
-          "sha256header": "c13a7afe7393ef46c666156ed9043a662a1cebeaa94740ea2d66610fe42d171c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5092,9 +3919,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "79f882f4d38589d0748205907c0d8b58",
-          "sha1header": "fe41b3b3ba6f502cb1a6cf1c25c20b51112b29b7",
-          "sha256header": "cc9de3080168288e784b111b963c1f18997441cbb3850a51c775c4eaa14b6cfc",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5105,9 +3929,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ecf98355fc24064434a7a659f16a9694",
-          "sha1header": "42306dce775c5309b16b025a18f6ab1bde860387",
-          "sha256header": "d8f720e9c8389383cc209906b7c6ac4d709cf81868f6290d973bc2d0257c28b2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5118,9 +3939,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "548b809439d89117ae7aa500b6948829",
-          "sha1header": "4a9e36d508d718ba3ea5a2629a4ae8eb5034ce87",
-          "sha256header": "468c9228530bb43f1aed7ac08290bb0e53a618a27cfd05f6627f9bd63846f8ed",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5131,9 +3949,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "fd52d4190301540d90def2e764b9b367",
-          "sha1header": "0e24b9669f5b3b93e0fb304db047f84587951a5e",
-          "sha256header": "92b00a52335e32806e311d3b7348ae0c4fc7e00965a487c8c34b8ded2f088d3b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5144,9 +3959,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "8a2c144224683deae3df2ad1c54e7818",
-          "sha1header": "bed3583cf5269ad59a364acfd4fb3611975a49fb",
-          "sha256header": "6b58304cdb736b78aed9c37ad16b86b996c500d2e533770d7e43b0ace462a705",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5157,9 +3969,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "458ec46597b726c96be208fa5da10777",
-          "sha1header": "9329236b7372b6df31f9b55626f233a78ed017f2",
-          "sha256header": "6c5dae40990905c94d4f885e5af2579367d23f830a25c1af8b88ca3096247778",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5170,9 +3979,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "60dc9dcf7f5a8fdb6e2e0c017e785b60",
-          "sha1header": "19380d9c48694650a372e4375e726b6e2d229464",
-          "sha256header": "608ec05dfd7cedc6601ba0b494fca20d6b11e7316b48bcf2c3ec860de5c70a59",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5183,9 +3989,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f341d75729ad6c268a972f5ac07274bb",
-          "sha1header": "1900a6fde286599b1e0baf78ba109db2831ed5af",
-          "sha256header": "e4b1fb2806fdd567bbdfe0245567f5a1a547110a33b954c9eb4ed815a8ee7562",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5196,9 +3999,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "99d422d21bf24c403b92b5846541cd65",
-          "sha1header": "0c2c5af9904b024ca5a79f2671eea73c3da6cdb5",
-          "sha256header": "337987b17d423149fdbffe0af3f68f2f1300e8b32baeedb8c5aba8ebf206d129",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5209,9 +4009,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "63bd1741687442c5fd13769534fa7250",
-          "sha1header": "3a3fdf775e25f60bf8b26722c3e487d8acf9f9cc",
-          "sha256header": "c07f72df820a4a3c2d342dc0dd4f3c1bfb733f1306c22177f4b237e9f25bb106",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5222,9 +4019,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "89cf66a07736a1d09750788e390d6d50",
-          "sha1header": "5f4a3161da1317bc2d7cbec7c8460d494e006d0d",
-          "sha256header": "f99c247bde6acb9b6400134f42fc3f944e3d864357d338f76f0c43323f2a3249",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5235,9 +4029,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "d4672bc427a1b210a6bc171191fe2e0b",
-          "sha1header": "619a2c7e8a5faa9cabe0a61de3fd62cb5eacd887",
-          "sha256header": "7469650b037f697c6e123f89c3f2d398441993e0907d755590b4372305f5bd20",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5248,9 +4039,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "d2da1829f6456cff9a6fb8f0747ad0c4",
-          "sha1header": "80981922de102cd0b2dfc500abba4fa5d6c55360",
-          "sha256header": "c0ae6acba936b74a23813b48ae04ea3f15a51cbd1d85cc3f092797e7c2a59dfd",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5261,9 +4049,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "d09e05821212c940c550d2bbd2ee7c33",
-          "sha1header": "5ab9cdea4821a0919b13f244ab406d85c71c6414",
-          "sha256header": "14730193a748b474f9938a2c1569f9ddc92f9b8d25cd0405b7dfb3b45b44762a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5274,9 +4059,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b5f3ce5363b33baf3ef5ac9e1b1840c9",
-          "sha1header": "edd34bebb93e176073d148ed2b08975af6f56c06",
-          "sha256header": "e4901d19f5701894db7c8f53b9a4283d72ca604f63946b481afe2ea0c4790c89",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5287,9 +4069,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "33dbc8d1ccb84b467bdf3fe7600c86cc",
-          "sha1header": "e8038a0dc786d490e2f8a39108b9a9a34ffaa436",
-          "sha256header": "ca1e2740fd5d968283226116ba5aa87714861ae0dd9e41a7f7cc6db4e185c5aa",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5300,9 +4079,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e4134d2d1de91319c06a0ba676ab9725",
-          "sha1header": "4436dba45be1910b2634aaf48d67cbf546281778",
-          "sha256header": "3f9322559b75b6d5cd57575f7e2e1d74bbf8168d014e8b4e317acdd628dff483",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5313,9 +4089,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "95fd7a30e598157c8addf234f73d2aa4",
-          "sha1header": "493d507de051572ea29175817f09d933a89da2b4",
-          "sha256header": "a7b867ce59e488a18bca64ed0711a63fa0272af9c9a9cf87d01a314c39880652",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5326,9 +4099,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "99a08fe53428f036d06ad9c572fe8883",
-          "sha1header": "2c5b9286cda5b6b5f17e67f84a29e9df89f953d8",
-          "sha256header": "7dddc45003f7c64aa39a32b191c64d4645e32bd8f6bbcdd064a11920f6b9bdf9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5339,9 +4109,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1f090c576368e85f1b70b708c429016d",
-          "sha1header": "6ab46739129a778bff50b5aee99f6ed240e92c3c",
-          "sha256header": "00f9019b712dfb7a1392e0025c3d51ae84cf403092505c0a8698f178af75b79c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5352,9 +4119,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "fb3e3776496257e6b6264ffb6760ffa1",
-          "sha1header": "9e6cdf64c3270d74fe16ada7a370e640e36eabf8",
-          "sha256header": "284c36ba33c2a93995933f007b05d3c6bf0c1258dedf1d890c8817c7351938b4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5365,9 +4129,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5fdc4c27d850f91985a5c0171547dc29",
-          "sha1header": "40b81e153de39a174d3c0f75e42e46f7acef30ca",
-          "sha256header": "7b4470f5cdd95ae69e3f4ed11bee4c77932a33624bc34c0a63e6f1e1eb9edfd5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5378,9 +4139,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "2daf095dc487abeb82771eb0eb1807b4",
-          "sha1header": "13e5525a601f3523d4cfdf66f551b376e9b5d7f7",
-          "sha256header": "982534afcbb1bea5b502b3d7be0b1742ab80a12a928e64530423c81e04990d2c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5391,9 +4149,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "74cd98d0287a447fff39b31490d59de6",
-          "sha1header": "a812aceffa100d45367385c9e2454984e313ccdc",
-          "sha256header": "b176b3538ed47c515d1cd6ae161f3073fb82db3a91e805ee6283ddc254514fe5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5404,9 +4159,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ddfccf13aa504b31290cf13f5d131381",
-          "sha1header": "c4f3ae08e68abc7df43cd5da15c7474598b1fa64",
-          "sha256header": "c84e12686a4e16872d47ece4dcfad4c936b4c45ce54369d9d124a10a5c5040f8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5417,9 +4169,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "21221b4ab6e0a7e96dc0ee7dad621a7f",
-          "sha1header": "0be21f55c71aa297b8deb2b4848d9cbda6739458",
-          "sha256header": "5be8e5fb53d74f6bec2ac9a8ab49d8f4d44ecbad57519fd6219ca08d287ce659",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5430,9 +4179,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "25fac92cf29cdf5051303ad9d443268c",
-          "sha1header": "ba6acc44dd54ea1682f12e0192dcf381a740809b",
-          "sha256header": "63c647fa50541f6b466c0f570d73e4b93ea986164df86fec6266e53b43f98401",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5443,9 +4189,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9ad306399e37f94f72da781a919e8bcb",
-          "sha1header": "287590d0087cf52ef527b46d4ce3ff07f2399191",
-          "sha256header": "27ab7e309317fdecc7e247a014306bfd95a342166d37697c25b3cd864e7506bb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5456,9 +4199,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "a4dac7f913c25a4d54229c5a76b6e4df",
-          "sha1header": "f5c386e67b0dfe21335e3c37a322c82f1bfaf7eb",
-          "sha256header": "bd3319d40d27ef24503e0372e0b51db87d7360b36309a6b91dc4d8fc9f8cffe6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5469,9 +4209,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "56ce72485960d09bf5d7813921b55707",
-          "sha1header": "2dd1325f8b551a1e4a823fba8ff2ec26496de7c8",
-          "sha256header": "df2eb035b5cb2857bf2524eb3ad46bbabd37ced9d42ffe0fda9f7ea9b6e9f6b5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5482,9 +4219,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f270934ddf8fbc4fc93905dc6b163d73",
-          "sha1header": "1714be223d83774e639c1b0b5773af93df1dde84",
-          "sha256header": "6f856113a09f202edef0fb5c5896a0e45a1d2437c9dec30b164a293baf44a324",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5495,9 +4229,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "92cecf33edd8c4b437029ffe6c20fd06",
-          "sha1header": "c053c207dfa2fed2a17d1fdf2b059039f1590d54",
-          "sha256header": "d5a38727dbd421ded0479281c555c3f34b2d946029d2d21cd2fab5b217100573",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5508,9 +4239,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "8d230ccc70fafa1377fe090cfe827395",
-          "sha1header": "2590311b31573d85db092e3038c7a5abbca60c73",
-          "sha256header": "b9662d262b49cc67da1b64d1a016ce0ac58772d46f7b87300b0a700310cada03",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5521,9 +4249,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "56e99c5044099f0c37b7c4be6a898bcd",
-          "sha1header": "230ee4866e7eea7bfb29b9dd51c84d7cc5fcb3e4",
-          "sha256header": "6345ce408e387f5036390a60d30d145357964e287766e327bb28a6627b5aabc8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5534,9 +4259,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "4036232bafb7da8c25e9a29069993e95",
-          "sha1header": "dab8bd7b04ea1add59d60a3e8929c9bc74b62077",
-          "sha256header": "5e6141969edfa1c82c1ae3f9342f1b375330c5c3502792cc5097c1bf350e313b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5547,9 +4269,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e0fa48f7f18338fd5044d139016acc7d",
-          "sha1header": "5cde1f042105c139ad988a4940a11e49db2393ee",
-          "sha256header": "a6f7bcdd46ae8de0a77514b4e6058b9cf50bac7ed13c902eb752be0c009002cf",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5560,9 +4279,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "667cb37d1f245d38398a6d64e01bd3ec",
-          "sha1header": "89f0538c76d347827c20130b4817c8cd276a80c7",
-          "sha256header": "97d2a2af108b8c46dcb5c71873c6877a81f03ad4b237ffabbfccf5e0903444ed",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5573,9 +4289,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b068cfb2f5f0b77bc8ebd80ad9db96ef",
-          "sha1header": "d0addbc9d4661cc48fcadc397c83071ad8986eeb",
-          "sha256header": "b4050e87d4e483d5eee4bb94b5e34ec97faa5b9b5d258f168d58ab549c0d5c63",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5586,9 +4299,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f8923bd2dc299f8804c184c583e6eb5f",
-          "sha1header": "77b6b9b100b839c33a26b97ee448cf978de04b49",
-          "sha256header": "56debf432cc42f2472d5d9043277e113e073214e16eee5ad1674c2058f79a325",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5599,9 +4309,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "edc9bc6b7ced9a49b77204413349c44b",
-          "sha1header": "fb976c559e6360a4566607e1e2146fedfd5c97f4",
-          "sha256header": "001c535bfd290d33268a8b3c837b54e7a239d45ac59f011ab12c29e461d613d5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5612,9 +4319,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "426c8b99a0890fd72dd13b1ae6bfb6bd",
-          "sha1header": "30f6ec42d4f8bb353e87b8c08922ba0b5fd1d918",
-          "sha256header": "5829839e7a58a4d160199ac6546d8ef4724e32ef2541df04d517febc8f50ddb5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5625,9 +4329,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b5be85797caff74c5da10abed6a41169",
-          "sha1header": "31d0c2700ddd4d717a1b0fa0c8c4cd721f4f2c6a",
-          "sha256header": "42554e8b51978777c194a8554eb1476cd94b20dad8f725dbd163c9a7f6c456c2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5638,9 +4339,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c5c0824e36b1c26d8e0e9c5e1b8ff096",
-          "sha1header": "3bcf435170b218329293de5aeb55fee8dcf15591",
-          "sha256header": "571cf138328b3c2bd86bc7dbeb7b75b508301e48c7aa52761e9a6ec56250000b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5651,9 +4349,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a4929f858f659adc4f2e2526cafe9213",
-          "sha1header": "612bc5df2e983a4524cbc7050bd7f3365ad4d160",
-          "sha256header": "604e0ab85c0bf48cf0fbd4e455aba826a79c09cf17b37489333f9822d5f1eb77",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5664,9 +4359,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7c836b9c3a97fb0ce9d6e47b103f63ca",
-          "sha1header": "5510fe3b2d81645bae39562311af17149fc552eb",
-          "sha256header": "f04e3b343943bc67875216749e5688944b2d492bd3938aea3e143a307aeac8be",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5677,9 +4369,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7c19261d09c5ed739a155b84c6a9d8e5",
-          "sha1header": "3cf673d330c4aad3008966fac21b3339041cb182",
-          "sha256header": "4349ed56143c3a419c0c15bad0a151bc46a58581fffba832d9e4048e4737e2ba",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5690,9 +4379,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "66964fc91db59bd5b0254a1b35d0d164",
-          "sha1header": "fecdf3fb278e0a911bf531370918bb836fc480e3",
-          "sha256header": "9763deb20d0c701dd6a53fcef84951b91ee3a52e68f2b9d48857e68fc202e4c2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5703,9 +4389,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c82a92cccace0dca457dde271a520bef",
-          "sha1header": "63815eaf802e9b55b33cd175225d3a3f3e0d9ded",
-          "sha256header": "bfe3061f059ab8f96757d7b3b4ad695749f9c3bf90f52aaacb62326ba9801e32",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5716,9 +4399,6 @@
           "epoch": "5",
           "arch": "x86_64",
           "sigmd5": "717b0ec28ee123769d5fcb96386e3913",
-          "sha1header": "ed772f0f325d47817beb46c9d532728e9bfeb104",
-          "sha256header": "8134f334e38f54f8e0a762d2382f0b8df089171b64ca74e2de7bf8aee135d923",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5729,9 +4409,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c9e243a8c2810949bb1349eac8e3c32f",
-          "sha1header": "1b943196bf2a718d161a20b4597ab42b767fd436",
-          "sha256header": "051b987b33e0ef07774febcecad2f1400a48df373f1a91a292c369b2551d9072",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5742,9 +4419,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "262a64ffe95e61da819d3367df12930e",
-          "sha1header": "78f6809605f01bc4736407288d8fbbc9e2355fc4",
-          "sha256header": "8da20ce76ec66e2cf6da3629b78e85f88578f13dc0db3f5dbc8d7d1bc4203526",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5755,9 +4429,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "ec8861d850ed9a3b5349c8edbf0111e0",
-          "sha1header": "73b2a707dc5f86bcdcfe569c8eb2d67c1df4f369",
-          "sha256header": "5d7eb12508e27c1ecb4328566d8e71eb39676f9eb3092b5e5728086e613e79c3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5768,9 +4439,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7d7e6fc0f7b8099ef61b5d6d90906a38",
-          "sha1header": "f6cab5097c16803c084c8204ba433ccf1d1750c6",
-          "sha256header": "dbeec04f7c8ea95d9d46321bc353f2e75ace58f94b8ba4a88c4065dda790cda3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5781,9 +4449,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "445d98813b2142c0d1eb2febe28fb629",
-          "sha1header": "be7c453857b6a7be422a5aacf4db57280c7c40ee",
-          "sha256header": "bb2f87a15bfd1b5ee81b470048c9914899dad064040eaf6d62f1ae28a6f1b034",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5794,9 +4459,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "78f7742abe7cf44022093056dc6c18af",
-          "sha1header": "1dd2bd42f62ab0f20ed93ede423fa62ffc471e19",
-          "sha256header": "c5b6d9a5fd9bedad5ec034e8e14fdb775120aac59cec0de3ea330becfdf9db0c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5807,9 +4469,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "efd625c3ee5e7bdf384b0842ca859f15",
-          "sha1header": "7148dfb1b247bdf4e3332fc885cd605dbd6ec817",
-          "sha256header": "efb46c8db28a76157f1d5c8b731307beaf3d1eef96c8ae56e499a0ad02d5f6e2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5820,9 +4479,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "963ade815137a7e61a1339bff17bd327",
-          "sha1header": "5c7ebcba20583e73b375635db9c8f28c4b500980",
-          "sha256header": "daac33a0662314ca47057ec5e9ae7e5371926056a17c4eb4ae03535e2575c4f1",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5833,9 +4489,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "bba19aa75d55b0263d780b1e7afcc4e1",
-          "sha1header": "6d3b633c02e37a9f8223558abf8940489f27d2f7",
-          "sha256header": "27c0330eb3b28812fece81b0dc11ed20072e8c9bacf7bf34f85e719894396fb9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5846,9 +4499,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "be3d4ae3db565c7e69939645ec859e8c",
-          "sha1header": "9bfe8e2670e9dc6f01c3f76ff8d4894c88fa232a",
-          "sha256header": "4372b30272d165deac75ae6493ed0cf3efa52d8c7c774f36237277a19f7be61b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5859,9 +4509,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "33485f94e1d14271b2f9ef3cb5075e97",
-          "sha1header": "1902372c173cd35556f70baf29102abd648189b3",
-          "sha256header": "3f2ac742dc23282ed60810692269c8d09e62a32674b43f0ec25282c22d430705",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5872,9 +4519,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9ba49d6025b97b8e2feab24389edf87d",
-          "sha1header": "89b14f5595b1975b658657a932767871338c7966",
-          "sha256header": "e2b0c661695870376850472a2d6fc8eccc1a2b00083829a3a06812dd82bb15db",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5885,9 +4529,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "04311ce6c1b6c5db1549f755b54d7bad",
-          "sha1header": "d25d572e90e0711c27e2d3017c3bed4662abe083",
-          "sha256header": "409fc9f70ed7728506443a243b8136adf5749941112fdfe0a6b800be55112dbc",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5898,9 +4539,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "ac292fea951040eea62868c10f645478",
-          "sha1header": "5a0b1ac2293f1abb8ace7460c2ff957d37ca8191",
-          "sha256header": "bc3a1178a98ecc89ad26e27517d759f1516d68d4fba5bab193fb7a87f54e873c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5911,9 +4549,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "2aeb8c2627b0a28f0878521ed209087e",
-          "sha1header": "6e3421471f72d350d81c0b94fa50a3a58b169a27",
-          "sha256header": "35604fa77485742d8d210ee22faacb81a84ee7a0a46c55972285d3771dc75b41",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5924,9 +4559,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "221bf6676af8c14da8babc0d452da36a",
-          "sha1header": "6711cbbfc5ab9ad3f0c715fcb455b0ed674ee87e",
-          "sha256header": "cb3888ff9510eb16ba1994e0dfd342730632aa5ecc9f0d923e57c9047443756b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5937,9 +4569,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "149302fe3009f8db5c6177193c8e08a4",
-          "sha1header": "0131ac965dc9562590d21bf72019d897dad60706",
-          "sha256header": "2ee5e2ce63e302b469ee22d6bd735229a2040b5092820ef65013b95317c5aa4c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5950,9 +4579,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "5c7b7a2108e59e6673e441ebad8d7882",
-          "sha1header": "84490a057bf64772b8045e63468aeebf4d0c5506",
-          "sha256header": "f15f47b0429603a40865d029163b299d1b1d484745357eef2355fa600f380243",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5963,9 +4589,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ce1e8507617db9d244d5d332d8aec944",
-          "sha1header": "e096debc4bec3ba5fa2b36d0183811710e59713f",
-          "sha256header": "2e32c86e9673bbad8f5e6be804df42414e2cc9167252581243b16f0eec2707a3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5976,9 +4599,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "5a781f89da9d2d60ef13cd46c297ff1d",
-          "sha1header": "78d19520a9c1adf48db65951d470f0b582a3df33",
-          "sha256header": "8bb3b191f4749ca3864052fe3cb417a739eace95c8973483bbb7b85d232d56e6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -5989,9 +4609,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "07e5f9ad6e126c569a6c4ec5fc6ca5c0",
-          "sha1header": "03b787ad4879f292f17787a3da72013406807130",
-          "sha256header": "5c370b60c2aad14baf05b9f1c91e540fb3737ad5be7ecfac104b8481f6725b43",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6002,9 +4619,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "029953ca0f83b38448a295c95ede7f97",
-          "sha1header": "cb1449ee33c8da796da5068778d5cb9404c8276c",
-          "sha256header": "3a40a2bfc7b07e7001ad5b8ebe6e0e0686f65d13d0ad2f448676997e4119792f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6015,9 +4629,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7d4f7817b6e7983dff69a37a27f3d955",
-          "sha1header": "63bd498aa2c764bc9e7dd7f9ec6e093edda45e9d",
-          "sha256header": "abd5dff750790ad8e956bdbf8f3a028bd73ca66b21fe079533c72e0d38fa5b08",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6028,9 +4639,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9e13daf7db9ddfdd882bcc0934f40d50",
-          "sha1header": "53ef6aabc5e56c11bcc9de4e21f64438ba90ec53",
-          "sha256header": "080dbd6e560284dd8defd334aee2322ab112460f429a5293d9ee3d90ff135874",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6041,9 +4649,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "3be1fd59085d89170eeb5c4448656920",
-          "sha1header": "c958c90f432db4049ffce13533cd39e49f1467dc",
-          "sha256header": "eb2d6c218785025a33c2d77a2097a742882fc145134bdff4970bc9617f5ce505",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6054,9 +4659,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "e3f09dc979e65801c3994da52fee0332",
-          "sha1header": "040b8cce3432b320fd53b78a99e24d0d6bb25ea6",
-          "sha256header": "d4c4636db81bcb0e89b1b86e11dcb97a5eafd5142c46aeef4ea26621d2e05f4e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6067,9 +4669,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "dad36d0d0912cabf42aad58b99a14684",
-          "sha1header": "d86d50a4985fb32da626ec0f9e88cd48828b4ee0",
-          "sha256header": "39d379775677c57f3aa9e979ef48aa6640af347319833ac73bcff83610a5bdeb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6080,9 +4679,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "22810512c6a0fca236ad0d6059a62d82",
-          "sha1header": "0955c2edb3309839527b282a22913070e78049bf",
-          "sha256header": "b9a7a2d8a9a99e8eb3284c1b7f8459a8f4a959925a94a1e8c7ff8286c7f9049b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6093,9 +4689,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "c0514360889b135d6cedeb0ec8b6d9b5",
-          "sha1header": "3504faafe1d4798c815831307f79270fa9ca4e8e",
-          "sha256header": "27b58192f92ad951678ce9e6281e121413da08dd27f19c86060dae8a7d2888f5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6106,9 +4699,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "54707b9136014a8a302efca2ddaaf4a5",
-          "sha1header": "b0e7a5507e1c0da43bf523d304b5c8afb9917bea",
-          "sha256header": "94ba8f5c0c956129000d181d49005f3fe9f020ef99f26a6ef3e9a3974c2df54d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6119,9 +4709,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "17b95b6310bcad7e016199f4cd7680c4",
-          "sha1header": "4e5579797def1d9fa0d81db8fdf673eabc5cf950",
-          "sha256header": "9a693b53b7cb999f423930a8705210848455fcd800398758ae672bfeecca4d98",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6132,9 +4719,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "1eaccbc4e25b5c35244868be163fea63",
-          "sha1header": "b259ebf5d228f6fa41b29b5ef5a94d7b23d61cf6",
-          "sha256header": "2ec8358078b25c726a6c41ed656b2fba6ae45a48d041a2a8b9329d7f412aa85b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6145,9 +4729,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "cce27e93cdaf5dd0c28672c94cedf7a6",
-          "sha1header": "ab9e44fe9728623fe9f712920401c4794f3af113",
-          "sha256header": "734a80aeaa7a4c1ffe7817aab1afa4fa535d36a11148903ef57a9a259eab26cb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6158,9 +4739,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "17005dc4929d1c9439688d4dde812051",
-          "sha1header": "6392c9820aede7ca1942cdbd1bfbefd8d3fa79a1",
-          "sha256header": "672c9e4a3b895a3b8a7e0907eed19d98de61115fb48b3ff6c15ab407d06c9a4b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6171,9 +4749,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "341de5e7f01506f57eaa44c7dfdf5ebb",
-          "sha1header": "e3edb4566511f1d459b8d78809ad1d24caf6d265",
-          "sha256header": "086de12870d64b25db780e88236a03c66f1a2ceee9bd03e123a87052c7245ef6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6184,9 +4759,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "fe9afb4ca9b1bc6067d240dadcc561bf",
-          "sha1header": "e0402bc515042e923a9fbb254bb90843756e8622",
-          "sha256header": "fdd1d7e3e6baf8c51197e0e8732f1a4e46117e6cfc93a2542fa40b6bbc408b42",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6197,9 +4769,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "893f74710753463f268d7f56cafdb648",
-          "sha1header": "94d61f5115f5ec70ad79ea7426b2509354f02ebf",
-          "sha256header": "6941d5544e43af499e2c7999336d2e09ab622fff5f1c0ab8cb6f8bdf27bb679b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6210,9 +4779,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "5dce084dc0be8f5bfcee6d316c68ba7c",
-          "sha1header": "3c76f525812c8f55671726a460016f62d61e7aea",
-          "sha256header": "44f017e910b7062604c30d2ee5a1859e74f48b77700691737f7ba5effe5647fa",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6223,9 +4789,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2149a272635bee5bfbc8dded5cb7d848",
-          "sha1header": "cbdfb40cbbac554d01aef5b47e2ed89450ed9648",
-          "sha256header": "021bf2e44f1c1b79e8643a53f2b622303b029d11bc92bddd23581eb1e8470536",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6236,9 +4799,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "96a8331c23910bdf466092ae022844b1",
-          "sha1header": "7159e3bca3629e60d1e878819448cd15d9633dcd",
-          "sha256header": "a07555e881b1d4eccfd92e4e27e1b868c4b494e84f6ef833aed6b5aa330c39fa",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6249,9 +4809,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "8f0fc3019e8f6db1e5a972390af1589b",
-          "sha1header": "eb36ebb68ddded0037dfc9724aa49f32119e56ef",
-          "sha256header": "00df28a43060574868cbb50e6ed4405337e28f8368895c84405f7cb3c320411a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6262,9 +4819,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "e46ba6903bc440fead07f481b3aa87fe",
-          "sha1header": "107ec1ec0b807c8079b6f10113f7b7d8f15d116a",
-          "sha256header": "1300028f4d140e7ddaa96776b23736a65659a95902c5d381d26d6d6c926c2ff6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6275,9 +4829,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "7b87b8d23b057f0339d72bec64541585",
-          "sha1header": "81dadb564c29fba4d083fa2d3f5c481755573af4",
-          "sha256header": "3e58d6cea23b181e832e789f7107dc100f934fdc451d8ba2c401f12cd4c4933b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6288,9 +4839,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "e9407821c37bc446343b965831d6409c",
-          "sha1header": "013a38e5db6138889c131a4085a6cd0ef7ecf435",
-          "sha256header": "761c37d292b7394e9ae1e07858f0a857b67a06d4c8f1dd2c90c4833bf870488d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6301,9 +4849,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "31c40e167e1a8d26c91bbacdff64eba6",
-          "sha1header": "fbe8c330bd59eefec15741ced1cf5bb70e2eeca3",
-          "sha256header": "df29e97b35b689c653dbf69222433835689996eabe9e3c8273f411d9a37db2dd",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6314,9 +4859,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "2708c99ad2eaddf87c88dd0300128095",
-          "sha1header": "e52a3e543de08e6bea4c8b6ed7b3cfb201f4286c",
-          "sha256header": "8b36ff3c69e708c52fb9e1ba1447c4f671d78442ddf76a52ecb2f421b1b90115",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6327,9 +4869,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "9f0db46aecad3c162c88f9b090059f36",
-          "sha1header": "715dc60751e47d0cdb4da1ff20ca9a56a7887387",
-          "sha256header": "bf83c4b3d4266d9595bbd1f144c06b88eeebce0421b0c134ed1f15949c85e888",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6340,9 +4879,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f4e43d112a4bd3e464b27565d4e689b5",
-          "sha1header": "770160aa3f05956ff358da31eaa535d3818ab3d4",
-          "sha256header": "a1154a043f6b5734178393b931542a96b82860fa51ddc13d38fff6490d06901c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6353,9 +4889,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "767e0769e024b29645cf98cc66d3e849",
-          "sha1header": "631b254295b62c0a3b05da673e1b78e063aa1efb",
-          "sha256header": "766dd3668c2dc261bdfc42491e3c38747bb8ebb077f0635e2ce31fe353e1b85e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6366,9 +4899,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e42b4e2d841b933a91e04cf34c2e1f69",
-          "sha1header": "71d967fe3a8691bc475e0101dbdb7b0efdc2222e",
-          "sha256header": "8bf57beb0385234459fa07ae6ad0b7ff934db38dc7d81af98a4a788652b9c0fe",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6379,9 +4909,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "9df3880d41da183efa7094914e867a7c",
-          "sha1header": "58933f2af0b1b0a885ef1d49a68d81daf04a428f",
-          "sha256header": "1410d4620d5535d825fa6cd955a192a0e31dbd42c5ec746beb2ce552f9410ed7",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6392,9 +4919,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "1a4af2545c6e809ce878bbc9d35351fe",
-          "sha1header": "9ff70d9fb96ddf942e8f0c57e2b46e78e6ed8760",
-          "sha256header": "a34d6001fc87851d0151a52e64097fa91e8da1ec58a654d5fc373fdbe5cab4aa",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6405,9 +4929,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "f7c39d33ebf05f5cf97da9fe33350307",
-          "sha1header": "db975b7cdb279b13fb183250780c4d10b0cee671",
-          "sha256header": "14d6eb4f8987135665e98833ac945553ab8b134977f49d73482dc5128fb6c571",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6418,9 +4939,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "0050c1705b83a922dd8be9219171dea6",
-          "sha1header": "5317419d327040beea8b0a90267a915c945e3106",
-          "sha256header": "e3e50e25c7b693df2d1b146e71961b7c995f707f13df44abbc9fd716657e25cb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6431,9 +4949,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "2a180da81c237305a2e0234a6b56e25f",
-          "sha1header": "ecad83134b2aa586fce0fe931999ff26f71665a1",
-          "sha256header": "c49596eb3d9a61ce2b7276fd40dbb3d581759f3d9d30b1d755389999b3600ab2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6444,9 +4959,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "35dcd93afbbd5785122965c4703c0a4e",
-          "sha1header": "c7d623eb40790377099c09ef3df09b6fefd882d6",
-          "sha256header": "fdc64f720fa134b4d58c32464e65dfae0bc8cc0c7405bee6d1131eea9e4ed09f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6457,9 +4969,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "5e46655d757a4f774ce26bf6cad5f1b3",
-          "sha1header": "57afa7c4942c278c057650095f5b03f09cbf100f",
-          "sha256header": "0521887671cceb0d8ae235eab52002c81896c55c85a2903f4dadb1b2c2017f56",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6470,9 +4979,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "484663be2d95a7d1784b0ad8ec5688a8",
-          "sha1header": "e54a2837f631d3f4e9c489700940c828de30eec7",
-          "sha256header": "cf1b644c7ee9bff4cd4f590635e2f524fd5889861d2192e8402242a8753cd492",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6483,9 +4989,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "da9fd0f9e990c89f162710b0c57c77c5",
-          "sha1header": "2486ef1bb6172e4fcef79f63ab2d7a3ba1d1e705",
-          "sha256header": "cf1fbe0bdbbfadf7ae1cb7107e1695b1c971ccd2cfcf605dffe74ea9b338457f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6496,9 +4999,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "309d752771b96e8c135cb251f2bf418b",
-          "sha1header": "6b567b820b2abaefe62b4e5b78d3d2e9de46cf79",
-          "sha256header": "5439bab1ec73393a3ff08009551175b24a2698777fa08fbbeef33e0cad403dd2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6509,9 +5009,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "8c7fe7d23c7d45b2e2a643ddb49f635b",
-          "sha1header": "c33bcce5099a66a10605185ff10da43b46a95250",
-          "sha256header": "86e07d27cf612a6870a2ba3721428255ddc8b056bdbf7267b74f299ef6f78877",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6522,9 +5019,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "2446be3076b3ff3d13d5ab6bf06b84fe",
-          "sha1header": "e79096f9981c1cafa9763608daea73b5a8139527",
-          "sha256header": "4c00e7b53ea05efddaca07e5b588db5045941f79a5e6a73e9f535d6f25b299a1",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6535,9 +5029,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "be1e25334fe86ddf59ee23ad7c53ee17",
-          "sha1header": "25a9330f0fd8f0523cb232ac838623842e1286f3",
-          "sha256header": "c4874a40878b92c250e4deeddb5452f5777e9278f6de975c7d44f9c78db7a7f4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6548,9 +5039,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "3522eb99e55ca32e00c2327c4fbc3aef",
-          "sha1header": "20519c582d3cf0d79e45c9bdc9f0974678cf765f",
-          "sha256header": "87d8c2961274191ca5a7eb14e59d5b6b078c1a9f11f9f64ec79c6b29e4407c05",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6561,9 +5049,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "e5f2e673078c514b1e85c709e3658314",
-          "sha1header": "8ec0c8cc0c020e49ee7f57f662fa09a12995b463",
-          "sha256header": "abee82149388c7347827c943a0b78fa287698a3471faf3d33e9e54446f387122",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6574,9 +5059,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "7696b83d8bf5efedd3d19147dd1479ed",
-          "sha1header": "eec79feaab47025bb5787ca4eeeb6dc08ba9e859",
-          "sha256header": "8aba91fa25a23134dd1c20f67ae60ccc98245ed946d88eee67fccf31f7577bde",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6587,9 +5069,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "389696e8374192c3faca211f6035e918",
-          "sha1header": "9bdd8132e2f98bbbee15a863c4c98142bab71ea6",
-          "sha256header": "3b68cedda4f282cf413e991a27197b2f88632c4432fda10a7714fb19c163881c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6600,9 +5079,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "64c838bb91eaddc886ac37f72ca53119",
-          "sha1header": "146eabd6c95b2eab104f07954d2992f7916f4eb9",
-          "sha256header": "6345be65babc41b309cee83f4f53924b4ed217d2fdb871954ac442f4f33a6940",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6613,9 +5089,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "39c0475ee24a6b793a19f6a89e2c8a1c",
-          "sha1header": "ac320e0c34b913c9aa0b88e66e803c52963b8705",
-          "sha256header": "28382e198623c4935e406233be5e775a04a7f707b04fc977bc88e44ca6a399f1",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6626,9 +5099,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "6de2e01a4dec98571d0a42e072147605",
-          "sha1header": "96271dea5c2251b9e10c625864baee0ec57e61a2",
-          "sha256header": "a5e9647ad045a6dad969acead77f9912e0cfec91b80c327d069d65d58830adeb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6639,9 +5109,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "c7d857985d06d1c9322a8edd30b063e3",
-          "sha1header": "c264877fe9872334e271a719b628f3e35b6f42bb",
-          "sha256header": "ae86c6a2981959d0c929c7eb1c1e96334dd37bf61a0992409c5f63b7d2805cc0",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6652,9 +5119,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "fa12a45c6075d213c15a70dc5914775a",
-          "sha1header": "4c8216396ae7c7027cc3ad2c456516f6c2d7f51b",
-          "sha256header": "7255dc5becd28e4e019232c6a5b55b59a21b4dd6c19797349706a60f5e5e470f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6665,9 +5129,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "9421d175d72d388e299b6a098e8d73e5",
-          "sha1header": "dd1504967bd4409673121673204e589f6253b54b",
-          "sha256header": "5625cd9cc0ac7977ef12cbfa7adb3f1aae70f4e18e38d96d4965808e375faa2e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6678,9 +5139,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "2707d4104d7131467e67cb50228c2178",
-          "sha1header": "4eb30ce666e0a437d9704ef6fc2561af80def876",
-          "sha256header": "595c2f7496053cf4f71008b6a0661e46d632941ad091484aa6fba02e12950f2d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6691,9 +5149,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "950619cf4a0b2c1a5d5b960534b1224a",
-          "sha1header": "63fc1d4b7e980c057b7e81d7e4013ffba8c947ae",
-          "sha256header": "2e92e701d96ba9e15554b96d5ffb4169146b1a017e39bda2b40bff0c20f27edb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6704,9 +5159,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "db4acfb6aad4c24ddc36a8501dd0c1bb",
-          "sha1header": "f1c0ae8b7974124fa8e489738710723a42a05167",
-          "sha256header": "a0f6ed725dfae19f906f14142e5d2972301a3eef72671cd1f831f0936186c5ac",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6717,9 +5169,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "8af096dd97adc52c45bc69cbcda64f39",
-          "sha1header": "9db57d37439494d7b911c05f77f6be50baf60f5f",
-          "sha256header": "ba334d32d90e5a4e076602478213c26bdfab1dc725320ede6be51798617fc677",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6730,9 +5179,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "da454d1f84b7e6c7834c7c1c193ffe7c",
-          "sha1header": "478d0553254f2a2ac1a22b7aed410b3cc6b00ccd",
-          "sha256header": "d959f78eac677fce1e50fb765dc81668946934a5208cf449ee0cbd383c9f6600",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6743,9 +5189,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "56bccdec8a6645f4aab9cd1ac335b62c",
-          "sha1header": "43295726375a42b127c2b04fc352932bd4bffee7",
-          "sha256header": "54a329772acdf8713bc83fc7eb7866fa4ff28f1eb874939b1ba422e22f84c35c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6756,9 +5199,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "620506e3284d2eca0dc84a15f677ad20",
-          "sha1header": "ed8f377b97c56545598872a92cce55d9c4d05678",
-          "sha256header": "01a571bb1eb08a396702e1f7030c59cf94d713427de2b5bf6be63836bc11168e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6769,9 +5209,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "140b7f1c4c846d7324f99d447aeda083",
-          "sha1header": "93667b8246914dd7852890461b8183971aecc692",
-          "sha256header": "da36f7a9afc6088d222abfb94bd49f3d375924119c431e94bf7c8246af0bad57",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6782,9 +5219,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a93611bec097c085ee04561c756bfd4b",
-          "sha1header": "8fbb4bc95285978cfeff220d4478d652e8df0a13",
-          "sha256header": "9a4b1ab8d64ca0c3533c856c4f7d4546493627500b666ff795536c82297b3817",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6795,9 +5229,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "d84e972d05df9db6927d4752d6e73c84",
-          "sha1header": "0f156f606792bdcf0295f50c5460b09b9a366817",
-          "sha256header": "88b1fe8b35f9d06bb018bd713467fb700a0f8a1658087b58a98797e4def1e6a9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6808,9 +5239,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "fef7e3dea1fff65af13ad482dce4df54",
-          "sha1header": "4c703c53fc98f1e816a08f4591ee3ad8370a16cc",
-          "sha256header": "4a0d6fbfc41e402ee5a1dad87e11810887f250d23a7b3919c20df66856861a33",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6821,9 +5249,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c1ed08b20c0383ba9b63db85f090f41a",
-          "sha1header": "6459053ce90d228db86bea6d687cea8c0062a85c",
-          "sha256header": "66d8d119b9da0312dfaa851e2c54c5f9880f789b32471e58625009b4170cb6da",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6834,9 +5259,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e514da351d8773dac35c721279bb97dc",
-          "sha1header": "27ac75e155ad4584f9649a3876d698eb47dc38ea",
-          "sha256header": "8d790587aa9f733bc5feefc14aa83c201dd09e83eb9e2a722d4b62c5d11057b9",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6847,9 +5269,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "cf5609ca2821a7a00a28d01713043a4a",
-          "sha1header": "feeee82eaabb42da6e6abb3983982290e24661b7",
-          "sha256header": "6a5f005542afa7d07972ae9245f3efe7d0c5b8a9414bf95602f1487c6814b3c8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6860,9 +5279,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "c3c361e417568a3fef596a2be9978835",
-          "sha1header": "5af6ab29ab8d1e212b6bcc35dcbccd41b89082ff",
-          "sha256header": "f207edc6f22b8e224dede7637b1671d8e2476016f29fa8064edbcf7775a28546",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6873,9 +5289,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "7ee1a7e9208fb46a1ccf6bd62be29e7d",
-          "sha1header": "a234ddb4fd3a86fabdc948ccce812855b645deba",
-          "sha256header": "938ba9c7e1b9813b8107d4f2d3b7fc3ca0141b08f50e9a1b445892a26212cd6b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6886,9 +5299,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3c8cb9746bb114b4756b03d8a47308c8",
-          "sha1header": "17746304ef6b43bca6cd5d776968df9bfe62b119",
-          "sha256header": "bd29f42c62779d2deedafe756abb73be1b3924188081ed83e42f0ef34b9a37e6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6899,9 +5309,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "56110476b91fa5f5c8d2c8399dc6dc02",
-          "sha1header": "eb115431b53b40c5fb30929fbc0159c93557183a",
-          "sha256header": "f153d3d6f0cdc05b10320994d711242886139f9ff8dd8956ee87df993080976a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6912,9 +5319,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "256d2d165c027059239e7e77ef902956",
-          "sha1header": "522a34f36acd46d1918ed2475b26c130d01e1486",
-          "sha256header": "0201087fcea6a1149291ebc3b98ae1bf7402955f1762766ffe74144de82df2cb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6925,9 +5329,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "957d6a85bd4f2dd98cfda8ea09b15e34",
-          "sha1header": "f9bf52946996fceedb775ff18cbb599f57b2da38",
-          "sha256header": "cb4d60d051f3a5479409f75689f945f203e576f6be3a6bbd69992264c7e04623",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6938,9 +5339,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6ef356246c3dbd955825720a12d6c3cb",
-          "sha1header": "bc39a97037d8e81066e5356c287dead8aa62b84a",
-          "sha256header": "3e3693c8c490bab61fbb3ff39392d11adfdc641c599315d869278fbd93ab6c74",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6951,9 +5349,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "dc631b1af2020c32147fb432d287d3e6",
-          "sha1header": "451821c372b4ca2834c2f26b68b8315bf59065a2",
-          "sha256header": "b063de300a9a69c1337c24817b013a98c0027cc0de41cd9a20955de7bedda529",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6964,9 +5359,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "d58d73659e42eb392abfda531b93b2a8",
-          "sha1header": "4fdc1b45e9b578c475e282fbb9a084ea9e845dc5",
-          "sha256header": "88fc81446eb7cc025bb3911914d56af009aac07f14713a3ca4b97b76bddd0399",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6977,9 +5369,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2d0aa536909c67a05b393b28a9939957",
-          "sha1header": "331fd776fc18e12713a625fa655875afc14fde5d",
-          "sha256header": "cac4244f3f2925aa9516e8aef6e19b4fdbfefec2d633bb9ab981bade1b9b8981",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -6990,9 +5379,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2346ba371323aad8f69cc887d83a2d2a",
-          "sha1header": "36bbd7ad0d3c5ba3df503adf492ebbdb60cdd59d",
-          "sha256header": "14d494f1618720f2ceac2806368c2e9607dacb3d2b021f15880c0df1667f5814",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7003,9 +5389,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "788e6d029afef4f8d98d567a1e3ce449",
-          "sha1header": "df88832dac505a85e33492c34e5973f6fe0e041a",
-          "sha256header": "5f5e578038948d86738db1cdcbb6278d05deec4af5dbc1f9780e2dfb52277bf6",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7016,9 +5399,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "3c94cc5f158fc75059a86f6aa40b56c1",
-          "sha1header": "63c0f74e7580795ea128d288a998fc5535113f60",
-          "sha256header": "3783b4125ffa517b36f7be1b0f10d9675a5fadaf526d9eb77949bb121b93d273",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7029,9 +5409,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "39598bfaca10b02e0025259338723227",
-          "sha1header": "f6cc09fff75aab1fc9b228e41ff1c935de0d905a",
-          "sha256header": "3965ecc6fc969eaf7192cb8a0f9a9d645dfb0483fba52e6a98f832f28f3d4c86",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7042,9 +5419,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "0bd9832f32902f526cb600559971ee58",
-          "sha1header": "f94b7affa536ba210b6679efb5fcaf778b99b755",
-          "sha256header": "b26187f6f1e4a7de3536f42d5707bc5f8460692eb165975bd1ec88d93946e53d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7055,9 +5429,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "fe90a2998a8c3b2be238932757905c80",
-          "sha1header": "40142f86fae5c060dbfcb5ba9c912aaccd9312eb",
-          "sha256header": "7ff6c2dcc507be1bf42ac23f649eb6e443f869ee50a1c793af527a6da143c760",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7068,9 +5439,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5d44cbf0db52812718e9adf5cce05f9d",
-          "sha1header": "6eef164184f710cde054cd767fda5111208e0730",
-          "sha256header": "cd817266f19e69bc5681f40db475dbe889b2920107ec431b65f3bd7bca0fdb0d",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7081,9 +5449,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "e53e77c2ecfb1c2542cc177bee9abe20",
-          "sha1header": "d9cf94a413cd5deb528e5462f13134dd87652268",
-          "sha256header": "dc1224c47a312c7c776e93bfa6721f01a986ba58b4b9ece9b1c0c53c4f7f2fa8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7094,9 +5459,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "a52a0f8e883fc74ade037f4b7fe60c01",
-          "sha1header": "d138ae621929f1ea23bb5ea8361dee6f945d7fd7",
-          "sha256header": "b2a19482ffa3b51564b99cc45fe2352fbabf9346557d23a1c4e4ae07b998ad2c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7107,9 +5469,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "1756350831265beb6e395b8259733634",
-          "sha1header": "0f505fa993ebcc1de75b70b98b71bbb30e6771ae",
-          "sha256header": "ad4772890b604b653ee8dba73cc61a2da72e4ab05710ede4500bbea79f15a831",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7120,9 +5479,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "c3b3197d292f53a56969cf4f6ea96581",
-          "sha1header": "a19a92510fcb6f8e6aa579cdcf8db0cd7f5789e6",
-          "sha256header": "a10aed4d36cd720f906e1a653e8c80bf7e31ec8fdc94b0111cd9bf12c8cec661",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7133,9 +5489,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "2929f0e7be3dbe2e4f7bcad1c3818bca",
-          "sha1header": "3d0370a53fc9aa16b1d9b5007e04a455bd0e5fa5",
-          "sha256header": "0750f5d64da02afdd1404d068dda5461b0a0b13705f713dacb44eb914d42fb95",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7146,9 +5499,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "5fbe4ca5929c908ed42dceea00d24e03",
-          "sha1header": "678d618cdca5300ccaf507f84054b2578164304d",
-          "sha256header": "aa9a19d4a0c6e77bb3e011855c04d9923b7773f689d60cbbfe22bb7eac002661",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7159,9 +5509,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "37588afaaf9e2bb1b61a9e58f073e6df",
-          "sha1header": "586c05f701b4e5fe2af608365e68c2fc814bd4af",
-          "sha256header": "2923e9bde560314e65070f3e8a4a3c64a745a23a6970c1bc49008f49fb9ffe67",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7172,9 +5519,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "021d990beb36249846e1824b44df4f64",
-          "sha1header": "f7d837b3aa4749588ca2711e617685914e7c575e",
-          "sha256header": "c4c1aaf86df26a1804f10dfdbacb68b7e78ed21425509d64cc2b932de0e9fa92",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7185,9 +5529,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "02d1e1dd37167809fbc6f87638377aac",
-          "sha1header": "bf196de6df8eff6be04045512af820eb17efe943",
-          "sha256header": "204e841cd0e23288a6308e3be4b16eadadd2c9770c30efd227c8588fe4bfc8f7",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7198,9 +5539,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ab4877f80f72b8d93a4130019f70b85a",
-          "sha1header": "f94aceb612b178fb2446b331b5b721f21381ba09",
-          "sha256header": "245a108ebeb717861db9e9eece354fed049a73c1c5610225b48103255d66bb71",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7211,9 +5549,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "121be2921b5368b0dcb94416bf796132",
-          "sha1header": "e7afb4eeff17bcaa9c80e2fd8b72f8bf0137f29c",
-          "sha256header": "484b9ab360f0bbc44bed71e75f01db627920c4ef6d53bc83eacd8f3e6e4cebf0",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7224,9 +5559,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "9e43483ad52970bf30bf0ae1b406d9b4",
-          "sha1header": "0d93097383fda43a86b77b55b115ab3e90283882",
-          "sha256header": "0717a3839ed52538b5a006c93c948f787e458cd83b84032de2d26dbc694f6b68",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7237,9 +5569,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "65768641ff254b168a7f193f6209cd92",
-          "sha1header": "a18fb5aaa701d680da5bed6fa232e656069201cc",
-          "sha256header": "7d5447bff70de1978147832aa4723d90f88ffa8d90d048a5aae43fdbcea06e8b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7250,9 +5579,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e179cdcad64bb2c4c1b56f523b72e2f1",
-          "sha1header": "95de559cce88ad552ba614792618b9d3421c0511",
-          "sha256header": "7d4ac8ce76aaf31e15c9db8ae056217ee6920115df01bcd14a7beec0459caada",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7263,9 +5589,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "a011eb208193ff1886de0d7d672b6ec0",
-          "sha1header": "f8a09decef4a767feb40834e05ca2f060eb304e4",
-          "sha256header": "78f87d902a289388968969fdca19f11226d35d643c95583195938dbc4f1198fd",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7276,9 +5599,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "55d4dc332ed8a91663f22c606848077b",
-          "sha1header": "01c2ab65b2142944bbfb090bc2479cf1464d3179",
-          "sha256header": "41e68af53616b7f0ebcac90adce1f9cf7fc973cfcfad384c20989e4095a2b364",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7289,9 +5609,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a7d359ff47c15f6f3e1f25c593dd7628",
-          "sha1header": "a3a205050d3301b0f154e1d2df2d1d4c37159ede",
-          "sha256header": "2cbba507703c525ea2b881348f5da19aa93dfdc8281647e57782c4d6dd4b47b5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7302,9 +5619,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "bd5676c7802123bc1064a296cae15acb",
-          "sha1header": "a3294180153e00a7b23a914a6fbbedb44138bfa2",
-          "sha256header": "4600c8c0c6a0fd85c3febdf2fba7e553da1747beae999893eb4ffcb204e0c267",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7315,9 +5629,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "36763879a3f1a676d749dca8613dc90a",
-          "sha1header": "ac1d52b756440204c52d1125c9c3012b478e236f",
-          "sha256header": "58c4151c100b5c4fa043ad70ef9c7e2b1cfad33ba58b9124c2df41adc325d319",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7328,9 +5639,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "02cda0887d174a448befac74a96156b2",
-          "sha1header": "f61be0e75fae2784979cb51792c0d35dcd9470f8",
-          "sha256header": "ff77e49e3324eee3df45bf7078c09060cacd2f9a16224545bc4a9edc3935d3c7",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7341,9 +5649,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "7c256443e0bf17e0a3987131155e91bf",
-          "sha1header": "34e74adbe28e4ce1a463d3ef06ef1107e5809e1f",
-          "sha256header": "1100c18072e4f31ca20af9e6c7f3dcb70cfddd24187c339b2046f876aaae34ad",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7354,9 +5659,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "23818ebce2532bd420a376ee52ae3d44",
-          "sha1header": "149daf165a6555766358438414d8b5088c80ef44",
-          "sha256header": "a5b76adac91d072d2994ebe8d3077323918f7b8b2349d87659c36f4c23613b3f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7367,9 +5669,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "143637802abd9415f1ec2b2ba2483932",
-          "sha1header": "3b1257f23714a0e6583d58723dedcc78094fa316",
-          "sha256header": "b8396317b6374f6fe6e96f5f8a8dc0eda8b6c86e16e931401f89fbccf35347eb",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7380,9 +5679,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "75cc00b384fcc6bc498c7e636a002ab9",
-          "sha1header": "d2a7bd0799eda9dfb57fc70f6960e97c1219ee5e",
-          "sha256header": "edf65c57d238d11770c5815e3d55adc50ad89b3add2974b2fde5013181a8d383",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7393,9 +5689,6 @@
           "epoch": "2",
           "arch": "x86_64",
           "sigmd5": "ebe1129fc8ac8efaa315bef8762cb64d",
-          "sha1header": "3d1af005565cf30b533a88e0c0b8363b1b03c37d",
-          "sha256header": "366f66de4b075e2769014c39bfe37f2cc7b24a953f09036dcfd279005ee97dc5",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7406,9 +5699,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "9300a254ceb4e4e6c4314b49e93b3bb5",
-          "sha1header": "e173a96855a12f63eef61a17914add3608e85307",
-          "sha256header": "ecef9ead0761a1eea4ba0e6f26a8614886af97804c4245ce0464cbb18f77122c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7419,9 +5709,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "b89614b46adcc2e389da02792ff8591f",
-          "sha1header": "4d2261095f1a64f5c782b22c0d220bf41d465d2b",
-          "sha256header": "1358707ee4f47f3f9651429842557d59026c931f4ed299966996d218bb03be9e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7432,9 +5719,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "fcf75192156bed476a64345a39f40b32",
-          "sha1header": "da77e4c1fcfcd5d191de80905f43cc27c5bf304e",
-          "sha256header": "14c95b462784b8d505723c4af12e13d774688ee0e621103b4859d93e4de6e0ab",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7445,9 +5729,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "6b9e29af3bcdf0eac20cd5c61cb893ab",
-          "sha1header": "ca6f57e478f4f24d74008677539006bbbb43469e",
-          "sha256header": "5a9893037d5dc219035655fa5982c1afb895c1b71085c2b080a99e0ede937522",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7458,9 +5739,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "ab98d01b19bc22b79024c5aa54ebab03",
-          "sha1header": "3972fab8b2b324482d51bb3c349ccdc1d523af5c",
-          "sha256header": "5218b5dd3db75ef8cad8275a03b363f26693036ba0bb364083436c7dde26595e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7471,9 +5749,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "5fe895db4ff44289dff61691f03cd319",
-          "sha1header": "2778ba6891b8ad3caf8fd6f60cbc967c1fd7006c",
-          "sha256header": "0f6596fa6cc9d24c64e8d048daf1281cf4c378064d7e9d3a6094e7383b5a0080",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7484,9 +5759,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "15ad9d61130ff2d9214afb3c2f8c562e",
-          "sha1header": "03a192896bb400287171ba5d450860bc7bffcf31",
-          "sha256header": "27b3312021acdb876ce21e63569c19963fb4a9f92a036df3ae8f8efbdf425104",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7497,9 +5769,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "2cf27de94ca08f3db8b077ac0ae5f2f0",
-          "sha1header": "08e6b30f6a4a3d89dd9020f282446e62253757ef",
-          "sha256header": "2d029073a828fdabf999ff174edb7a638ac30d79e46f4d74605459aa6ba970e2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7510,9 +5779,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "3bead8a2b2d45662365b5f1e548fb290",
-          "sha1header": "c47a2cfa6fd4f8f0fe241e1fa57d9f430555fb5c",
-          "sha256header": "4d477237d26c913921bd8c57f1c8170dbd29bfe4db8f1cd061ca6b0d8c3d66b1",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7523,9 +5789,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "48fafec87ea09d07b6fd0356f842c2f3",
-          "sha1header": "619b39eecbaa963d95d2439911da95fa7d5b41b9",
-          "sha256header": "db5804de567afeea7febf24beb93b568f4b29cd4ebe6057fab75629c66f4304c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7536,9 +5799,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a5b676e692a25f452caba8d4ae00c0b4",
-          "sha1header": "0c094637d1be25b1bc0c84fe21c52af3a4a1d05a",
-          "sha256header": "78a1afe5fc8a4168e94b1c5d7410f680521013fc9113174f0c1fba1d17537961",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7549,9 +5809,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "578e88fe39f55bafdf12905b9482445f",
-          "sha1header": "1c1064336982598c40f0a0f3b0fc7010c20a00e2",
-          "sha256header": "62586f2b2396a2390c9aed38792bfb327f39835667e2f915f1da82597949907b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7562,9 +5819,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "440522e852f4c3fc8a3c8b7c4d2ec16b",
-          "sha1header": "6b5517bfe770be22e35cdd4ddb12f0d0912335f7",
-          "sha256header": "85e5e456487d0dc358764469daf0cd360ccdf9fccc577b75539a2ee92cd10a96",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7575,9 +5829,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "50e57a058e0e65631b6e668d48f36141",
-          "sha1header": "9aa8c4dcabed4c724208fb883f9c439719bd30e8",
-          "sha256header": "344a76920620fb7de9f1245b4ef2b76686de1bdaac9fe1c8d5473a2775c40533",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7588,9 +5839,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "01c5034d23f9da7e527d49f4e90135a6",
-          "sha1header": "9ca3e027f224a8b56d1769290875daf1bca2ae35",
-          "sha256header": "188b40da8b57e48788608a31452c9575df9cf31f5f628f4d4766574cf66f6165",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7601,9 +5849,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "5a54d40ffbaa550391ba00d0a5271c54",
-          "sha1header": "13e9dc4aa2a18bb612c0a2fa8e3532ac084ad4eb",
-          "sha256header": "38b69ffa9215a67a5ef09bd3ec6a8ce5df0bab50181eb963683b6d33735e180a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7614,9 +5859,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "bdce78bdd9dbcf999db62090dacefe89",
-          "sha1header": "115835f1610221b5a77155c7c0fd5e95791223f9",
-          "sha256header": "b79fd4c62077af7d1abb4f881d6cb8a4dbb0b3e46d2c05f141d5d360fd48618a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7627,9 +5869,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c3dfb0c17746194bd4916c48014e9bf0",
-          "sha1header": "b31516ec729e731112d70e955ae123985d7a327d",
-          "sha256header": "2f8f57bfafb1c9d20c85d0ec365c1dd45fd3f2251bb88224d0f37acdd42ff0fc",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7640,9 +5879,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "eb6ee46711569d63db39c3b775a558fd",
-          "sha1header": "2bfefa14036efc220e5c76732b9956535b2383c3",
-          "sha256header": "a1840eadb1ca5f9ed62a30b8e01a705f720c0eb7b96e5cbfca99423c9b8811d3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7653,9 +5889,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a82245b2f1f6589ed2da6470013a98a4",
-          "sha1header": "880e5b2c3fd0e50a87f7d73092474a88fd6d9942",
-          "sha256header": "b3040b532b73965f918d83c34596075fe446f3e1269e833df9f891825af75d96",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7666,9 +5899,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "78513d8c574c4d186cd8a95d793158f1",
-          "sha1header": "5141c3ef165a5ea0d44c50bfc5f8473e3d6fe4e9",
-          "sha256header": "60da6d8c6a5e9f14151ab705671f7b9baeaff6474e3a2d5befabd702691687f1",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7679,9 +5909,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "bd85fec72c21a8e96289c48073bdca41",
-          "sha1header": "7e6c60400e2ba30b4b7f76d8f1153fad5fc86c3e",
-          "sha256header": "89ad98ff6606ffa4b5b21371fa8f5475419bc84881ea922aead1b4b295f8defd",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7692,9 +5919,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "ad9d7748165cefd37be8ef8cab7be466",
-          "sha1header": "42bccb6b10adadbc4bdf8a3205bd353b43f4aaa3",
-          "sha256header": "604b5d84315967efc4f8f430a8b5d09f6788f8e8143fcc1ade83983a195829e4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7705,9 +5929,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "9b9983df43c8a47395689a2c882c373d",
-          "sha1header": "51ca493dabf431135681c2279ca4fa6c02bc1cd9",
-          "sha256header": "5c5d68315069536c6702f61203dc29620ac6a2bdb35b095de3968032057d1dcc",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7718,9 +5939,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "9151115cf161abb4ba6b031d2689ea79",
-          "sha1header": "706e9df2578748309ee421e4a26e3429899a59ab",
-          "sha256header": "ef3686f08ee4d044b145af30334fa8e07ffa47a7565becaeabcd55d4720c0aa8",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7731,9 +5949,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "85e33c8cc954bbfdfe39016594825f6d",
-          "sha1header": "131f5976cbb53b97354068d3b6937d13b3dbbc21",
-          "sha256header": "6d5483d46dbe831002d48db090f3b36bfae8bf20020b8ace7a4d5c7720580c47",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7744,9 +5959,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "0a59b2a11ea5c4775f5be80202cdcb66",
-          "sha1header": "c59026c7db3ffa459188506344a2069ccf969831",
-          "sha256header": "db599fd82e3adffe0eb9a51a20fc6769c5e686c267bd3f275495748a5c5eefd2",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7757,9 +5969,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "c59194691ec2b8f31889af95d0d5dad3",
-          "sha1header": "e7d217d189f47d2a9f7ae5d3bc6bcae4c0e01db7",
-          "sha256header": "e410535fa6357958e23acbbb72dd29d814f8c8eb506576334640a533f67f1f1b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7770,9 +5979,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "f09c141965b45f6820aa39b57d004ad5",
-          "sha1header": "98f65569c64373675a98da5c0d5ecf7ad1a63a61",
-          "sha256header": "3da26702be47f7532315aefe86440a4fc52f0c4ac97d6e8cf44b2ce0743d6eb4",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7783,9 +5989,6 @@
           "epoch": "1",
           "arch": "x86_64",
           "sigmd5": "f4a193f0c6c6274d2e91ae874d70061e",
-          "sha1header": "4dcfc347cdb194b687101dde02f884a31df30a43",
-          "sha256header": "f8d806a5d20059ebc476716ffbac99d23ce8d062bd40c9b9f73522025037b53b",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7796,9 +5999,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "24651c6b1efa82afd1bc19a8b0b0d407",
-          "sha1header": "770a0bd69d9e8f6a72816fe246a080b09fb9980d",
-          "sha256header": "c467094e00aeb20edda4d02a69e9eb24a1e4f92cd475e0f9b7cadb659e873a59",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7809,9 +6009,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "0858281948eac6758819dd037068e925",
-          "sha1header": "8241ef3f70ee0be4f75279603165a00eb4de7206",
-          "sha256header": "6765ed54a536e9d426688efdef91c76c231f611dc22261a16f5a09ef254761d3",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7822,9 +6019,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "94cd3250d88ced106ff7a40decde0df4",
-          "sha1header": "b2a1d85ad4e433138b7b14ea6541099006e9e708",
-          "sha256header": "42283c2169cac4ddc3edfdd83f5cfbe7442ab74a9601312b5af18015d00ef209",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7835,9 +6029,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "a12e65a2ec312769a4bf78b66588f98a",
-          "sha1header": "c2fc68ff0245709cbaf6130a7ba02f5cce0bc05b",
-          "sha256header": "96149e5d64caa5e6a9181d15c54be55b522f8331389052ea68542d944ffad23f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7848,9 +6039,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "c37129dfc3e4883006975d7561e56fc8",
-          "sha1header": "7a3f2315861899afc0630681157a2d1b967bfcc5",
-          "sha256header": "64bd2c51f2173c6d6e98867e1302f227ad5b25a10639f7f8b47126cfbe46d51e",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7861,9 +6049,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "e5945edff8463fdfd68c6dad7c95eed3",
-          "sha1header": "47aa8b8491eb6a6aebce12310c6e29852e130bf1",
-          "sha256header": "ee25707fd5c4cd890e9f4de89c91868354a551d89612928a883489ac3c14333a",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         }
@@ -7880,9 +6065,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "09e2809fc5f22dc6302d74d10f6ae05f",
-          "sha1header": "110a7f70c1187f68684c29f7c31fd676020be79c",
-          "sha256header": "a7109e1857a151935a3857ee49a02166c3ccdd149da638fe692c5f82a0e65c53",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7893,9 +6075,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "5d11b2158529b688d1ba39e4bb40751a",
-          "sha1header": "3ace728041a84bab99d32c96fc297e0d875934ce",
-          "sha256header": "3ca4cbbeedc50afb5ca6b31b436216febc15e5214e6d82bcffc1e2ce66ad864c",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7906,9 +6085,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "0ca346bad6eda9af02a54598fdc08466",
-          "sha1header": "d74c3b259cae46eeda95294ffac10bcb279343e2",
-          "sha256header": "e38718606bb8d7ddee02b57c7fd2e7f96ac6e0c50b17d321f33a15a327dcb896",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7919,9 +6095,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "2b298ab79b33797efc1ee992d74dd6a7",
-          "sha1header": "603ad79bb418d4e1e9046c9268a9ea63c29a09a4",
-          "sha256header": "12b455af51bcbca4c171a455bc1c1350e9fa411c94556524e5098e9a28770c05",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7932,9 +6105,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "6eab1408ad49d7b48b783d6bc3799426",
-          "sha1header": "f921c1403baa0deb24473f9912960484c73aa78b",
-          "sha256header": "42781bf2f422272bde70f1d73f46772126e4eae96f96fdd0892e8ce794379f85",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7945,9 +6115,6 @@
           "epoch": null,
           "arch": "x86_64",
           "sigmd5": "ae7dfec82f04ecbfadbc75c5798126e8",
-          "sha1header": "9ba88a6fa6657435c95dd0bc8a9e98d17a8485f3",
-          "sha256header": "3bc68a8f289b121ba7904a4118fd37fe628bf0b1986bab2094dbbfc9e8e5164f",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         },
@@ -7958,9 +6125,6 @@
           "epoch": null,
           "arch": null,
           "sigmd5": null,
-          "sha1header": "d487d50c2f29ad851e3839b4e3fba5b98a80f334",
-          "sha256header": "2e55c7b02910e0ccf51771630979b450ce2d63e8e72171988bc57b26a156faed",
-          "sha3_256header": "12f62bb7d55572dcefd9cc04904f208cf4917319632de249ad21505d41503c9f",
           "sigpgp": null,
           "siggpg": null
         },
@@ -7971,9 +6135,6 @@
           "epoch": null,
           "arch": "noarch",
           "sigmd5": "1756350831265beb6e395b8259733634",
-          "sha1header": "0f505fa993ebcc1de75b70b98b71bbb30e6771ae",
-          "sha256header": "ad4772890b604b653ee8dba73cc61a2da72e4ab05710ede4500bbea79f15a831",
-          "sha3_256header": null,
           "sigpgp": null,
           "siggpg": null
         }


### PR DESCRIPTION
PR #2529 fixed the issue we had with the changing header checksums for newer versions of rpm, but on older versions (e.g. rpm v4 in CentOS Stream 10), this change causes rpm stage metadata to produce empty package lists.

Revert this until we figure out the problem and add a test for metadata generation on all supported versions to verify the change.

I tested this locally with a simple manifest build with `--json` and inspected the metadata.  With the feature on from `main`, the package lists in the metadata for both build and os pipelines are empty.  With this revert, they are generated normally.

----

On older versions of RPM (e.g. on CentOS 10), this breaks metadata generation.  Revert until we figure out the problem.

This reverts commit d1047b7fb2ecf94d85ddbb3cbf60e21a0186ed95.