### PR TITLE
stages/dd: create `dd` stage

### DIFF
--- a/stages/org.osbuild.dd
+++ b/stages/org.osbuild.dd
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+import os
+import subprocess
+import sys
+
+import osbuild.api
+from osbuild.util import parsing
+
+
+def main(args, options):
+    src = parsing.parse_location(options["src"], args)
+    dst = os.path.join(args["tree"], options["dst"].lstrip("/"))
+    src_offset = options.get("src_offset", 0)
+    count = options["count"]
+
+    cmd = [
+        "dd",
+        f"if={src}",
+        f"of={dst}",
+        "bs=4096",
+        f"skip={src_offset}",
+        f"count={count}",
+        "iflag=skip_bytes,count_bytes",
+        "conv=notrunc",
+    ]
+
+    subprocess.run(cmd, check=True)
+
+    return 0
+
+
+if __name__ == '__main__':
+    _args = osbuild.api.arguments()
+    ret = main(_args, _args["options"])
+    sys.exit(ret)

--- a/stages/org.osbuild.dd.meta.json
+++ b/stages/org.osbuild.dd.meta.json
@@ -1,0 +1,44 @@
+{
+  "summary": "Copy raw bytes from an input to the tree.",
+  "description": [
+    "Copy raw bytes from a source file  to a destination file in the current tree",
+    "Thin wrapper around `dd`.",
+    "Buildhost commands used: `dd`."
+  ],
+  "schema_2": {
+    "options": {
+      "additionalProperties": false,
+      "required": [
+        "src",
+        "dst",
+        "count"
+      ],
+      "properties": {
+        "src": {
+          "description": "Source URL (e.g. input://image/disk.img)",
+          "type": "string",
+          "pattern": "^(input|tree|mount)://."
+        },
+        "dst": {
+          "description": "Destination filename in the tree",
+          "type": "string"
+        },
+        "src_offset": {
+          "description": "Byte offset into the source",
+          "type": "integer",
+          "default": 0,
+          "minimum": 0
+        },
+        "count": {
+          "description": "Number of bytes to copy",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/stages/test/test_dd.py
+++ b/stages/test/test_dd.py
@@ -1,0 +1,156 @@
+#!/usr/bin/python3
+
+import os
+from unittest import mock
+
+import pytest
+
+from osbuild import testutil
+from osbuild.testutil import make_fake_input_tree
+
+STAGE_NAME = "org.osbuild.dd"
+
+
+def make_fake_args(tmp_path, input_tree, input_name="image"):
+    return {
+        "tree": str(tmp_path / "tree"),
+        "inputs": {
+            input_name: {
+                "path": input_tree,
+                "data": {
+                    "files": {},
+                },
+            },
+        },
+    }
+
+
+@mock.patch("subprocess.run")
+def test_dd_basic(mock_run, tmp_path, stage_module):
+    tree = tmp_path / "tree"
+    tree.mkdir()
+
+    input_tree = make_fake_input_tree(tmp_path, {
+        "/disk.img": "x" * 4096,
+    })
+
+    args = make_fake_args(tmp_path, input_tree)
+
+    stage_module.main(args, {
+        "src": "input://image/disk.img",
+        "dst": "partition.raw",
+        "count": 1024,
+    })
+
+    mock_run.assert_called_once_with([
+        "dd",
+        f"if={os.path.join(input_tree, 'disk.img')}",
+        f"of={os.path.join(tree, 'partition.raw')}",
+        "bs=4096",
+        "skip=0",
+        "count=1024",
+        "iflag=skip_bytes,count_bytes",
+        "conv=notrunc",
+    ], check=True)
+
+
+@mock.patch("subprocess.run")
+def test_dd_with_offset(mock_run, tmp_path, stage_module):
+    tree = tmp_path / "tree"
+    tree.mkdir()
+
+    input_tree = make_fake_input_tree(tmp_path, {
+        "/disk.img": "x" * 4096,
+    })
+
+    args = make_fake_args(tmp_path, input_tree)
+
+    stage_module.main(args, {
+        "src": "input://image/disk.img",
+        "dst": "partition.raw",
+        "src_offset": 2048,
+        "count": 1024,
+    })
+
+    mock_run.assert_called_once_with([
+        "dd",
+        f"if={os.path.join(input_tree, 'disk.img')}",
+        f"of={os.path.join(tree, 'partition.raw')}",
+        "bs=4096",
+        "skip=2048",
+        "count=1024",
+        "iflag=skip_bytes,count_bytes",
+        "conv=notrunc",
+    ], check=True)
+
+
+@mock.patch("subprocess.run")
+def test_dd_tree_src(mock_run, tmp_path, stage_module):
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    (tree / "disk.img").write_bytes(b"\x00" * 4096)
+
+    args = {"tree": str(tree), "inputs": {}}
+
+    stage_module.main(args, {
+        "src": "tree:///disk.img",
+        "dst": "partition.raw",
+        "count": 512,
+    })
+
+    mock_run.assert_called_once_with([
+        "dd",
+        f"if={os.path.join(tree, 'disk.img')}",
+        f"of={os.path.join(tree, 'partition.raw')}",
+        "bs=4096",
+        "skip=0",
+        "count=512",
+        "iflag=skip_bytes,count_bytes",
+        "conv=notrunc",
+    ], check=True)
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    # bad
+    ({"extra": "option"}, "'extra' was unexpected"),
+    ({"count": -1}, "-1 is less than the minimum"),
+    ({"count": 0}, "0 is less than the minimum"),
+    ({"src_offset": -1}, "-1 is less than the minimum"),
+    ({"src": "bad://no/scheme"}, "does not match"),
+    # good
+    ({}, ""),
+    ({"src_offset": 0}, ""),
+    ({"src_offset": 1048576}, ""),
+])
+def test_schema_validation_dd(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "options": {
+            "src": "input://image/disk.img",
+            "dst": "partition.raw",
+            "count": 1024,
+        }
+    }
+    test_input["options"].update(test_data)
+    res = stage_schema.validate(test_input)
+
+    if expected_err == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)
+
+
+@pytest.mark.parametrize("test_data,expected_err", [
+    ({"dst": "out.raw", "count": 512}, "'src' is a required property"),
+    ({"src": "input://image/disk.img", "count": 512}, "'dst' is a required property"),
+    ({"src": "input://image/disk.img", "dst": "out.raw"}, "'count' is a required property"),
+])
+def test_schema_required_fields(stage_schema, test_data, expected_err):
+    test_input = {
+        "type": STAGE_NAME,
+        "options": test_data,
+    }
+    res = stage_schema.validate(test_input)
+    assert res.valid is False
+    testutil.assert_jsonschema_error_contains(res, expected_err, expected_num_errs=1)


### PR DESCRIPTION
This stage allows us to copy out sections of files (most importantly: disk images). This would allow us to copy out given partitions so they can be exported separately, or together (once we support multiple exports).

Useful for sysupdate based systems that want to download a partition for their updates, this stage allows for the 'raw' style of updating.