### PR TITLE
test: fix missing mock_run

### DIFF
--- a/stages/test/test_rpm.py
+++ b/stages/test/test_rpm.py
@@ -62,7 +62,7 @@ def test_schema_validation(stage_schema, test_data, expected_err):
     ],
 )
 @mock.patch("subprocess.run")
-def test_env_conflict_detection(tmp_path, stage_module, generic_env, kernel_install_env, expected_err):
+def test_env_conflict_detection(_mock_run, tmp_path, stage_module, generic_env, kernel_install_env, expected_err):
     tree = str(tmp_path / "tree")
     os.makedirs(tree)
     inputs = {"packages": {"path": str(tmp_path), "data": {"files": {}}}}


### PR DESCRIPTION
When not passing mock_run the actual call to run isn't mocked and the argument values are mixed up; this leads to test failures.