### PR TITLE
Schutzfile: update Fedora 43 repo snapshots

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -14,14 +14,24 @@
           {
             "title": "fedora",
             "name": "fedora",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f43/f43-x86_64-branched-20250901"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f43/f43-x86_64-fedora-20260106"
+          },
+          {
+            "title": "fedora-updates",
+            "name": "fedora-updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f43/f43-x86_64-updates-released-20260809"
           }
         ],
         "aarch64": [
           {
             "title": "fedora",
             "name": "fedora",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f43/f43-aarch64-branched-20250901"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f43/f43-aarch64-fedora-20260106"
+          },
+          {
+            "title": "fedora-updates",
+            "name": "fedora-updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f43/f43-aarch64-updates-released-20260809"
           }
         ]
       }


### PR DESCRIPTION
Somehow these never got updated after F43 GA.