### PR TITLE
rhsm: prefer Katello CA on Satellite-registered hosts (SAT-37848)

### DIFF
--- a/osbuild/util/rhsm.py
+++ b/osbuild/util/rhsm.py
@@ -28,6 +28,14 @@ class Subscriptions:
             self.DEFAULT_ENTITLEMENT_DIR = "/run/secrets/etc-pki-entitlement"
             self.DEFAULT_REPO_FILE = "/run/secrets/redhat.repo"
 
+        # Prefer the Katello CA on Satellite-registered hosts. The
+        # katello-server-ca.pem contains the CA chain needed to validate
+        # TLS certificates of Satellite content proxies, while the default
+        # redhat-uep.pem only covers direct Red Hat CDN access.
+        katello_ca = os.path.join(os.path.dirname(self.DEFAULT_SSL_CA_CERT), "katello-server-ca.pem")
+        if os.path.exists(katello_ca):
+            self.DEFAULT_SSL_CA_CERT = katello_ca
+
     @staticmethod
     def is_container_with_rhsm_secrets():
         """Detect if we are running inside a podman container and RHSM secrets are available."""

--- a/test/mod/test_util_rhsm.py
+++ b/test/mod/test_util_rhsm.py
@@ -150,6 +150,56 @@ class TestContainerDetection:
         assert subscriptions.DEFAULT_REPO_FILE == "/run/secrets/redhat.repo"
 
 
+class TestKatelloCA:
+    """Tests for Katello CA preference on Satellite-registered hosts."""
+
+    def test_prefers_katello_ca_on_host(self, tmp_path):
+        make_fake_tree(tmp_path, {
+            "etc/rhsm/ca/redhat-uep.pem": "FAKE UEP CA",
+            "etc/rhsm/ca/katello-server-ca.pem": "FAKE KATELLO CA",
+        })
+        with patched_path_exists(tmp_path):
+            subscriptions = Subscriptions(repositories=None)
+            assert subscriptions.DEFAULT_SSL_CA_CERT == "/etc/rhsm/ca/katello-server-ca.pem"
+
+    def test_falls_back_to_uep_without_katello(self, tmp_path):
+        make_fake_tree(tmp_path, {
+            "etc/rhsm/ca/redhat-uep.pem": "FAKE UEP CA",
+        })
+        with patched_path_exists(tmp_path):
+            subscriptions = Subscriptions(repositories=None)
+            assert subscriptions.DEFAULT_SSL_CA_CERT == "/etc/rhsm/ca/redhat-uep.pem"
+
+    def test_prefers_katello_ca_in_container(self, tmp_path):
+        make_fake_tree(tmp_path, {
+            "run/.containerenv": "",
+            "run/secrets/rhsm/ca/redhat-uep.pem": "FAKE UEP CA",
+            "run/secrets/rhsm/ca/katello-server-ca.pem": "FAKE KATELLO CA",
+        })
+        with patched_path_exists(tmp_path):
+            subscriptions = Subscriptions(repositories=None)
+            assert subscriptions.DEFAULT_SSL_CA_CERT == "/run/secrets/rhsm/ca/katello-server-ca.pem"
+
+    def test_explicit_sslcacert_takes_precedence_over_katello(self, tmp_path):
+        # Even when the Katello CA is present and becomes the default, an
+        # sslcacert explicitly set in the repo file must still win.
+        make_fake_tree(tmp_path, {
+            "etc/rhsm/ca/redhat-uep.pem": "FAKE UEP CA",
+            "etc/rhsm/ca/katello-server-ca.pem": "FAKE KATELLO CA",
+        })
+        with patched_path_exists(tmp_path):
+            subscriptions = Subscriptions.parse_repo_file(StringIO(REPO_FILE))
+
+        # The instance default was switched to the Katello CA, but REPO_FILE
+        # explicitly sets sslcacert to redhat-uep.pem, which must override it.
+        assert subscriptions.DEFAULT_SSL_CA_CERT == "/etc/rhsm/ca/katello-server-ca.pem"
+        assert subscriptions.repositories["jpp"]["sslcacert"] == "/etc/rhsm/ca/redhat-uep.pem"
+
+        secrets = subscriptions.get_secrets(
+            ["https://cdn.redhat.com/1.0/x86_64/os/Packages/test.rpm"])
+        assert secrets["ssl_ca_cert"] == "/etc/rhsm/ca/redhat-uep.pem"
+
+
 class TestSubscribedSystem:
     """Tests for regular subscribed RHEL systems."""
 


### PR DESCRIPTION
On Satellite-registered hosts, content is served through the Satellite content proxy whose TLS certificate is signed by the Katello CA. The default redhat-uep.pem only contains the Red Hat CDN CA and cannot validate these certificates, causing TLS failures when osbuild fetches packages from RHSM-backed repositories.

A hybrid approach of combining both the RHSM CA and the system CA bundle was considered but rejected: osbuild uses three different download backends (curl, librepo, dnf) and each handles CA configuration differently. curl supports both cacert and capath options simultaneously, but librepo has no sslcapath support (no LRO_SSLCAPATH) and dnf does not expose sslcapath in its repo configuration. Maintaining a reliable hybrid CA setup across all three backends, and across different curl/Python/library versions on RHEL 9+, would be fragile and hard to test.

Instead, when /etc/rhsm/ca/katello-server-ca.pem exists (installed by the Satellite registration process), use it as the default CA. This file contains the CA chain needed to validate the Satellite content proxy's TLS certificates. This single-point fix works transparently across all download paths since they all read the default CA from the same Subscriptions class. When the repo file explicitly sets sslcacert, that value still takes precedence.

---

https://redhat.atlassian.net/browse/SAT-37848