### PR TITLE
stages: create `os-release`

### DIFF
--- a/stages/org.osbuild.os-release
+++ b/stages/org.osbuild.os-release
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+import os
+import sys
+
+import osbuild.api
+
+
+def format_value(value):
+    if ' ' in value or any(c in value for c in ('"', "'", '\\', '`', '$')):
+        escaped = value.replace('\\', '\\\\').replace('"', '\\"').replace('$', '\\$').replace('`', '\\`')
+        return f'"{escaped}"'
+    return value
+
+
+def main(tree, options):
+    path = options.get("path", "usr/lib/os-release")
+    filepath = os.path.join(tree, path)
+
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+
+    with open(filepath, "w", encoding="utf8") as f:
+        for key, value in options["vars"].items():
+            f.write(f"{key}={format_value(value)}\n")
+
+    if not options.get("extension-release-strict", True):
+        os.setxattr(filepath, "user.extension-release.strict", b"0")
+
+    return 0
+
+
+if __name__ == '__main__':
+    args = osbuild.api.arguments()
+    r = main(args["tree"], args["options"])
+    sys.exit(r)

--- a/stages/org.osbuild.os-release.meta.json
+++ b/stages/org.osbuild.os-release.meta.json
@@ -1,0 +1,202 @@
+{
+  "summary": "Create an os-release file",
+  "description": [
+    "Create an os-release file at a given path in the tree.",
+    "The default path is /usr/lib/os-release.",
+    "This file format is also used for extension-release files in sysexts",
+    "and confexts (see systemd-sysext(8)).",
+    "See os-release(5) for details on the format and recognized variables."
+  ],
+  "schema": {
+    "additionalProperties": false,
+    "required": [
+      "vars"
+    ],
+    "properties": {
+      "path": {
+        "type": "string",
+        "default": "usr/lib/os-release",
+        "description": "Path to the os-release file to write, relative to the tree root."
+      },
+      "extension-release-strict": {
+        "type": "boolean",
+        "default": true,
+        "description": "Set to false to add the user.extension-release.strict=0 xattr, relaxing image name matching for sysexts."
+      },
+      "vars": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Variables to set in the os-release file.",
+        "properties": {
+          "NAME": {
+            "type": "string",
+            "description": "A string identifying the operating system."
+          },
+          "ID": {
+            "type": "string",
+            "pattern": "^[a-z0-9._-]+$",
+            "description": "A lower-case string identifying the operating system."
+          },
+          "ID_LIKE": {
+            "type": "string",
+            "pattern": "^[a-z0-9._\\- ]+$",
+            "description": "A space-separated list of operating system identifiers."
+          },
+          "VERSION": {
+            "type": "string",
+            "description": "A string identifying the operating system version."
+          },
+          "VERSION_ID": {
+            "type": "string",
+            "pattern": "^[a-z0-9._-]+$",
+            "description": "A lower-case string identifying the operating system version."
+          },
+          "VERSION_CODENAME": {
+            "type": "string",
+            "pattern": "^[a-z0-9._-]+$",
+            "description": "A lower-case string identifying the operating system release code name."
+          },
+          "PRETTY_NAME": {
+            "type": "string",
+            "description": "A pretty operating system name in a format suitable for presentation to the user."
+          },
+          "ANSI_COLOR": {
+            "type": "string",
+            "description": "A suggested presentation color when showing the OS name on the console."
+          },
+          "CPE_NAME": {
+            "type": "string",
+            "description": "A CPE name for the operating system, in URI binding syntax."
+          },
+          "HOME_URL": {
+            "type": "string",
+            "description": "A URL to the homepage of the operating system."
+          },
+          "DOCUMENTATION_URL": {
+            "type": "string",
+            "description": "A URL to the documentation of the operating system."
+          },
+          "SUPPORT_URL": {
+            "type": "string",
+            "description": "A URL to the support page of the operating system."
+          },
+          "BUG_REPORT_URL": {
+            "type": "string",
+            "description": "A URL to the bug tracker of the operating system."
+          },
+          "PRIVACY_POLICY_URL": {
+            "type": "string",
+            "description": "A URL to the privacy policy of the operating system."
+          },
+          "BUILD_ID": {
+            "type": "string",
+            "description": "A string uniquely identifying the system image used as the origin for a distribution."
+          },
+          "VARIANT": {
+            "type": "string",
+            "description": "A string identifying a specific variant or edition of the operating system."
+          },
+          "VARIANT_ID": {
+            "type": "string",
+            "pattern": "^[a-z0-9._-]+$",
+            "description": "A lower-case string identifying a specific variant or edition of the operating system."
+          },
+          "LOGO": {
+            "type": "string",
+            "description": "A string specifying the name of an icon for the operating system."
+          },
+          "IMAGE_ID": {
+            "type": "string",
+            "pattern": "^[a-z0-9._-]+$",
+            "description": "A lower-case string identifying a specific image of the operating system."
+          },
+          "IMAGE_VERSION": {
+            "type": "string",
+            "pattern": "^[a-z0-9._-]+$",
+            "description": "A lower-case string identifying the image version of the operating system."
+          },
+          "DEFAULT_HOSTNAME": {
+            "type": "string",
+            "description": "A string specifying the default hostname for the operating system."
+          },
+          "ARCHITECTURE": {
+            "type": "string",
+            "description": "A string identifying the native CPU architecture of the operating system."
+          },
+          "VENDOR_NAME": {
+            "type": "string",
+            "description": "The name of the OS vendor."
+          },
+          "VENDOR_URL": {
+            "type": "string",
+            "description": "The homepage of the OS vendor."
+          },
+          "SYSEXT_LEVEL": {
+            "type": "string",
+            "description": "A string identifying the system extension compatibility level."
+          },
+          "CONFEXT_LEVEL": {
+            "type": "string",
+            "description": "A string identifying the configuration extension compatibility level."
+          },
+          "SYSEXT_SCOPE": {
+            "type": "string",
+            "description": "The scope of system extensions. A space-separated list of system, initrd, portable."
+          },
+          "CONFEXT_SCOPE": {
+            "type": "string",
+            "description": "The scope of configuration extensions. A space-separated list of system, initrd, portable."
+          },
+          "PORTABLE_PREFIXES": {
+            "type": "string",
+            "description": "A space-separated list of unit name prefixes for portable services."
+          },
+          "PLATFORM_ID": {
+            "type": "string",
+            "description": "A string identifying the platform for which packages are built."
+          },
+          "SUPPORT_END": {
+            "type": "string",
+            "description": "The date at which support for this version of the OS ends."
+          },
+          "OSTREE_VERSION": {
+            "type": "string",
+            "description": "The OSTree version string."
+          },
+          "EXTENSION_RELOAD_MANAGER": {
+            "type": "string",
+            "enum": [
+              "1"
+            ],
+            "description": "Set to 1 if the extension requires a daemon-reload after merge."
+          },
+          "PORTABLE_SCOPE": {
+            "type": "string",
+            "enum": [
+              "system",
+              "user",
+              "any"
+            ],
+            "description": "The scope of the portable service."
+          },
+          "RELEASE_TYPE": {
+            "type": "string",
+            "enum": [
+              "stable",
+              "lts",
+              "development",
+              "experiment"
+            ],
+            "description": "The release type of the operating system."
+          }
+        },
+        "patternProperties": {
+          "^SYSEXT_[A-Z_]+$": {
+            "type": "string",
+            "description": "A SYSEXT_-prefixed variable identifying properties of the extension itself."
+          }
+        }
+      }
+    }
+  }
+}

--- a/stages/test/test_os_release.py
+++ b/stages/test/test_os_release.py
@@ -1,0 +1,221 @@
+#!/usr/bin/python3
+
+import os
+
+import pytest
+
+from osbuild import testutil
+
+STAGE_NAME = "org.osbuild.os-release"
+
+
+@pytest.mark.parametrize("test_data,expected_errs", [
+    # minimal
+    (
+        {"vars": {"ID": "fedora"}},
+        "",
+    ),
+    # full
+    (
+        {
+            "vars": {
+                "NAME": "Fedora Linux",
+                "ID": "fedora",
+                "VERSION": "40 (Workstation Edition)",
+                "VERSION_ID": "40",
+                "PRETTY_NAME": "Fedora Linux 40 (Workstation Edition)",
+                "VARIANT": "Workstation Edition",
+                "VARIANT_ID": "workstation",
+                "PLATFORM_ID": "platform:f40",
+                "HOME_URL": "https://fedoraproject.org/",
+                "BUG_REPORT_URL": "https://bugzilla.redhat.com/",
+            },
+        },
+        "",
+    ),
+    # custom path
+    (
+        {"path": "usr/lib/initrd-release", "vars": {"ID": "fedora"}},
+        "",
+    ),
+    # empty vars (bad)
+    (
+        {"vars": {}},
+        "",
+    ),
+    # missing vars (bad)
+    (
+        {},
+        "'vars' is a required property",
+    ),
+    # bad ID pattern
+    (
+        {"vars": {"ID": "INVALID UPPER"}},
+        "'INVALID UPPER' does not match",
+    ),
+    # bad VERSION_ID pattern
+    (
+        {"vars": {"VERSION_ID": "NOT VALID"}},
+        "'NOT VALID' does not match",
+    ),
+    # bad VERSION_CODENAME pattern
+    (
+        {"vars": {"VERSION_CODENAME": "NOT VALID"}},
+        "'NOT VALID' does not match",
+    ),
+    # bad VARIANT_ID pattern
+    (
+        {"vars": {"VARIANT_ID": "NOT VALID"}},
+        "'NOT VALID' does not match",
+    ),
+    # bad IMAGE_ID pattern
+    (
+        {"vars": {"IMAGE_ID": "NOT VALID"}},
+        "'NOT VALID' does not match",
+    ),
+    # bad IMAGE_VERSION pattern
+    (
+        {"vars": {"IMAGE_VERSION": "NOT VALID"}},
+        "'NOT VALID' does not match",
+    ),
+    # bad ID_LIKE pattern
+    (
+        {"vars": {"ID_LIKE": "UPPER"}},
+        "'UPPER' does not match",
+    ),
+    # valid ID_LIKE with spaces
+    (
+        {"vars": {"ID_LIKE": "rhel fedora"}},
+        "",
+    ),
+    # extension-release fields
+    (
+        {
+            "vars": {
+                "ID": "fedora",
+                "EXTENSION_RELOAD_MANAGER": "1",
+                "PORTABLE_SCOPE": "system",
+                "RELEASE_TYPE": "stable",
+            },
+        },
+        "",
+    ),
+    # bad EXTENSION_RELOAD_MANAGER value
+    (
+        {"vars": {"EXTENSION_RELOAD_MANAGER": "0"}},
+        "'0' is not one of",
+    ),
+    # bad PORTABLE_SCOPE value
+    (
+        {"vars": {"PORTABLE_SCOPE": "invalid"}},
+        "'invalid' is not one of",
+    ),
+    # bad RELEASE_TYPE value
+    (
+        {"vars": {"RELEASE_TYPE": "invalid"}},
+        "'invalid' is not one of",
+    ),
+    # SYSEXT_ prefixed variables
+    (
+        {
+            "vars": {
+                "ID": "fedora",
+                "SYSEXT_ID": "myext",
+                "SYSEXT_VERSION_ID": "1.0",
+            },
+        },
+        "",
+    ),
+    # unknown variable (bad)
+    (
+        {"vars": {"UNKNOWN_VAR": "value"}},
+        "does not match any of the regexes",
+    ),
+])
+@pytest.mark.parametrize("stage_schema", ["1"], indirect=True)
+def test_schema_validation(stage_schema, test_data, expected_errs):
+    test_input = {
+        "name": STAGE_NAME,
+        "options": test_data,
+    }
+    res = stage_schema.validate(test_input)
+    if expected_errs == "":
+        assert res.valid is True, f"err: {[e.as_dict() for e in res.errors]}"
+    else:
+        assert res.valid is False
+        testutil.assert_jsonschema_error_contains(res, expected_errs)
+
+
+@pytest.mark.parametrize("options,expected_lines", [
+    (
+        {"vars": {"NAME": "Fedora Linux", "ID": "fedora", "VERSION_ID": "40"}},
+        ['NAME="Fedora Linux"', "ID=fedora", "VERSION_ID=40"],
+    ),
+    (
+        {
+            "vars": {
+                "NAME": "Red Hat Enterprise Linux",
+                "VERSION": "8.2 (Ootpa)",
+                "ID": "rhel",
+                "ID_LIKE": "fedora",
+            },
+        },
+        [
+            'NAME="Red Hat Enterprise Linux"',
+            'VERSION="8.2 (Ootpa)"',
+            "ID=rhel",
+            "ID_LIKE=fedora",
+        ],
+    ),
+    # custom path
+    (
+        {"path": "etc/os-release", "vars": {"ID": "fedora"}},
+        ["ID=fedora"],
+    ),
+])
+def test_os_release_contents(tmp_path, stage_module, options, expected_lines):
+    stage_module.main(tmp_path, options)
+
+    path = options.get("path", "usr/lib/os-release")
+    filepath = os.path.join(tmp_path, path)
+    assert os.path.exists(filepath)
+
+    with open(filepath, encoding="utf-8") as f:
+        content = f.read()
+
+    for line in expected_lines:
+        assert line in content
+
+
+def test_os_release_default_path(tmp_path, stage_module):
+    stage_module.main(tmp_path, {"vars": {"ID": "test"}})
+    assert os.path.exists(os.path.join(tmp_path, "usr", "lib", "os-release"))
+
+
+def test_os_release_creates_intermediate_dirs(tmp_path, stage_module):
+    stage_module.main(tmp_path, {"path": "some/deep/nested/dir/os-release", "vars": {"ID": "test"}})
+    filepath = os.path.join(tmp_path, "some", "deep", "nested", "dir", "os-release")
+    assert os.path.exists(filepath)
+
+
+def test_extension_release_strict_false(tmp_path, stage_module):
+    options = {"extension-release-strict": False, "vars": {"ID": "fedora"}}
+    stage_module.main(tmp_path, options)
+    filepath = os.path.join(tmp_path, "usr", "lib", "os-release")
+    xattr = os.getxattr(filepath, "user.extension-release.strict")
+    assert xattr == b"0"
+
+
+def test_extension_release_strict_default(tmp_path, stage_module):
+    stage_module.main(tmp_path, {"vars": {"ID": "fedora"}})
+    filepath = os.path.join(tmp_path, "usr", "lib", "os-release")
+    with pytest.raises(OSError):
+        os.getxattr(filepath, "user.extension-release.strict")
+
+
+def test_format_value_quoting(stage_module):
+    assert stage_module.format_value("simple") == "simple"
+    assert stage_module.format_value("has space") == '"has space"'
+    assert stage_module.format_value('has"quote') == '"has\\"quote"'
+    assert stage_module.format_value("has$dollar") == '"has\\$dollar"'
+    assert stage_module.format_value("has`backtick") == '"has\\`backtick"'


### PR DESCRIPTION
This stage allows creating `os-release` compatible files with all documentated variables available. Since `os-release` compatible files are also used in `confexts` and `sysexts` this stage also allows for their variables and idiosyncrasies.

This would *mostly* be used when creating `(sys|conf)exts` or when building trees from packages that do *not* include an `os-release` file with the latter not being a use case at the moment.