### PR TITLE
Support rootless osbuild runs without container

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -2,7 +2,7 @@
 %global         selinuxtype targeted
 
 Version:        191
-%global         osbuild_initrd_version 0.1
+%global         osbuild_initrd_version 0.2
 
 %forgemeta
 

--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -4,10 +4,18 @@ This specifies the entrypoint of the osbuild module when run as executable. For
 compatibility we will continue to run the CLI.
 """
 
+import os
 import sys
 
+from osbuild.main_cli import _reexec_in_userns
 from osbuild.main_cli import osbuild_cli as main
 
 if __name__ == "__main__":
+    if os.getuid() != 0:
+        # Re-exec in a user namespace when possible; returns the child's exit
+        # status to propagate, or None to fall back to the normal code path.
+        r = _reexec_in_userns()
+        if r is not None:
+            sys.exit(r)
     r = main()
     sys.exit(r)

--- a/osbuild/api.py
+++ b/osbuild/api.py
@@ -43,8 +43,9 @@ class BaseAPI(abc.ABC):
     endpoint: ClassVar[str]
     """The name of the API endpoint"""
 
-    def __init__(self, socket_address: Optional[PathLike] = None):
+    def __init__(self, socket_address: Optional[PathLike] = None, rundir="/run/osbuild"):
         self.socket_address = socket_address
+        self._rundir = rundir
         self.barrier = threading.Barrier(2)
         self.event_loop = None
         self.thread = None
@@ -103,7 +104,7 @@ class BaseAPI(abc.ABC):
         assert not self.running
 
         if not self.socket_address:
-            self._socketdir = self._make_socket_dir()
+            self._socketdir = self._make_socket_dir(self._rundir)
             address = os.path.join(self._socketdir.name, self.endpoint)
             self.socket_address = address
 
@@ -138,8 +139,8 @@ class API(BaseAPI):
 
     endpoint = "osbuild"
 
-    def __init__(self, *, socket_address=None):
-        super().__init__(socket_address)
+    def __init__(self, *, socket_address=None, rundir="/run/osbuild"):
+        super().__init__(socket_address, rundir=rundir)
         self.error = None
 
     def _message(self, msg, fds, sock):

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -153,6 +153,11 @@ class BuildRoot(contextlib.AbstractContextManager):
             self._bind_dev(self.dev, "tty")
             self._bind_dev(self.dev, "zero")
 
+            # /dev/fuse is needed by podman for fuse-overlayfs in a vm
+            # in some cases
+            if os.path.exists("/dev/fuse"):
+                self._bind_dev(self.dev, "fuse")
+
             # Prepare all registered API endpoints
             for api in self._apis:
                 self._exitstack.enter_context(api)

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -11,7 +11,7 @@ import json
 import os
 import sys
 import typing
-from typing import List
+from typing import List, Optional
 
 import osbuild
 import osbuild.meta
@@ -19,6 +19,7 @@ import osbuild.monitor
 from osbuild.meta import ValidationResult
 from osbuild.objectstore import ObjectStore
 from osbuild.pipeline import Manifest
+from osbuild.util.linux import IdMaps
 from osbuild.util.parsing import parse_size
 from osbuild.util.term import fmt as vt
 
@@ -124,7 +125,30 @@ def _default_rundir() -> str:
     return f"/run/user/{os.getuid()}/osbuild"
 
 
+def _reexec_in_userns() -> Optional[int]:
+    """Re-exec osbuild inside a user namespace with full uid/gid mappings.
+
+    Returns the exit status of the re-exec'd osbuild, for the caller to
+    `sys.exit()` with. Returns None if the required support is missing or the
+    namespace cannot be set up, so the caller can fall back to the normal code
+    path.
+    """
+    maps = IdMaps.gather()
+    if maps is None:
+        return None
+
+    argv = sys.argv.copy()
+    if argv[0].endswith("__main__.py"):
+        argv[:1] = [sys.executable, "-m", "osbuild"]
+    if "--rundir" not in argv:
+        # Keep the user rundir even though uid will be 0 in the userns
+        argv += ["--rundir", _default_rundir()]
+
+    return maps.exec(argv)
+
 # pylint: disable=too-many-branches,too-many-return-statements,too-many-statements
+
+
 def osbuild_cli() -> int:
     args = parse_arguments(sys.argv)
     if args.rundir is None:

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -105,15 +105,30 @@ def parse_arguments(sys_argv: List[str]) -> argparse.Namespace:
     # nargs='?' const='*' means `--break` is equivalent to `--break=*`
     parser.add_argument("--break", dest='debug_break', type=str, nargs='?', const='*',
                         help="open debug shell when executing stage. Accepts stage name or id or * (for all)")
+    parser.add_argument("--rundir", metavar="DIRECTORY", type=os.path.abspath,
+                        default=None,
+                        help="directory for temporary runtime data "
+                             "(default: /run/osbuild for root, $XDG_RUNTIME_DIR/osbuild otherwise)")
     parser.add_argument("--quiet", "-q", action="store_true",
                         help="suppress normal output")
 
     return parser.parse_args(sys_argv[1:])
 
 
+def _default_rundir() -> str:
+    if os.getuid() == 0:
+        return "/run/osbuild"
+    xdg = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg:
+        return os.path.join(xdg, "osbuild")
+    return f"/run/user/{os.getuid()}/osbuild"
+
+
 # pylint: disable=too-many-branches,too-many-return-statements,too-many-statements
 def osbuild_cli() -> int:
     args = parse_arguments(sys.argv)
+    if args.rundir is None:
+        args.rundir = _default_rundir()
     desc = parse_manifest(args.manifest_path)
 
     index = osbuild.meta.Index(args.libdir)
@@ -193,7 +208,8 @@ def osbuild_cli() -> int:
                 args.libdir,
                 debug_break,
                 in_vm=in_vm,
-                stage_timeout=stage_timeout
+                stage_timeout=stage_timeout,
+                rundir=args.rundir
             )
             if r.success:
                 monitor.log(f"manifest {args.manifest_path} finished successfully\n", origin="osbuild.main_cli")

--- a/osbuild/objectstore.py
+++ b/osbuild/objectstore.py
@@ -503,8 +503,8 @@ class StoreServer(api.BaseAPI):
 
     endpoint = "store"
 
-    def __init__(self, store: ObjectStore, *, socket_address=None):
-        super().__init__(socket_address)
+    def __init__(self, store: ObjectStore, *, socket_address=None, rundir="/run/osbuild"):
+        super().__init__(socket_address, rundir=rundir)
         self.store = store
         self.tmproot = store.tempdir(prefix="store-server-")
         self._stack = contextlib.ExitStack()

--- a/osbuild/pipeline.py
+++ b/osbuild/pipeline.py
@@ -225,10 +225,11 @@ class Stage:
             monitor,
             libdir,
             debug_break="",
-            timeout=None) -> StageResult:
+            timeout=None,
+            rundir="/run/osbuild") -> StageResult:
         with contextlib.ExitStack() as cm:
 
-            build_root = buildroot.BuildRoot(build_tree, runner.path, libdir, store.tmp)
+            build_root = buildroot.BuildRoot(build_tree, runner.path, libdir, store.tmp, rundir=rundir)
             cm.enter_context(build_root)
 
             # if we have a build root, then also bind-mount the boot
@@ -281,7 +282,7 @@ class Stage:
                 f"{mounts_tmpdir}:{mounts_mapped}"
             ]
 
-            storeapi = objectstore.StoreServer(store)
+            storeapi = objectstore.StoreServer(store, rundir=rundir)
             cm.enter_context(storeapi)
 
             mgr = host.ServiceManager(monitor=monitor)
@@ -303,10 +304,10 @@ class Stage:
 
             self.prepare_arguments(args, args_path)
 
-            api = API()
+            api = API(rundir=rundir)
             build_root.register_api(api)
 
-            rls = remoteloop.LoopServer()
+            rls = remoteloop.LoopServer(rundir=rundir)
             build_root.register_api(rls)
 
             extra_env = {}
@@ -395,7 +396,8 @@ class Pipeline:
         return stage
 
     def build_stages(self, object_store, monitor, libdir,
-                     debug_break="", stage_timeout=None, in_vm=False):
+                     debug_break="", stage_timeout=None, in_vm=False,
+                     rundir="/run/osbuild"):
         results = []
 
         # If there are no stages, just return here
@@ -483,7 +485,8 @@ class Pipeline:
                                       monitor,
                                       libdir,
                                       debug_break,
-                                      stage_timeout)
+                                      stage_timeout,
+                                      rundir=rundir)
 
                 md = tree.meta.get(r.id)
                 monitor.result(r, md)
@@ -499,7 +502,8 @@ class Pipeline:
 
         return results
 
-    def run(self, store, monitor, libdir, debug_break="", stage_timeout=None, in_vm=False):
+    def run(self, store, monitor, libdir, debug_break="", stage_timeout=None, in_vm=False,
+            rundir="/run/osbuild"):
         self.run_in_vm = in_vm
         monitor.begin(self)
         pr = PipelineResult(self.name)
@@ -508,7 +512,8 @@ class Pipeline:
                                           libdir,
                                           debug_break,
                                           stage_timeout,
-                                          in_vm)
+                                          in_vm,
+                                          rundir=rundir)
         pr.set_stages(stage_results)
         monitor.finish({"name": self.name})
         return pr
@@ -655,7 +660,8 @@ class Manifest:
         return list(map(lambda x: x.name, reversed(build.values())))
 
     def build(self, store, pipelines, monitor, libdir,
-              debug_break="", stage_timeout=None, in_vm=None) -> ManifestBuildResult:
+              debug_break="", stage_timeout=None, in_vm=None,
+              rundir="/run/osbuild") -> ManifestBuildResult:
         """Build the manifest
 
         Returns a dict of string keys that contains the overall
@@ -672,7 +678,14 @@ class Manifest:
 
         for name_or_id in pipelines:
             pl = self[name_or_id]
-            res = pl.run(store, monitor, libdir, debug_break, stage_timeout, in_vm=in_vm and pl.name in in_vm)
+            res = pl.run(
+                store,
+                monitor,
+                libdir,
+                debug_break,
+                stage_timeout,
+                in_vm=in_vm and pl.name in in_vm,
+                rundir=rundir)
             mbr.add_pipeline(pl.id, res)
             if not mbr.success:
                 return mbr

--- a/osbuild/remoteloop.py
+++ b/osbuild/remoteloop.py
@@ -36,8 +36,8 @@ class LoopServer(api.BaseAPI):
 
     endpoint = "remoteloop"
 
-    def __init__(self, *, socket_address=None):
-        super().__init__(socket_address)
+    def __init__(self, *, socket_address=None, rundir):
+        super().__init__(socket_address, rundir=rundir)
         self.devs = []
         self.ctl = None
 

--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -19,12 +19,18 @@ import hashlib
 import hmac
 import os
 import platform
+import pwd
+import shutil
 import struct
+import subprocess
 import threading
+import typing
 import uuid
+from typing import List, Optional, Tuple
 
 __all__ = [
     "fcntl_flock",
+    "IdMaps",
     "ioctl_get_immutable",
     "ioctl_toggle_immutable",
     "Libc",
@@ -291,6 +297,10 @@ class Libc:
     RENAME_NOREPLACE = ctypes.c_uint(1)
     RENAME_WHITEOUT = ctypes.c_uint(4)
 
+    # flags for unshare(2)/clone(2)
+    CLONE_NEWNS = 0x00020000
+    CLONE_NEWUSER = 0x10000000
+
     # see /usr/include/x86_64-linux-gnu/bits/stat.h
     UTIME_NOW = ctypes.c_long(((1 << 30) - 1))
     UTIME_OMIT = ctypes.c_long(((1 << 30) - 2))
@@ -373,6 +383,21 @@ class Libc:
         setattr(proto, "__name__", "prctl")
         self.prctl = proto
 
+        # prototype: unshare
+        proto = ctypes.CFUNCTYPE(
+            ctypes.c_int,  # restype (return type)
+            ctypes.c_int,
+            use_errno=True,
+        )(
+            ("unshare", self._lib),
+            (
+                (1, "flags"),
+            ),
+        )
+        setattr(proto, "errcheck", self._errcheck_errno)
+        setattr(proto, "__name__", "unshare")
+        self.unshare = proto
+
     # (can be removed once we move to python3.8)
     def memfd_create(self, name: str, flags: int = 0) -> int:
         """ create an anonymous file """
@@ -401,6 +426,112 @@ class Libc:
             msg = f"{func.__name__}{args} -> {result}: error ({err}): {os.strerror(err)}"
             raise OSError(err, msg)
         return result
+
+
+class IdMaps(typing.NamedTuple):
+    """The id/sub-id ranges needed to fully map a user namespace."""
+    uid: int
+    gid: int
+    subuid: Tuple[int, int]  # (start, count) from /etc/subuid
+    subgid: Tuple[int, int]  # (start, count) from /etc/subgid
+
+    @staticmethod
+    def _subid_range(path: str, keys: set) -> Optional[Tuple[int, int]]:
+        """Return (start, count) of the first sub-id range in `path` for `keys`."""
+        try:
+            with open(path, encoding="utf8") as f:
+                for line in f:
+                    fields = line.strip().split(":")
+                    if len(fields) != 3:
+                        continue
+                    owner, start, count = fields
+                    if owner in keys:
+                        return int(start), int(count)
+        except (FileNotFoundError, ValueError):
+            pass
+        return None
+
+    @classmethod
+    def gather(cls) -> Optional["IdMaps"]:
+        """Gather what we need to set up a fully-mapped user namespace ourselves."""
+        if shutil.which("newuidmap") is None or shutil.which("newgidmap") is None:
+            return None
+        uid, gid = os.getuid(), os.getgid()
+        name = pwd.getpwuid(uid).pw_name
+        subuid = cls._subid_range("/etc/subuid", {name, str(uid)})
+        if subuid is None:
+            return None
+        subgid = cls._subid_range("/etc/subgid", {name, str(gid)})
+        if subgid is None:
+            return None
+        return cls(uid, gid, subuid, subgid)
+
+    def install(self, pid: int) -> None:
+        """Install these uid/gid maps for the user namespace of process `pid`."""
+        su_start, su_count = self.subuid
+        sg_start, sg_count = self.subgid
+        subprocess.run(
+            ["newuidmap", str(pid),
+             "0", str(self.uid), "1",
+             "1", str(su_start), str(su_count)],
+            check=True)
+        subprocess.run(
+            ["newgidmap", str(pid),
+             "0", str(self.gid), "1",
+             "1", str(sg_start), str(sg_count)],
+            check=True)
+
+    def exec(self, argv: List[str]) -> Optional[int]:
+        """Run `argv` inside a new user namespace mapped by these id maps.
+
+        On success the parent supervises the child and returns its exit status,
+        so the caller can `sys.exit()` with it. Returns None if the namespace
+        cannot be set up.
+        """
+        ready_r, ready_w = os.pipe()  # child -> parent: namespace created
+        go_r, go_w = os.pipe()        # parent -> child: maps installed
+
+        pid = os.fork()
+        if pid == 0:
+            # --- child ---
+            os.close(ready_r)
+            os.close(go_w)
+            try:
+                Libc.default().unshare(Libc.CLONE_NEWUSER | Libc.CLONE_NEWNS)
+            except OSError:
+                os.write(ready_w, b"E")  # tell parent to fall back
+                os._exit(0)
+            os.write(ready_w, b"K")
+            os.close(ready_w)
+            # Block until the parent has installed the maps (K) or wants us
+            # to abort (EOF / anything else), in which case fall back.
+            if os.read(go_r, 1) != b"K":
+                os._exit(0)
+            os.close(go_r)
+            os.execvp(argv[0], argv)
+            os._exit(127)
+
+        # --- parent ---
+        os.close(ready_w)
+        os.close(go_r)
+        if os.read(ready_r, 1) != b"K":
+            # The child could not create the namespace: reap it and fall back.
+            os.close(go_w)
+            os.waitpid(pid, 0)
+            return None
+        os.close(ready_r)
+        try:
+            self.install(pid)
+        except (OSError, subprocess.CalledProcessError):
+            os.close(go_w)  # EOF -> child aborts
+            os.waitpid(pid, 0)
+            return None
+        os.write(go_w, b"K")
+        os.close(go_w)
+        _, status = os.waitpid(pid, 0)
+        if os.WIFEXITED(status):
+            return os.WEXITSTATUS(status)
+        return 1
 
 
 def proc_boot_id(appid: str):


### PR DESCRIPTION
This just reruns osbuild inside `unshare --map-auto --map-root-user --keep-caps -m` if not run as uid 0. This will make it run in a user namespace where it looks like uid is 0 and we have full capabilities (in the user namespace). This, in combination with using --in-vm where appropriate will make osbuild run as a user.

There are some minor other details:
 * As a user we can't just create and/or write stuff in /run/osbuild, so instead we switch to using a per-user path as the backing storage. It is still /run/osbuild inside the pipeline when the stages run.
 * For some reason podman falls back to fuse-overlayfs in the vm, so I added /dev/fuse to the buildroot.
 * I had to update osbuild-initrd to get the cgroupv2 mount.

Note: This is somewhat similar to https://github.com/osbuild/osbuild/pull/2396, although that approaches things from a different approach, moving setup into the bwrap commandline instead of wrapping everything in a user namespace so we can keep the current mount() calls. I think longterm we should maybe go that way, but this is a minimal change that shouldn't affect anything that lets us make progress.