### PR TITLE
main: Make rootless work when using the /usr/bin/osbuild wrapper

### DIFF
--- a/osbuild/__main__.py
+++ b/osbuild/__main__.py
@@ -4,18 +4,10 @@ This specifies the entrypoint of the osbuild module when run as executable. For
 compatibility we will continue to run the CLI.
 """
 
-import os
 import sys
 
-from osbuild.main_cli import _reexec_in_userns
 from osbuild.main_cli import osbuild_cli as main
 
 if __name__ == "__main__":
-    if os.getuid() != 0:
-        # Re-exec in a user namespace when possible; returns the child's exit
-        # status to propagate, or None to fall back to the normal code path.
-        r = _reexec_in_userns()
-        if r is not None:
-            sys.exit(r)
     r = main()
     sys.exit(r)

--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -149,7 +149,17 @@ def _reexec_in_userns() -> Optional[int]:
 # pylint: disable=too-many-branches,too-many-return-statements,too-many-statements
 
 
-def osbuild_cli() -> int:
+def osbuild_cli(no_reexec: bool = False) -> int:
+    if not no_reexec and os.getuid() != 0:
+        # Re-exec inside a user namespace when running rootless. Do this here in
+        # the shared entrypoint (rather than in __main__.py) so it also triggers
+        # for the installed `osbuild` console-script, which loads this function
+        # directly and never runs __main__.py. Returns the child's exit status,
+        # or None to fall through to the normal code path.
+        r = _reexec_in_userns()
+        if r is not None:
+            return r
+
     args = parse_arguments(sys.argv)
     if args.rundir is None:
         args.rundir = _default_rundir()

--- a/osbuild/util/mnt.py
+++ b/osbuild/util/mnt.py
@@ -44,7 +44,7 @@ def umount(target, lazy=False):
     if lazy:
         args += ["--lazy"]
     subprocess.run(["sync", "-f", target], check=True)
-    subprocess.run(["umount", "-R"] + args + [target], check=True)
+    subprocess.run(["umount", "--lazy"] + args + [target], check=True)
 
 
 class MountGuard(contextlib.AbstractContextManager):
@@ -63,7 +63,7 @@ class MountGuard(contextlib.AbstractContextManager):
         self.remount = remount
         options = []
         if bind:
-            options += ["bind"]
+            options += ["rbind"]
         if remount:
             options += ["remount"]
         if permissions:
@@ -99,7 +99,7 @@ class MountGuard(contextlib.AbstractContextManager):
             # Calling  `sync` does not hurt so we keep it for now.
             if not self.remount:
                 subprocess.run(["sync", "-f", target], check=True)
-                subprocess.run(["umount", target], check=True)
+                subprocess.run(["umount", "--lazy", target], check=True)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.umount()

--- a/test/run/test_noop.py
+++ b/test/run/test_noop.py
@@ -79,7 +79,7 @@ def test_noop_cli(monkeypatch, capfd, tmp_path, jsondata):
         f"--store={tmp_path}",
         "--quiet",
     ])
-    ret_code = osbuild.main_cli.osbuild_cli()
+    ret_code = osbuild.main_cli.osbuild_cli(no_reexec=True)
     assert ret_code == 0
 
     captured = capfd.readouterr()


### PR DESCRIPTION
This moves the user-namespace reexec from __main__.py to osbuild_cli() which means it is hit also when starting usbuild via the setuptools generated binary wrapper.

We also add a no_reexec (default to False) option so that we can avoid issues with this when this code is called directly from the testsuite (as a user).