### PR TITLE
rootless: Use the correct container storage

### DIFF
--- a/osbuild/main_cli.py
+++ b/osbuild/main_cli.py
@@ -125,6 +125,32 @@ def _default_rundir() -> str:
     return f"/run/user/{os.getuid()}/osbuild"
 
 
+def _rootless_container_storage_env() -> dict:
+    """Compute CONTAINERS_GRAPHROOT/RUNROOT for the calling (rootless) user.
+
+    Inside the user namespace we appear as uid 0, so c/storage would otherwise
+    default to the system-global storage (/var/lib/containers, /run/containers).
+    Point it back at the per-user rootless storage instead, just like
+    `podman unshare` does, using the rootless c/storage defaults.
+    """
+    env = {}
+
+    graphroot = os.environ.get("CONTAINERS_GRAPHROOT")
+    if not graphroot:
+        data_home = os.environ.get("XDG_DATA_HOME") or \
+            os.path.join(os.path.expanduser("~"), ".local", "share")
+        graphroot = os.path.join(data_home, "containers", "storage")
+    env["CONTAINERS_GRAPHROOT"] = graphroot
+
+    runroot = os.environ.get("CONTAINERS_RUNROOT")
+    if not runroot:
+        runtime_dir = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
+        runroot = os.path.join(runtime_dir, "containers")
+    env["CONTAINERS_RUNROOT"] = runroot
+
+    return env
+
+
 def _reexec_in_userns() -> Optional[int]:
     """Re-exec osbuild inside a user namespace with full uid/gid mappings.
 
@@ -144,7 +170,7 @@ def _reexec_in_userns() -> Optional[int]:
         # Keep the user rundir even though uid will be 0 in the userns
         argv += ["--rundir", _default_rundir()]
 
-    return maps.exec(argv)
+    return maps.exec(argv, env=_rootless_container_storage_env())
 
 # pylint: disable=too-many-branches,too-many-return-statements,too-many-statements
 

--- a/osbuild/util/host.py
+++ b/osbuild/util/host.py
@@ -4,6 +4,8 @@ Utility functions that only run on the host (osbuild internals or host modules l
 These should not be used by stages or code that runs in the build root.
 """
 
+import os
+
 
 def get_container_storage():
     """
@@ -20,10 +22,28 @@ def get_container_storage():
         raise FileNotFoundError("could not find toml parser to read container storage configuration") from e
 
     config_paths = ("/etc/containers/storage.conf", "/usr/share/containers/storage.conf")
+    conf = None
     for conf_path in config_paths:
         try:
-            return toml.load_from_file(conf_path)
+            conf = toml.load_from_file(conf_path)
+            break
         except FileNotFoundError:
             pass
+
+    # Handle CONTAINERS_GRAPHROOT and CONTAINERS_RUNROOT env var overrides, as set by
+    # `podman unshare`.
+    env_graphroot = os.environ.get("CONTAINERS_GRAPHROOT")
+    env_runroot = os.environ.get("CONTAINERS_RUNROOT")
+
+    if env_graphroot:
+        conf = conf or {}
+        storage = conf.setdefault("storage", {})
+        storage["graphroot"] = env_graphroot
+        if env_runroot:
+            storage["runroot"] = env_runroot
+        return conf
+
+    if conf:
+        return conf
 
     raise FileNotFoundError(f"could not find container storage configuration in any of {config_paths}")

--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -26,7 +26,7 @@ import subprocess
 import threading
 import typing
 import uuid
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 __all__ = [
     "fcntl_flock",
@@ -481,12 +481,15 @@ class IdMaps(typing.NamedTuple):
              "1", str(sg_start), str(sg_count)],
             check=True)
 
-    def exec(self, argv: List[str]) -> Optional[int]:
+    def exec(self, argv: List[str], env: Optional[Dict[str, str]] = None) -> Optional[int]:
         """Run `argv` inside a new user namespace mapped by these id maps.
 
         On success the parent supervises the child and returns its exit status,
         so the caller can `sys.exit()` with it. Returns None if the namespace
         cannot be set up.
+
+        If `env` is given, those variables are added to (overriding) the current
+        environment for the re-exec'd process.
         """
         ready_r, ready_w = os.pipe()  # child -> parent: namespace created
         go_r, go_w = os.pipe()        # parent -> child: maps installed
@@ -508,7 +511,10 @@ class IdMaps(typing.NamedTuple):
             if os.read(go_r, 1) != b"K":
                 os._exit(0)
             os.close(go_r)
-            os.execvp(argv[0], argv)
+            if env:
+                os.execvpe(argv[0], argv, {**os.environ, **env})
+            else:
+                os.execvp(argv[0], argv)
             os._exit(127)
 
         # --- parent ---


### PR DESCRIPTION
When running rootless (not in a container) the containers used should be from the per-user storage. However, to make things work rootless we're running as uid 0 in the user namespace, which makes things pick up the system storage (/var/lib/containers/storage). To fix this, we set the podman env vars for the storage (CONTAINERS_GRAPHROOT and CONTAINERS_RUNROOT) to the user storage. This is the same thing that "podman unshare" uses, and podman will pick it up automatically.

We also respect these env vars in get_container_storage() so that stages and sources use the correct storage location instead of hardcoding the system one.