### PR TITLE
qemu: Uncompress kernels not supported by qemu

### DIFF
--- a/osbuild/qemu.py
+++ b/osbuild/qemu.py
@@ -8,6 +8,7 @@ import platform
 import shutil
 import signal
 import socket
+import struct
 import subprocess
 import sys
 import tempfile
@@ -35,6 +36,77 @@ def find_kernel_dir(tree):
             return modules_dir / subdir.name
 
     raise ValueError("No valid kernel directory found in /usr/lib/modules")
+
+
+def _decompress_zstd(payload):
+    # Python 3.14 added compression.zstd
+    try:
+        # pylint: disable=import-outside-toplevel
+        from compression import zstd as _zstd
+        return _zstd.ZstdDecompressor().decompress(payload)
+    except ImportError:
+        pass
+
+    # Else fall back to zstd tool
+    return subprocess.run(
+        ["zstd", "-dc"],
+        input=payload, stdout=subprocess.PIPE, check=True,
+    ).stdout
+
+
+# EFI zboot ("zimg") self-decompressing kernel image support.
+#
+# Format reference (struct linux_efi_zboot_header):
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/firmware/efi/libstub/zboot-header.S
+_EFI_ZBOOT_HEADER = struct.Struct("<2s2s4sII8s32s4sI")
+_EFI_ZBOOT_MSDOS_MAGIC = b"MZ"
+_EFI_ZBOOT_ZIMG_MAGIC = b"zimg"
+_EFI_ZBOOT_LINUX_MAGIC = b"\xcd\x23\x82\x81"
+
+
+def unpack_kernel_image_if_needed(path):
+    """Uncompress kernel image formats that qemu doesn't support.
+
+    Returns the raw (decompressed) kernel image bytes, or None if there
+    is no need to uncompress the kernel. Currently this only handles
+    EFI zboot images, as used on aarch64.
+    """
+    with open(path, "rb") as f:
+        header = f.read(_EFI_ZBOOT_HEADER.size)
+
+        if len(header) < _EFI_ZBOOT_HEADER.size:
+            return None
+
+        (msdos_magic, _reserved0, zimg, payload_offset, payload_size,
+         _reserved1, compression_type, linux_magic, _pe_header_offset) = \
+            _EFI_ZBOOT_HEADER.unpack_from(header, 0)
+
+        if (msdos_magic != _EFI_ZBOOT_MSDOS_MAGIC or
+                zimg != _EFI_ZBOOT_ZIMG_MAGIC or
+                linux_magic != _EFI_ZBOOT_LINUX_MAGIC):
+            return None
+
+        compression = compression_type.split(b"\x00", 1)[0].decode("ascii")
+
+        # QEMU'can handle gzip, no need to unpack
+        if compression == "gzip":
+            return None
+
+        f.seek(payload_offset)
+        payload = f.read(payload_size)
+        if len(payload) < payload_size:
+            raise RuntimeError(f"corrupt EFI zboot image {os.fspath(path)!r}")
+
+    if compression in ("zstd", "zstd22"):
+        return _decompress_zstd(payload)
+    if compression == "xz":
+        return lzma.LZMADecompressor(format=lzma.FORMAT_XZ).decompress(payload)
+    if compression == "lzma":
+        return lzma.LZMADecompressor(format=lzma.FORMAT_ALONE).decompress(payload)
+
+    raise RuntimeError(
+        f"unable to handle EFI zboot image {os.fspath(path)!r} "
+        f"with {compression!r} compression")
 
 
 def get_module_dependencies(module_path):
@@ -305,6 +377,11 @@ class Qemu:
 
         kerneldir = find_kernel_dir(rootfs_path)
         kernel_path = kerneldir / "vmlinuz"
+
+        raw_kernel = unpack_kernel_image_if_needed(kernel_path)
+        if raw_kernel is not None:
+            kernel_path = Path(self._tmpdir.name) / "vmlinuz"
+            kernel_path.write_bytes(raw_kernel)
 
         initrd_path = Path(self._tmpdir.name) / "initrd"
         create_initrd(libdir_path, rootfs_path, initrd_path)


### PR DESCRIPTION
On aarch64, the fedora default seems to be zstd zboot kernels, which qemu doesn't support. So, auto-decompress these as needed.

This is what I get on aarch64 before this fix:
```
bin/image-builder --in-vm --verbose --output-dir bib-out --bootc-default-fs ext4 --output-name image --bootc-ref quay.io/fedora/fedora-bootc:43  build raw
Manifest generation step
Building manifest for bootc-based-raw
Image building step
starting -Pipeline source org.osbuild.containers-storage: 5e5d39b5cf729ec87c2d183e39804c10958dcd51bfa337f807499f6f661d05c6
Build
  root: <host>
Pipeline build: 4635f860ad4b5b8c82a6ff10c8aedf456860e9fead5a41cac8e3c4b705814f61
Build
  root: <host>
  runner: org.osbuild.fedora-asahi-remix (org.osbuild.fedora-asahi-remix)
org.osbuild.container-deploy: 960b716a7e0c92d9c922aa7be3c862a995773ee7a44b8f463f5fa2cb5218c738 {
  "remove-signatures": true
}
Failed to read '/usr/lib/tmpfiles.d/audit.conf': Permission denied
fchownat() of /sys/kernel/security/ima/binary_runtime_measurements failed: Read-only file system
6b84e472b283f8000f1623f24b9c35901a9fd266a0d295fbf0b1640468835d72
umount: /run/osbuild/containers/storage/overlay: must be superuser to unmount.
WARNING: umount of overlay dir failed with an error: CompletedProcess(args=['umount', '-f', '--lazy', '/run/osbuild/containers/storage/overlay'], returncode=32)

⏱  Duration: 13.99s
org.osbuild.selinux: 4635f860ad4b5b8c82a6ff10c8aedf456860e9fead5a41cac8e3c4b705814f61 {
  "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
  "exclude_paths": [
    "/sysroot"
  ],
  "labels": {
    "/usr/bin/mount": "system_u:object_r:install_exec_t:s0",
    "/usr/bin/ostree": "system_u:object_r:install_exec_t:s0",
    "/usr/bin/umount": "system_u:object_r:install_exec_t:s0"
  }
}
Failed to read '/usr/lib/tmpfiles.d/audit.conf': Permission denied
fchownat() of /sys/kernel/security/ima/binary_runtime_measurements failed: Read-only file system

⏱  Duration: 1.20s
Pipeline image: a06aae04c9c2df866a7b1e916157cb37a0ad6a7ac19a0c33eda501d9672bb8a3
Build
  root: 4635f860ad4b5b8c82a6ff10c8aedf456860e9fead5a41cac8e3c4b705814f61
  runner: org.osbuild.linux (org.osbuild.linux) in vm
unable to handle EFI zboot image with "zstd" compression
qemu-system-aarch64: could not load kernel '/home/alex/.cache/image-builder/store/stage/uuid-a594f43c68c6447389b98371fe3733f8/data/tree/usr/lib/modules/7.1.9-100.fc43.aarch64/vmlinuz'
Traceback (most recent call last):
  File "/usr/bin/osbuild", line 33, in <module>
    sys.exit(load_entry_point('osbuild==192', 'console_scripts', 'osbuild')())
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/osbuild/main_cli.py", line 264, in osbuild_cli
    r = manifest.build(
        object_store,
    ...<6 lines>...
        rundir=args.rundir
    )
  File "/usr/lib/python3.14/site-packages/osbuild/pipeline.py", line 681, in build
    res = pl.run(
        store,
    ...<4 lines>...
        in_vm=in_vm and pl.name in in_vm,
        rundir=rundir)
  File "/usr/lib/python3.14/site-packages/osbuild/pipeline.py", line 510, in run
    stage_results = self.build_stages(store,
                                      monitor,
    ...<3 lines>...
                                      in_vm,
                                      rundir=rundir)
  File "/usr/lib/python3.14/site-packages/osbuild/pipeline.py", line 456, in build_stages
    cm.enter_context(qemu)
    ~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib64/python3.14/contextlib.py", line 530, in enter_context
    result = _enter(cm)
  File "/usr/lib/python3.14/site-packages/osbuild/qemu.py", line 498, in __enter__
    self.start()
    ~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/osbuild/qemu.py", line 470, in start
    raise RuntimeError("QEMU did not become ready")
RuntimeError: QEMU did not become ready
error: error running osbuild: exit status 1
```

With the fix it works.