### PR TITLE
rootless: Handle unknown selinux types

### DIFF
--- a/osbuild.spec
+++ b/osbuild.spec
@@ -476,6 +476,7 @@ fi
 %files tools
 %{_bindir}/osbuild-image-info
 %{_bindir}/osbuild-mpp
+%{_bindir}/osbuild-add-selinux-labels
 %{?fedora:%{_bindir}/osbuild-dev}
 %{_libexecdir}/osbuild-store
 

--- a/osbuild/buildroot.py
+++ b/osbuild/buildroot.py
@@ -233,6 +233,8 @@ class BuildRoot(contextlib.AbstractContextManager):
         mounts += ["--proc", "/proc"]
         mounts += ["--ro-bind", "/sys", "/sys"]
         mounts += ["--ro-bind-try", "/sys/fs/selinux", "/sys/fs/selinux"]
+        # Writable so stages can validate contexts via security_check_context()
+        mounts += ["--bind-try", "/sys/fs/selinux/context", "/sys/fs/selinux/context"]
 
         # There was a bug in mke2fs (fixed in versionv 1.45.7) where mkfs.ext4
         # would fail because the default config, created on the fly, would

--- a/osbuild/util/linux.py
+++ b/osbuild/util/linux.py
@@ -31,11 +31,25 @@ from typing import Dict, List, Optional, Tuple
 __all__ = [
     "fcntl_flock",
     "IdMaps",
+    "in_init_user_namespace",
     "ioctl_get_immutable",
     "ioctl_toggle_immutable",
     "Libc",
     "proc_boot_id",
 ]
+
+
+# This is the inode number of initial user namespace. See
+# `proc_ns_operations` in the kernel and `PROC_USER_INIT_INO`.
+USER_NS_INIT_INO = 0xEFFF_FFFD
+
+
+def in_init_user_namespace() -> bool:
+    """Check whether we run in the initial (host) user namespace."""
+    try:
+        return os.stat("/proc/self/ns/user").st_ino == USER_NS_INIT_INO
+    except OSError:
+        return False
 
 
 # NOTE: These are wrong on at least ALPHA and SPARC. They use different

--- a/osbuild/util/selinux.py
+++ b/osbuild/util/selinux.py
@@ -2,8 +2,9 @@
 
 import errno
 import os
+import re
 import subprocess
-from typing import Dict, List, Optional, TextIO
+from typing import Dict, List, Optional, Set, TextIO
 
 # Extended attribute name for SELinux labels
 XATTR_NAME_SELINUX = b"security.selinux"
@@ -33,6 +34,89 @@ def config_get_policy(config: Dict[str, str]):
     if enabled not in ['enforcing', 'permissive']:
         return None
     return config.get('SELINUXTYPE', None)
+
+
+def is_selinux_enabled() -> bool:
+    """Check whether SELinux is enabled on the running system."""
+    return os.path.exists("/sys/fs/selinux/context")
+
+
+def is_known_type(type_name: str) -> bool:
+    """Check if an SELinux type exists in the kernel's loaded policy."""
+    try:
+        # This is the same implementation as security_check_context()
+        fd = os.open("/sys/fs/selinux/context", os.O_WRONLY)
+        try:
+            os.write(fd, f"system_u:object_r:{type_name}:s0".encode())
+            return True
+        except OSError:
+            return False
+        finally:
+            os.close(fd)
+    except OSError:
+        return False
+
+
+def parse_file_contexts(path: str) -> Dict[str, List[str]]:
+    """Parse a file_contexts file and return a mapping of type -> list of path patterns."""
+    type_patterns: Dict[str, List[str]] = {}
+    with open(path, encoding="utf8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            # each line is `pathname_regexp  [file_type]  security_context`, whitespace separated
+            parts = line.split()
+            context = parts[-1]
+            # Ignore no-context rules
+            if context == "<<none>>":
+                continue
+            fields = context.split(":")
+            if len(fields) >= 3:
+                type_patterns.setdefault(fields[2], []).append(parts[0])
+    return type_patterns
+
+
+def find_unknown_types_used(file_contexts: str, root: str,
+                            exclude_paths: Optional[List[str]] = None) -> Set[str]:
+    """Find unknown SELinux types whose file_contexts patterns match files in the tree."""
+    exclude = set(exclude_paths or [])
+    type_patterns = parse_file_contexts(file_contexts)
+
+    # Compile a regexp that matches for each unknown type a list of
+    # all pathname patterns that would be used by it.
+    unknown_regexes = {}
+    for t, patterns in type_patterns.items():
+        if not is_known_type(t):
+            alt = "|".join(f"(?:{p})" for p in patterns)
+            try:
+                unknown_regexes[t] = re.compile(f"^(?:{alt})$")
+            except re.error:
+                continue
+
+    if not unknown_regexes:
+        return set()
+
+    # Walk the tree and see if any path matches one of the
+    # regexps for an unknown regexp.
+    used = set()
+    prefix_len = len(root)
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Don't descend into excluded directories; they won't be relabeled.
+        dirnames[:] = [d for d in dirnames if os.path.join(dirpath, d) not in exclude]
+        for name in [dirpath] + [os.path.join(dirpath, f) for f in filenames + dirnames]:
+            if name in exclude:
+                continue
+            logical = name[prefix_len:]
+            if not logical:
+                logical = "/"
+            for t, rx in list(unknown_regexes.items()):
+                if rx.match(logical):
+                    used.add(t)
+                    del unknown_regexes[t]  # No need to look for this type again
+            if not unknown_regexes:
+                return used  # Found all, return early
+    return used
 
 
 def setfiles(spec_file: str, root: str, *paths, exclude_paths: Optional[List[str]] = None) -> None:

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setuptools.setup(
         "tools/osbuild-mpp",
         "tools/osbuild-dev",
         "tools/osbuild-image-info",
+        "tools/osbuild-add-selinux-labels",
     ],
 )

--- a/stages/org.osbuild.selinux
+++ b/stages/org.osbuild.selinux
@@ -4,7 +4,7 @@ import pathlib
 import sys
 
 import osbuild.api
-from osbuild.util import parsing, selinux
+from osbuild.util import linux, parsing, selinux
 
 
 def main(args):
@@ -21,8 +21,26 @@ def main(args):
             file_contexts = os.path.normpath(f"{tree}/{file_contexts}")
         else:
             file_contexts = parsing.parse_location(file_contexts, args)
+
         if exclude_paths:
             exclude_paths = [os.path.normpath(f"{root}/{target}/{p}") for p in exclude_paths]
+
+        # As root, the osbuild selinux policy allows osbuild to transition to setfiles_mac,
+        # which lets it set file context types that are not known to the host policy. However,
+        # if running unprivileged, there is no way to do this, so we pre-check for unknown
+        # types to produce an actionable error message. This only applies when SELinux is
+        # enabled; otherwise there is no host policy to validate against.
+        if not linux.in_init_user_namespace() and selinux.is_selinux_enabled():
+            unknown = sorted(selinux.find_unknown_types_used(
+                file_contexts, os.path.normpath(f"{root}{target}"), exclude_paths=exclude_paths))
+            if unknown:
+                print("The following SELinux types from file_contexts are not in the host policy:")
+                for t in unknown:
+                    print(f"  {t}")
+                print("\nUnprivileged osbuild cannot create such files. To allow this, run:")
+                print(f"  sudo osbuild-add-selinux-labels add {' '.join(unknown)}")
+                return 1
+
         selinux.setfiles(file_contexts, os.path.normpath(root), target, exclude_paths=exclude_paths)
 
     labels = options.get("labels", {})
@@ -39,6 +57,8 @@ def main(args):
         # Note that this is missing from the selinux(8) and selinux_config(5) man-pages
         # [0] https://src.fedoraproject.org/rpms/policycoreutils/blob/rawhide/f/selinux-autorelabel#_54
         stamp.write_text("-F", encoding="utf-8")
+
+    return 0
 
 
 if __name__ == '__main__':

--- a/tools/osbuild-add-selinux-labels
+++ b/tools/osbuild-add-selinux-labels
@@ -1,0 +1,202 @@
+#!/usr/bin/python3
+"""Manage an SELinux policy module that declares types for osbuild rootless builds.
+
+When running osbuild as a regular user, osbuild cannot set
+security.selinux xattrs with type labels unknown to the host
+policy. This tool declares those types in a minimal SELinux module (no
+allow rules), making them known to the kernel (but having no
+permissions) so that context validation succeeds without requiring
+CAP_MAC_ADMIN.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+MODULE_NAME = "osbuild-labels"
+
+_verbose = False
+
+
+def verbose(msg):
+    if _verbose:
+        print(msg)
+
+
+def run_semodule(args, check=True, cwd=None):
+    return subprocess.run(["semodule"] + args, capture_output=True, text=True, check=check, cwd=cwd)
+
+
+def get_module_types():
+    """Extract the current set of types from the osbuild-labels module."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        r = run_semodule(["-H", "-E", MODULE_NAME], check=False, cwd=tmpdir)
+        if r.returncode != 0:
+            return set()
+        cil_path = os.path.join(tmpdir, f"{MODULE_NAME}.cil")
+        try:
+            with open(cil_path) as f:
+                content = f.read()
+        except FileNotFoundError:
+            return set()
+        except PermissionError as e:
+            # semodule runs under sudo and writes the extracted module as
+            # root; a restrictive root umask can leave it unreadable to us.
+            # Bail out rather than silently treating it as an empty module,
+            # which would drop the already-declared types on the next install.
+            print(f"Error: cannot read extracted module {cil_path}: {e}", file=sys.stderr)
+            sys.exit(1)
+    types = set()
+    for m in re.finditer(r"\(type\s+(\S+)\)", content):
+        types.add(m.group(1))
+    return types
+
+
+def get_policy_types():
+    """Get all types currently defined in the loaded policy."""
+    try:
+        import sepolicy
+        return set(sepolicy.get_all_types())
+    except ImportError:
+        r = subprocess.run(["seinfo", "-t"], capture_output=True, text=True, check=True)
+        types = set()
+        for line in r.stdout.splitlines():
+            # `seinfo -t` prints a "Types: <count>" header followed by one
+            # indented type name per line.
+            line = line.strip()
+            if line and not line.startswith("Types:"):
+                types.add(line)
+        return types
+
+
+def generate_cil(types):
+    lines = [f"(type {t})" for t in sorted(types)]
+    return "\n".join(lines) + "\n"
+
+
+def install_module(types):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cil_path = os.path.join(tmpdir, f"{MODULE_NAME}.cil")
+        with open(cil_path, "w") as f:
+            f.write(generate_cil(types))
+        try:
+            run_semodule(["-i", cil_path], check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Error installing module: {e.stderr}", file=sys.stderr)
+            sys.exit(1)
+
+
+def remove_module():
+    r = run_semodule(["-r", MODULE_NAME], check=False)
+    if r.returncode != 0 and "No such file or directory" not in r.stderr:
+        print(f"Error removing module: {r.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_add(args):
+    policy_types = get_policy_types()
+    current = get_module_types()
+    to_add = set()
+    for t in args.types:
+        if t in current:
+            verbose(f"Type '{t}' is already in {MODULE_NAME} module, skipping.")
+        elif t in policy_types:
+            verbose(f"Type '{t}' already exists in the host policy, skipping.")
+        else:
+            to_add.add(t)
+
+    if not to_add:
+        verbose("No new types to add.")
+        return
+
+    new_types = current | to_add
+    install_module(new_types)
+    for t in sorted(to_add):
+        verbose(f"Added type '{t}'.")
+
+
+def cmd_remove(args):
+    current = get_module_types()
+    if not current:
+        verbose(f"Module {MODULE_NAME} does not exist, nothing to remove.")
+        return
+
+    to_remove = set()
+    for t in args.types:
+        if t in current:
+            to_remove.add(t)
+        else:
+            verbose(f"Type '{t}' is not in {MODULE_NAME} module, skipping.")
+
+    if not to_remove:
+        verbose("No types to remove.")
+        return
+
+    remaining = current - to_remove
+    if remaining:
+        install_module(remaining)
+    else:
+        remove_module()
+    for t in sorted(to_remove):
+        verbose(f"Removed type '{t}'.")
+
+
+def cmd_clear(args):
+    current = get_module_types()
+    if not current:
+        verbose(f"Module {MODULE_NAME} does not exist, nothing to clear.")
+        return
+    remove_module()
+    verbose(f"Removed module {MODULE_NAME} ({len(current)} types).")
+
+
+def cmd_list(args):
+    current = get_module_types()
+    if not current:
+        verbose(f"Module {MODULE_NAME} does not exist or has no types.")
+        return
+    for t in sorted(current):
+        print(t)
+
+
+def main():
+    if os.getuid() != 0:
+        print("This tool must be run as root")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(
+        description="Manage SELinux type declarations for osbuild rootless builds."
+    )
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="print informational messages")
+    sub = parser.add_subparsers(dest="command")
+
+    p_add = sub.add_parser("add", help="Add type declarations")
+    p_add.add_argument("types", nargs="+", metavar="TYPE")
+    p_add.set_defaults(func=cmd_add)
+
+    p_remove = sub.add_parser("remove", help="Remove type declarations")
+    p_remove.add_argument("types", nargs="+", metavar="TYPE")
+    p_remove.set_defaults(func=cmd_remove)
+
+    p_clear = sub.add_parser("clear", help="Remove the entire module")
+    p_clear.set_defaults(func=cmd_clear)
+
+    p_list = sub.add_parser("list", help="List declared types")
+    p_list.set_defaults(func=cmd_list)
+
+    args = parser.parse_args()
+    global _verbose
+    _verbose = args.verbose
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
When running rootless there is no way to use selinux roles to set the selinux policy to allow setting file contexts to types unknown in the host policy. So, instead we have another approach of fixing this. 

First of all there is code  in the selinux stage that looks for these unknown types and prints a useful error including the problematic types, rather than the tons of EINVAL errors for each problematic path.

Secondly, there is a new tool osbuild-add-selinux-labels that makes it easy to add (unused) types to the host policy by creating (and updating) a module called `osbuilld-labels`. Running this requires root, but only needs to happen once for all future runs (for each problematic type).