### PR TITLE
Add OS Features to disk images 

### DIFF
--- a/osbuild/util/features.py
+++ b/osbuild/util/features.py
@@ -1,0 +1,35 @@
+"""OS Features
+
+Shared utility for generating the OS features table (features.json),
+which is read by coreos-installer.
+"""
+
+import json
+import os
+import yaml
+
+
+def write_os_features(tree, *destinations):
+    features = json.dumps(get_os_features(tree), indent=2, sort_keys=True) + '\n'
+    for dest in destinations:
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, 'w', encoding='utf8') as fh:
+            fh.write(features)
+
+
+def get_os_features(tree):
+    features = {
+        # coreos-installer >= 0.12.0
+        'installer-config': True,
+        # coreos/fedora-coreos-config@3edd2f28
+        'live-initrd-network': True,
+        # coreos-installer > 0.26.0
+        'initrd-copy-network': True,
+    }
+    file = os.path.join(tree, 'usr/share/coreos-installer/example-config.yaml')
+    with open(file, encoding='utf8') as f:
+        example_config_yaml = yaml.safe_load(f)
+    features['installer-config-directives'] = {
+        k: True for k in example_config_yaml
+    }
+    return features

--- a/stages/org.osbuild.coreos.live-artifacts.mono
+++ b/stages/org.osbuild.coreos.live-artifacts.mono
@@ -20,11 +20,10 @@ import subprocess
 import sys
 import tempfile
 
-import yaml
-
 import osbuild.api
 import osbuild.remoteloop as remoteloop
 from osbuild.util import checksum, makeefi, osrelease
+from osbuild.util.features import write_os_features
 from osbuild.util.chroot import Chroot
 from osbuild.util.path import ensure_glob
 
@@ -56,24 +55,6 @@ def align_initrd_for_uncompressed_append(destf):
     offset = destf.tell()
     if offset % 4:
         destf.write(b'\0' * (4 - offset % 4))
-
-
-# Return OS features table for features.json, which is read by
-# coreos-installer {iso|pxe} customize
-def get_os_features(tree):
-    features = {
-        # coreos-installer >= 0.12.0
-        'installer-config': True,
-        # coreos/fedora-coreos-config@3edd2f28
-        'live-initrd-network': True,
-    }
-    file = os.path.join(tree, 'usr/share/coreos-installer/example-config.yaml')
-    with open(file, encoding='utf8') as f:
-        example_config_yaml = yaml.safe_load(f)
-    features['installer-config-directives'] = {
-        k: True for k in example_config_yaml
-    }
-    return features
 
 
 # https://www.kernel.org/doc/html/latest/admin-guide/initrd.html#compressed-cpio-images
@@ -824,13 +805,11 @@ def main(workdir, tree, inputs, options, loop_client):
     # Generate JSON file that lists OS features available to
     # coreos-installer {iso|pxe} customize.  Put it in the initramfs for
     # pxe customize and the ISO for iso customize.
-    features = json.dumps(get_os_features(tree=deployed_tree), indent=2, sort_keys=True) + '\n'
-    featurespath = paths["initrd/etc/coreos/features.json"]
-    os.makedirs(os.path.dirname(featurespath), exist_ok=True)
-    with open(featurespath, 'w', encoding='utf8') as fh:
-        fh.write(features)
-    with open(paths["iso/coreos/features.json"], 'w', encoding='utf8') as fh:
-        fh.write(features)
+    write_os_features(
+        deployed_tree,
+        paths["initrd/etc/coreos/features.json"],
+        paths["iso/coreos/features.json"],
+    )
 
     mk_osmet_files(deployed_tree, img_metal, img_metal4k, loop_client, paths, os_release)
 

--- a/stages/org.osbuild.coreos.platform
+++ b/stages/org.osbuild.coreos.platform
@@ -6,6 +6,7 @@ import sys
 
 import osbuild.api
 from osbuild.util import bls
+from osbuild.util.features import write_os_features
 
 # Constants
 # For console.cfg see https://github.com/coreos/bootupd/pull/620
@@ -66,6 +67,7 @@ def main(paths, options):
     # Append kernel arguments in bls entries
     bls.options_append(boot_path, kernel_arguments)
 
+    write_os_features(root, os.path.join(root, "boot/coreos/features.json"))
 
 if __name__ == "__main__":
     args = osbuild.api.arguments()

--- a/stages/test/test_coreos_live_artifacts_mono.py
+++ b/stages/test/test_coreos_live_artifacts_mono.py
@@ -6,10 +6,12 @@ import textwrap
 
 import pytest
 
+from osbuild.util.features import get_os_features
+
 STAGE_NAME = "org.osbuild.coreos.live-artifacts.mono"
 
 
-def test_get_os_features(tmp_path, stage_module):
+def test_get_os_features(tmp_path):
     cfg_path = tmp_path / "usr/share/coreos-installer/example-config.yaml"
     cfg_path.parent.mkdir(parents=True)
     cfg_path.write_text(textwrap.dedent("""\
@@ -18,7 +20,7 @@ def test_get_os_features(tmp_path, stage_module):
     # Manually specify the image URL
     image-url: URL
     """))
-    features = stage_module.get_os_features(tmp_path)
+    features = get_os_features(tmp_path)
     assert {
         "installer-config": True,
         "installer-config-directives": {


### PR DESCRIPTION
- Move OS Features to `util` so they can be reused in other parts of the codebase. We now need the feature information to be available for disk images as well, rather than only for Live images.
-  Add OS Features to disk images via `org.osbuild.coreos.platform`.
- Update the feature list to include `initrd-copy-network`.
